### PR TITLE
Enable 3rd party to handle violations

### DIFF
--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SessionBeanRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SessionBeanRulesTest.java
@@ -96,7 +96,7 @@ public class SessionBeanRulesTest {
             new ArchCondition<JavaClass>("have an unique implementation") {
                 @Override
                 public void check(JavaClass businessInterface, ConditionEvents events) {
-                    events.add(new SimpleConditionEvent<>(businessInterface,
+                    events.add(new SimpleConditionEvent(businessInterface,
                             businessInterface.getAllSubClasses().size() <= 1,
                             describe(businessInterface)));
                 }

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/DaoRulesWithRunnerTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/DaoRulesWithRunnerTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
-
 @ArchIgnore
 @RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")

--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     testCompile dependency.junit
+    testCompile dependency.assertj
     testCompile dependency.guava
     testCompile dependency.log4j_api
     testCompile dependency.log4j_core

--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     testCompile dependency.log4j_core
     testCompile dependency.log4j_slf4j
     testCompile project(path: ':archunit-junit')
-    testCompile project(path: ':archunit-junit', configuration: 'tests')
     testCompile project(path: ':archunit-example')
     testCompile project(path: ':archunit-example', configuration: 'tests')
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
@@ -152,7 +152,7 @@ public class PublicAPIRules {
             @Override
             public void check(JavaMember item, ConditionEvents events) {
                 boolean satisfied = !item.getModifiers().contains(PUBLIC);
-                events.add(new SimpleConditionEvent<>(item, satisfied,
+                events.add(new SimpleConditionEvent(item, satisfied,
                         String.format("member %s.%s is %spublic in %s",
                                 item.getOwner().getName(),
                                 item.getName(),
@@ -267,7 +267,7 @@ public class PublicAPIRules {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = item.isInterface();
-                events.add(new SimpleConditionEvent<>(item, satisfied,
+                events.add(new SimpleConditionEvent(item, satisfied,
                         String.format("class %s is %sinterface", item.getName(), satisfied ? "" : "no ")));
             }
         };
@@ -279,7 +279,7 @@ public class PublicAPIRules {
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = item.isAnnotatedWith(publicApiForInheritance()) ||
                         markedAsPublicAPIForInheritance().apply(item);
-                events.add(new SimpleConditionEvent<>(item, satisfied,
+                events.add(new SimpleConditionEvent(item, satisfied,
                         String.format("class %s is %smeant for inheritance", item.getName(), satisfied ? "" : "not ")));
             }
         };

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/CodingRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/CodingRulesIntegrationTest.java
@@ -4,11 +4,13 @@ import com.tngtech.archunit.example.ClassViolatingCodingRules;
 import com.tngtech.archunit.example.SomeCustomException;
 import com.tngtech.archunit.example.service.ServiceViolatingLayerRules;
 import com.tngtech.archunit.exampletest.CodingRulesTest;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
 import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 public class CodingRulesIntegrationTest extends CodingRulesTest {
     @Rule
@@ -30,8 +32,9 @@ public class CodingRulesIntegrationTest extends CodingRulesTest {
         super.classes_should_not_access_standard_streams_from_library();
     }
 
-    static void expectViolationByWritingToStandardStream(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("no classes should access standard streams")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationByWritingToStandardStream(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("no classes should access standard streams")
                 .byAccess(from(ClassViolatingCodingRules.class, "printToStandardStream")
                         .accessing().field(System.class, "out")
                         .inLine(12))
@@ -54,8 +57,9 @@ public class CodingRulesIntegrationTest extends CodingRulesTest {
         super.classes_should_not_throw_generic_exceptions();
     }
 
-    static void expectViolationByThrowingGenericException(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("no classes should throw generic exceptions")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationByThrowingGenericException(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("no classes should throw generic exceptions")
                 .byCall(from(ClassViolatingCodingRules.class, "throwGenericExceptions")
                         .toConstructor(Throwable.class)
                         .inLine(22))
@@ -78,8 +82,9 @@ public class CodingRulesIntegrationTest extends CodingRulesTest {
         super.classes_should_not_use_java_util_logging();
     }
 
-    public static void expectViolationByUsingJavaUtilLogging(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("no classes should use java.util.logging")
+    @CalledByArchUnitIntegrationTestRunner
+    public static void expectViolationByUsingJavaUtilLogging(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("no classes should use java.util.logging")
                 .byAccess(from(ClassViolatingCodingRules.class, "<clinit>")
                         .setting().field(ClassViolatingCodingRules.class, "log")
                         .inLine(9));

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/LayerDependencyRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/LayerDependencyRulesIntegrationTest.java
@@ -6,7 +6,9 @@ import com.tngtech.archunit.example.controller.two.UseCaseTwoController;
 import com.tngtech.archunit.example.persistence.layerviolation.DaoCallingService;
 import com.tngtech.archunit.example.service.ServiceViolatingLayerRules;
 import com.tngtech.archunit.exampletest.LayerDependencyRulesTest;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
 import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -15,7 +17,7 @@ import static com.tngtech.archunit.example.controller.one.UseCaseOneController.s
 import static com.tngtech.archunit.example.controller.two.UseCaseTwoController.doSomethingTwo;
 import static com.tngtech.archunit.example.persistence.layerviolation.DaoCallingService.violateLayerRules;
 import static com.tngtech.archunit.example.service.ServiceViolatingLayerRules.illegalAccessToController;
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 public class LayerDependencyRulesIntegrationTest extends LayerDependencyRulesTest {
 
@@ -30,8 +32,9 @@ public class LayerDependencyRulesIntegrationTest extends LayerDependencyRulesTes
         super.services_should_not_access_controllers();
     }
 
-    static void expectViolationByAccessFromServiceToController(ExpectedViolation expectViolation) {
-        expectViolation.ofRule("no classes that reside in a package '..service..' " +
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationByAccessFromServiceToController(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("no classes that reside in a package '..service..' " +
                 "should access classes that reside in a package '..controller..'")
                 .byAccess(from(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .getting().field(UseCaseOneController.class, someString)
@@ -52,8 +55,9 @@ public class LayerDependencyRulesIntegrationTest extends LayerDependencyRulesTes
         super.persistence_should_not_access_services();
     }
 
-    static void expectViolationByAccessFromPersistenceToService(ExpectedViolation expectViolation) {
-        expectViolation.ofRule("no classes that reside in a package '..persistence..' should " +
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationByAccessFromPersistenceToService(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("no classes that reside in a package '..persistence..' should " +
                 "access classes that reside in a package '..service..'")
                 .byCall(from(DaoCallingService.class, violateLayerRules)
                         .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)
@@ -68,8 +72,9 @@ public class LayerDependencyRulesIntegrationTest extends LayerDependencyRulesTes
         super.services_should_only_be_accessed_by_controllers_or_other_services();
     }
 
-    static void expectViolationByIllegalAccessToService(ExpectedViolation expectViolation) {
-        expectViolation.ofRule("classes that reside in a package '..service..' should " +
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationByIllegalAccessToService(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("classes that reside in a package '..service..' should " +
                 "only be accessed by any package ['..controller..', '..service..']")
                 .byCall(from(DaoCallingService.class, violateLayerRules)
                         .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SessionBeanRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SessionBeanRulesIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import static com.google.common.base.Predicates.containsPattern;
 import static com.google.common.collect.Collections2.filter;
 import static com.tngtech.archunit.example.OtherClassViolatingSessionBeanRules.init;
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 public class SessionBeanRulesIntegrationTest extends SessionBeanRulesTest {
     @Rule

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ThirdPartyRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ThirdPartyRulesIntegrationTest.java
@@ -8,7 +8,7 @@ import com.tngtech.archunit.junit.ExpectedViolation;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 public class ThirdPartyRulesIntegrationTest extends ThirdPartyRulesTest {
     private static final String RULE_TEXT = "classes should " + THIRD_PARTY_CLASS_RULE_TEXT;

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/CyclicDependencyRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/CyclicDependencyRulesIntegrationTest.java
@@ -33,13 +33,14 @@ import com.tngtech.archunit.exampletest.junit.CyclicDependencyRulesTest;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitIntegrationTestRunner;
-import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.integration.junit.CyclicErrorMatcher.cycle;
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 @RunWith(ArchUnitIntegrationTestRunner.class)
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.cycle")
@@ -75,9 +76,9 @@ public class CyclicDependencyRulesIntegrationTest {
     public static final ArchRule NO_CYCLES_IN_COMPLEX_SCENARIO =
             CyclicDependencyRulesTest.NO_CYCLES_IN_COMPLEX_SCENARIO;
 
-
-    static void expectViolationFromSimpleCycle(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..(simplecycle).(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromSimpleCycle(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..(simplecycle).(*)..' should be free of cycles")
                 .by(cycle()
                         .from("slice1 of simplecycle")
                         .byAccess(from(SliceOneCallingMethodInSliceTwo.class, "callSliceTwo")
@@ -93,8 +94,9 @@ public class CyclicDependencyRulesIntegrationTest {
                                 .inLine(9)));
     }
 
-    static void expectViolationFromConstructorCycle(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..(constructorcycle).(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromConstructorCycle(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..(constructorcycle).(*)..' should be free of cycles")
                 .by(cycle()
                         .from("slice1 of constructorcycle")
                         .byAccess(from(SliceOneCallingConstructorInSliceTwo.class, "callSliceTwo")
@@ -106,8 +108,9 @@ public class CyclicDependencyRulesIntegrationTest {
                                 .inLine(7)));
     }
 
-    static void expectViolationFromInheritanceCycle(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..(inheritancecycle).(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromInheritanceCycle(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..(inheritancecycle).(*)..' should be free of cycles")
                 .by(cycle()
                         .from("slice1 of inheritancecycle")
                         .byAccess(from(ClassThatInheritsFromSliceTwo.class, CONSTRUCTOR_NAME)
@@ -119,9 +122,9 @@ public class CyclicDependencyRulesIntegrationTest {
                                 .inLine(5)));
     }
 
-
-    static void expectViolationFromFieldAccessCycle(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..(fieldaccesscycle).(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromFieldAccessCycle(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..(fieldaccesscycle).(*)..' should be free of cycles")
                 .by(cycle()
                         .from("slice1 of fieldaccesscycle")
                         .byAccess(from(SliceOneAccessingFieldInSliceTwo.class, "accessSliceTwo")
@@ -133,8 +136,9 @@ public class CyclicDependencyRulesIntegrationTest {
                                 .inLine(10)));
     }
 
-    static void expectViolationFromSimpleCyclicScenario(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..simplescenario.(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromSimpleCyclicScenario(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..simplescenario.(*)..' should be free of cycles")
                 .by(cycle().from("administration")
                         .byAccess(from(AdministrationService.class, "saveNewInvoice", Invoice.class)
                                 .toMethod(ReportService.class, "getReport", String.class)
@@ -152,8 +156,9 @@ public class CyclicDependencyRulesIntegrationTest {
                                 .inLine(11)));
     }
 
-    static void expectViolationFromComplexCyclicScenario(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule("slices matching '..(complexcycles).(*)..' should be free of cycles")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromComplexCyclicScenario(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("slices matching '..(complexcycles).(*)..' should be free of cycles")
                 .by(cycle()
                         .from("slice1 of complexcycles")
                         .byAccess(from(ClassOfMinimalCircleCallingSliceTwo.class, "callSliceTwo")

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/CyclicErrorMatcher.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/CyclicErrorMatcher.java
@@ -9,7 +9,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.tngtech.archunit.junit.ExpectedViolation.ExpectedAccess;
+import com.tngtech.archunit.junit.ExpectedAccess;
 import com.tngtech.archunit.junit.MessageAssertionChain;
 
 import static com.google.common.base.Functions.toStringFunction;

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/DaoRulesWithRunnerIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/DaoRulesWithRunnerIntegrationTest.java
@@ -8,11 +8,12 @@ import com.tngtech.archunit.exampletest.junit.DaoRulesWithRunnerTest;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitIntegrationTestRunner;
-import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 @RunWith(ArchUnitIntegrationTestRunner.class)
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
@@ -25,8 +26,9 @@ public class DaoRulesWithRunnerIntegrationTest {
     public static final ArchRule only_DAOs_may_use_the_EntityManager =
             DaoRulesWithRunnerTest.only_DAOs_may_use_the_EntityManager;
 
-    private static void expectViolationByIllegalUseOfEntityManager(ExpectedViolation expectedViolation) {
-        expectedViolation.ofRule(ONLY_DAOS_MAY_ACCESS_THE_ENTITYMANAGER_RULE_TEXT)
+    @CalledByArchUnitIntegrationTestRunner
+    private static void expectViolationByIllegalUseOfEntityManager(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule(ONLY_DAOS_MAY_ACCESS_THE_ENTITYMANAGER_RULE_TEXT)
                 .byCall(from(ServiceViolatingDaoRules.class, "illegallyUseEntityManager")
                         .toMethod(EntityManager.class, "persist", Object.class)
                         .inLine(24))

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/LayeredArchitectureIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/LayeredArchitectureIntegrationTest.java
@@ -9,11 +9,12 @@ import com.tngtech.archunit.exampletest.junit.LayeredArchitectureTest;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitIntegrationTestRunner;
-import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 import static java.lang.System.lineSeparator;
 
 @RunWith(ArchUnitIntegrationTestRunner.class)
@@ -23,8 +24,9 @@ public class LayeredArchitectureIntegrationTest {
     @ExpectedViolationFrom(location = LayeredArchitectureIntegrationTest.class, method = "expectLayerViolations")
     public static final ArchRule layer_dependencies_are_respected = LayeredArchitectureTest.layer_dependencies_are_respected;
 
-    static void expectLayerViolations(ExpectedViolation expectViolation) {
-        expectViolation.ofRule("Layered architecture consisting of" + lineSeparator() +
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectLayerViolations(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("Layered architecture consisting of" + lineSeparator() +
                 "layer 'Controllers' ('com.tngtech.archunit.example.controller..')" + lineSeparator() +
                 "layer 'Services' ('com.tngtech.archunit.example.service..')" + lineSeparator() +
                 "layer 'Persistence' ('com.tngtech.archunit.example.persistence..')" + lineSeparator() +

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/SliceDependencyErrorMatcher.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/SliceDependencyErrorMatcher.java
@@ -7,7 +7,7 @@ import java.util.Set;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.tngtech.archunit.junit.ExpectedViolation.ExpectedAccess;
+import com.tngtech.archunit.junit.ExpectedAccess;
 import com.tngtech.archunit.junit.MessageAssertionChain;
 
 class SliceDependencyErrorMatcher implements MessageAssertionChain.Link {
@@ -21,12 +21,12 @@ class SliceDependencyErrorMatcher implements MessageAssertionChain.Link {
     private SliceDependencyErrorMatcher() {
     }
 
-    public SliceDependencyErrorMatcher described(String description) {
+    SliceDependencyErrorMatcher described(String description) {
         dependencyDescription = description;
         return this;
     }
 
-    public SliceDependencyErrorMatcher byAccess(ExpectedAccess expectedAccess) {
+    SliceDependencyErrorMatcher byAccess(ExpectedAccess expectedAccess) {
         expectedAccesses.add(expectedAccess);
         return this;
     }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/SlicesIsolationIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/SlicesIsolationIntegrationTest.java
@@ -6,14 +6,15 @@ import com.tngtech.archunit.exampletest.junit.SlicesIsolationTest;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitIntegrationTestRunner;
-import com.tngtech.archunit.junit.ExpectedViolation;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.ExpectsViolations;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.example.controller.one.UseCaseOneController.doSomethingOne;
 import static com.tngtech.archunit.example.controller.two.UseCaseTwoController.doSomethingTwo;
 import static com.tngtech.archunit.integration.junit.SliceDependencyErrorMatcher.sliceDependency;
-import static com.tngtech.archunit.junit.ExpectedViolation.from;
+import static com.tngtech.archunit.junit.ExpectedAccess.from;
 
 @RunWith(ArchUnitIntegrationTestRunner.class)
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
@@ -23,8 +24,9 @@ public class SlicesIsolationIntegrationTest {
     public static final ArchRule controllers_should_only_use_their_own_slice =
             SlicesIsolationTest.controllers_should_only_use_their_own_slice;
 
-    static void expectViolationFromDependencies(ExpectedViolation expectViolation) {
-        expectViolation.ofRule("Controllers should not depend on each other")
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromDependencies(ExpectsViolations expectsViolations) {
+        expectsViolations.ofRule("Controllers should not depend on each other")
                 .by(sliceDependency()
                         .described("Controller one calls Controller two")
                         .byAccess(from(UseCaseOneController.class, doSomethingOne)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
@@ -1,14 +1,19 @@
 package com.tngtech.archunit.junit;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.integration.junit.ExpectedViolationFrom;
+import com.tngtech.archunit.lang.EvaluationResult;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
     public ArchUnitIntegrationTestRunner(Class<?> testClass) throws InitializationError {
@@ -18,11 +23,14 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
     @Override
     protected void runChild(final ArchTestExecution child, final RunNotifier notifier) {
         ExpectedViolation expectedViolation = ExpectedViolation.none();
+        HandlingAssertion handlingAssertion = HandlingAssertion.none();
         Description description = describeChild(child);
         notifier.fireTestStarted(description);
         try {
-            extractExpectedConfiguration(child).configure(expectedViolation);
-            expectedViolation.apply(new IntegrationTestStatement(child), description).evaluate();
+            ExpectedViolationDefinition violationDefinition = extractExpectedConfiguration(child);
+            violationDefinition.configure(expectedViolation);
+            violationDefinition.configure(handlingAssertion);
+            expectedViolation.apply(new IntegrationTestStatement(child, handlingAssertion), description).evaluate();
         } catch (Throwable throwable) {
             notifier.fireTestFailure(new Failure(description, throwable));
         } finally {
@@ -41,16 +49,26 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
 
     private class IntegrationTestStatement extends Statement {
         private final ArchRuleExecution child;
+        private final HandlingAssertion handlingAssertion;
 
-        IntegrationTestStatement(ArchTestExecution child) {
+        IntegrationTestStatement(ArchTestExecution child, HandlingAssertion handlingAssertion) {
             this.child = (ArchRuleExecution) child;
+            this.handlingAssertion = handlingAssertion;
         }
 
         @Override
         public void evaluate() throws Throwable {
             FailureSniffer sniffer = new FailureSniffer();
             ArchUnitIntegrationTestRunner.super.runChild(child, sniffer);
+            checkHandling();
             sniffer.rethrowIfFailure();
+        }
+
+        private void checkHandling() {
+            ClassesCaptor classesCaptor = new ClassesCaptor();
+            ArchUnitIntegrationTestRunner.super.runChild(classesCaptor, new RunNotifier());
+            EvaluationResult result = child.rule.evaluate(classesCaptor.getClasses());
+            handlingAssertion.assertResult(result);
         }
     }
 
@@ -84,10 +102,47 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
                 expectViolation.setAccessible(true);
                 expectViolation.invoke(null, expectsViolations);
             } catch (NoSuchMethodException e) {
-                throw new RuntimeException("Cannot find method '" + method + "' on " + location.getSimpleName());
+                throw new RuntimeException("Cannot find method '" + method + "' on " + location.getSimpleName(), e);
             } catch (InvocationTargetException | IllegalAccessException e) {
-                throw new RuntimeException("Can't call method '" + method + "' on " + location.getSimpleName());
+                throw new RuntimeException("Can't call method '" + method + "' on " + location.getSimpleName(), e);
             }
+        }
+    }
+
+    private static class ClassesCaptor extends ArchTestExecution {
+        private JavaClasses classes;
+
+        ClassesCaptor() {
+            super(Object.class);
+        }
+
+        @Override
+        Result evaluateOn(JavaClasses classes) {
+            this.classes = classes;
+            return new Result() {
+                @Override
+                void notify(RunNotifier notifier) {
+                }
+            };
+        }
+
+        @Override
+        Description describeSelf() {
+            return null;
+        }
+
+        @Override
+        String getName() {
+            return null;
+        }
+
+        @Override
+        <T extends Annotation> T getAnnotation(Class<T> type) {
+            return null;
+        }
+
+        JavaClasses getClasses() {
+            return checkNotNull(classes, "Couldn't retrieve any classes from evaluation");
         }
     }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
@@ -10,19 +10,14 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 
-/**
- * Doesn't reside within integration.junit, because this forces extended visibility on production code
- */
 public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
-    private ExpectedViolation expectedViolation;
-
     public ArchUnitIntegrationTestRunner(Class<?> testClass) throws InitializationError {
         super(testClass);
     }
 
     @Override
     protected void runChild(final ArchTestExecution child, final RunNotifier notifier) {
-        expectedViolation = ExpectedViolation.none();
+        ExpectedViolation expectedViolation = ExpectedViolation.none();
         Description description = describeChild(child);
         notifier.fireTestStarted(description);
         try {
@@ -47,7 +42,7 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
     private class IntegrationTestStatement extends Statement {
         private final ArchRuleExecution child;
 
-        public IntegrationTestStatement(ArchTestExecution child) {
+        IntegrationTestStatement(ArchTestExecution child) {
             this.child = (ArchRuleExecution) child;
         }
 
@@ -78,16 +73,16 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
         private final Class<?> location;
         private final String method;
 
-        public ExpectedViolationDefinition(ExpectedViolationFrom annotation) {
+        ExpectedViolationDefinition(ExpectedViolationFrom annotation) {
             location = annotation.location();
             method = annotation.method();
         }
 
-        public void configure(ExpectedViolation expectedViolation) {
+        void configure(ExpectsViolations expectsViolations) {
             try {
-                Method expectViolation = location.getDeclaredMethod(method, ExpectedViolation.class);
+                Method expectViolation = location.getDeclaredMethod(method, ExpectsViolations.class);
                 expectViolation.setAccessible(true);
-                expectViolation.invoke(null, expectedViolation);
+                expectViolation.invoke(null, expectsViolations);
             } catch (NoSuchMethodException e) {
                 throw new RuntimeException("Cannot find method '" + method + "' on " + location.getSimpleName());
             } catch (InvocationTargetException | IllegalAccessException e) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/CalledByArchUnitIntegrationTestRunner.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/CalledByArchUnitIntegrationTestRunner.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.junit;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+@Retention(SOURCE)
+public @interface CalledByArchUnitIntegrationTestRunner {
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedAccess.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedAccess.java
@@ -1,0 +1,130 @@
+package com.tngtech.archunit.junit;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.junit.ExpectedMember.ExpectedOrigin;
+import com.tngtech.archunit.junit.ExpectedMember.ExpectedTarget;
+
+public abstract class ExpectedAccess {
+    private final ExpectedOrigin origin;
+    private final ExpectedTarget target;
+    private final int lineNumber;
+
+    ExpectedAccess(ExpectedOrigin origin, ExpectedTarget target, int lineNumber) {
+        this.origin = origin;
+        this.target = target;
+        this.lineNumber = lineNumber;
+    }
+
+    String expectedMessage() {
+        return target.messageFor(this);
+    }
+
+    ExpectedOrigin getOrigin() {
+        return origin;
+    }
+
+    ExpectedTarget getTarget() {
+        return target;
+    }
+
+    int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return expectedMessage();
+    }
+
+    public static ExpectedAccessViolationCreationProcess from(Class<?> origin, String method, Class<?>... paramTypes) {
+        return new ExpectedAccessViolationCreationProcess(origin, method, paramTypes);
+    }
+
+    public static class ExpectedAccessViolationCreationProcess {
+        private ExpectedOrigin origin;
+
+        private ExpectedAccessViolationCreationProcess(Class<?> clazz, String method, Class<?>[] paramTypes) {
+            origin = new ExpectedOrigin(clazz, method, paramTypes);
+        }
+
+        public ExpectedFieldAccessViolationBuilderStep1 accessing() {
+            return new ExpectedFieldAccessViolationBuilderStep1(origin, JavaFieldAccess.AccessType.GET, JavaFieldAccess.AccessType.SET);
+        }
+
+        public ExpectedFieldAccessViolationBuilderStep1 getting() {
+            return new ExpectedFieldAccessViolationBuilderStep1(origin, JavaFieldAccess.AccessType.GET);
+        }
+
+        public ExpectedFieldAccessViolationBuilderStep1 setting() {
+            return new ExpectedFieldAccessViolationBuilderStep1(origin, JavaFieldAccess.AccessType.SET);
+        }
+
+        public ExpectedMethodCallViolationBuilder toMethod(Class<?> target, String member, Class<?>... paramTypes) {
+            return new ExpectedMethodCallViolationBuilder(
+                    origin, new ExpectedMember.ExpectedMethodTarget(target, member, paramTypes));
+        }
+
+        public ExpectedMethodCallViolationBuilder toConstructor(Class<?> target, Class<?>... paramTypes) {
+            return new ExpectedMethodCallViolationBuilder(
+                    origin, new ExpectedMember.ExpectedConstructorTarget(target, paramTypes));
+        }
+    }
+
+    private abstract static class ExpectedAccessViolationBuilder {
+        final ExpectedOrigin origin;
+        final ExpectedTarget target;
+
+        private ExpectedAccessViolationBuilder(ExpectedOrigin origin, ExpectedTarget target) {
+            this.origin = origin;
+            this.target = target;
+        }
+    }
+
+    public static class ExpectedFieldAccessViolationBuilderStep1 {
+        private final ExpectedOrigin origin;
+        private final ImmutableSet<JavaFieldAccess.AccessType> accessType;
+
+        private ExpectedFieldAccessViolationBuilderStep1(ExpectedOrigin origin, JavaFieldAccess.AccessType... accessType) {
+            this.origin = origin;
+            this.accessType = ImmutableSet.copyOf(accessType);
+        }
+
+        public ExpectedFieldAccessViolationBuilderStep2 field(Class<?> target, String member) {
+            return new ExpectedFieldAccessViolationBuilderStep2(
+                    origin, new ExpectedMember.ExpectedFieldTarget(target, member, accessType));
+        }
+    }
+
+    public static class ExpectedFieldAccessViolationBuilderStep2 extends ExpectedAccessViolationBuilder {
+        private ExpectedFieldAccessViolationBuilderStep2(ExpectedOrigin origin, ExpectedMember.ExpectedFieldTarget target) {
+            super(origin, target);
+        }
+
+        public ExpectedFieldAccess inLine(int number) {
+            return new ExpectedFieldAccess(origin, target, number);
+        }
+    }
+
+    public static class ExpectedMethodCallViolationBuilder extends ExpectedAccessViolationBuilder {
+        private ExpectedMethodCallViolationBuilder(ExpectedOrigin origin, ExpectedMember.ExpectedMethodTarget target) {
+            super(origin, target);
+        }
+
+        public ExpectedMethodCall inLine(int number) {
+            return new ExpectedMethodCall(origin, target, number);
+        }
+    }
+
+    static class ExpectedFieldAccess extends ExpectedAccess {
+        private ExpectedFieldAccess(ExpectedOrigin origin, ExpectedTarget target, int lineNumber) {
+            super(origin, target, lineNumber);
+        }
+    }
+
+    static class ExpectedMethodCall extends ExpectedAccess {
+        private ExpectedMethodCall(ExpectedOrigin origin, ExpectedTarget target, int lineNumber) {
+            super(origin, target, lineNumber);
+        }
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedMember.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedMember.java
@@ -1,6 +1,7 @@
 package com.tngtech.archunit.junit;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +10,11 @@ import java.util.Set;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasParameterTypes;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static java.util.Collections.singleton;
@@ -35,9 +40,25 @@ abstract class ExpectedMember {
         return params;
     }
 
+    public String getMemberName() {
+        return memberName;
+    }
+
     @Override
     public String toString() {
         return String.format("%s.%s", clazz.getName(), memberName);
+    }
+
+    <T extends HasOwner<JavaClass> & HasName> boolean matches(T member) {
+        return member.getOwner().isEquivalentTo(clazz) &&
+                member.getName().equals(memberName) &&
+                getParameters(member).equals(params);
+    }
+
+    private List<String> getParameters(Object member) {
+        return member instanceof HasParameterTypes ?
+                ((HasParameterTypes) member).getParameters().getNames() :
+                Collections.<String>emptyList();
     }
 
     static class ExpectedOrigin extends ExpectedMember {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedMember.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedMember.java
@@ -1,0 +1,113 @@
+package com.tngtech.archunit.junit;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static java.util.Collections.singleton;
+
+abstract class ExpectedMember {
+    private final Class<?> clazz;
+    private final String memberName;
+    private final List<String> params = new ArrayList<>();
+
+    ExpectedMember(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
+        this.clazz = clazz;
+        this.memberName = memberName;
+        for (Class<?> paramType : paramTypes) {
+            params.add(paramType.getName());
+        }
+    }
+
+    String lineMessage(int number) {
+        return String.format("(%s.java:%d)", clazz.getSimpleName(), number);
+    }
+
+    List<String> getParams() {
+        return params;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s.%s", clazz.getName(), memberName);
+    }
+
+    static class ExpectedOrigin extends ExpectedMember {
+        ExpectedOrigin(Class<?> clazz, String methodName, Class<?>[] paramTypes) {
+            super(clazz, methodName, paramTypes);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", super.toString(), Joiner.on(", ").join(getParams()));
+        }
+    }
+
+    abstract static class ExpectedTarget extends ExpectedMember {
+        private ExpectedTarget(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
+            super(clazz, memberName, paramTypes);
+        }
+
+        String messageFor(ExpectedAccess access) {
+            return String.format(template(),
+                    access.getOrigin(), access.getTarget(), access.getOrigin().lineMessage(access.getLineNumber()));
+        }
+
+        abstract String template();
+    }
+
+    static class ExpectedFieldTarget extends ExpectedTarget {
+        private final Map<Set<JavaFieldAccess.AccessType>, String> accessDescription = ImmutableMap.of(
+                singleton(JavaFieldAccess.AccessType.GET), "gets",
+                singleton(JavaFieldAccess.AccessType.SET), "sets",
+                EnumSet.of(JavaFieldAccess.AccessType.GET, JavaFieldAccess.AccessType.SET), "accesses"
+        );
+
+        private final String accesses;
+
+        ExpectedFieldTarget(Class<?> clazz, String memberName, ImmutableSet<JavaFieldAccess.AccessType> accessTypes) {
+            super(clazz, memberName, new Class<?>[0]);
+            this.accesses = accessDescription.get(accessTypes);
+        }
+
+        @Override
+        String template() {
+            return "Method <%s> " + accesses + " field <%s> in %s";
+        }
+    }
+
+    static class ExpectedMethodTarget extends ExpectedTarget {
+        ExpectedMethodTarget(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
+            super(clazz, memberName, paramTypes);
+        }
+
+        @Override
+        String template() {
+            return "Method <%s> calls method <%s> in %s";
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", super.toString(), Joiner.on(", ").join(getParams()));
+        }
+    }
+
+    static class ExpectedConstructorTarget extends ExpectedMethodTarget {
+        ExpectedConstructorTarget(Class<?> clazz, Class<?>[] paramTypes) {
+            super(clazz, CONSTRUCTOR_NAME, paramTypes);
+        }
+
+        @Override
+        String template() {
+            return "Method <%s> calls constructor <%s> in %s";
+        }
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -15,34 +15,25 @@
  */
 package com.tngtech.archunit.junit;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.Internal;
-import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedFieldAccess;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedMethodCall;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.junit.MessageAssertionChain.containsConsecutiveLines;
 import static com.tngtech.archunit.junit.MessageAssertionChain.containsLine;
 import static com.tngtech.archunit.junit.MessageAssertionChain.matchesLine;
 import static java.lang.System.lineSeparator;
-import static java.util.Collections.singleton;
 import static java.util.regex.Pattern.quote;
 
-public class ExpectedViolation implements TestRule {
+public class ExpectedViolation implements TestRule, ExpectsViolations {
     private final MessageAssertionChain assertionChain = new MessageAssertionChain();
 
     private ExpectedViolation() {
@@ -57,6 +48,7 @@ public class ExpectedViolation implements TestRule {
         return new ExpectedViolation();
     }
 
+    @Override
     public ExpectedViolation ofRule(String ruleText) {
         LinkedList<String> ruleLines = new LinkedList<>(Splitter.on(lineSeparator()).splitToList(ruleText));
         checkArgument(!ruleLines.isEmpty(), "Rule text may not be empty");
@@ -80,16 +72,19 @@ public class ExpectedViolation implements TestRule {
         assertionChain.add(containsConsecutiveLines(ruleLines));
     }
 
+    @Override
     public ExpectedViolation byAccess(ExpectedFieldAccess access) {
         assertionChain.add(containsLine(access.expectedMessage()));
         return this;
     }
 
+    @Override
     public ExpectedViolation byCall(ExpectedMethodCall call) {
         assertionChain.add(containsLine(call.expectedMessage()));
         return this;
     }
 
+    @Override
     public ExpectedViolation by(MessageAssertionChain.Link assertion) {
         assertionChain.add(assertion);
         return this;
@@ -133,217 +128,6 @@ public class ExpectedViolation implements TestRule {
     private static class NoExpectedViolationException extends RuntimeException {
         private NoExpectedViolationException(MessageAssertionChain assertionChain) {
             super("Rule was not violated in the expected way: Expected " + assertionChain);
-        }
-    }
-
-    public static ExpectedAccessViolationCreationProcess from(Class<?> origin, String method, Class<?>... paramTypes) {
-        return new ExpectedAccessViolationCreationProcess(origin, method, paramTypes);
-    }
-
-    @Internal
-    public static class ExpectedAccessViolationCreationProcess {
-        private Origin origin;
-
-        private ExpectedAccessViolationCreationProcess(Class<?> clazz, String method, Class<?>[] paramTypes) {
-            origin = new Origin(clazz, method, paramTypes);
-        }
-
-        public ExpectedFieldAccessViolationBuilderStep1 accessing() {
-            return new ExpectedFieldAccessViolationBuilderStep1(origin, AccessType.GET, AccessType.SET);
-        }
-
-        public ExpectedFieldAccessViolationBuilderStep1 getting() {
-            return new ExpectedFieldAccessViolationBuilderStep1(origin, AccessType.GET);
-        }
-
-        public ExpectedFieldAccessViolationBuilderStep1 setting() {
-            return new ExpectedFieldAccessViolationBuilderStep1(origin, AccessType.SET);
-        }
-
-        public ExpectedMethodCallViolationBuilder toMethod(Class<?> target, String member, Class<?>... paramTypes) {
-            return new ExpectedMethodCallViolationBuilder(
-                    origin, new MethodTarget(target, member, paramTypes));
-        }
-
-        public ExpectedMethodCallViolationBuilder toConstructor(Class<?> target, Class<?>... paramTypes) {
-            return new ExpectedMethodCallViolationBuilder(
-                    origin, new ConstructorTarget(target, paramTypes));
-        }
-    }
-
-    private abstract static class ExpectedAccessViolationBuilder {
-        final Origin origin;
-        final Target target;
-
-        private ExpectedAccessViolationBuilder(Origin origin, Target target) {
-            this.origin = origin;
-            this.target = target;
-        }
-    }
-
-    @Internal
-    public static class ExpectedFieldAccessViolationBuilderStep1 {
-        private final Origin origin;
-        private final ImmutableSet<AccessType> accessType;
-
-        private ExpectedFieldAccessViolationBuilderStep1(Origin origin, AccessType... accessType) {
-            this.origin = origin;
-            this.accessType = ImmutableSet.copyOf(accessType);
-        }
-
-        public ExpectedFieldAccessViolationBuilderStep2 field(Class<?> target, String member) {
-            return new ExpectedFieldAccessViolationBuilderStep2(
-                    origin, new FieldTarget(target, member, accessType));
-        }
-    }
-
-    @Internal
-    public static class ExpectedFieldAccessViolationBuilderStep2 extends ExpectedAccessViolationBuilder {
-        private ExpectedFieldAccessViolationBuilderStep2(Origin origin, FieldTarget target) {
-            super(origin, target);
-        }
-
-        public ExpectedFieldAccess inLine(int number) {
-            return new ExpectedFieldAccess(origin, target, number);
-        }
-    }
-
-    @Internal
-    public static class ExpectedMethodCallViolationBuilder extends ExpectedAccessViolationBuilder {
-        private ExpectedMethodCallViolationBuilder(Origin origin, MethodTarget target) {
-            super(origin, target);
-        }
-
-        public ExpectedMethodCall inLine(int number) {
-            return new ExpectedMethodCall(origin, target, number);
-        }
-    }
-
-    @Internal
-    public abstract static class ExpectedAccess {
-        private final Origin origin;
-        private final Target target;
-        private final int lineNumber;
-
-        private ExpectedAccess(Origin origin, Target target, int lineNumber) {
-            this.origin = origin;
-            this.target = target;
-            this.lineNumber = lineNumber;
-        }
-
-        String expectedMessage() {
-            return target.messageFor(this);
-        }
-
-        @Override
-        public String toString() {
-            return expectedMessage();
-        }
-    }
-
-    static class ExpectedFieldAccess extends ExpectedAccess {
-        private ExpectedFieldAccess(Origin origin, Target target, int lineNumber) {
-            super(origin, target, lineNumber);
-        }
-    }
-
-    static class ExpectedMethodCall extends ExpectedAccess {
-        private ExpectedMethodCall(Origin origin, Target target, int lineNumber) {
-            super(origin, target, lineNumber);
-        }
-    }
-
-    private abstract static class Member {
-        private final Class<?> clazz;
-        private final String memberName;
-        final List<String> params = new ArrayList<>();
-
-        private Member(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
-            this.clazz = clazz;
-            this.memberName = memberName;
-            for (Class<?> paramType : paramTypes) {
-                params.add(paramType.getName());
-            }
-        }
-
-        String lineMessage(int number) {
-            return String.format("(%s.java:%d)", clazz.getSimpleName(), number);
-        }
-
-        @Override
-        public String toString() {
-            return String.format("%s.%s", clazz.getName(), memberName);
-        }
-    }
-
-    private static class Origin extends Member {
-        private Origin(Class<?> clazz, String methodName, Class<?>[] paramTypes) {
-            super(clazz, methodName, paramTypes);
-        }
-
-        @Override
-        public String toString() {
-            return String.format("%s(%s)", super.toString(), Joiner.on(", ").join(params));
-        }
-    }
-
-    private abstract static class Target extends Member {
-        private Target(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
-            super(clazz, memberName, paramTypes);
-        }
-
-        String messageFor(ExpectedAccess access) {
-            return String.format(template(),
-                    access.origin, access.target, access.origin.lineMessage(access.lineNumber));
-        }
-
-        abstract String template();
-    }
-
-    private static class FieldTarget extends Target {
-        private final Map<Set<AccessType>, String> accessDescription = ImmutableMap.of(
-                singleton(AccessType.GET), "gets",
-                singleton(AccessType.SET), "sets",
-                EnumSet.of(AccessType.GET, AccessType.SET), "accesses"
-        );
-
-        private final String accesses;
-
-        private FieldTarget(Class<?> clazz, String memberName, ImmutableSet<AccessType> accessTypes) {
-            super(clazz, memberName, new Class<?>[0]);
-            this.accesses = accessDescription.get(accessTypes);
-        }
-
-        @Override
-        String template() {
-            return "Method <%s> " + accesses + " field <%s> in %s";
-        }
-    }
-
-    private static class MethodTarget extends Target {
-        private MethodTarget(Class<?> clazz, String memberName, Class<?>[] paramTypes) {
-            super(clazz, memberName, paramTypes);
-        }
-
-        @Override
-        String template() {
-            return "Method <%s> calls method <%s> in %s";
-        }
-
-        @Override
-        public String toString() {
-            return String.format("%s(%s)", super.toString(), Joiner.on(", ").join(params));
-        }
-    }
-
-    private static class ConstructorTarget extends MethodTarget {
-        private ConstructorTarget(Class<?> clazz, Class<?>[] paramTypes) {
-            super(clazz, CONSTRUCTOR_NAME, paramTypes);
-        }
-
-        @Override
-        String template() {
-            return "Method <%s> calls constructor <%s> in %s";
         }
     }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -19,8 +19,8 @@ import java.util.LinkedList;
 
 import com.google.common.base.Splitter;
 import com.tngtech.archunit.Internal;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedCall;
 import com.tngtech.archunit.junit.ExpectedAccess.ExpectedFieldAccess;
-import com.tngtech.archunit.junit.ExpectedAccess.ExpectedMethodCall;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -79,7 +79,7 @@ public class ExpectedViolation implements TestRule, ExpectsViolations {
     }
 
     @Override
-    public ExpectedViolation byCall(ExpectedMethodCall call) {
+    public ExpectedViolation byCall(ExpectedCall call) {
         assertionChain.add(containsLine(call.expectedMessage()));
         return this;
     }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -42,7 +42,6 @@ import static java.lang.System.lineSeparator;
 import static java.util.Collections.singleton;
 import static java.util.regex.Pattern.quote;
 
-@Internal
 public class ExpectedViolation implements TestRule {
     private final MessageAssertionChain assertionChain = new MessageAssertionChain();
 

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectsViolations.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectsViolations.java
@@ -1,14 +1,14 @@
 package com.tngtech.archunit.junit;
 
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedCall;
 import com.tngtech.archunit.junit.ExpectedAccess.ExpectedFieldAccess;
-import com.tngtech.archunit.junit.ExpectedAccess.ExpectedMethodCall;
 
 public interface ExpectsViolations {
     ExpectsViolations ofRule(String ruleText);
 
     ExpectsViolations byAccess(ExpectedFieldAccess access);
 
-    ExpectsViolations byCall(ExpectedMethodCall call);
+    ExpectsViolations byCall(ExpectedCall call);
 
     ExpectsViolations by(MessageAssertionChain.Link assertion);
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectsViolations.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectsViolations.java
@@ -1,0 +1,14 @@
+package com.tngtech.archunit.junit;
+
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedFieldAccess;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedMethodCall;
+
+public interface ExpectsViolations {
+    ExpectsViolations ofRule(String ruleText);
+
+    ExpectsViolations byAccess(ExpectedFieldAccess access);
+
+    ExpectsViolations byCall(ExpectedMethodCall call);
+
+    ExpectsViolations by(MessageAssertionChain.Link assertion);
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/HandlingAssertion.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/HandlingAssertion.java
@@ -1,0 +1,152 @@
+package com.tngtech.archunit.junit;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedCall;
+import com.tngtech.archunit.junit.ExpectedAccess.ExpectedFieldAccess;
+import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.ViolationHandler;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+class HandlingAssertion implements ExpectsViolations, TestRule {
+    private final Set<ExpectedFieldAccess> expectedFieldAccesses = new HashSet<>();
+    private final Set<ExpectedCall> expectedMethodCalls = new HashSet<>();
+    private final Set<ExpectedCall> expectedConstructorCalls = new HashSet<>();
+
+    @Override
+    public ExpectsViolations ofRule(String ruleText) {
+        return this;
+    }
+
+    @Override
+    public ExpectsViolations byAccess(ExpectedFieldAccess access) {
+        expectedFieldAccesses.add(access);
+        return this;
+    }
+
+    @Override
+    public ExpectsViolations byCall(ExpectedCall call) {
+        if (call.isToConstructor()) {
+            expectedConstructorCalls.add(call);
+        } else {
+            expectedMethodCalls.add(call);
+        }
+        return this;
+    }
+
+    @Override
+    public ExpectsViolations by(MessageAssertionChain.Link assertion) {
+        return this;
+    }
+
+    static HandlingAssertion none() {
+        return new HandlingAssertion();
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return base;
+    }
+
+    void assertResult(EvaluationResult result) {
+        checkFieldAccesses(result);
+        checkMethodCalls(result);
+        checkConstructorCalls(result);
+        checkCalls(result);
+        checkAccesses(result);
+    }
+
+    // Too bad Java erases types, otherwise a lot of boilerplate could be avoided here :-(
+    // This way we must write explicitly ViolationHandler<ConcreteType> or the bound wont work correctly
+    private void checkFieldAccesses(EvaluationResult result) {
+        final Set<ExpectedFieldAccess> left = new HashSet<>(this.expectedFieldAccesses);
+        result.handleViolations(new ViolationHandler<JavaFieldAccess>() {
+            @Override
+            public void handle(Collection<JavaFieldAccess> violatingObjects, String message) {
+                removeExpectedAccesses(violatingObjects, left);
+            }
+        });
+        checkEmpty(left);
+    }
+
+    private void checkMethodCalls(EvaluationResult result) {
+        final Set<ExpectedCall> left = new HashSet<>(expectedMethodCalls);
+        result.handleViolations(new ViolationHandler<JavaMethodCall>() {
+            @Override
+            public void handle(Collection<JavaMethodCall> violatingObjects, String message) {
+                removeExpectedAccesses(violatingObjects, left);
+            }
+        });
+        checkEmpty(left);
+    }
+
+    private void checkConstructorCalls(EvaluationResult result) {
+        final Set<ExpectedCall> left = new HashSet<>(expectedConstructorCalls);
+        result.handleViolations(new ViolationHandler<JavaConstructorCall>() {
+            @Override
+            public void handle(Collection<JavaConstructorCall> violatingObjects, String message) {
+                removeExpectedAccesses(violatingObjects, left);
+            }
+        });
+        checkEmpty(left);
+    }
+
+    private void checkCalls(EvaluationResult result) {
+        final Set<ExpectedCall> left = new HashSet<>(Sets.union(expectedConstructorCalls, expectedMethodCalls));
+        result.handleViolations(new ViolationHandler<JavaCall<?>>() {
+            @Override
+            public void handle(Collection<JavaCall<?>> violatingObjects, String message) {
+                removeExpectedAccesses(violatingObjects, left);
+            }
+        });
+        checkEmpty(left);
+    }
+
+    private void checkAccesses(EvaluationResult result) {
+        final Set<ExpectedAccess> left = new HashSet<ExpectedAccess>() {
+            {
+                addAll(expectedConstructorCalls);
+                addAll(expectedMethodCalls);
+                addAll(expectedFieldAccesses);
+            }
+        };
+        result.handleViolations(new ViolationHandler<JavaAccess<?>>() {
+            @Override
+            public void handle(Collection<JavaAccess<?>> violatingObjects, String message) {
+                removeExpectedAccesses(violatingObjects, left);
+            }
+        });
+        checkEmpty(left);
+    }
+
+    private void removeExpectedAccesses(Collection<? extends JavaAccess<?>> violatingObjects, Set<? extends ExpectedAccess> left) {
+        JavaAccess<?> violatingObject = getOnlyElement(violatingObjects);
+        for (Iterator<? extends ExpectedAccess> actualMethodCalls = left.iterator(); actualMethodCalls.hasNext(); ) {
+            ExpectedAccess next = actualMethodCalls.next();
+            if (next.matches(violatingObject)) {
+                actualMethodCalls.remove();
+                return;
+            }
+        }
+        throw new RuntimeException("Unexpected access: " + violatingObject); // NOTE: Don't throw AssertionError, since that will be caught and analyzed
+    }
+
+    private void checkEmpty(Set<?> set) {
+        if (!set.isEmpty()) {
+            throw new RuntimeException("Unhandled accesses: " + set); // NOTE: Don't throw AssertionError, since that will be caught and analyzed
+        }
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/MessageAssertionChain.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/MessageAssertionChain.java
@@ -30,11 +30,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.tngtech.archunit.junit.MessageAssertionChain.Link.Result.difference;
 import static java.util.Collections.singletonList;
 
-@Internal
 public class MessageAssertionChain {
     private final List<Link> links = new ArrayList<>();
 
-    public void add(Link link) {
+    void add(Link link) {
         links.add(link);
     }
 
@@ -47,7 +46,7 @@ public class MessageAssertionChain {
         return Joiner.on(System.lineSeparator()).join(descriptions);
     }
 
-    public static Link matchesLine(final String pattern) {
+    static Link matchesLine(final String pattern) {
         final Pattern p = Pattern.compile(pattern);
         return new Link() {
             @Override
@@ -67,7 +66,7 @@ public class MessageAssertionChain {
         };
     }
 
-    public static Link containsLine(String text, Object... args) {
+    static Link containsLine(String text, Object... args) {
         final String expectedLine = String.format(text, args);
         return new Link() {
             @Override
@@ -84,7 +83,7 @@ public class MessageAssertionChain {
         };
     }
 
-    public static Link containsConsecutiveLines(final List<String> lines) {
+    static Link containsConsecutiveLines(final List<String> lines) {
         checkArgument(!lines.isEmpty(), "Asserting zero consecutive lines makes no sense");
         final String linesDesription = Joiner.on(System.lineSeparator()).join(lines);
         final String description = "Message contains consecutive lines " + System.lineSeparator() + linesDesription;
@@ -112,7 +111,7 @@ public class MessageAssertionChain {
         };
     }
 
-    public void evaluate(AssertionError error) {
+    void evaluate(AssertionError error) {
         List<String> remainingLines = Splitter.on(System.lineSeparator()).splitToList(error.getMessage());
         for (Link link : links) {
             Link.Result result = link.filterMatching(remainingLines);
@@ -146,15 +145,15 @@ public class MessageAssertionChain {
             private final List<String> remainingLines;
             private final Optional<String> mismatchDescription;
 
-            public static Result success(List<String> remainingLines) {
+            static Result success(List<String> remainingLines) {
                 return new Result(true, remainingLines);
             }
 
-            public static Result failure(List<String> lines) {
+            static Result failure(List<String> lines) {
                 return failure(lines, "Lines were " + Joiner.on(System.lineSeparator()).join(lines));
             }
 
-            public static Result failure(List<String> lines, String mismatchDescription, Object... args) {
+            static Result failure(List<String> lines, String mismatchDescription, Object... args) {
                 return new Result(false, lines, String.format(mismatchDescription, args));
             }
 
@@ -172,11 +171,11 @@ public class MessageAssertionChain {
                 this.remainingLines = remainingLines;
             }
 
-            public static List<String> difference(List<String> list, String toSubtract) {
+            static List<String> difference(List<String> list, String toSubtract) {
                 return difference(list, singletonList(toSubtract));
             }
 
-            public static List<String> difference(List<String> list, List<String> toSubtract) {
+            static List<String> difference(List<String> list, List<String> toSubtract) {
                 List<String> result = new ArrayList<>(list);
                 result.removeAll(toSubtract);
                 return result;

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -41,7 +41,7 @@ public @interface AnalyzeClasses {
     /**
      * @return Classes that specify packages to look for in all URLs known to the actual {@link java.net.URLClassLoader}
      */
-    Class[] packagesOf() default {};
+    Class<?>[] packagesOf() default {};
 
     /**
      * Allows to filter the class import. The supplied types will be instantiated and used to create the

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
@@ -18,23 +18,47 @@ package com.tngtech.archunit.junit;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.Description;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 class ArchRuleExecution extends ArchTestExecution {
     private final Field ruleField;
+    @VisibleForTesting
+    final ArchRule rule;
 
     ArchRuleExecution(Class<?> testClass, Field ruleField) {
         super(testClass);
-        this.ruleField = validate(ruleField);
+
+        validatePublicStatic(ruleField);
+        checkArgument(ArchRule.class.isAssignableFrom(ruleField.getType()),
+                "Rule field %s.%s to check must be of type %s",
+                testClass.getSimpleName(), ruleField.getName(), ArchRule.class.getSimpleName());
+
+        this.ruleField = validatePublicStatic(ruleField);
+        rule = getArchRule(testClass, ruleField);
+    }
+
+    private ArchRule getArchRule(Class<?> testClass, Field ruleField) {
+        try {
+            return (ArchRule) ruleField.get(testClass);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(String.format(
+                    "Cannot access field %s.%s", testClass.getName(), ruleField.getName()), e);
+        }
     }
 
     @Override
     Result evaluateOn(JavaClasses classes) {
-        return RuleToEvaluate.from(testClass, ruleField)
-                .evaluateOn(classes)
-                .asResult(describeSelf());
+        try {
+            rule.check(classes);
+        } catch (Exception | AssertionError e) {
+            return new NegativeResult(describeSelf(), e);
+        }
+        return new PositiveResult();
     }
 
     @Override
@@ -51,101 +75,4 @@ class ArchRuleExecution extends ArchTestExecution {
     <T extends Annotation> T getAnnotation(Class<T> type) {
         return ruleField.getAnnotation(type);
     }
-
-    private abstract static class RuleToEvaluate {
-        static RuleToEvaluate retrievalFailedWith(RuleEvaluationException exception) {
-            return new FailedToRetrieve(exception);
-        }
-
-        static RuleToEvaluate from(Class<?> testClass, Field ruleField) {
-            try {
-                Object ruleCandidate = ruleField.get(testClass);
-                return ruleCandidate instanceof ArchRule ?
-                        new Retrieved(asArchRule(ruleCandidate)) :
-                        new FailedToRetrieve(fieldTypeFailure(ruleField));
-            } catch (IllegalAccessException e) {
-                return RuleToEvaluate.retrievalFailedWith(new RuleEvaluationException(
-                        String.format("Cannot access field %s.%s", testClass.getName(), ruleField.getName()), e));
-            }
-        }
-
-        @SuppressWarnings("unchecked")
-        private static ArchRule asArchRule(Object ruleCandidate) {
-            return (ArchRule) ruleCandidate;
-        }
-
-        private static RuleEvaluationException fieldTypeFailure(Field ruleField) {
-            String hint = String.format("Only fields of type %s may be annotated with @%s",
-                    ArchRule.class.getSimpleName(), ArchTest.class.getSimpleName());
-            String problem = String.format("Cannot evaluate @%s on field %s.%s",
-                    ArchTest.class.getSimpleName(), ruleField.getDeclaringClass().getName(), ruleField.getName());
-            return new RuleEvaluationException(hint + problem);
-        }
-
-        abstract Evaluation evaluateOn(JavaClasses classes);
-
-        private static class Retrieved extends RuleToEvaluate {
-            private ArchRule rule;
-
-            Retrieved(ArchRule rule) {
-                this.rule = rule;
-            }
-
-            @Override
-            Evaluation evaluateOn(JavaClasses classes) {
-                return new RetrievalEvaluation(rule, classes);
-            }
-        }
-
-        private static class FailedToRetrieve extends RuleToEvaluate {
-            private RuleEvaluationException failure;
-
-            FailedToRetrieve(RuleEvaluationException failure) {
-                this.failure = failure;
-            }
-
-            @Override
-            Evaluation evaluateOn(JavaClasses classes) {
-                return new FailureEvaluation(failure);
-            }
-        }
-    }
-
-    private abstract static class Evaluation {
-        abstract Result asResult(Description description);
-    }
-
-    private static class RetrievalEvaluation extends Evaluation {
-        private final ArchRule rule;
-        private final JavaClasses classes;
-
-        RetrievalEvaluation(ArchRule rule, JavaClasses classes) {
-            this.rule = rule;
-            this.classes = classes;
-        }
-
-        @Override
-        Result asResult(Description description) {
-            try {
-                rule.check(classes);
-            } catch (Exception | AssertionError e) {
-                return new NegativeResult(description, e);
-            }
-            return new PositiveResult();
-        }
-    }
-
-    private static class FailureEvaluation extends Evaluation {
-        private final RuleEvaluationException failure;
-
-        FailureEvaluation(RuleEvaluationException failure) {
-            this.failure = failure;
-        }
-
-        @Override
-        Result asResult(Description description) {
-            return new NegativeResult(description, failure);
-        }
-    }
-
 }

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
@@ -33,7 +33,7 @@ abstract class ArchTestExecution {
         this.testClass = testClass;
     }
 
-    static <T extends Member> T validate(T member) {
+    static <T extends Member> T validatePublicStatic(T member) {
         checkArgument(Modifier.isPublic(member.getModifiers()) && Modifier.isStatic(member.getModifiers()),
                 "With @%s annotated members must be public and static", ArchTest.class.getSimpleName());
         return member;

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -28,7 +28,7 @@ class ArchTestMethodExecution extends ArchTestExecution {
 
     ArchTestMethodExecution(Class<?> testClass, Method testMethod) {
         super(testClass);
-        this.testMethod = validate(testMethod);
+        this.testMethod = validatePublicStatic(testMethod);
     }
 
     @Override

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
@@ -86,7 +86,7 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
     }
 
     private ArchRules getArchRules(FrameworkField ruleField) {
-        ArchTestExecution.validate(ruleField.getField());
+        ArchTestExecution.validatePublicStatic(ruleField.getField());
         try {
             return (ArchRules) ruleField.get(null);
         } catch (IllegalAccessException e) {

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ClassCache.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ClassCache.java
@@ -59,9 +59,9 @@ class ClassCache {
         return new LocationsKey(analyzeClasses.importOptions(), locations);
     }
 
-    private Set<String> toPackageStrings(Class[] classes) {
+    private Set<String> toPackageStrings(Class<?>[] classes) {
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
-        for (Class clazz : classes) {
+        for (Class<?> clazz : classes) {
             result.add(clazz.getPackage().getName());
         }
         return result.build();

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
@@ -99,7 +99,8 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     public void should_fail_on_wrong_field_visibility() throws InitializationError {
         ArchUnitRunner runner = new ArchUnitRunner(WrongArchTestWrongModifier.class);
 
-        thrown.expectMessage("With @ArchTest annotated members must be public and static");
+        thrown.expectMessage("With @" + ArchTest.class.getSimpleName() +
+                " annotated members must be public and static");
 
         runner.runChild(ArchUnitRunnerTestUtils.getRule(WRONG_MODIFIER_FIELD_NAME, runner), runNotifier);
     }
@@ -108,10 +109,11 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     public void should_fail_on_wrong_field_type() throws InitializationError {
         ArchUnitRunner runner = new ArchUnitRunner(WrongArchTestWrongFieldType.class);
 
+        thrown.expectMessage("Rule field " +
+                WrongArchTestWrongFieldType.class.getSimpleName() + "." + NO_RULE_AT_ALL_FIELD_NAME +
+                " to check must be of type " + ArchRule.class.getSimpleName());
+
         runner.runChild(ArchUnitRunnerTestUtils.getRule(NO_RULE_AT_ALL_FIELD_NAME, runner), runNotifier);
-        verify(runNotifier).fireTestFailure(failureCaptor.capture());
-        assertThat(failureCaptor.getValue().getMessage())
-                .contains("Only fields of type ArchRule may be annotated with @ArchTest");
     }
 
     @Test

--- a/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
@@ -190,7 +190,7 @@ public abstract class Optional<T> {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final Present other = (Present) obj;
+            final Present<?> other = (Present<?>) obj;
             return Objects.equals(this.object, other.object);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -193,7 +193,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         private final ImmutableList<JavaClass> parameters;
         private final JavaClass returnType;
 
-        CodeUnitCallTarget(CodeUnitCallTargetBuilder builder) {
+        CodeUnitCallTarget(CodeUnitCallTargetBuilder<?> builder) {
             super(builder.getOwner(), builder.getName(), builder.getFullName());
             this.parameters = ImmutableList.copyOf(builder.getParameters());
             this.returnType = builder.getReturnType();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -840,7 +840,7 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
     }
 
     @ResolvesTypesViaReflection
-    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution procecss")
+    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution process")
     private class ReflectClassSupplier implements Supplier<Class<?>> {
         @Override
         public Class<?> get() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -102,7 +102,7 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
     }
 
     @ResolvesTypesViaReflection
-    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution procecss")
+    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution process")
     static Class<?>[] reflect(JavaClassList parameters) {
         List<Class<?>> result = new ArrayList<>();
         for (JavaClass parameter : parameters) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
@@ -71,7 +71,7 @@ public final class JavaConstructor extends JavaCodeUnit {
     }
 
     @ResolvesTypesViaReflection
-    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution procecss")
+    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution process")
     private class ReflectConstructorSupplier implements Supplier<Constructor<?>> {
         @Override
         public Constructor<?> get() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -67,7 +67,7 @@ public class JavaField extends JavaMember implements HasType {
     }
 
     @ResolvesTypesViaReflection
-    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution procecss")
+    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution process")
     private class ReflectFieldSupplier implements Supplier<Field> {
         @Override
         public Field get() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -77,7 +77,7 @@ public class JavaMethod extends JavaCodeUnit {
     }
 
     @ResolvesTypesViaReflection
-    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution procecss")
+    @MayResolveTypesViaReflection(reason = "Just part of a bigger resolution process")
     private class ReflectMethodSupplier implements Supplier<Method> {
         @Override
         public Method get() {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
@@ -102,10 +102,10 @@ public abstract class ArchCondition<T> {
             }
         }
 
-        List<ConditionWithEvents> evaluateConditions(T item) {
-            List<ConditionWithEvents> evaluate = new ArrayList<>();
+        List<ConditionWithEvents<T>> evaluateConditions(T item) {
+            List<ConditionWithEvents<T>> evaluate = new ArrayList<>();
             for (ArchCondition<T> condition : conditions) {
-                evaluate.add(new ConditionWithEvents(condition, item));
+                evaluate.add(new ConditionWithEvents<>(condition, item));
             }
             return evaluate;
         }
@@ -116,15 +116,15 @@ public abstract class ArchCondition<T> {
         }
     }
 
-    private static class ConditionWithEvents {
-        private final ArchCondition<?> condition;
+    private static class ConditionWithEvents<T> {
+        private final ArchCondition<T> condition;
         private final ConditionEvents events;
 
-        <T> ConditionWithEvents(ArchCondition<T> condition, T item) {
+        ConditionWithEvents(ArchCondition<T> condition, T item) {
             this(condition, check(condition, item));
         }
 
-        ConditionWithEvents(ArchCondition<?> condition, ConditionEvents events) {
+        ConditionWithEvents(ArchCondition<T> condition, ConditionEvents events) {
             this.condition = condition;
             this.events = events;
         }
@@ -144,11 +144,11 @@ public abstract class ArchCondition<T> {
         }
     }
 
-    private abstract static class JoinConditionEvent<T> implements ConditionEvent<T> {
+    private abstract static class JoinConditionEvent<T> implements ConditionEvent {
         private final T correspondingObject;
-        final List<ConditionWithEvents> evaluatedConditions;
+        final List<ConditionWithEvents<T>> evaluatedConditions;
 
-        JoinConditionEvent(T correspondingObject, List<ConditionWithEvents> evaluatedConditions) {
+        JoinConditionEvent(T correspondingObject, List<ConditionWithEvents<T>> evaluatedConditions) {
             this.correspondingObject = correspondingObject;
             this.evaluatedConditions = evaluatedConditions;
         }
@@ -161,7 +161,7 @@ public abstract class ArchCondition<T> {
                     result.add(line);
                 }
             };
-            for (ConditionWithEvents evaluation : evaluatedConditions) {
+            for (ConditionWithEvents<T> evaluation : evaluatedConditions) {
                 for (ConditionEvent event : evaluation.events) {
                     if (event.isViolation()) {
                         event.describeTo(lines);
@@ -183,20 +183,20 @@ public abstract class ArchCondition<T> {
                     .toString();
         }
 
-        List<ConditionWithEvents> invert(List<ConditionWithEvents> evaluatedConditions) {
-            List<ConditionWithEvents> inverted = new ArrayList<>();
-            for (ConditionWithEvents evaluation : evaluatedConditions) {
+        List<ConditionWithEvents<T>> invert(List<ConditionWithEvents<T>> evaluatedConditions) {
+            List<ConditionWithEvents<T>> inverted = new ArrayList<>();
+            for (ConditionWithEvents<T> evaluation : evaluatedConditions) {
                 inverted.add(invert(evaluation));
             }
             return inverted;
         }
 
-        ConditionWithEvents invert(ConditionWithEvents evaluation) {
+        ConditionWithEvents<T> invert(ConditionWithEvents<T> evaluation) {
             ConditionEvents invertedEvents = new ConditionEvents();
             for (ConditionEvent event : evaluation.events) {
                 event.addInvertedTo(invertedEvents);
             }
-            return new ConditionWithEvents(evaluation.condition, invertedEvents);
+            return new ConditionWithEvents<>(evaluation.condition, invertedEvents);
         }
     }
 
@@ -223,13 +223,13 @@ public abstract class ArchCondition<T> {
     }
 
     private static class AndConditionEvent<T> extends JoinConditionEvent<T> {
-        AndConditionEvent(T item, List<ConditionWithEvents> evaluatedConditions) {
+        AndConditionEvent(T item, List<ConditionWithEvents<T>> evaluatedConditions) {
             super(item, evaluatedConditions);
         }
 
         @Override
         public boolean isViolation() {
-            for (ConditionWithEvents evaluation : evaluatedConditions) {
+            for (ConditionWithEvents<T> evaluation : evaluatedConditions) {
                 if (evaluation.events.containViolation()) {
                     return true;
                 }
@@ -251,13 +251,13 @@ public abstract class ArchCondition<T> {
     }
 
     private static class OrConditionEvent<T> extends JoinConditionEvent<T> {
-        OrConditionEvent(T item, List<ConditionWithEvents> evaluatedConditions) {
+        OrConditionEvent(T item, List<ConditionWithEvents<T>> evaluatedConditions) {
             super(item, evaluatedConditions);
         }
 
         @Override
         public boolean isViolation() {
-            for (ConditionWithEvents evaluation : evaluatedConditions) {
+            for (ConditionWithEvents<T> evaluation : evaluatedConditions) {
                 if (!evaluation.events.containViolation()) {
                     return false;
                 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/CollectsLines.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/CollectsLines.java
@@ -19,6 +19,9 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
+/**
+ * Generic interface for an object that gathers lines of text.
+ */
 @PublicAPI(usage = INHERITANCE)
 public interface CollectsLines {
     void add(String line);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/CollectsLinesToJoin.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/CollectsLinesToJoin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Joiner;
+
+class CollectsLinesToJoin implements CollectsLines {
+    private final List<String> lines = new ArrayList<>();
+
+    @Override
+    public void add(String line) {
+        lines.add(line);
+    }
+
+    String joinOn(String separator) {
+        return Joiner.on(separator).join(lines);
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
@@ -20,12 +20,12 @@ import com.tngtech.archunit.PublicAPI;
 import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
 @PublicAPI(usage = INHERITANCE)
-public interface ConditionEvent<T> {
+public interface ConditionEvent {
     boolean isViolation();
 
     void addInvertedTo(ConditionEvents events);
 
     void describeTo(CollectsLines messages);
 
-    T getCorrespondingObject();
+    Object getCorrespondingObject();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
@@ -15,17 +15,67 @@
  */
 package com.tngtech.archunit.lang;
 
-import com.tngtech.archunit.PublicAPI;
+import java.util.Collection;
 
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
 @PublicAPI(usage = INHERITANCE)
 public interface ConditionEvent {
+    /**
+     * @return true, IFF this event represents a violation of an evaluated rule.
+     */
     boolean isViolation();
 
+    /**
+     * Adds the 'opposite' of the event. <br>
+     * E.g. <i>The event is a violation, if some conditions A and B are both true?</i>
+     * <br> -> <i>The 'inverted' event is a violation if either A or B (or both) are not true</i><br>
+     * In the most simple case, this is just an equivalent event evaluating {@link #isViolation()}
+     * inverted.
+     *
+     * @param events The events to add the 'inverted self' to
+     */
     void addInvertedTo(ConditionEvents events);
 
+    /**
+     * Adds a textual description of this event to the supplied {@link CollectsLines}.
+     *
+     * @param messages The message lines to append the description to.
+     */
     void describeTo(CollectsLines messages);
 
-    Object getCorrespondingObject();
+    /**
+     * Supplies the corresponding objects and description to the supplied handler.
+     * <br><br>
+     * The term "corresponding objects" refers to the objects involved in the evaluation of this rule.
+     * E.g. the rule checks for illegal field accesses,
+     * then this object might be a single field access checked by the rule.<br>
+     * May also be a collection of objects, if the evaluation of the rule depends on sets of objects.
+     * E.g. the rule checks that some access to another class happened? The rule can only be violated,
+     * by a whole set (all accesses from a class) of objects, but not by a single one (if there is more than one).
+     *
+     * @param handler The handler to supply the data of this event to.
+     */
+    void handleWith(Handler handler);
+
+    /**
+     * Handles the data of a {@link ConditionEvent}, that is the corresponding objects and the description
+     * (compare {@link #handleWith(Handler)}).<br>
+     * As an example, this could be a single element of type {@link JavaMethodCall} together with a description, like
+     * <p>
+     * <i>'Method A.foo() calls method B.bar() in (A.java:123)'</i>
+     * </p>
+     */
+    interface Handler {
+        /**
+         * @param correspondingObjects The objects this event describes (e.g. method calls, field accesses, ...)
+         * @param message              Describes the event
+         */
+        @PublicAPI(usage = ACCESS)
+        void handle(Collection<?> correspondingObjects, String message);
+    }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
@@ -15,24 +15,18 @@
  */
 package com.tngtech.archunit.lang;
 
-import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Set;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.reflect.TypeToken;
 import com.tngtech.archunit.PublicAPI;
 
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static java.lang.System.lineSeparator;
 
 public final class ConditionEvents implements Iterable<ConditionEvent> {
-    private static final String HANDLER_METHOD_NAME = "handle";
 
     @PublicAPI(usage = ACCESS)
     public ConditionEvents() {
@@ -73,51 +67,37 @@ public final class ConditionEvents implements Iterable<ConditionEvent> {
     }
 
     @PublicAPI(usage = ACCESS)
-    public void handleViolations(ViolationHandler<?> handler) {
-        handleViolationsInternal(handler);
-    }
-
-    private <T> void handleViolationsInternal(final ViolationHandler<T> handler) {
-        Class<T> supportedType = findSupportedTypeFor(handler);
+    public void handleViolations(ViolationHandler<?> violationHandler) {
+        ConditionEvent.Handler eventHandler = convertToEventHandler(violationHandler);
         for (final ConditionEvent event : eventsByViolation.get(Type.VIOLATION)) {
-            handleIfPossible(handler, supportedType, event);
+            event.handleWith(eventHandler);
         }
     }
 
-    private <T> void handleIfPossible(ViolationHandler<T> handler, Class<T> supportedType, ConditionEvent event) {
-        if (supportedType.isInstance(event.getCorrespondingObject())) {
-            T correspondingObject = supportedType.cast(event.getCorrespondingObject());
-            CollectsLinesToJoin linesToJoin = new CollectsLinesToJoin();
-            event.describeTo(linesToJoin);
-            handler.handle(correspondingObject, linesToJoin.joinOn(lineSeparator()));
-        }
+    private <T> ConditionEvent.Handler convertToEventHandler(final ViolationHandler<T> handler) {
+        final Class<?> supportedElementType = TypeToken.of(handler.getClass())
+                .resolveType(ViolationHandler.class.getTypeParameters()[0]).getRawType();
+
+        return new ConditionEvent.Handler() {
+            @Override
+            public void handle(Collection<?> correspondingObjects, String message) {
+                if (allElementTypesMatch(correspondingObjects, supportedElementType)) {
+                    // If all elements are assignable to T (= supportedElementType), covariance of Collection allows this cast
+                    @SuppressWarnings("unchecked")
+                    Collection<T> collection = (Collection<T>) correspondingObjects;
+                    handler.handle(collection, message);
+                }
+            }
+        };
     }
 
-    private <T> Class<T> findSupportedTypeFor(ViolationHandler<T> handler) {
-        Set<Method> candidates = new HashSet<>();
-        for (Method method : handler.getClass().getMethods()) {
-            if (matchesHandlerMethod(method)) {
-                candidates.add(method);
+    private boolean allElementTypesMatch(Collection<?> violatingObjects, Class<?> supportedElementType) {
+        for (Object violatingObject : violatingObjects) {
+            if (!supportedElementType.isInstance(violatingObject)) {
+                return false;
             }
         }
-
-        checkState(candidates.size() == 1,
-                "Couldn't find an unique method %s.handle(T, String.class)",
-                handler.getClass().getName());
-
-        // Cast is safe, because we identified the handler interface method, thus first parameter T matches handler type <T>
-        @SuppressWarnings("unchecked")
-        Class<T> result = (Class<T>) getOnlyElement(candidates).getParameterTypes()[0];
-        return result;
-    }
-
-    private boolean matchesHandlerMethod(Method method) {
-        boolean nameMatches = method.getName().equals(HANDLER_METHOD_NAME);
-        boolean parametersMatch = method.getParameterTypes().length == 2 &&
-                method.getParameterTypes()[1] == String.class;
-        boolean methodWasntCreatedByCompiler = !method.isSynthetic() && !method.isBridge();
-
-        return nameMatches && parametersMatch && methodWasntCreatedByCompiler;
+        return true;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
@@ -15,17 +15,25 @@
  */
 package com.tngtech.archunit.lang;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.tngtech.archunit.PublicAPI;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static java.lang.System.lineSeparator;
 
 public final class ConditionEvents implements Iterable<ConditionEvent> {
+    private static final String HANDLER_METHOD_NAME = "handle";
+
     @PublicAPI(usage = ACCESS)
     public ConditionEvents() {
     }
@@ -62,6 +70,54 @@ public final class ConditionEvents implements Iterable<ConditionEvent> {
         for (ConditionEvent event : getViolating()) {
             event.describeTo(messages);
         }
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public void handleViolations(ViolationHandler<?> handler) {
+        handleViolationsInternal(handler);
+    }
+
+    private <T> void handleViolationsInternal(final ViolationHandler<T> handler) {
+        Class<T> supportedType = findSupportedTypeFor(handler);
+        for (final ConditionEvent event : eventsByViolation.get(Type.VIOLATION)) {
+            handleIfPossible(handler, supportedType, event);
+        }
+    }
+
+    private <T> void handleIfPossible(ViolationHandler<T> handler, Class<T> supportedType, ConditionEvent event) {
+        if (supportedType.isInstance(event.getCorrespondingObject())) {
+            T correspondingObject = supportedType.cast(event.getCorrespondingObject());
+            CollectsLinesToJoin linesToJoin = new CollectsLinesToJoin();
+            event.describeTo(linesToJoin);
+            handler.handle(correspondingObject, linesToJoin.joinOn(lineSeparator()));
+        }
+    }
+
+    private <T> Class<T> findSupportedTypeFor(ViolationHandler<T> handler) {
+        Set<Method> candidates = new HashSet<>();
+        for (Method method : handler.getClass().getMethods()) {
+            if (matchesHandlerMethod(method)) {
+                candidates.add(method);
+            }
+        }
+
+        checkState(candidates.size() == 1,
+                "Couldn't find an unique method %s.handle(T, String.class)",
+                handler.getClass().getName());
+
+        // Cast is safe, because we identified the handler interface method, thus first parameter T matches handler type <T>
+        @SuppressWarnings("unchecked")
+        Class<T> result = (Class<T>) getOnlyElement(candidates).getParameterTypes()[0];
+        return result;
+    }
+
+    private boolean matchesHandlerMethod(Method method) {
+        boolean nameMatches = method.getName().equals(HANDLER_METHOD_NAME);
+        boolean parametersMatch = method.getParameterTypes().length == 2 &&
+                method.getParameterTypes()[1] == String.class;
+        boolean methodWasntCreatedByCompiler = !method.isSynthetic() && !method.isBridge();
+
+        return nameMatches && parametersMatch && methodWasntCreatedByCompiler;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
@@ -50,4 +50,9 @@ public final class EvaluationResult {
             events.add(event);
         }
     }
+
+    @PublicAPI(usage = ACCESS)
+    public void handleViolations(ViolationHandler<?> violationHandler) {
+        events.handleViolations(violationHandler);
+    }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
@@ -27,12 +27,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.transform;
 
-public class SimpleConditionEvent<T> implements ConditionEvent<T> {
-    private final T correspondingObject;
+public class SimpleConditionEvent implements ConditionEvent {
+    private final Object correspondingObject;
     private final boolean conditionSatisfied;
     private final String message;
 
-    public SimpleConditionEvent(T correspondingObject, boolean conditionSatisfied, String message) {
+    public SimpleConditionEvent(Object correspondingObject, boolean conditionSatisfied, String message) {
         this.correspondingObject = correspondingObject;
         this.conditionSatisfied = conditionSatisfied;
         this.message = message;
@@ -46,7 +46,7 @@ public class SimpleConditionEvent<T> implements ConditionEvent<T> {
 
     @Override
     public void addInvertedTo(ConditionEvents events) {
-        events.add(new SimpleConditionEvent<>(correspondingObject, !conditionSatisfied, message));
+        events.add(new SimpleConditionEvent(correspondingObject, !conditionSatisfied, message));
     }
 
     @Override
@@ -55,7 +55,7 @@ public class SimpleConditionEvent<T> implements ConditionEvent<T> {
     }
 
     @Override
-    public T getCorrespondingObject() {
+    public Object getCorrespondingObject() {
         return correspondingObject;
     }
 
@@ -68,7 +68,7 @@ public class SimpleConditionEvent<T> implements ConditionEvent<T> {
                 .toString();
     }
 
-    protected static String joinMessages(Collection<ConditionEvent> violating) {
+    protected static String joinMessages(Collection<? extends ConditionEvent> violating) {
         Iterable<String> lines = concat(transform(violating, TO_MESSAGES));
         return Joiner.on(System.lineSeparator()).join(lines);
     }
@@ -87,11 +87,11 @@ public class SimpleConditionEvent<T> implements ConditionEvent<T> {
         }
     };
 
-    public static <T> ConditionEvent<T> violated(T correspondingObject, String message) {
-        return new SimpleConditionEvent<>(correspondingObject, false, message);
+    public static ConditionEvent violated(Object correspondingObject, String message) {
+        return new SimpleConditionEvent(correspondingObject, false, message);
     }
 
-    public static <T> ConditionEvent<T> satisfied(T correspondingObject, String message) {
-        return new SimpleConditionEvent<>(correspondingObject, true, message);
+    public static ConditionEvent satisfied(Object correspondingObject, String message) {
+        return new SimpleConditionEvent(correspondingObject, true, message);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
@@ -17,10 +17,14 @@ package com.tngtech.archunit.lang;
 
 import java.util.Collections;
 
+import com.tngtech.archunit.PublicAPI;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public class SimpleConditionEvent implements ConditionEvent {
+@PublicAPI(usage = ACCESS)
+public final class SimpleConditionEvent implements ConditionEvent {
     private final Object correspondingObject;
     private final boolean conditionSatisfied;
     private final String message;

--- a/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/SimpleConditionEvent.java
@@ -15,17 +15,10 @@
  */
 package com.tngtech.archunit.lang;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
+import java.util.Collections;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.transform;
 
 public class SimpleConditionEvent implements ConditionEvent {
     private final Object correspondingObject;
@@ -55,8 +48,8 @@ public class SimpleConditionEvent implements ConditionEvent {
     }
 
     @Override
-    public Object getCorrespondingObject() {
-        return correspondingObject;
+    public void handleWith(Handler handler) {
+        handler.handle(Collections.singleton(correspondingObject), message);
     }
 
     @Override
@@ -67,25 +60,6 @@ public class SimpleConditionEvent implements ConditionEvent {
                 .add("message", message)
                 .toString();
     }
-
-    protected static String joinMessages(Collection<? extends ConditionEvent> violating) {
-        Iterable<String> lines = concat(transform(violating, TO_MESSAGES));
-        return Joiner.on(System.lineSeparator()).join(lines);
-    }
-
-    private static final Function<ConditionEvent, Iterable<String>> TO_MESSAGES = new Function<ConditionEvent, Iterable<String>>() {
-        @Override
-        public Iterable<String> apply(ConditionEvent input) {
-            final List<String> result = new ArrayList<>();
-            input.describeTo(new CollectsLines() {
-                @Override
-                public void add(String line) {
-                    result.add(line);
-                }
-            });
-            return result;
-        }
-    };
 
     public static ConditionEvent violated(Object correspondingObject, String message) {
         return new SimpleConditionEvent(correspondingObject, false, message);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ViolationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ViolationHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang;
+
+import com.tngtech.archunit.PublicAPI;
+
+import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+
+@PublicAPI(usage = INHERITANCE)
+public interface ViolationHandler<T> {
+    void handle(T violatingObject, String message);
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ViolationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ViolationHandler.java
@@ -15,11 +15,13 @@
  */
 package com.tngtech.archunit.lang;
 
+import java.util.Collection;
+
 import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
 @PublicAPI(usage = INHERITANCE)
 public interface ViolationHandler<T> {
-    void handle(T violatingObject, String message);
+    void handle(Collection<T> violatingObjects, String message);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AccessTargetCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AccessTargetCondition.java
@@ -31,6 +31,6 @@ class AccessTargetCondition extends ArchCondition<JavaAccess<?>> {
 
     @Override
     public void check(JavaAccess<?> item, ConditionEvents events) {
-        events.add(new SimpleConditionEvent<>(item, callIdentifier.apply(item), item.getDescription()));
+        events.add(new SimpleConditionEvent(item, callIdentifier.apply(item), item.getDescription()));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllAttributesMatchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllAttributesMatchCondition.java
@@ -32,7 +32,7 @@ abstract class AllAttributesMatchCondition<T> extends ArchCondition<JavaClass> {
     }
 
     @Override
-    public final void check(JavaClass item, ConditionEvents events) {
+    public void check(JavaClass item, ConditionEvents events) {
         containOnlyElementsThat(condition).check(relevantAttributes(item), events);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -186,8 +186,8 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> accessClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
         @SuppressWarnings({"RedundantTypeArguments", "unchecked"})
-        ChainableFunction<JavaAccess, AccessTarget> getTarget =
-                JavaAccess.Functions.Get.<JavaAccess, AccessTarget>target(); // This seems to be a compiler nightmare...
+        ChainableFunction<JavaAccess<?>, AccessTarget> getTarget =
+                JavaAccess.Functions.Get.<JavaAccess<?>, AccessTarget>target(); // This seems to be a compiler nightmare...
         return new AnyAccessFromClassCondition("access classes that",
                 getTarget.then(Get.<JavaClass>owner()).is(predicate));
     }
@@ -261,7 +261,7 @@ public final class ArchConditions {
                 boolean satisfied = haveFullyQualifiedName.apply(item);
                 String message = String.format("class %s %s fully qualified name '%s'",
                         item.getName(), satisfied ? "has" : "doesn't have", name);
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -286,7 +286,7 @@ public final class ArchConditions {
                 boolean satisfied = haveSimpleName.apply(item);
                 String message = String.format("class %s %s simple name '%s'",
                         item.getName(), satisfied ? "has" : "doesn't have", name);
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -305,7 +305,7 @@ public final class ArchConditions {
                 boolean satisfied = haveNameMatching.apply(item);
                 String infix = satisfied ? "matches" : "doesn't match";
                 String message = String.format("class %s %s '%s'", item.getName(), infix, regex);
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -342,7 +342,7 @@ public final class ArchConditions {
                 boolean satisfied = resideInAPackage.apply(item);
                 String message = String.format("Class %s %s %s",
                         item.getName(), satisfied ? "does" : "doesn't", resideInAPackage.getDescription());
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -356,7 +356,7 @@ public final class ArchConditions {
                 boolean satisfied = haveModifier.apply(item);
                 String message = String.format("class %s %s modifier %s",
                         item.getName(), satisfied ? "has" : "doesn't have", modifier);
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -446,7 +446,7 @@ public final class ArchConditions {
                 boolean satisfied = annotatedWith.apply(item);
                 String message = String.format("class %s is %s%s",
                         item.getName(), satisfied ? "" : "not ", annotatedWith.getDescription());
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -496,7 +496,7 @@ public final class ArchConditions {
                         ? implement.getDescription().replace("implement", "implements")
                         : implement.getDescription().replace("implement", "doesn't implement");
                 String message = String.format("class %s %s", item.getName(), description);
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
@@ -568,7 +568,7 @@ public final class ArchConditions {
                 boolean satisfied = assignable.apply(item);
                 String message = String.format("class %s is %s%s",
                         item.getName(), satisfied ? "" : "not ", assignable.getDescription());
-                events.add(new SimpleConditionEvent<>(item, satisfied, message));
+                events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/CodeUnitCallCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/CodeUnitCallCondition.java
@@ -31,6 +31,6 @@ class CodeUnitCallCondition extends ArchCondition<JavaCall<?>> {
 
     @Override
     public void check(JavaCall<?> item, ConditionEvents events) {
-        events.add(new SimpleConditionEvent<>(item, callIdentifier.apply(item), item.getDescription()));
+        events.add(new SimpleConditionEvent(item, callIdentifier.apply(item), item.getDescription()));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
@@ -37,7 +37,7 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
             condition.check(element, subEvents);
         }
         if (!subEvents.isEmpty()) {
-            events.add(new AnyConditionEvent<>(collection, subEvents));
+            events.add(new AnyConditionEvent(collection, subEvents));
         }
     }
 
@@ -46,15 +46,18 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
         return getClass().getSimpleName() + "{condition=" + condition + "}";
     }
 
-    private static class AnyConditionEvent<T> extends SimpleConditionEvent<Collection<T>> {
+    private static class AnyConditionEvent extends SimpleConditionEvent {
         private Collection<ConditionEvent> violating;
         private Collection<ConditionEvent> allowed;
 
-        private AnyConditionEvent(Collection<T> correspondingObject, ConditionEvents events) {
+        private AnyConditionEvent(Collection<?> correspondingObject, ConditionEvents events) {
             this(correspondingObject, !events.getAllowed().isEmpty(), events.getAllowed(), events.getViolating());
         }
 
-        private AnyConditionEvent(Collection<T> correspondingObject, boolean conditionSatisfied, Collection<ConditionEvent> allowed, Collection<ConditionEvent> violating) {
+        private AnyConditionEvent(Collection<?> correspondingObject,
+                                  boolean conditionSatisfied,
+                                  Collection<ConditionEvent> allowed,
+                                  Collection<ConditionEvent> violating) {
             super(correspondingObject, conditionSatisfied, joinMessages(violating));
             this.allowed = allowed;
             this.violating = violating;
@@ -62,7 +65,12 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
 
         @Override
         public void addInvertedTo(ConditionEvents events) {
-            events.add(new AnyConditionEvent<>(getCorrespondingObject(), isViolation(), violating, allowed));
+            events.add(new AnyConditionEvent(getCorrespondingObject(), isViolation(), violating, allowed));
+        }
+
+        @Override
+        public Collection<?> getCorrespondingObject() {
+            return (Collection<?>) super.getCorrespondingObject(); // This is safe, because we ensure Collection<?> within constructor
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
@@ -37,7 +37,7 @@ class ContainsOnlyCondition<T> extends ArchCondition<Collection<? extends T>> {
             condition.check(item, subEvents);
         }
         if (!subEvents.isEmpty()) {
-            events.add(new OnlyConditionEvent<>(collection, subEvents));
+            events.add(new OnlyConditionEvent(collection, subEvents));
         }
     }
 
@@ -46,15 +46,15 @@ class ContainsOnlyCondition<T> extends ArchCondition<Collection<? extends T>> {
         return getClass().getSimpleName() + "{condition=" + condition + "}";
     }
 
-    private static class OnlyConditionEvent<T> extends SimpleConditionEvent<Collection<T>> {
+    private static class OnlyConditionEvent extends SimpleConditionEvent {
         private Collection<ConditionEvent> allowed;
         private Collection<ConditionEvent> violating;
 
-        private OnlyConditionEvent(Collection<T> correspondingObject, ConditionEvents events) {
+        private OnlyConditionEvent(Collection<?> correspondingObject, ConditionEvents events) {
             this(correspondingObject, !events.containViolation(), events.getAllowed(), events.getViolating());
         }
 
-        private OnlyConditionEvent(Collection<T> correspondingObject,
+        private OnlyConditionEvent(Collection<?> correspondingObject,
                                    boolean conditionSatisfied,
                                    Collection<ConditionEvent> allowed,
                                    Collection<ConditionEvent> violating) {
@@ -65,7 +65,12 @@ class ContainsOnlyCondition<T> extends ArchCondition<Collection<? extends T>> {
 
         @Override
         public void addInvertedTo(ConditionEvents events) {
-            events.add(new OnlyConditionEvent<>(getCorrespondingObject(), isViolation(), violating, allowed));
+            events.add(new OnlyConditionEvent(getCorrespondingObject(), isViolation(), violating, allowed));
+        }
+
+        @Override
+        public Collection<?> getCorrespondingObject() {
+            return (Collection<?>) super.getCorrespondingObject(); // This is safe, because we ensure Collection<?> within constructor
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/EventsDescription.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/EventsDescription.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.conditions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.tngtech.archunit.lang.CollectsLines;
+import com.tngtech.archunit.lang.ConditionEvent;
+
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterables.transform;
+
+class EventsDescription {
+    static String describe(Collection<? extends ConditionEvent> violating) {
+        Iterable<String> lines = concat(transform(violating, TO_MESSAGES));
+        return Joiner.on(System.lineSeparator()).join(lines);
+    }
+
+    private static final Function<ConditionEvent, Iterable<String>> TO_MESSAGES = new Function<ConditionEvent, Iterable<String>>() {
+        @Override
+        public Iterable<String> apply(ConditionEvent input) {
+            final List<String> result = new ArrayList<>();
+            input.describeTo(new CollectsLines() {
+                @Override
+                public void add(String line) {
+                    result.add(line);
+                }
+            });
+            return result;
+        }
+    };
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/FieldAccessCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/FieldAccessCondition.java
@@ -50,7 +50,7 @@ class FieldAccessCondition extends ArchCondition<JavaFieldAccess> {
     @Override
     public void check(JavaFieldAccess item, ConditionEvents events) {
         String message = item.getDescriptionWithTemplate(descriptionTemplate);
-        events.add(new SimpleConditionEvent<>(item, fieldAccessIdentifier.apply(item), message));
+        events.add(new SimpleConditionEvent(item, fieldAccessIdentifier.apply(item), message));
     }
 
     static class FieldGetAccessCondition extends FieldAccessCondition {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JavaAccessCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JavaAccessCondition.java
@@ -32,7 +32,7 @@ class JavaAccessCondition extends ArchCondition<JavaAccess<?>> {
     @Override
     public void check(JavaAccess<?> item, ConditionEvents events) {
         if (!item.getOriginOwner().equals(item.getTargetOwner())) {
-            events.add(new SimpleConditionEvent<>(item, predicate.apply(item), item.getDescription()));
+            events.add(new SimpleConditionEvent(item, predicate.apply(item), item.getDescription()));
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
@@ -160,7 +160,7 @@ class SliceCycleArchCondition extends ArchCondition<Slice> {
             Map<String, Edge<Slice, Dependency>> descriptionsToEdges = sortEdgesByDescription(cycle);
             String description = createDescription(descriptionsToEdges);
             String details = createDetails(descriptionsToEdges);
-            return new SimpleConditionEvent<>(cycle,
+            return new SimpleConditionEvent(cycle,
                     false,
                     String.format(MESSAGE_TEMPLATE, description, details));
         }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -33,7 +33,6 @@ import com.google.common.collect.Sets;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
-import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
@@ -187,7 +186,6 @@ import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
 import static com.tngtech.archunit.core.domain.TestUtils.MD5_SUM_DISABLED;
 import static com.tngtech.archunit.core.domain.TestUtils.asClasses;
 import static com.tngtech.archunit.core.domain.TestUtils.md5sumOf;
-import static com.tngtech.archunit.core.domain.TestUtils.resolvedTargetFrom;
 import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.OTHER_VALUE;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.SOME_VALUE;
@@ -197,6 +195,8 @@ import static com.tngtech.archunit.core.importer.testexamples.annotationmethodim
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.stringAndIntAnnotatedMethod;
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.stringAnnotatedMethod;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
+import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.constructor;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
@@ -1997,111 +1997,6 @@ public class ClassFileImporterTest {
                 fields.addAll(clazz.getFields());
             }
             return fields;
-        }
-    }
-
-    private static AccessToFieldAssertion assertThatAccess(JavaFieldAccess access) {
-        return new AccessToFieldAssertion(access);
-    }
-
-    private static MethodCallAssertion assertThatCall(JavaMethodCall call) {
-        return new MethodCallAssertion(call);
-    }
-
-    private static ConstructorCallAssertion assertThatCall(JavaConstructorCall call) {
-        return new ConstructorCallAssertion(call);
-    }
-
-    protected abstract static class BaseAccessAssertion<
-            SELF extends BaseAccessAssertion<SELF, ACCESS, TARGET>,
-            ACCESS extends JavaAccess<TARGET>,
-            TARGET extends AccessTarget> {
-
-        ACCESS access;
-
-        BaseAccessAssertion(ACCESS access) {
-            this.access = access;
-        }
-
-        SELF isFrom(String name, Class<?>... parameterTypes) {
-            return isFrom(access.getOrigin().getOwner().getCodeUnitWithParameterTypes(name, parameterTypes));
-        }
-
-        SELF isFrom(JavaCodeUnit codeUnit) {
-            assertThat(access.getOrigin()).as("Origin of field access").isEqualTo(codeUnit);
-            return newAssertion(access);
-        }
-
-        SELF isTo(TARGET target) {
-            assertThat(access.getTarget()).as("Target of " + access.getName()).isEqualTo(target);
-            return newAssertion(access);
-        }
-
-        SELF isTo(Condition<TARGET> target) {
-            assertThat(access.getTarget()).as("Target of " + access.getName()).is(target);
-            return newAssertion(access);
-        }
-
-        void inLineNumber(int number) {
-            assertThat(access.getLineNumber())
-                    .as("Line number of access to " + access.getName())
-                    .isEqualTo(number);
-        }
-
-        protected abstract SELF newAssertion(ACCESS access);
-    }
-
-    private static class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAssertion, JavaFieldAccess, FieldAccessTarget> {
-        private AccessToFieldAssertion(JavaFieldAccess access) {
-            super(access);
-        }
-
-        @Override
-        protected AccessToFieldAssertion newAssertion(JavaFieldAccess access) {
-            return new AccessToFieldAssertion(access);
-        }
-
-        private AccessToFieldAssertion isTo(String name) {
-            return isTo(access.getOrigin().getOwner().getField(name));
-        }
-
-        private AccessToFieldAssertion isTo(JavaField field) {
-            return isTo(targetFrom(field));
-        }
-
-        private AccessToFieldAssertion isOfType(AccessType type) {
-            assertThat(access.getAccessType()).isEqualTo(type);
-            return newAssertion(access);
-        }
-    }
-
-    private static class MethodCallAssertion extends BaseAccessAssertion<MethodCallAssertion, JavaMethodCall, MethodCallTarget> {
-        private MethodCallAssertion(JavaMethodCall call) {
-            super(call);
-        }
-
-        MethodCallAssertion isTo(JavaMethod target) {
-            return isTo(resolvedTargetFrom(target));
-        }
-
-        @Override
-        protected MethodCallAssertion newAssertion(JavaMethodCall call) {
-            return new MethodCallAssertion(call);
-        }
-    }
-
-    private static class ConstructorCallAssertion extends BaseAccessAssertion<ConstructorCallAssertion, JavaConstructorCall, ConstructorCallTarget> {
-        private ConstructorCallAssertion(JavaConstructorCall call) {
-            super(call);
-        }
-
-        ConstructorCallAssertion isTo(JavaConstructor target) {
-            return isTo(targetFrom(target));
-        }
-
-        @Override
-        protected ConstructorCallAssertion newAssertion(JavaConstructorCall call) {
-            return new ConstructorCallAssertion(call);
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
@@ -1,7 +1,13 @@
 package com.tngtech.archunit.lang;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -46,6 +52,25 @@ public class ArchConditionTest {
     }
 
     @Test
+    public void and_handles_each_violating_object_separately() {
+        ArchCondition<Integer> condition = greaterThan(1).and(greaterThan(2)).and(greaterThan(3));
+
+        ConditionEvents events = new ConditionEvents();
+        condition.check(2, events);
+        final List<HandledViolation> handledViolations = new ArrayList<>();
+        events.handleViolations(new ViolationHandler<Integer>() {
+            @Override
+            public void handle(Collection<Integer> violatingObjects, String message) {
+                handledViolations.add(new HandledViolation(violatingObjects, message));
+            }
+        });
+
+        assertThat(handledViolations).containsOnly(
+                new HandledViolation(2, "2 is not greater than 2"),
+                new HandledViolation(2, "2 is not greater than 3"));
+    }
+
+    @Test
     public void or_checks_all_conditions() {
         ArchCondition<Integer> greaterThan15OrGreater14And20 =
                 greaterThan(15).or(greaterThan(14, 20));
@@ -72,6 +97,24 @@ public class ArchConditionTest {
         ConditionEvents events = new ConditionEvents();
         isGreaterThan15OrEndsWith1.check(12, events);
         assertThat(events).containViolations("12 does not end with 1 and 12 is not greater than 15");
+    }
+
+    @Test
+    public void or_handles_all_violated_conditions_as_unit() {
+        ArchCondition<Integer> condition = greaterThan(1).or(greaterThan(2)).or(greaterThan(3));
+
+        ConditionEvents events = new ConditionEvents();
+        condition.check(1, events);
+        final List<HandledViolation> handledViolations = new ArrayList<>();
+        events.handleViolations(new ViolationHandler<Integer>() {
+            @Override
+            public void handle(Collection<Integer> violatingObjects, String message) {
+                handledViolations.add(new HandledViolation(violatingObjects, message));
+            }
+        });
+
+        assertThat(handledViolations).containsOnly(new HandledViolation(
+                1, "1 is not greater than 1 and 1 is not greater than 2 and 1 is not greater than 3"));
     }
 
     @DataProvider
@@ -227,5 +270,45 @@ public class ArchConditionTest {
         }
 
         abstract <T> ArchCondition<T> combine(ArchCondition<T> first, ArchCondition<T> second);
+    }
+
+    private static class HandledViolation {
+        final Multiset<Integer> objects;
+        final String message;
+
+        HandledViolation(int object, String message) {
+            this(singleton(object), message);
+        }
+
+        HandledViolation(Collection<Integer> objects, String message) {
+            this.objects = HashMultiset.create(objects);
+            this.message = message;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(objects, message);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            final HandledViolation other = (HandledViolation) obj;
+            return Objects.equals(this.objects, other.objects)
+                    && Objects.equals(this.message, other.message);
+        }
+
+        @Override
+        public String toString() {
+            return "HandledViolation{" +
+                    "objects=" + objects +
+                    ", message='" + message + '\'' +
+                    '}';
+        }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
@@ -183,7 +183,7 @@ public class ArchConditionTest {
             @Override
             public void check(final Integer item, ConditionEvents events) {
                 boolean matches = item.toString().endsWith(Integer.toString(number));
-                events.add(new SimpleConditionEvent<>(item, matches,
+                events.add(new SimpleConditionEvent(item, matches,
                         item + (matches ? " ends with " : " does not end with ") + number));
             }
         };
@@ -193,7 +193,7 @@ public class ArchConditionTest {
         return new ConditionWithInit(description);
     }
 
-    private static class GreaterThanEvent extends SimpleConditionEvent<Integer> {
+    private static class GreaterThanEvent extends SimpleConditionEvent {
         GreaterThanEvent(int item, int number) {
             super(item, item > number,
                     String.format(

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
@@ -215,7 +215,7 @@ public class ArchConditionTest {
             @Override
             public void check(final Integer item, ConditionEvents events) {
                 for (int number : numbers) {
-                    events.add(new GreaterThanEvent(item, number));
+                    events.add(greaterThanEvent(item, number));
                 }
             }
         };
@@ -236,13 +236,10 @@ public class ArchConditionTest {
         return new ConditionWithInit(description);
     }
 
-    private static class GreaterThanEvent extends SimpleConditionEvent {
-        GreaterThanEvent(int item, int number) {
-            super(item, item > number,
-                    String.format(
-                            "%d is%s greater than %d",
-                            item, item <= number ? " not" : "", number));
-        }
+    private ConditionEvent greaterThanEvent(Integer item, int number) {
+        return new SimpleConditionEvent(item, item > number,
+                String.format("%d is%s greater than %d",
+                        item, item <= number ? " not" : "", number));
     }
 
     public static class ConditionWithInit extends ArchCondition<String> {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
@@ -174,7 +174,7 @@ public class ArchRuleTest {
             new ArchCondition<JavaClass>("always be violated") {
                 @Override
                 public void check(JavaClass item, ConditionEvents events) {
-                    events.add(new SimpleConditionEvent<>(item, false, "I'm violated"));
+                    events.add(new SimpleConditionEvent(item, false, "I'm violated"));
                 }
             };
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/CollectsLinesToJoinTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/CollectsLinesToJoinTest.java
@@ -1,0 +1,16 @@
+package com.tngtech.archunit.lang;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectsLinesToJoinTest {
+    @Test
+    public void ToJoin_joins_lines_on_given_separator() {
+        CollectsLinesToJoin linesToJoin = new CollectsLinesToJoin();
+        linesToJoin.add("one");
+        linesToJoin.add("two");
+        linesToJoin.add("three");
+        assertThat(linesToJoin.joinOn("#")).isEqualTo("one#two#three");
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ConditionEventsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ConditionEventsTest.java
@@ -1,9 +1,14 @@
 package com.tngtech.archunit.lang;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
@@ -12,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(DataProviderRunner.class)
 public class ConditionEventsTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
     @DataProvider
     public static Object[][] eventsWithEmpty() {
         return $$(
@@ -26,6 +34,72 @@ public class ConditionEventsTest {
         assertThat(events.isEmpty()).as("events are empty").isEqualTo(expectedEmpty);
     }
 
+    @Test
+    public void handleViolations_reports_only_violations_referring_to_the_correct_type() {
+        ConditionEvents events = events(
+                SimpleConditionEvent.satisfied(new CorrectType("don't handle"), "I'm not violated"),
+                SimpleConditionEvent.violated(new WrongType(), "I'm violated, but wrong type"),
+                SimpleConditionEvent.violated(new WrongSuperType(), "I'm violated, but wrong type"),
+                SimpleConditionEvent.violated(new CorrectType("handle type"), "I'm violated and correct type"),
+                SimpleConditionEvent.violated(new CorrectSubType("handle sub type"), "I'm violated and correct sub type"));
+
+        final Set<String> handledFailures = new HashSet<>();
+        events.handleViolations(new ObjectToStringAndMessageJoiningTestHandler(handledFailures));
+
+        assertThat(handledFailures).containsOnly(
+                "handle type: I'm violated and correct type",
+                "handle sub type: I'm violated and correct sub type");
+
+        handledFailures.clear();
+        events.handleViolations(new ViolationHandler<CorrectType>() {
+            @Override
+            public void handle(CorrectType violatingObject, String message) {
+                new ObjectToStringAndMessageJoiningTestHandler(handledFailures).handle(violatingObject, message);
+            }
+        });
+
+        assertThat(handledFailures).containsOnly(
+                "handle type: I'm violated and correct type",
+                "handle sub type: I'm violated and correct sub type");
+    }
+
+    @Test
+    public void handleViolations_joins_lines_with_new_line() {
+        ConditionEvents events = events(new SimpleConditionEvent(new CorrectType("ignore"), false, "ignore") {
+            @Override
+            public void describeTo(CollectsLines messages) {
+                messages.add("line one");
+                messages.add("line two");
+            }
+        });
+
+        final Set<String> onlyMessage = new HashSet<>();
+        events.handleViolations(new ViolationHandler<CorrectType>() {
+            @Override
+            public void handle(CorrectType violatingObject, String message) {
+                onlyMessage.add(message);
+            }
+        });
+        assertThat(onlyMessage).containsOnly("line one" + System.lineSeparator() + "line two");
+    }
+
+    @Test
+    public void handleViolations_reports_error_on_finding_handle_method() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage(getClass().getName() + "$");
+        thrown.expectMessage("unique method");
+        thrown.expectMessage("handle(T, String.class)");
+
+        events().handleViolations(new ViolationHandler<Object>() {
+            @Override
+            public void handle(Object violatingObject, String message) {
+            }
+
+            public void handle(String violatingObject, String message) {
+            }
+        });
+    }
+
     private static ConditionEvents events(ConditionEvent... events) {
         ConditionEvents result = new ConditionEvents();
         for (ConditionEvent event : events) {
@@ -33,4 +107,30 @@ public class ConditionEventsTest {
         }
         return result;
     }
+
+    private static class CorrectSubType extends CorrectType {
+        CorrectSubType(String message) {
+            super(message);
+        }
+    }
+
+    static class CorrectType extends WrongSuperType {
+        String message;
+
+        CorrectType(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public String toString() {
+            return message;
+        }
+    }
+
+    private static class WrongType {
+    }
+
+    private static class WrongSuperType {
+    }
+
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
@@ -24,7 +24,7 @@ public class EvaluationResultTest {
     private ConditionEvents events(String... messages) {
         ConditionEvents result = new ConditionEvents();
         for (String message : messages) {
-            result.add(new SimpleConditionEvent<>(new Object(), false, message));
+            result.add(new SimpleConditionEvent(new Object(), false, message));
         }
         return result;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
@@ -1,5 +1,11 @@
 package com.tngtech.archunit.lang;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.tngtech.archunit.core.domain.properties.HasDescription;
 import org.junit.Test;
 
@@ -21,10 +27,42 @@ public class EvaluationResultTest {
                 .contains("second bummer");
     }
 
+    @Test
+    public void allows_clients_to_handle_violations() {
+        EvaluationResult result = evaluationResultWith(
+                new SimpleConditionEvent(ImmutableSet.of("message"), false, "expected"),
+                new SimpleConditionEvent(ImmutableSet.of("other message"), true, "not expected"),
+                new SimpleConditionEvent(ImmutableList.of("yet another message"), false, "not expected"),
+                new SimpleConditionEvent(ImmutableSet.of("second message"), false, "also expected"));
+
+        final Set<String> actual = new HashSet<>();
+        result.handleViolations(new ViolationHandler<Set<?>>() {
+            @Override
+            public void handle(Set<?> violatingObject, String message) {
+                actual.add(Iterables.getOnlyElement(violatingObject) + ": " + message);
+            }
+        });
+
+        assertThat(actual).containsOnly("message: expected", "second message: also expected");
+    }
+
+
+    private EvaluationResult evaluationResultWith(ConditionEvent... events) {
+        return new EvaluationResult(hasDescription("unimportant"), events(events), Priority.MEDIUM);
+    }
+
     private ConditionEvents events(String... messages) {
-        ConditionEvents result = new ConditionEvents();
+        Set<ConditionEvent> events = new HashSet<>();
         for (String message : messages) {
-            result.add(new SimpleConditionEvent(new Object(), false, message));
+            events.add(new SimpleConditionEvent(new Object(), false, message));
+        }
+        return events(events.toArray(new ConditionEvent[events.size()]));
+    }
+
+    private ConditionEvents events(ConditionEvent... events) {
+        ConditionEvents result = new ConditionEvents();
+        for (ConditionEvent event : events) {
+            result.add(event);
         }
         return result;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
@@ -1,14 +1,15 @@
 package com.tngtech.archunit.lang;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.tngtech.archunit.core.domain.properties.HasDescription;
 import org.junit.Test;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EvaluationResultTest {
@@ -38,8 +39,8 @@ public class EvaluationResultTest {
         final Set<String> actual = new HashSet<>();
         result.handleViolations(new ViolationHandler<Set<?>>() {
             @Override
-            public void handle(Set<?> violatingObject, String message) {
-                actual.add(Iterables.getOnlyElement(violatingObject) + ": " + message);
+            public void handle(Collection<Set<?>> violatingObject, String message) {
+                actual.add(getOnlyElement(getOnlyElement(violatingObject)) + ": " + message);
             }
         });
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ObjectToStringAndMessageJoiningTestHandler.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ObjectToStringAndMessageJoiningTestHandler.java
@@ -1,0 +1,18 @@
+package com.tngtech.archunit.lang;
+
+import java.util.Set;
+
+import com.tngtech.archunit.lang.ConditionEventsTest.CorrectType;
+
+class ObjectToStringAndMessageJoiningTestHandler implements ViolationHandler<CorrectType> {
+    private final Set<String> messages;
+
+    ObjectToStringAndMessageJoiningTestHandler(Set<String> messages) {
+        this.messages = messages;
+    }
+
+    @Override
+    public void handle(CorrectType violatingObject, String message) {
+        messages.add(violatingObject + ": " + message);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ObjectToStringAndMessageJoiningTestHandler.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ObjectToStringAndMessageJoiningTestHandler.java
@@ -1,7 +1,9 @@
 package com.tngtech.archunit.lang;
 
+import java.util.Collection;
 import java.util.Set;
 
+import com.google.common.base.Joiner;
 import com.tngtech.archunit.lang.ConditionEventsTest.CorrectType;
 
 class ObjectToStringAndMessageJoiningTestHandler implements ViolationHandler<CorrectType> {
@@ -12,7 +14,7 @@ class ObjectToStringAndMessageJoiningTestHandler implements ViolationHandler<Cor
     }
 
     @Override
-    public void handle(CorrectType violatingObject, String message) {
-        messages.add(violatingObject + ": " + message);
+    public void handle(Collection<CorrectType> violatingObjects, String message) {
+        messages.add(Joiner.on(", ").join(violatingObjects) + ": " + message);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/SimpleConditionEventTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/SimpleConditionEventTest.java
@@ -1,0 +1,30 @@
+package com.tngtech.archunit.lang;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleConditionEventTest {
+    @Test
+    public void passes_corresponding_object_as_single_element_collection_with_message() {
+        final List<String> messages = new ArrayList<>();
+        ConditionEvent.Handler handler = new ConditionEvent.Handler() {
+            @Override
+            public void handle(Collection<?> correspondingObjects, String message) {
+                messages.add(getOnlyElement(correspondingObjects) + ": " + message);
+            }
+        };
+
+        SimpleConditionEvent.satisfied(77, "satisfied").handleWith(handler);
+        assertThat(messages).containsExactly("77: satisfied");
+
+        messages.clear();
+        SimpleConditionEvent.violated(88, "violated").handleWith(handler);
+        assertThat(messages).containsExactly("88: violated");
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainAnyConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainAnyConditionTest.java
@@ -18,7 +18,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 public class ContainAnyConditionTest {
-    static final List<Object> TWO_NONSERIALIZABLE_OBJECTS = asList(new Object(), new Object());
+    private static final List<Object> TWO_NONSERIALIZABLE_OBJECTS = asList(new Object(), new Object());
 
     @Test
     public void satisfied_works_and_description_contains_mismatches() {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainsOnlyConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainsOnlyConditionTest.java
@@ -22,7 +22,7 @@ public class ContainsOnlyConditionTest {
         @Override
         public void check(Object item, ConditionEvents events) {
             boolean satisfied = item instanceof Serializable;
-            events.add(new SimpleConditionEvent<>(item, satisfied, isSerializableMessageFor(item.getClass())));
+            events.add(new SimpleConditionEvent(item, satisfied, isSerializableMessageFor(item.getClass())));
         }
     };
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/NeverConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/NeverConditionTest.java
@@ -19,8 +19,8 @@ public class NeverConditionTest {
     private static final ArchCondition<Object> ONE_VIOLATED_ONE_SATISFIED = new ArchCondition<Object>("irrelevant") {
         @Override
         public void check(Object item, ConditionEvents events) {
-            events.add(new SimpleConditionEvent<>(item, false, ORIGINALLY_MISMATCH));
-            events.add(new SimpleConditionEvent<>(item, true, ORIGINALLY_NO_MISMATCH));
+            events.add(new SimpleConditionEvent(item, false, ORIGINALLY_MISMATCH));
+            events.add(new SimpleConditionEvent(item, true, ORIGINALLY_NO_MISMATCH));
         }
     };
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/handling/ViolationHandlingTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/handling/ViolationHandlingTest.java
@@ -1,0 +1,216 @@
+package com.tngtech.archunit.lang.handling;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.properties.HasOwner.Functions.Get;
+import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.ViolationHandler;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.domain.JavaAccess.Predicates.target;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatAccesses;
+import static com.tngtech.archunit.testutil.Assertions.expectedAccess;
+
+public class ViolationHandlingTest {
+    @Test
+    public void field_accesses_are_handled() {
+        EvaluationResult result = noClasses().should()
+                .accessTargetWhere(target(
+                        Get.<JavaClass>owner().is(equivalentTo(Target.class))))
+                .evaluate(importClasses(Origin.class, Target.class));
+
+        FieldAccessRecorder fieldAccessRecorder = new FieldAccessRecorder();
+        result.handleViolations(fieldAccessRecorder);
+
+        assertThat(fieldAccessRecorder.getRecords()).as("number of violations").hasSize(3);
+        assertThatAccesses(fieldAccessRecorder.getAccesses()).containOnly(
+                accessToTargetField("fieldOne"),
+                accessToTargetField("fieldTwo"),
+                accessToTargetField("fieldThree"));
+
+    }
+
+    @Test
+    public void method_calls_are_handled() {
+        EvaluationResult result = noClasses().should().accessClassesThat().haveFullyQualifiedName(Target.class.getName())
+                .evaluate(importClasses(Origin.class, Target.class));
+
+        MethodCallRecorder methodCallRecorder = new MethodCallRecorder();
+        result.handleViolations(methodCallRecorder);
+
+        assertThatAccesses(methodCallRecorder.getAccesses()).containOnly(
+                expectedAccess()
+                        .from(Origin.class, "call")
+                        .to(Target.class, "callMeOne"),
+                expectedAccess()
+                        .from(Origin.class, "call")
+                        .to(Target.class, "callMeTwo"));
+    }
+
+    @Test
+    public void constructor_calls_are_handled() {
+        EvaluationResult result = noClasses().should().accessClassesThat().haveFullyQualifiedName(Target.class.getName())
+                .evaluate(importClasses(Origin.class, Target.class));
+
+        ConstructorCallRecorder constructorCallRecorder = new ConstructorCallRecorder();
+        result.handleViolations(constructorCallRecorder);
+
+        assertThatAccesses(constructorCallRecorder.getAccesses()).containOnly(
+                expectedAccess()
+                        .from(Origin.class, "callConstructor")
+                        .toConstructor(Target.class),
+                expectedAccess()
+                        .from(Origin.class, "callConstructor")
+                        .toConstructor(Target.class, String.class));
+    }
+
+    @Test
+    public void accesses_are_handled() {
+        EvaluationResult result = noClasses().should().accessClassesThat().haveFullyQualifiedName(Target.class.getName())
+                .evaluate(importClasses(Origin.class, Target.class));
+
+        CallRecorder callRecorder = new CallRecorder();
+        result.handleViolations(callRecorder);
+
+        assertThat(callRecorder.getRecords()).as("Recorded calls").hasSize(4);
+
+        AccessRecorder accessRecorder = new AccessRecorder();
+        result.handleViolations(accessRecorder);
+
+        assertThat(accessRecorder.getRecords()).as("Recorded accesses").hasSize(7);
+    }
+
+    @Test
+    public void multiple_accesses_necessary_for_violation_are_reported_together() {
+        EvaluationResult result = classes().should().accessField(Target.class, "notExisting")
+                .evaluate(importClasses(Origin.class, Target.class));
+
+        FieldAccessRecorder fieldAccessRecorder = new FieldAccessRecorder();
+        result.handleViolations(fieldAccessRecorder);
+
+        assertThat(fieldAccessRecorder.getRecords()).as("number of violations").hasSize(1);
+        ReportedViolation<JavaFieldAccess> reportedViolation = getOnlyElement(fieldAccessRecorder.getRecords());
+        assertThatAccesses(reportedViolation.accesses)
+                .contain(accessToTargetField("fieldOne"))
+                .contain(accessToTargetField("fieldTwo"))
+                .contain(accessToTargetField("fieldThree"));
+    }
+
+    private Condition<JavaAccess<?>> accessToTargetField(String fieldOne) {
+        return expectedAccess()
+                .from(Origin.class, CONSTRUCTOR_NAME)
+                .to(Target.class, fieldOne);
+    }
+
+    private static class Origin {
+        Target target;
+
+        public Origin() {
+            target.fieldOne = "changed";
+            target.fieldTwo = "changed";
+            target.fieldThree = 42;
+        }
+
+        void call() {
+            target.callMeOne();
+            target.callMeTwo();
+        }
+
+        void callConstructor() {
+            new Target();
+            new Target("fieldOne");
+        }
+    }
+
+    private static class Target {
+        String fieldOne;
+        Object fieldTwo;
+        int fieldThree;
+
+        Target() {
+        }
+
+        Target(String fieldOne) {
+        }
+
+        void callMeOne() {
+        }
+
+        void callMeTwo() {
+
+        }
+    }
+
+    private static class ReportedViolation<T extends JavaAccess<?>> {
+        final Collection<T> accesses;
+        final String message;
+
+        ReportedViolation(Collection<? extends T> accesses, String message) {
+            this.accesses = ImmutableList.copyOf(accesses);
+            this.message = message;
+        }
+
+        @Override
+        public String toString() {
+            return "ReportedViolation{" +
+                    "accesses=" + accesses +
+                    ", message='" + message + '\'' +
+                    '}';
+        }
+    }
+
+    private static class AbstractAccessRecorder<T extends JavaAccess<?>> implements ViolationHandler<T> {
+        private final List<ReportedViolation<T>> reportedViolations = new ArrayList<>();
+
+        @Override
+        public void handle(Collection<T> violatingObjects, String message) {
+            reportedViolations.add(new ReportedViolation<>(violatingObjects, message));
+        }
+
+        List<ReportedViolation<T>> getRecords() {
+            return reportedViolations;
+        }
+
+        Set<T> getAccesses() {
+            Set<T> result = new HashSet<>();
+            for (ReportedViolation<T> violation : reportedViolations) {
+                result.addAll(violation.accesses);
+            }
+            return result;
+        }
+    }
+
+    private static class AccessRecorder extends AbstractAccessRecorder<JavaAccess<?>> {
+    }
+
+    private static class CallRecorder extends AbstractAccessRecorder<JavaCall<?>> {
+    }
+
+    private static class FieldAccessRecorder extends AbstractAccessRecorder<JavaFieldAccess> {
+    }
+
+    private static class MethodCallRecorder extends AbstractAccessRecorder<JavaMethodCall> {
+    }
+
+    private static class ConstructorCallRecorder extends AbstractAccessRecorder<JavaConstructorCall> {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/GraphTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/GraphTest.java
@@ -63,6 +63,7 @@ public class GraphTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void multiple_cycles_are_detected() {
         Graph<String, String> graph = new Graph<>();
 
@@ -102,7 +103,8 @@ public class GraphTest {
         return new Cycle<>(path.append(new SimpleEdge(path.getEnd(), path.getStart())));
     }
 
-    private void addCycles(Graph<String, String> graph, Cycle<String, String>... cycles) {
+    @SafeVarargs
+    private final void addCycles(Graph<String, String> graph, Cycle<String, String>... cycles) {
         for (Cycle<String, String> cycle : cycles) {
             for (Edge<String, String> edge : cycle.getEdges()) {
                 graph.add(edge.getFrom(), Collections.<Edge<String, String>>emptySet());
@@ -118,7 +120,7 @@ public class GraphTest {
         graph.add(target, ImmutableSet.copyOf(singleEdgeList(origin, target)));
     }
 
-    static void assertEdgeExists(Cycle<?, ?> cycle, Object from, Object to) {
+    private static void assertEdgeExists(Cycle<?, ?> cycle, Object from, Object to) {
         for (Edge<?, ?> edge : cycle.getEdges()) {
             if (edge.getFrom().equals(from) && edge.getTo().equals(to)) {
                 return;

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SimpleEdge.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SimpleEdge.java
@@ -9,11 +9,11 @@ class SimpleEdge extends Edge<String, String> {
         super(from, to);
     }
 
-    public static List<Edge<String, String>> singleEdgeList(String from, String to) {
+    static List<Edge<String, String>> singleEdgeList(String from, String to) {
         return Collections.<Edge<String, String>>singletonList(new SimpleEdge(from, to));
     }
 
-    public static Set<Edge<String, String>> singleEdge(String from, String to) {
+    static Set<Edge<String, String>> singleEdge(String from, String to) {
         return Collections.<Edge<String, String>>singleton(new SimpleEdge(from, to));
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -61,7 +61,6 @@ import static com.tngtech.archunit.core.domain.JavaModifier.STATIC;
 import static com.tngtech.archunit.core.domain.JavaModifier.SYNCHRONIZED;
 import static com.tngtech.archunit.core.domain.JavaModifier.TRANSIENT;
 import static com.tngtech.archunit.core.domain.JavaModifier.VOLATILE;
-import static com.tngtech.archunit.core.domain.TestUtils.classForName;
 import static com.tngtech.archunit.core.domain.TestUtils.invoke;
 
 public class Assertions extends org.assertj.core.api.Assertions {
@@ -341,10 +340,11 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return String.format("(%s)", formatMethodParameterTypeNames(namesOf(parameterTypes)));
     }
 
+    @SuppressWarnings("rawtypes")
     private static Set<Map<String, Object>> propertiesOf(Set<JavaAnnotation> annotations) {
         List<Annotation> converted = new ArrayList<>();
         for (JavaAnnotation annotation : annotations) {
-            converted.add(annotation.as((Class) classForName(annotation.getType().getName())));
+            converted.add(annotation.as((Class) annotation.getType().reflect()));
         }
         return propertiesOf(converted.toArray(new Annotation[converted.size()]));
     }
@@ -377,7 +377,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
             return new SimpleEnumConstantReference((Enum<?>) value);
         }
         if (value instanceof Enum[]) {
-            return SimpleEnumConstantReference.allOf((Enum[]) value);
+            return SimpleEnumConstantReference.allOf((Enum<?>[]) value);
         }
         if (value instanceof Annotation) {
             return propertiesOf((Annotation) value);
@@ -458,9 +458,9 @@ public class Assertions extends org.assertj.core.api.Assertions {
             return type + "." + name;
         }
 
-        static List<SimpleEnumConstantReference> allOf(Enum[] values) {
+        static List<SimpleEnumConstantReference> allOf(Enum<?>[] values) {
             ImmutableList.Builder<SimpleEnumConstantReference> result = ImmutableList.builder();
-            for (Enum value : values) {
+            for (Enum<?> value : values) {
                 result.add(new SimpleEnumConstantReference(value));
             }
             return result.build();
@@ -490,7 +490,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
             }
         }
 
-        private List<String> messagesOf(Collection<ConditionEvent> events) {
+        private List<String> messagesOf(Collection<? extends ConditionEvent> events) {
             final List<String> result = new ArrayList<>();
             CollectsLines messages = new CollectsLines() {
                 @Override

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -27,15 +28,23 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassList;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.lang.CollectsLines;
 import com.tngtech.archunit.lang.ConditionEvent;
@@ -44,11 +53,13 @@ import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Condition;
 import org.objectweb.asm.Type;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethodParameterTypeNames;
+import static com.tngtech.archunit.core.domain.Formatters.formatMethodSimple;
 import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT;
@@ -62,6 +73,8 @@ import static com.tngtech.archunit.core.domain.JavaModifier.SYNCHRONIZED;
 import static com.tngtech.archunit.core.domain.JavaModifier.TRANSIENT;
 import static com.tngtech.archunit.core.domain.JavaModifier.VOLATILE;
 import static com.tngtech.archunit.core.domain.TestUtils.invoke;
+import static com.tngtech.archunit.core.domain.TestUtils.resolvedTargetFrom;
+import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     public static ConditionEventsAssert assertThat(ConditionEvents events) {
@@ -110,6 +123,77 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static JavaEnumConstantsAssertion assertThat(JavaEnumConstant[] enumConstants) {
         return new JavaEnumConstantsAssertion(enumConstants);
+    }
+
+    @SuppressWarnings("unchecked") // covariant
+    public static AccessesAssertion assertThatAccesses(Collection<? extends JavaAccess<?>> accesses) {
+        return new AccessesAssertion((Collection<JavaAccess<?>>) accesses);
+    }
+
+    public static ExectedAccessCreation expectedAccess() {
+        return new ExectedAccessCreation();
+    }
+
+    public static class ExectedAccessCreation {
+        private ExectedAccessCreation() {
+        }
+
+        public Step2 from(Class<?> originClass, String codeUnitName) {
+            return new Step2(originClass, codeUnitName);
+        }
+
+        public class Step2 {
+            private final Class<?> originClass;
+            private final String originCodeUnitName;
+
+            private Step2(Class<?> originClass, String originCodeUnitName) {
+                this.originClass = originClass;
+                this.originCodeUnitName = originCodeUnitName;
+            }
+
+            public Condition<JavaAccess<?>> to(final Class<?> targetClass, final String targetName) {
+                return new Condition<JavaAccess<?>>(
+                        String.format("%s from %s.%s to %s.%s",
+                                JavaAccess.class.getSimpleName(),
+                                originClass.getName(), originCodeUnitName,
+                                targetClass.getSimpleName(), targetName)) {
+                    @Override
+                    public boolean matches(JavaAccess<?> access) {
+                        return access.getOriginOwner().isEquivalentTo(originClass) &&
+                                access.getOrigin().getName().equals(originCodeUnitName) &&
+                                access.getTargetOwner().isEquivalentTo(targetClass) &&
+                                access.getTarget().getName().equals(targetName);
+                    }
+                };
+            }
+
+            public Condition<JavaAccess<?>> toConstructor(final Class<?> targetClass, final Class<?>... paramTypes) {
+                final List<String> paramTypeNames = namesOf(paramTypes);
+                return new Condition<JavaAccess<?>>(
+                        String.format("%s from %s.%s to %s",
+                                JavaAccess.class.getSimpleName(),
+                                originClass.getName(), originCodeUnitName,
+                                formatMethodSimple(targetClass.getSimpleName(), CONSTRUCTOR_NAME, paramTypeNames))) {
+                    @Override
+                    public boolean matches(JavaAccess<?> access) {
+                        return to(targetClass, CONSTRUCTOR_NAME).matches(access) &&
+                                ((ConstructorCallTarget) access.getTarget()).getParameters().getNames().equals(paramTypeNames);
+                    }
+                };
+            }
+        }
+    }
+
+    public static AccessToFieldAssertion assertThatAccess(JavaFieldAccess access) {
+        return new AccessToFieldAssertion(access);
+    }
+
+    public static MethodCallAssertion assertThatCall(JavaMethodCall call) {
+        return new MethodCallAssertion(call);
+    }
+
+    public static ConstructorCallAssertion assertThatCall(JavaConstructorCall call) {
+        return new ConstructorCallAssertion(call);
     }
 
     public static class JavaClassesAssertion extends AbstractObjectAssert<JavaClassesAssertion, JavaClass[]> {
@@ -532,6 +616,156 @@ public class Assertions extends org.assertj.core.api.Assertions {
                 assertion.as("Violation message").contains(part);
             }
             return this;
+        }
+    }
+
+    public static class AccessesAssertion {
+        private final Set<JavaAccess<?>> actualRemaining;
+
+        AccessesAssertion(Collection<JavaAccess<?>> accesses) {
+            this.actualRemaining = new HashSet<>(accesses);
+        }
+
+        public AccessesAssertion contain(Condition<? super JavaAccess<?>> condition) {
+            for (Iterator<JavaAccess<?>> iterator = actualRemaining.iterator(); iterator.hasNext(); ) {
+                if (condition.matches(iterator.next())) {
+                    iterator.remove();
+                    return this;
+                }
+            }
+            throw new AssertionError("No access matches " + condition);
+        }
+
+        @SafeVarargs
+        public final AccessesAssertion containOnly(Condition<? super JavaAccess<?>>... conditions) {
+            for (Condition<? super JavaAccess<?>> condition : conditions) {
+                contain(condition);
+            }
+            assertThat(actualRemaining).as("Unexpected " + JavaAccess.class.getSimpleName()).isEmpty();
+            return this;
+        }
+    }
+
+    protected abstract static class BaseAccessAssertion<
+            SELF extends BaseAccessAssertion<SELF, ACCESS, TARGET>,
+            ACCESS extends JavaAccess<TARGET>,
+            TARGET extends AccessTarget> {
+
+        ACCESS access;
+
+        BaseAccessAssertion(ACCESS access) {
+            this.access = access;
+        }
+
+        public SELF isFrom(Class<?> owner, String name, Class<?>... parameterTypes) {
+            assertThat(access.getOrigin().getOwner()).matches(owner);
+            return isFrom(access.getOrigin().getOwner().getCodeUnitWithParameterTypes(name, parameterTypes));
+        }
+
+        public SELF isFrom(String name, Class<?>... parameterTypes) {
+            return isFrom(access.getOrigin().getOwner().getCodeUnitWithParameterTypes(name, parameterTypes));
+        }
+
+        public SELF isFrom(JavaCodeUnit codeUnit) {
+            assertThat(access.getOrigin()).as("Origin of field access").isEqualTo(codeUnit);
+            return newAssertion(access);
+        }
+
+        public SELF isTo(TARGET target) {
+            assertThat(access.getTarget()).as("Target of " + access.getName()).isEqualTo(target);
+            return newAssertion(access);
+        }
+
+        public SELF isTo(Condition<TARGET> target) {
+            assertThat(access.getTarget()).as("Target of " + access.getName()).is(target);
+            return newAssertion(access);
+        }
+
+        public void inLineNumber(int number) {
+            assertThat(access.getLineNumber())
+                    .as("Line number of access to " + access.getName())
+                    .isEqualTo(number);
+        }
+
+        protected abstract SELF newAssertion(ACCESS access);
+    }
+
+    public static class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAssertion, JavaFieldAccess, FieldAccessTarget> {
+        private AccessToFieldAssertion(JavaFieldAccess access) {
+            super(access);
+        }
+
+        @Override
+        protected AccessToFieldAssertion newAssertion(JavaFieldAccess access) {
+            return new AccessToFieldAssertion(access);
+        }
+
+        public AccessToFieldAssertion isTo(Class<?> owner, String name) {
+            assertThat(access.getTarget().getOwner()).matches(owner);
+
+            return isTo(access.getTarget().getOwner().getField(name));
+        }
+
+        public AccessToFieldAssertion isTo(String name) {
+            return isTo(access.getTarget().getOwner().getField(name));
+        }
+
+        public AccessToFieldAssertion isTo(JavaField field) {
+            return isTo(targetFrom(field));
+        }
+
+        public AccessToFieldAssertion isOfType(JavaFieldAccess.AccessType type) {
+            assertThat(access.getAccessType()).isEqualTo(type);
+            return newAssertion(access);
+        }
+    }
+
+    public static class MethodCallAssertion extends BaseAccessAssertion<MethodCallAssertion, JavaMethodCall, MethodCallTarget> {
+        private MethodCallAssertion(JavaMethodCall call) {
+            super(call);
+        }
+
+        public MethodCallAssertion isTo(final Class<?> targetOwner, final String methodName) {
+            return isTo(new Condition<MethodCallTarget>() {
+                @Override
+                public boolean matches(MethodCallTarget target) {
+                    return target.getOwner().isEquivalentTo(targetOwner) && target.getName().equals(methodName);
+                }
+            });
+        }
+
+        public MethodCallAssertion isTo(JavaMethod target) {
+            return isTo(resolvedTargetFrom(target));
+        }
+
+        @Override
+        protected MethodCallAssertion newAssertion(JavaMethodCall call) {
+            return new MethodCallAssertion(call);
+        }
+    }
+
+    public static class ConstructorCallAssertion extends BaseAccessAssertion<ConstructorCallAssertion, JavaConstructorCall, ConstructorCallTarget> {
+        private ConstructorCallAssertion(JavaConstructorCall call) {
+            super(call);
+        }
+
+        public ConstructorCallAssertion isTo(final Class<?> targetOwner) {
+            return isTo(new Condition<ConstructorCallTarget>() {
+                @Override
+                public boolean matches(ConstructorCallTarget target) {
+                    return target.getOwner().isEquivalentTo(targetOwner);
+                }
+            });
+        }
+
+
+        public ConstructorCallAssertion isTo(JavaConstructor target) {
+            return isTo(targetFrom(target));
+        }
+
+        @Override
+        protected ConstructorCallAssertion newAssertion(JavaConstructorCall call) {
+            return new ConstructorCallAssertion(call);
         }
     }
 }


### PR DESCRIPTION
This adds an API for 3rd party clients to access information about violations.
Up to now, `rule.evaluate(classes)` didn't give a lot of useful information to react to violations, e.g. for drawing some kind of external report, etc.
Now it's possible to react to certain types of objects, contributing to a violation, like `JavaFieldAccess`, etc.
The first draft of the API can be used the following way

```
ArchRule rule = noClasses().should().accessField(System.class, "out");
EvaluationResult result = rule.evaluate(classes);
result.handleViolations(new ViolationHandler<JavaFieldAccess>() {
    @Override
    public void handle(Collection<JavaFieldAccess> violatingObjects, String message) {
        // handle field accesses causing a violation
    }
});
```

The handler will be notified about all objects of an assignable type, i.e. `ViolationHandler<JavaAccess<?>>` will be notified about all violations any `JavaAccess` contributed to, `ViolationHandler<JavaMethodCall>` will only be notified about violations caused by method calls.