### PR TITLE
Allows to import multiple Jars at once

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.jar.JarFile;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.tngtech.archunit.PublicAPI;
@@ -68,7 +69,21 @@ public final class ClassFileImporter {
 
     @PublicAPI(usage = ACCESS)
     public JavaClasses importJar(JarFile jar) {
-        return importLocations(singleton(Location.of(jar)));
+        return importJars(jar);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public JavaClasses importJars(JarFile... jarFiles) {
+        return importJars(ImmutableList.copyOf(jarFiles));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public JavaClasses importJars(Iterable<JarFile> jarFiles) {
+        Set<Location> locations = new HashSet<>();
+        for (JarFile jarFile : jarFiles) {
+            locations.add(Location.of(jarFile));
+        }
+        return importLocations(locations);
     }
 
     /**

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -155,13 +155,25 @@ public class Assertions extends org.assertj.core.api.Assertions {
             }
         }
 
+        public void contain(Class<?>... classes) {
+            contain(ImmutableSet.copyOf(classes));
+        }
+
+        public void dontContain(Class<?>... classes) {
+            assertThat(actualNames()).doesNotContainAnyElementsOf(JavaClass.namesOf(classes));
+        }
+
         public void contain(Iterable<Class<?>> classes) {
+            List<String> expectedNames = JavaClass.namesOf(Lists.newArrayList(classes));
+            assertThat(actualNames()).as("actual classes").containsAll(expectedNames);
+        }
+
+        private Set<String> actualNames() {
             Set<String> actualNames = new HashSet<>();
             for (JavaClass javaClass : actual) {
                 actualNames.add(javaClass.getName());
             }
-            List<String> expectedNames = JavaClass.namesOf(Lists.newArrayList(classes));
-            assertThat(actualNames).as("actual classes").containsAll(expectedNames);
+            return actualNames;
         }
     }
 


### PR DESCRIPTION
Allows to import a varargs array `JarFile` and an `Iterable<JarFile>`, thus resolving issue #7 