### PR TITLE
Implement haveNameEndingWith / haveNameNotEndingWith

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -54,7 +54,7 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Utils.toAnnotationOfType;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 
-public class JavaClass implements HasName, HasAnnotations, HasModifiers {
+public class JavaClass implements HasName.AndSimpleName, HasAnnotations, HasModifiers {
     private final Optional<Source> source;
     private final JavaType javaType;
     private final boolean isInterface;
@@ -106,7 +106,7 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         return javaType.getName();
     }
 
-    @PublicAPI(usage = ACCESS)
+    @Override
     public String getSimpleName() {
         return javaType.getSimpleName();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -32,6 +32,11 @@ public interface HasName {
         String getFullName();
     }
 
+    interface AndSimpleName extends HasName {
+        @PublicAPI(usage = ACCESS)
+        String getSimpleName();
+    }
+
     final class Predicates {
         private Predicates() {
         }
@@ -51,11 +56,11 @@ public interface HasName {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameEndingWith(final String suffix) {
-            return new DescribedPredicate<HasName>(String.format("name ending with '%s'", suffix)) {
+        public static DescribedPredicate<AndSimpleName> simpleClassNameEndingWith(final String suffix) {
+            return new DescribedPredicate<AndSimpleName>(String.format("simple class name ending with '%s'", suffix)) {
                 @Override
-                public boolean apply(HasName input) {
-                    return input.getName().endsWith(suffix);
+                public boolean apply(AndSimpleName input) {
+                    return input.getSimpleName().endsWith(suffix);
                 }
             };
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -56,6 +56,16 @@ public interface HasName {
         }
 
         @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<AndSimpleName> simpleClassNameStartingWith(final String prefix) {
+            return new DescribedPredicate<AndSimpleName>(String.format("simple class name starting with '%s'", prefix)) {
+                @Override
+                public boolean apply(AndSimpleName input) {
+                    return input.getSimpleName().startsWith(prefix);
+                }
+            };
+        }
+
+        @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<AndSimpleName> simpleClassNameEndingWith(final String suffix) {
             return new DescribedPredicate<AndSimpleName>(String.format("simple class name ending with '%s'", suffix)) {
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -51,6 +51,16 @@ public interface HasName {
         }
 
         @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<HasName> nameEndingWith(final String suffix) {
+            return new DescribedPredicate<HasName>(String.format("name ending with '%s'", suffix)) {
+                @Override
+                public boolean apply(HasName input) {
+                    return input.getName().endsWith(suffix);
+                }
+            };
+        }
+
+        @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<HasName> name(final String name) {
             return new DescribedPredicate<HasName>(String.format("name '%s'", name)) {
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -59,6 +59,7 @@ import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicate
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameStartingWith;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.parameterTypes;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.be;
@@ -309,6 +310,26 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notHaveSimpleName(String name) {
         return not(haveSimpleName(name));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveSimpleClassNameStartingWith(final String prefix) {
+        final DescribedPredicate<HasName.AndSimpleName> predicate = have(simpleClassNameStartingWith(prefix));
+
+        return new ArchCondition<JavaClass>(predicate.getDescription()) {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean satisfied = predicate.apply(item);
+                String infix = satisfied ? "starts with" : "doesn't start with";
+                String message = String.format("simple class name of %s %s '%s'", item.getName(), infix, prefix);
+                events.add(new SimpleConditionEvent(item, satisfied, message));
+            }
+        };
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveSimpleClassNameNotStartingWith(String prefix) {
+        return not(haveSimpleClassNameStartingWith(prefix)).as("have simple class name not starting with '%s'", prefix);
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -57,7 +57,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
-import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameEndingWith;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.parameterTypes;
@@ -312,23 +312,23 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveNameEndsWith(final String suffix) {
-        final DescribedPredicate<HasName> predicate = have(nameEndingWith(suffix));
+    public static ArchCondition<JavaClass> haveSimpleClassNameEndingWith(final String suffix) {
+        final DescribedPredicate<HasName.AndSimpleName> predicate = have(simpleClassNameEndingWith(suffix));
 
         return new ArchCondition<JavaClass>(predicate.getDescription()) {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = predicate.apply(item);
                 String infix = satisfied ? "ends with" : "doesn't end with";
-                String message = String.format("classname of %s %s '%s'", item.getName(), infix, suffix);
+                String message = String.format("simple class name of %s %s '%s'", item.getName(), infix, suffix);
                 events.add(new SimpleConditionEvent(item, satisfied, message));
             }
         };
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveNameNotEndsWith(String suffix) {
-        return not(haveNameEndsWith(suffix)).as("have name not ending with '%s'", suffix);
+    public static ArchCondition<JavaClass> haveSimpleClassNameNotEndingWith(String suffix) {
+        return not(haveSimpleClassNameEndingWith(suffix)).as("have simple class name not ending with '%s'", suffix);
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -57,6 +57,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.parameterTypes;
@@ -308,6 +309,26 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notHaveSimpleName(String name) {
         return not(haveSimpleName(name));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveNameEndsWith(final String suffix) {
+        final DescribedPredicate<HasName> predicate = have(nameEndingWith(suffix));
+
+        return new ArchCondition<JavaClass>(predicate.getDescription()) {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean satisfied = predicate.apply(item);
+                String infix = satisfied ? "ends with" : "doesn't end with";
+                String message = String.format("classname of %s %s '%s'", item.getName(), infix, suffix);
+                events.add(new SimpleConditionEvent(item, satisfied, message));
+            }
+        };
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveNameNotEndsWith(String suffix) {
+        return not(haveNameEndsWith(suffix)).as("have name not ending with '%s'", suffix);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -575,7 +596,8 @@ public final class ArchConditions {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean isInterface = item.isInterface();
-                events.add(new SimpleConditionEvent(item, isInterface, String.format("class %s is %s interface", item.getName(), isInterface ? "an" : "not an")));
+                events.add(new SimpleConditionEvent(item, isInterface,
+                        String.format("class %s is %s interface", item.getName(), isInterface ? "an" : "not an")));
             }
         };
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -80,6 +80,16 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldConjunction haveSimpleClassNameStartingWith(String prefix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleClassNameStartingWith(prefix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleClassNameNotStartingWith(String prefix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleClassNameNotStartingWith(prefix)));
+    }
+
+    @Override
     public ClassesShouldConjunction haveSimpleClassNameEndingWith(String suffix) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleClassNameEndingWith(suffix)));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -80,13 +80,13 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
-    public ClassesShouldConjunction haveNameEndingWith(String suffix) {
-        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveNameEndsWith(suffix)));
+    public ClassesShouldConjunction haveSimpleClassNameEndingWith(String suffix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleClassNameEndingWith(suffix)));
     }
 
     @Override
-    public ClassesShouldConjunction haveNameNotEndingWith(String suffix) {
-        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveNameNotEndsWith(suffix)));
+    public ClassesShouldConjunction haveSimpleClassNameNotEndingWith(String suffix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleClassNameNotEndingWith(suffix)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -80,6 +80,16 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldConjunction haveNameEndingWith(String suffix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveNameEndsWith(suffix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveNameNotEndingWith(String suffix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveNameNotEndsWith(suffix)));
+    }
+
+    @Override
     public ClassesShouldConjunction haveNameMatching(String regex) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveNameMatching(regex)));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -74,6 +74,24 @@ public interface ClassesShould {
     ClassesShouldConjunction notHaveSimpleName(String name);
 
     /**
+     * Asserts that classes have a fully qualified class name having a given suffix.
+     *
+     * @param suffix A suffix the fully qualified class name should match against
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveNameEndingWith(String suffix);
+
+    /**
+     * Asserts that classes have a fully qualified class name not having a given suffix.
+     *
+     * @param suffix A suffix the fully qualified class name should not match against
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveNameNotEndingWith(String suffix);
+
+    /**
      * Asserts that classes have a fully qualified class name matching a given regular expression.
      *
      * @param regex A regular expression

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -74,22 +74,22 @@ public interface ClassesShould {
     ClassesShouldConjunction notHaveSimpleName(String name);
 
     /**
-     * Asserts that classes have a fully qualified class name having a given suffix.
+     * Asserts that classes' simple class names end with a given suffix.
      *
-     * @param suffix A suffix the fully qualified class name should match against
+     * @param suffix A suffix the simple class name should match against
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
     @PublicAPI(usage = ACCESS)
-    ClassesShouldConjunction haveNameEndingWith(String suffix);
+    ClassesShouldConjunction haveSimpleClassNameEndingWith(String suffix);
 
     /**
-     * Asserts that classes have a fully qualified class name not having a given suffix.
+     * Asserts that classes' simple class names do not end with a given suffix.
      *
-     * @param suffix A suffix the fully qualified class name should not match against
+     * @param suffix A suffix the simple class name should not match against
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
     @PublicAPI(usage = ACCESS)
-    ClassesShouldConjunction haveNameNotEndingWith(String suffix);
+    ClassesShouldConjunction haveSimpleClassNameNotEndingWith(String suffix);
 
     /**
      * Asserts that classes have a fully qualified class name matching a given regular expression.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -73,6 +73,25 @@ public interface ClassesShould {
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notHaveSimpleName(String name);
 
+
+    /**
+     * Asserts that classes' simple class names start with a given prefix.
+     *
+     * @param prefix A prefix the simple class name should match against
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveSimpleClassNameStartingWith(String prefix);
+
+    /**
+     * Asserts that classes' simple class names do not start with a given prefix.
+     *
+     * @param prefix A prefix the simple class name should not match against
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveSimpleClassNameNotStartingWith(String prefix);
+
     /**
      * Asserts that classes' simple class names end with a given suffix.
      *

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameStartingWith;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class HasNameTest {
@@ -34,9 +35,26 @@ public class HasNameTest {
     }
 
     @Test
+    public void match_against_prefix() {
+        HasName.AndSimpleName input = newHasName("some.Foo");
+        assertThat(simpleClassNameStartingWith("F").apply(input)).isTrue();
+        assertThat(simpleClassNameStartingWith("Fo").apply(input)).isTrue();
+        assertThat(simpleClassNameStartingWith("Foo").apply(input)).isTrue();
+        assertThat(simpleClassNameStartingWith(".Foo").apply(input)).isFalse();
+        assertThat(simpleClassNameStartingWith("").apply(input)).isTrue();
+
+        assertThat(simpleClassNameStartingWith("some").apply(input)).isFalse();
+
+        // Full match test
+        assertThat(simpleClassNameStartingWith("some.Foo").apply(input)).isFalse();
+
+        assertThat(simpleClassNameStartingWith("some.Foo").getDescription()).isEqualTo("simple class name starting with 'some.Foo'");
+    }
+
+    @Test
     public void match_against_suffix() {
         HasName.AndSimpleName input = newHasName("some.Foo");
-        assertThat(simpleClassNameEndingWith(".Foo").apply(input)).isTrue();
+
         assertThat(simpleClassNameEndingWith("Foo").apply(input)).isTrue();
         assertThat(simpleClassNameEndingWith("").apply(input)).isTrue();
 
@@ -45,7 +63,7 @@ public class HasNameTest {
         assertThat(simpleClassNameEndingWith(" ").apply(input)).isFalse();
         assertThat(simpleClassNameEndingWith(".").apply(input)).isFalse();
 
-        assertThat(simpleClassNameEndingWith(".Fo").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith(".Foo").apply(input)).isFalse();
         assertThat(simpleClassNameEndingWith("some.Fo").apply(input)).isFalse();
 
         assertThat(simpleClassNameEndingWith("some.Foo").getDescription()).isEqualTo("simple class name ending with 'some.Foo'");
@@ -70,7 +88,7 @@ public class HasNameTest {
                     return name;
                 }
 
-                return name.substring(i);
+                return name.substring(i + 1);
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
-import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameEndingWith;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.simpleClassNameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
@@ -35,17 +35,20 @@ public class HasNameTest {
 
     @Test
     public void match_against_suffix() {
-        HasName input = newHasName("some.Foo");
-        assertThat(nameEndingWith(".Foo").apply(input)).isTrue();
+        HasName.AndSimpleName input = newHasName("some.Foo");
+        assertThat(simpleClassNameEndingWith(".Foo").apply(input)).isTrue();
+        assertThat(simpleClassNameEndingWith("Foo").apply(input)).isTrue();
+        assertThat(simpleClassNameEndingWith("").apply(input)).isTrue();
+
         // Full match test
-        assertThat(nameEndingWith("some.Foo").apply(input)).isTrue();
-        assertThat(nameEndingWith("").apply(input)).isTrue();
-        assertThat(nameEndingWith(" ").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith("some.Foo").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith(" ").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith(".").apply(input)).isFalse();
 
-        assertThat(nameEndingWith(".Fo").apply(input)).isFalse();
-        assertThat(nameEndingWith("some.Fo").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith(".Fo").apply(input)).isFalse();
+        assertThat(simpleClassNameEndingWith("some.Fo").apply(input)).isFalse();
 
-        assertThat(nameEndingWith("some.Foo").getDescription()).isEqualTo("name ending with 'some.Foo'");
+        assertThat(simpleClassNameEndingWith("some.Foo").getDescription()).isEqualTo("simple class name ending with 'some.Foo'");
     }
 
     private AbstractBooleanAssert assertMatches(String input, String regex) {
@@ -53,11 +56,21 @@ public class HasNameTest {
                 .as(input + " =~ " + regex);
     }
 
-    private HasName newHasName(final String name) {
-        return new HasName() {
+    private HasName.AndSimpleName newHasName(final String name) {
+        return new HasName.AndSimpleName() {
             @Override
             public String getName() {
                 return name;
+            }
+
+            @Override
+            public String getSimpleName() {
+                int i = name.lastIndexOf('.');
+                if (i == -1) {
+                    return name;
+                }
+
+                return name.substring(i);
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
@@ -30,6 +31,21 @@ public class HasNameTest {
         assertThat(name("Foo").apply(newHasName("some.Foo"))).isFalse();
 
         assertThat(name("some.Foo").getDescription()).isEqualTo("name 'some.Foo'");
+    }
+
+    @Test
+    public void match_against_suffix() {
+        HasName input = newHasName("some.Foo");
+        assertThat(nameEndingWith(".Foo").apply(input)).isTrue();
+        // Full match test
+        assertThat(nameEndingWith("some.Foo").apply(input)).isTrue();
+        assertThat(nameEndingWith("").apply(input)).isTrue();
+        assertThat(nameEndingWith(" ").apply(input)).isFalse();
+
+        assertThat(nameEndingWith(".Fo").apply(input)).isFalse();
+        assertThat(nameEndingWith("some.Fo").apply(input)).isFalse();
+
+        assertThat(nameEndingWith("some.Foo").getDescription()).isEqualTo("name ending with 'some.Foo'");
     }
 
     private AbstractBooleanAssert assertMatches(String input, String regex) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -188,47 +188,47 @@ public class ClassesShouldTest {
     }
 
     @DataProvider
-    public static Object[][] haveNameEndsWith_rules() {
+    public static Object[][] haveSimpleClassnameEndingWith_rules() {
         String className = RightNamedClass.class.getSimpleName();
         String prefix = className.substring(1, className.length());
         return $$(
-                $(classes().should().haveNameEndingWith(prefix), prefix),
-                $(classes().should(ArchConditions.haveNameEndsWith(prefix)), prefix)
+                $(classes().should().haveSimpleClassNameEndingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleClassNameEndingWith(prefix)), prefix)
         );
     }
 
     @Test
-    @UseDataProvider("haveNameEndsWith_rules")
-    public void haveNameEndsWith(ArchRule rule, String suffix) {
+    @UseDataProvider("haveSimpleClassnameEndingWith_rules")
+    public void haveSimpleClassNameEndingWith(ArchRule rule, String suffix) {
         EvaluationResult result = rule.evaluate(importClasses(
                 RightNamedClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains(String.format("classes should have name ending with '%s'", suffix))
-                .contains(String.format("classname of %s doesn't end with '%s'",
+                .contains(String.format("classes should have simple class name ending with '%s'", suffix))
+                .contains(String.format("simple class name of %s doesn't end with '%s'",
                         WrongNamedClass.class.getName(), suffix))
                 .doesNotContain(RightNamedClass.class.getName());
     }
 
     @DataProvider
-    public static Object[][] haveNameNotEndsWith_rules() {
+    public static Object[][] haveSimpleClassNameNotEndingWith_rules() {
         String className = WrongNamedClass.class.getSimpleName();
         String prefix = className.substring(1, className.length());
         return $$(
-                $(classes().should().haveNameNotEndingWith(prefix), prefix),
-                $(classes().should(ArchConditions.haveNameNotEndsWith(prefix)), prefix)
+                $(classes().should().haveSimpleClassNameNotEndingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleClassNameNotEndingWith(prefix)), prefix)
         );
     }
 
     @Test
-    @UseDataProvider("haveNameNotEndsWith_rules")
-    public void haveNameNotEndsWith(ArchRule rule, String suffix) {
+    @UseDataProvider("haveSimpleClassNameNotEndingWith_rules")
+    public void haveSimpleClassNameNotEndingWith(ArchRule rule, String suffix) {
         EvaluationResult result = rule.evaluate(importClasses(
                 RightNamedClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains(String.format("classes should have name not ending with '%s'", suffix))
-                .contains(String.format("classname of %s ends with '%s'",
+                .contains(String.format("classes should have simple class name not ending with '%s'", suffix))
+                .contains(String.format("simple class name of %s ends with '%s'",
                         WrongNamedClass.class.getName(), suffix))
                 .doesNotContain(RightNamedClass.class.getName());
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -188,6 +188,53 @@ public class ClassesShouldTest {
     }
 
     @DataProvider
+    public static Object[][] haveNameEndsWith_rules() {
+        String className = RightNamedClass.class.getSimpleName();
+        String prefix = className.substring(1, className.length());
+        return $$(
+                $(classes().should().haveNameEndingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveNameEndsWith(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveNameEndsWith_rules")
+    public void haveNameEndsWith(ArchRule rule, String suffix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have name ending with '%s'", suffix))
+                .contains(String.format("classname of %s doesn't end with '%s'",
+                        WrongNamedClass.class.getName(), suffix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+    @DataProvider
+    public static Object[][] haveNameNotEndsWith_rules() {
+        String className = WrongNamedClass.class.getSimpleName();
+        String prefix = className.substring(1, className.length());
+        return $$(
+                $(classes().should().haveNameNotEndingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveNameNotEndsWith(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveNameNotEndsWith_rules")
+    public void haveNameNotEndsWith(ArchRule rule, String suffix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have name not ending with '%s'", suffix))
+                .contains(String.format("classname of %s ends with '%s'",
+                        WrongNamedClass.class.getName(), suffix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+
+    @DataProvider
     public static Object[][] resideInAPackage_rules() {
         String thePackage = ArchRule.class.getPackage().getName();
         return $$(

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -188,6 +188,52 @@ public class ClassesShouldTest {
     }
 
     @DataProvider
+    public static Object[][] haveSimpleClassnameStartingWith_rules() {
+        String className = RightNamedClass.class.getSimpleName();
+        String prefix = className.substring(0, className.length()-1);
+        return $$(
+                $(classes().should().haveSimpleClassNameStartingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleClassNameStartingWith(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveSimpleClassnameStartingWith_rules")
+    public void haveSimpleClassNameStartingWith(ArchRule rule, String suffix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have simple class name starting with '%s'", suffix))
+                .contains(String.format("simple class name of %s doesn't start with '%s'",
+                        WrongNamedClass.class.getName(), suffix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+    @DataProvider
+    public static Object[][] haveSimpleClassNameNotStartingWith_rules() {
+        String className = WrongNamedClass.class.getSimpleName();
+        String prefix = className.substring(0, className.length()-1);
+        return $$(
+                $(classes().should().haveSimpleClassNameNotStartingWith(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleClassNameNotStartingWith(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveSimpleClassNameNotStartingWith_rules")
+    public void haveSimpleClassNameNotStartingWith(ArchRule rule, String suffix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have simple class name not starting with '%s'", suffix))
+                .contains(String.format("simple class name of %s starts with '%s'",
+                        WrongNamedClass.class.getName(), suffix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+    @DataProvider
     public static Object[][] haveSimpleClassnameEndingWith_rules() {
         String className = RightNamedClass.class.getSimpleName();
         String prefix = className.substring(1, className.length());


### PR DESCRIPTION
When I was using the framework I wanted to make sure, that EventHandlers in our project are always called *EventHandler. Since no such method "endsWith" exists, I had to use a regex for that. I don't like that too much, so I thought I use the chance for my very first OpenSource contribution and here it is :)

For some reason 9 Unit tests are failing, however they also fail without my changes.