### PR TITLE
failing rules also show how often a rule was violated

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConfiguredMessageFormat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConfiguredMessageFormat.java
@@ -29,9 +29,8 @@ class ConfiguredMessageFormat {
 
     String formatFailure(HasDescription rule, Collection<String> failureMessages, Priority priority) {
         String violationTexts = Joiner.on(System.lineSeparator()).join(failureMessages);
-        String priorityPrefix = String.format("Architecture Violation [Priority: %s] - ", priority.asString());
-        String message = String.format("Rule '%s' was violated:%n%s", rule.getDescription(), violationTexts);
-        return priorityPrefix + message;
+        return String.format("Architecture Violation [Priority: %s] - Rule '%s' was violated (%d times):%n%s",
+                priority.asString(), rule.getDescription(), failureMessages.size(), violationTexts);
     }
 
     <T> String formatRuleText(HasDescription itemsUnderTest, ArchCondition<T> condition) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
@@ -111,6 +111,13 @@ public class ArchRuleTest {
                 "classes should access classes that have fully qualified name 'foo', because this is the way");
     }
 
+    @Test
+    public void reports_number_of_violations() {
+        EvaluationResult result = all(classes()).should(addFixedNumberOfViolations(3)).evaluate(javaClassesViaReflection(Object.class, String.class));
+
+        assertThat(result.getFailureReport().toString()).contains("(6 times)");
+    }
+
     private void writeIgnoreFileWithPatterns(String... patterns) throws IOException {
         File ignoreFile = ignoreFile();
         ignoreFile.delete();
@@ -165,6 +172,17 @@ public class ArchRuleTest {
             public void check(JavaClass item, ConditionEvents events) {
                 for (String message : messages) {
                     events.add(SimpleConditionEvent.violated(item, message));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> addFixedNumberOfViolations(final int number) {
+        return new ArchCondition<JavaClass>(String.format("be violated exactly %d times", number)) {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (int i = 0; i < number; i++) {
+                    events.add(SimpleConditionEvent.violated(item, item.getSimpleName() + " violation " + i));
                 }
             }
         };


### PR DESCRIPTION
Especially when working with _legacy_ code, rules may have a large number of violations.
It is often helpful to have this number explicitly displayed, for example to easily judge whether a refactoring reduces the number or not.

I hereby agree to the terms of the ArchUnit Contributor License Agreement.