### PR TITLE
Simplify build

### DIFF
--- a/build-utils/license/license.gradle
+++ b/build-utils/license/license.gradle
@@ -85,35 +85,13 @@ task updateLicenses {
     }
 }
 
-def configure3rdPartyLicenses = {
-    File jarPath = shrinkDependencies.archivePath
-    File jarTempPath = tempJar(jarPath)
-
-    task add3rdPartyLicenses(type: Zip, dependsOn: shrinkDependencies) {
-        onlyIf {
-            ext.repackagesAsm = zipTree(jarPath).find { it.absolutePath.contains('thirdparty/org/objectweb/asm') }
-        }
-
-        from {
-            zipTree(jarPath)
-        }
+project(':archunit') {
+    shadowJar {
         from(rootProject.file(asmLicenseFile)) {
             into "/${asmRelocationPackage.replace('.', '/')}"
         }
-
-        destinationDir jarTempPath.parentFile
-        archiveName jarTempPath.name
-
-        doLast {
-            assert jarPath.delete()
-            assert jarTempPath.renameTo(jarPath)
-        }
-
-        mustRunAfter updateLicenses
-        finalizedBy finishArchive
     }
-
-    assemble.dependsOn add3rdPartyLicenses
+    shadowJar.mustRunAfter updateLicenses
 }
 
 productionProjects*.with {
@@ -151,7 +129,5 @@ productionProjects*.with {
             }
         }
     }
-    assemble.dependsOn addLicenseHeader
-
-    it.with configure3rdPartyLicenses
+    compileJava.dependsOn addLicenseHeader
 }

--- a/build-utils/license/license.gradle
+++ b/build-utils/license/license.gradle
@@ -86,12 +86,7 @@ task updateLicenses {
 }
 
 project(':archunit') {
-    shadowJar {
-        from(rootProject.file(asmLicenseFile)) {
-            into "/${asmRelocationPackage.replace('.', '/')}"
-        }
-    }
-    shadowJar.mustRunAfter updateLicenses
+    ext.repackagesAsm = true
 }
 
 productionProjects*.with {
@@ -106,7 +101,7 @@ productionProjects*.with {
                     url app.license.url
                     distribution 'repo'
                 }
-                if (add3rdPartyLicenses.repackagesAsm) {
+                if (repackagesAsm) {
                     def asmLicense = rootProject.file(asmLicenseFile).readLines() as Queue
                     license {
                         name asmLicense.poll().replaceAll(/^.*?: /, '')
@@ -116,6 +111,15 @@ productionProjects*.with {
                 }
             }
         }
+    }
+
+    if (repackagesAsm) {
+        shadowJar {
+            from(rootProject.file(asmLicenseFile)) {
+                into "/${asmRelocationPackage.replace('.', '/')}"
+            }
+        }
+        shadowJar.mustRunAfter updateLicenses
     }
 
     task addLicenseHeader {

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '3.4.1'
+    gradleVersion = '4.0'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 }
 
 plugins {
+    id 'com.gradle.build-scan' version '1.8'
     id 'com.github.johnrengelman.shadow' version '2.0.0'
 }
 
@@ -206,3 +207,9 @@ productionProjects*.with {
 }
 
 apply from: 'build-utils/build-utils.gradle'
+
+buildScan {
+    publishAlways()
+    licenseAgreementUrl = "https://gradle.com/terms-of-service"
+    licenseAgree = "yes"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ ext.productionProjects = subprojects.findAll { productionProjectNames.contains(i
 subprojects {
     apply plugin: 'java'
 
+    ext.repackagesAsm = false
     def addModuleDescription = { "${it} - Module '${project.name}'" }
     description addModuleDescription(rootProject.description)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.parallel=true


### PR DESCRIPTION
I am going to try to simplify the build. The first step is adding the asm license directly to `archunit:shadowJar` instead of repackaging the jar again.
If at some point in the process you see a problem please advice what your intention was and I will try to adapt.
Feel free to merge this PR in its state. I will create a new one when I am ready with the next step.