### PR TITLE
@ArchIgnore should work correctly on ArchRules fields

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ArchUnitIntegrationTestRunner.java
@@ -1,6 +1,7 @@
 package com.tngtech.archunit.junit;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -14,6 +15,7 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.mockito.Mockito.mock;
 
 public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
     public ArchUnitIntegrationTestRunner(Class<?> testClass) throws InitializationError {
@@ -113,7 +115,7 @@ public class ArchUnitIntegrationTestRunner extends ArchUnitRunner {
         private JavaClasses classes;
 
         ClassesCaptor() {
-            super(Object.class);
+            super(Object.class, mock(AnnotatedElement.class), false);
         }
 
         @Override

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
@@ -30,8 +30,8 @@ class ArchRuleExecution extends ArchTestExecution {
     @VisibleForTesting
     final ArchRule rule;
 
-    ArchRuleExecution(Class<?> testClass, Field ruleField) {
-        super(testClass);
+    ArchRuleExecution(Class<?> testClass, Field ruleField, boolean forceIgnore) {
+        super(testClass, ruleField, forceIgnore);
 
         validatePublicStatic(ruleField);
         checkArgument(ArchRule.class.isAssignableFrom(ruleField.getType()),

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRules.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchRules.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.junit.ReflectionUtils.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.junit.ArchTestExecution.elementShouldBeIgnored;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllFields;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllMethods;
 
@@ -56,21 +57,21 @@ public final class ArchRules {
         return new ArchRules(definitionLocation);
     }
 
-    Set<ArchTestExecution> asTestExecutions() {
+    Set<ArchTestExecution> asTestExecutions(boolean forceIgnore) {
         ImmutableSet.Builder<ArchTestExecution> result = ImmutableSet.builder();
         for (Field field : fields) {
-            result.addAll(archRuleExecutionsOf(field));
+            result.addAll(archRuleExecutionsOf(field, forceIgnore));
         }
         for (Method method : methods) {
-            result.add(new ArchTestMethodExecution(method.getDeclaringClass(), method));
+            result.add(new ArchTestMethodExecution(method.getDeclaringClass(), method, forceIgnore));
         }
         return result.build();
     }
 
-    private Set<ArchTestExecution> archRuleExecutionsOf(Field field) {
+    private Set<ArchTestExecution> archRuleExecutionsOf(Field field, boolean forceIgnore) {
         return ArchRules.class.isAssignableFrom(field.getType()) ?
-                getArchRulesIn(field).asTestExecutions() :
-                Collections.<ArchTestExecution>singleton(new ArchRuleExecution(field.getDeclaringClass(), field));
+                getArchRulesIn(field).asTestExecutions(forceIgnore || elementShouldBeIgnored(field)) :
+                Collections.<ArchTestExecution>singleton(new ArchRuleExecution(field.getDeclaringClass(), field, forceIgnore));
     }
 
     private ArchRules getArchRulesIn(Field field) {

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -26,8 +26,8 @@ import org.junit.runners.model.FrameworkMethod;
 class ArchTestMethodExecution extends ArchTestExecution {
     private final Method testMethod;
 
-    ArchTestMethodExecution(Class<?> testClass, Method testMethod) {
-        super(testClass);
+    ArchTestMethodExecution(Class<?> testClass, Method testMethod, boolean forceIgnore) {
+        super(testClass, testMethod, forceIgnore);
         this.testMethod = validatePublicStatic(testMethod);
     }
 

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
@@ -33,6 +33,7 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.junit.ArchTestExecution.elementShouldBeIgnored;
 
 /**
  * Evaluates {@link ArchRule ArchRules} against the classes inside of the packages specified via
@@ -80,9 +81,10 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
 
     private Set<ArchTestExecution> findArchRulesIn(FrameworkField ruleField) {
         if (ruleField.getType() == ArchRules.class) {
-            return getArchRules(ruleField).asTestExecutions();
+            boolean ignore = elementShouldBeIgnored(ruleField.getField());
+            return getArchRules(ruleField).asTestExecutions(ignore);
         }
-        return Collections.<ArchTestExecution>singleton(new ArchRuleExecution(getTestClass().getJavaClass(), ruleField.getField()));
+        return Collections.<ArchTestExecution>singleton(new ArchRuleExecution(getTestClass().getJavaClass(), ruleField.getField(), false));
     }
 
     private ArchRules getArchRules(FrameworkField ruleField) {
@@ -97,7 +99,7 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
     private Collection<ArchTestExecution> findArchRuleMethods() {
         List<ArchTestExecution> result = new ArrayList<>();
         for (FrameworkMethod testMethod : getTestClass().getAnnotatedMethods(ArchTest.class)) {
-            result.add(new ArchTestMethodExecution(getTestClass().getJavaClass(), testMethod.getMethod()));
+            result.add(new ArchTestMethodExecution(getTestClass().getJavaClass(), testMethod.getMethod(), false));
         }
         return result;
     }


### PR DESCRIPTION
The following cases now behave as expected
```
@ArchTest
@ArchIgnore
public static final ArchRules rules = ArchRules.in(MyRules.class);
```
and
```
@ArchTest
public static final ArchRules rules = ArchRules.in(MyRules.class);

...

class MyRules {
    @ArchTest
    @ArchIgnore
    public static final ArchRules subRules = ArchRules.in(SomeSubRules.class);
}
```
This resolves #29 