### PR TITLE
Interfaces syntax

### DIFF
--- a/archunit-example/build.gradle
+++ b/archunit-example/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile 'org.apache.geronimo.specs:geronimo-jpa_2.0_spec:1.0'
 
     testCompile project(path: ':archunit-junit')
+    testCompile project(path: ':archunit', configuration: 'tests')
 }
 
 addTestJarTo this

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/service/impl/ServiceImplementation.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/service/impl/ServiceImplementation.java
@@ -1,0 +1,6 @@
+package com.tngtech.archunit.example.service.impl;
+
+import com.tngtech.archunit.example.service.ServiceInterface;
+
+public class ServiceImplementation implements ServiceInterface {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/service/impl/SomeInterfacePlacedInTheWrongPackage.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/service/impl/SomeInterfacePlacedInTheWrongPackage.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.example.service.impl;
+
+public interface SomeInterfacePlacedInTheWrongPackage {
+}

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/InterfaceRules.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/InterfaceRules.java
@@ -1,0 +1,32 @@
+package com.tngtech.archunit.exampletest;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.example.SomeBusinessInterface;
+import com.tngtech.archunit.example.persistence.first.dao.SomeDao;
+import com.tngtech.archunit.example.service.impl.SomeInterfacePlacedInTheWrongPackage;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@Category(Example.class)
+public class InterfaceRules {
+
+    @Test
+    public void interfaces_should_not_have_the_word_interface_in_the_name() {
+        JavaClasses classes = new ClassFileImporter().importClasses(
+                SomeBusinessInterface.class,
+                SomeDao.class
+        );
+
+        noClasses().that().areInterfaces().should().haveNameMatching(".*Interface").check(classes);
+    }
+
+    @Test
+    public void interfaces_must_not_be_placed_in_implementation_packages() {
+        JavaClasses classes = new ClassFileImporter().importPackagesOf(SomeInterfacePlacedInTheWrongPackage.class);
+
+        noClasses().that().resideInAPackage("..impl..").should().beInterfaces().check(classes);
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/InterfaceRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/InterfaceRulesIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.tngtech.archunit.integration;
+
+import com.tngtech.archunit.example.SomeBusinessInterface;
+import com.tngtech.archunit.example.service.impl.SomeInterfacePlacedInTheWrongPackage;
+import com.tngtech.archunit.exampletest.InterfaceRules;
+import com.tngtech.archunit.junit.ExpectedViolation;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.tngtech.archunit.junit.ExpectedViolation.clazz;
+
+public class InterfaceRulesIntegrationTest extends InterfaceRules {
+    @Rule
+    public final ExpectedViolation expectedViolation = ExpectedViolation.none();
+
+    @Test
+    @Override
+    public void interfaces_should_not_have_the_word_interface_in_the_name() {
+        expectedViolation.ofRule("no classes that are interfaces should have name matching '.*Interface'")
+                .by(clazz(SomeBusinessInterface.class).havingNameMatching(".*Interface"));
+
+        super.interfaces_should_not_have_the_word_interface_in_the_name();
+    }
+
+    @Test
+    @Override
+    public void interfaces_must_not_be_placed_in_implementation_packages() {
+        expectedViolation.ofRule("no classes that reside in a package '..impl..' should be interfaces")
+                .by(clazz(SomeInterfacePlacedInTheWrongPackage.class).beingAnInterface());
+
+        super.interfaces_must_not_be_placed_in_implementation_packages();
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -127,6 +127,27 @@ public class ExpectedViolation implements TestRule, ExpectsViolations {
         }
     }
 
+    public static ClassAssertionCreator clazz(Class<?> clazz) {
+        return new ClassAssertionCreator(clazz);
+    }
+
+    @Internal
+    public static class ClassAssertionCreator {
+        private final Class<?> clazz;
+
+        private ClassAssertionCreator(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        public MessageAssertionChain.Link havingNameMatching(String regex) {
+            return containsLine("class %s matches '%s'", clazz.getName(), regex);
+        }
+
+        public MessageAssertionChain.Link beingAnInterface() {
+            return containsLine("class %s is an interface", clazz.getName());
+        }
+    }
+
     private class ExpectedViolationStatement extends Statement {
         private final Statement base;
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -569,6 +569,22 @@ public final class ArchConditions {
         return not(beAssignableFrom(predicate));
     }
 
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beInterfaces() {
+        return new ArchCondition<JavaClass>("be interfaces") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean isInterface = item.isInterface();
+                events.add(new SimpleConditionEvent(item, isInterface, String.format("class %s is %s interface", item.getName(), isInterface ? "an" : "not an")));
+            }
+        };
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeInterfaces() {
+        return not(beInterfaces());
+    }
+
     private static ArchCondition<JavaClass> createAssignableCondition(final DescribedPredicate<JavaClass> assignable) {
         return new ArchCondition<JavaClass>(be(assignable).getDescription()) {
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -384,6 +384,16 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
         return new OnlyBeAccessedSpecificationInternal(this);
     }
 
+    @Override
+    public ClassesShouldConjunction beInterfaces() {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.beInterfaces()));
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeInterfaces() {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBeInterfaces()));
+    }
+
     ClassesShouldInternal copyWithNewCondition(ArchCondition<JavaClass> newCondition) {
         return new ClassesShouldInternal(classesTransformer, priority, newCondition, prepareCondition);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
@@ -208,6 +208,16 @@ class ClassesShouldThatInternal implements ClassesShouldThat, ClassesShouldConju
     }
 
     @Override
+    public ClassesShouldConjunction areInterfaces() {
+        return shouldWith(are(JavaClass.Predicates.INTERFACES));
+    }
+
+    @Override
+    public ClassesShouldConjunction areNotInterfaces() {
+        return shouldWith(are(not(JavaClass.Predicates.INTERFACES)));
+    }
+
+    @Override
     public ClassesShouldConjunction arePublic() {
         return shouldWith(ClassesThatPredicates.arePublic());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
@@ -192,6 +192,16 @@ class GivenClassesThatInternal implements GivenClassesThat {
     }
 
     @Override
+    public GivenClassesConjunction areInterfaces() {
+        return givenWith(are(JavaClass.Predicates.INTERFACES));
+    }
+
+    @Override
+    public GivenClassesConjunction areNotInterfaces() {
+        return givenWith(are(not(JavaClass.Predicates.INTERFACES)));
+    }
+
+    @Override
     public GivenClassesConjunction arePublic() {
         return givenWith(ClassesThatPredicates.arePublic());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -670,4 +670,21 @@ public interface ClassesShould {
      */
     @PublicAPI(usage = ACCESS)
     OnlyBeAccessedSpecification<ClassesShouldConjunction> onlyBeAccessed();
+
+
+    /**
+     * Asserts that classes are interfaces.
+     *
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beInterfaces();
+
+    /**
+     * Asserts that classes are not interfaces.
+     *
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeInterfaces();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -451,4 +451,22 @@ public interface ClassesThat<CONJUNCTION> {
      */
     @PublicAPI(usage = ACCESS)
     CONJUNCTION areNotAssignableFrom(DescribedPredicate<? super JavaClass> predicate);
+
+
+    /**
+     * Matches interfaces.
+     *
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areInterfaces();
+
+    /**
+     * Matches everything except interfaces.
+     *
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotInterfaces();
+
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -872,6 +872,42 @@ public class ClassesShouldTest {
                         ClassWithFieldMethodAndConstructor.class, ""));
     }
 
+    @DataProvider
+    public static Object[][] beInterfaces_rules() {
+        return $$(
+                $(classes().should().beInterfaces(), Collection.class, String.class),
+                $(classes().should(ArchConditions.beInterfaces()), Collection.class, String.class));
+    }
+
+    @Test
+    @UseDataProvider("beInterfaces_rules")
+    public void beInterfaces(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be interfaces")
+                .contains(String.format("class %s is not an interface", violated.getName()))
+                .doesNotMatch(String.format(".*class %s .* interface.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeInterfaces_rules() {
+        return $$(
+                $(classes().should().notBeInterfaces(), String.class, Collection.class),
+                $(classes().should(ArchConditions.notBeInterfaces()), String.class, Collection.class));
+    }
+
+    @Test
+    @UseDataProvider("notBeInterfaces_rules")
+    public void notBeInterfaces(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be interfaces")
+                .contains(String.format("class %s is an interface", violated.getName()))
+                .doesNotMatch(String.format(".*class %s .* interface.*", quote(satisfied.getName())));
+    }
+
     private String singleLineFailureReportOf(EvaluationResult result) {
         return result.getFailureReport().toString().replaceAll("\\r?\\n", FAILURE_REPORT_NEWLINE_MARKER);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -423,6 +423,22 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void areInterfaces_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areInterfaces())
+                .on(List.class, String.class, Collection.class, Integer.class);
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Collection.class);
+    }
+
+    @Test
+    public void areNotInterfaces_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotInterfaces())
+                .on(List.class, String.class, Collection.class, Integer.class);
+
+        assertThatClasses(classes).matchInAnyOrder(String.class, Integer.class);
+    }
+
+    @Test
     public void and_conjunction() {
         List<JavaClass> classes = filterResultOf(
                 classes().that().haveNameMatching(".*\\..*i.*")

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
@@ -444,6 +444,26 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
+    public void areInterfaces_predicate() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areInterfaces())
+                .on(ClassAccessingList.class, ClassAccessingString.class,
+                        ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingList.class, ClassAccessingCollection.class);
+    }
+
+    @Test
+    public void areNotInterfaces_predicate() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areNotInterfaces())
+                .on(ClassAccessingList.class, ClassAccessingString.class,
+                        ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
     public void accessClassesThat_predicate() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClasses().should().accessClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))))

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
@@ -13,6 +13,7 @@ import com.tngtech.archunit.lang.syntax.elements.testclasses.access.ClassAccessi
 import com.tngtech.archunit.lang.syntax.elements.testclasses.accessed.ClassBeingAccessedByOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.anotheraccess.YetAnotherClassAccessingOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.otheraccess.ClassAlsoAccessingOtherClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
@@ -532,6 +533,26 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
+    @Ignore("Only applicable starting with Java 8 (access from default methods)")
+    public void areInterfaces_predicate() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport (
+                classes().should().onlyBeAccessed().byClassesThat().areInterfaces())
+                .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingSimpleClass.class, SimpleClass.class);
+    }
+
+    @Test
+    @Ignore("Only applicable starting with Java 8 (access from default methods)")
+    public void areNotInterfaces_predicate() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areNotInterfaces())
+                .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
+    }
+
+    @Test
     public void accesses_by_the_class_itself_are_ignored() {
         ClassesShouldConjunction rule = classes().should().onlyBeAccessed()
                 .byClassesThat(classWithNameOf(ClassAccessingClassAccessingItself.class));
@@ -640,6 +661,20 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     interface SomeInterface {
+    }
+
+    private static class ClassBeingAccessedByInterface {
+        static final String SOME_CONSTANT = "Some value";
+    }
+
+    interface InterfaceAccessingAClass {
+        // TODO: this does not count as an access?
+        String SOME_CONSTANT = ClassBeingAccessedByInterface.SOME_CONSTANT;
+
+        // TODO Java 1.8: uncomment this access and enable tests areInterfaces_predicate and areNotInterfaces_predicate
+        // default void call() {
+        //     new ClassBeingAccessedByInterface();
+        // }
     }
 
     private static class ClassImplementingSomeInterface implements SomeInterface {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
@@ -533,7 +533,6 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    @Ignore("Only applicable starting with Java 8 (access from default methods)")
     public void areInterfaces_predicate() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport (
                 classes().should().onlyBeAccessed().byClassesThat().areInterfaces())
@@ -543,7 +542,6 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    @Ignore("Only applicable starting with Java 8 (access from default methods)")
     public void areNotInterfaces_predicate() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classes().should().onlyBeAccessed().byClassesThat().areNotInterfaces())
@@ -664,17 +662,11 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     private static class ClassBeingAccessedByInterface {
-        static final String SOME_CONSTANT = "Some value";
+        static final Object SOME_CONSTANT = "Some value";
     }
 
     interface InterfaceAccessingAClass {
-        // TODO: this does not count as an access?
-        String SOME_CONSTANT = ClassBeingAccessedByInterface.SOME_CONSTANT;
-
-        // TODO Java 1.8: uncomment this access and enable tests areInterfaces_predicate and areNotInterfaces_predicate
-        // default void call() {
-        //     new ClassBeingAccessedByInterface();
-        // }
+        Object SOME_CONSTANT = ClassBeingAccessedByInterface.SOME_CONSTANT;
     }
 
     private static class ClassImplementingSomeInterface implements SomeInterface {


### PR DESCRIPTION
This adds are(Not)Interfaces and (not)beInterfaces. 

The should().onlyBeAccessed().byClassesThat().are*Interfaces() doesn't make sense in Java 7, only with Java 8 with default methods. I added the relevant tests and tried them with Java 8, however currently they are ignored. See TODOs in ShouldOnlyBeAccessedByClassesThatTest.

Accessing a constant from an interface does not count as an access - is this as intended? Also see ShouldOnlyBeAccessedByClassesThatTest.java.

I hereby agree to the terms of the ArchUnit Contributor License Agreement.
Resolves #28 
