### PR TITLE
add missing gradle task dependencies, enabling to run `./gradlew clean test'

### DIFF
--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -10,4 +10,4 @@ dependencies {
     testCompile project(path: ':archunit-example', configuration: 'tests')
 }
 
-[project(':archunit'), project(':archunit-junit')].each { test.dependsOn(it.finishArchive) }
+test.dependsOn(':archunit:finishArchive', ':archunit-junit:removeDuplicateThirdParty')

--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -10,4 +10,4 @@ dependencies {
     testCompile project(path: ':archunit-example', configuration: 'tests')
 }
 
-test.dependsOn(':archunit:finishArchive', ':archunit-junit:removeDuplicateThirdParty')
+[project(':archunit'), project(':archunit-junit')].each { test.dependsOn(it.finishArchive) }

--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -52,9 +52,8 @@ task removeDuplicateThirdParty(type: Jar, dependsOn: [shrinkDependencies, projec
         assert shrinkDependencies.archivePath.delete()
         assert tempPath.renameTo(shrinkDependencies.archivePath)
     }
-
-    finalizedBy finishArchive
 }
+finishArchive.dependsOn removeDuplicateThirdParty
 assemble.dependsOn removeDuplicateThirdParty
 
 def configureDependenciesAfterShadow = { pom ->

--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -54,7 +54,6 @@ task removeDuplicateThirdParty(type: Jar, dependsOn: [shrinkDependencies, projec
     }
 }
 finishArchive.dependsOn removeDuplicateThirdParty
-assemble.dependsOn removeDuplicateThirdParty
 
 def configureDependenciesAfterShadow = { pom ->
     pom.dependencies.removeAll {

--- a/build-steps/archiving/archiving.gradle
+++ b/build-steps/archiving/archiving.gradle
@@ -88,7 +88,7 @@ def configureProGuard = {
     }
     assemble.dependsOn(shrinkDependencies)
 
-    task finishArchive {
+    task finishArchive(dependsOn: shrinkDependencies) {
         doLast {
             assert jar.archivePath.delete()
             Files.copy(shrinkDependencies.archivePath.toPath(), jar.archivePath.toPath())

--- a/build-steps/archiving/archiving.gradle
+++ b/build-steps/archiving/archiving.gradle
@@ -90,7 +90,7 @@ def configureProGuard = {
 
     task finishArchive(dependsOn: shrinkDependencies) {
         doLast {
-            assert jar.archivePath.delete()
+            jar.archivePath.delete()
             Files.copy(shrinkDependencies.archivePath.toPath(), jar.archivePath.toPath())
         }
         mustRunAfter jar


### PR DESCRIPTION
Previously, `./gradlew clean test` gave me:
```Parallel execution is an incubating feature.
:archunit:clean
:archunit-example:clean
:archunit-integration-test:clean
:archunit-junit:clean
:archunit-junit:addLicenseHeader
:archunit-junit:processResources NO-SOURCE
:archunit-junit:processTestResources NO-SOURCE
:archunit-integration-test:compileJava
:archunit-example:compileJava
:archunit-integration-test:compileJava NO-SOURCE
:archunit-integration-test:processResources NO-SOURCE
:archunit-integration-test:classes UP-TO-DATE
:archunit-integration-test:processTestResources
warning: [options] bootstrap class path not set in conjunction with -source 1.7
:archunit:addLicenseHeader
:archunit:compileJava1 warning

:archunit-example:processResources NO-SOURCE
:archunit-example:classes
:archunit-example:processTestResources
:archunit-example:jarwarning: [options] bootstrap class path not set in conjunction with -source 1.7

1 warning
:archunit:processResources NO-SOURCE
:archunit:classes
:archunit:compileTestJavawarning: [options] bootstrap class path not set in conjunction with -source 1.7
Note: $ArchUnit/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

:archunit:processTestResources
:archunit:testClasses
:archunit:test
:archunit:jar
:archunit:shadowJar
:archunit:testJar
:archunit-junit:compileJava
:archunit:finishArchive FAILED
warning: [options] bootstrap class path not set in conjunction with -source 1.7
1 warning

FAILURE: Build failed with an exception.

* Where:
Script '$ArchUnit/build-steps/archiving/archiving.gradle' line: 94

* What went wrong:
Execution failed for task ':archunit:finishArchive'.
> java.nio.file.NoSuchFileException: $ArchUnit/archunit/build/libs/archunit-0.5.0-SNAPSHOT-proguard.jar

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 13s
19 actionable tasks: 19 executed
```
I'm not very experienced with gradle, but adding some `dependsOn` clauses (seeming reasonable to me) has solved the issue.