### PR TITLE
NPE demonstration

### DIFF
--- a/archunit-example/src/main/java/com/bar/Allow.java
+++ b/archunit-example/src/main/java/com/bar/Allow.java
@@ -1,0 +1,4 @@
+package com.bar;
+
+public @interface Allow {
+}

--- a/archunit-example/src/main/java/com/bar/evil/Evil.java
+++ b/archunit-example/src/main/java/com/bar/evil/Evil.java
@@ -1,0 +1,4 @@
+package com.bar.evil;
+
+public class Evil {
+}

--- a/archunit-example/src/main/java/com/bar/some/Bad.java
+++ b/archunit-example/src/main/java/com/bar/some/Bad.java
@@ -1,0 +1,9 @@
+package com.bar.some;
+
+import com.bar.evil.Evil;
+
+public class Bad {
+    public Bad() {
+        new Evil();
+    }
+}

--- a/archunit-example/src/main/java/com/bar/some/Okay.java
+++ b/archunit-example/src/main/java/com/bar/some/Okay.java
@@ -1,0 +1,11 @@
+package com.bar.some;
+
+import com.bar.Allow;
+import com.bar.evil.Evil;
+
+@Allow
+public class Okay {
+    public Okay() {
+        new Evil();
+    }
+}

--- a/archunit-example/src/test/java/com/bar/IgnoreByAnnotationWorksTest.java
+++ b/archunit-example/src/test/java/com/bar/IgnoreByAnnotationWorksTest.java
@@ -1,0 +1,18 @@
+package com.bar;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "com.bar")
+public class IgnoreByAnnotationWorksTest {
+    @ArchTest
+    public static final ArchRule ignoring_classes_annotated_with_Allow =
+            noClasses().that().areNotAnnotatedWith(Allow.class)
+                    .should().accessClassesThat().resideInAPackage("com.bar.evil");
+}

--- a/archunit-example/src/test/resources/log4j2.xml
+++ b/archunit-example/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -250,6 +251,9 @@ class JavaClassProcessor extends ClassVisitor {
             return;
         }
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Found annotations {} on class '{}'", annotations.stream().map(a -> a.getJavaType().getName()).collect(Collectors.joining(", ", "[", "]")), this.className);
+        }
         declarationHandler.onDeclaredAnnotations(annotations);
         LOG.debug("Done analysing {}", className);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -27,6 +27,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nam
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 import static org.mockito.Matchers.any;
@@ -206,8 +207,24 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void areAnnotatedWith_type_inverse() {
+        List<JavaClass> classes = filterResultOf(noClasses().that().areNotAnnotatedWith(SomeAnnotation.class))
+                .on(AnnotatedClass.class, SimpleClass.class);
+
+        assertThat(getOnlyElement(classes)).matches(AnnotatedClass.class);
+    }
+
+    @Test
     public void areNotAnnotatedWith_type() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotAnnotatedWith(SomeAnnotation.class))
+                .on(AnnotatedClass.class, SimpleClass.class);
+
+        assertThat(getOnlyElement(classes)).matches(SimpleClass.class);
+    }
+
+    @Test
+    public void areNotAnnotatedWith_type_usingNoClasses() {
+        List<JavaClass> classes = filterResultOf(noClasses().that().areAnnotatedWith(SomeAnnotation.class))
                 .on(AnnotatedClass.class, SimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(SimpleClass.class);

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,8 @@ subprojects {
     def addModuleDescription = { "${it} - Module '${project.name}'" }
     description addModuleDescription(rootProject.description)
 
-    sourceCompatibility = '1.7'
-    targetCompatibility = '1.7'
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
 
     tasks.withType(Jar) {
         manifest {


### PR DESCRIPTION
I wanted to check the behavior of `noClasses: All classes having an annotation should be the same as no classes with not that annotation. But that test case simply throws an NPE. I don't know the reason for it. Maybe @codecholeric sees it directly.

<details>

```
java.lang.NullPointerException
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
	at java.util.regex.Matcher.reset(Matcher.java:309)
	at java.util.regex.Matcher.<init>(Matcher.java:229)
	at java.util.regex.Pattern.matcher(Pattern.java:1093)
	at java.util.Formatter.parse(Formatter.java:2547)
	at java.util.Formatter.format(Formatter.java:2501)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at com.tngtech.archunit.lang.ArchCondition.as(ArchCondition.java:65)
	at com.tngtech.archunit.lang.syntax.ArchRuleDefinition$1.apply(ArchRuleDefinition.java:119)
	at com.tngtech.archunit.lang.syntax.ArchRuleDefinition$1.apply(ArchRuleDefinition.java:116)
	at com.tngtech.archunit.lang.syntax.ObjectsShouldInternal$FinishedRule.createCondition(ObjectsShouldInternal.java:100)
	at com.tngtech.archunit.lang.syntax.ObjectsShouldInternal$FinishedRule.get(ObjectsShouldInternal.java:96)
	at com.tngtech.archunit.lang.syntax.ObjectsShouldInternal$FinishedRule.get(ObjectsShouldInternal.java:93)
	at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:131)
	at com.tngtech.archunit.lang.syntax.ObjectsShouldInternal.check(ObjectsShouldInternal.java:75)
	at com.tngtech.archunit.lang.syntax.elements.GivenClassesThatTest$Evaluator.on(GivenClassesThatTest.java:481)
	at com.tngtech.archunit.lang.syntax.elements.GivenClassesThatTest.areAnnotatedWith_type_inverse(GivenClassesThatTest.java:225)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.mockito.internal.junit.JUnitRule$1.evaluate(JUnitRule.java:16)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```
</details>