### PR TITLE
Layered architecture exceptions

### DIFF
--- a/archunit-example/build.gradle
+++ b/archunit-example/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile 'org.apache.geronimo.specs:geronimo-ejb_3.1_spec:1.0'
     compile 'org.apache.geronimo.specs:geronimo-jpa_2.0_spec:1.0'
 
+    testCompile project(path: ':archunit')
     testCompile project(path: ':archunit-junit')
 }
 

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/LayeredArchitectureTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/LayeredArchitectureTest.java
@@ -1,5 +1,7 @@
 package com.tngtech.archunit.exampletest.junit;
 
+import com.tngtech.archunit.example.SomeMediator;
+import com.tngtech.archunit.example.service.ServiceViolatingLayerRules;
 import com.tngtech.archunit.exampletest.Example;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -24,4 +26,17 @@ public class LayeredArchitectureTest {
             .whereLayer("Controllers").mayNotBeAccessedByAnyLayer()
             .whereLayer("Services").mayOnlyBeAccessedByLayers("Controllers")
             .whereLayer("Persistence").mayOnlyBeAccessedByLayers("Services");
+
+    @ArchTest
+    public static final ArchRule layer_dependencies_are_respected_with_exception = layeredArchitecture()
+
+            .layer("Controllers").definedBy("com.tngtech.archunit.example.controller..")
+            .layer("Services").definedBy("com.tngtech.archunit.example.service..")
+            .layer("Persistence").definedBy("com.tngtech.archunit.example.persistence..")
+
+            .whereLayer("Controllers").mayNotBeAccessedByAnyLayer()
+            .whereLayer("Services").mayOnlyBeAccessedByLayers("Controllers")
+            .whereLayer("Persistence").mayOnlyBeAccessedByLayers("Services")
+
+            .ignoreDependency(SomeMediator.class, ServiceViolatingLayerRules.class);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesOnClassCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesOnClassCondition.java
@@ -25,7 +25,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 class AllDependenciesOnClassCondition extends AllAttributesMatchCondition<Dependency> {
-    AllDependenciesOnClassCondition(String description, final DescribedPredicate<Dependency> predicate) {
+    AllDependenciesOnClassCondition(String description, final DescribedPredicate<? super Dependency> predicate) {
         super(description, new ArchCondition<Dependency>(predicate.getDescription()) {
             @Override
             public void check(Dependency item, ConditionEvents events) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.PackageMatcher;
 import com.tngtech.archunit.base.PackageMatchers;
 import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.Formatters;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
@@ -234,15 +235,28 @@ public final class ArchConditions {
 
     /**
      * @param packageIdentifiers Strings identifying packages according to {@link PackageMatcher}
-     * @return A condition matching {@link JavaClass classes} depending on this class (e.g. calling methods of this class)
+     * @return A condition matching {@link JavaClass classes} that have other classes
+     * depending on them (e.g. calling methods of this class)
      * with a package matching any of the identifiers
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyHaveDependentsInAnyPackage(String... packageIdentifiers) {
         String description = String.format("only have dependents in any package ['%s']",
                 Joiner.on("', '").join(packageIdentifiers));
-        return new AllDependenciesOnClassCondition(description,
-                dependencyOrigin(GET_PACKAGE.is(PackageMatchers.of(packageIdentifiers))));
+        return onlyHaveDependentsWhere(dependencyOrigin(GET_PACKAGE.is(PackageMatchers.of(packageIdentifiers))))
+                .as(description);
+    }
+
+    /**
+     * @param predicate A predicate identifying relevant dependencies on this class
+     * @return A condition matching {@link JavaClass classes} that have other classes
+     * depending on them (e.g. calling methods of this class)
+     * where the respective dependency is matched by the predicate
+     */
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> onlyHaveDependentsWhere(DescribedPredicate<? super Dependency> predicate) {
+        String description = "only have dependents where " + predicate.getDescription();
+        return new AllDependenciesOnClassCondition(description, predicate);
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
@@ -49,8 +49,8 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
 
     static class AnyConditionEvent implements ConditionEvent {
         private final Collection<?> correspondingObjects;
-        private final Collection<ConditionEvent> violating;
         private final Collection<ConditionEvent> allowed;
+        private final Collection<ConditionEvent> violating;
 
         private AnyConditionEvent(Collection<?> correspondingObjects, ConditionEvents events) {
             this(correspondingObjects, events.getAllowed(), events.getViolating());
@@ -82,6 +82,15 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
         @Override
         public void handleWith(Handler handler) {
             handler.handle(correspondingObjects, EventsDescription.describe(violating));
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{" +
+                    "correspondingObjects=" + correspondingObjects +
+                    ", allowed=" + allowed +
+                    ", violating=" + violating +
+                    '}';
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
@@ -85,5 +85,14 @@ class ContainsOnlyCondition<T> extends ArchCondition<Collection<? extends T>> {
                 event.handleWith(handler);
             }
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{" +
+                    "correspondingObjects=" + correspondingObjects +
+                    ", allowed=" + allowed +
+                    ", violating=" + violating +
+                    '}';
+        }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -27,16 +27,26 @@ import java.util.TreeSet;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.base.PackageMatchers;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.syntax.PredicateAggregator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyHaveDependentsInAnyPackage;
+import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependency;
+import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
+import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyHaveDependentsWhere;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
@@ -82,19 +92,23 @@ public final class Architectures {
     public static final class LayeredArchitecture implements ArchRule {
         private final Map<String, LayerDefinition> layerDefinitions;
         private final Set<LayerDependencySpecification> dependencySpecifications;
+        private final PredicateAggregator<Dependency> irrelevantDependenciesPredicate;
         private final Optional<String> overriddenDescription;
 
         private LayeredArchitecture() {
             this(new LinkedHashMap<String, LayerDefinition>(),
                     new LinkedHashSet<LayerDependencySpecification>(),
+                    new PredicateAggregator<Dependency>().thatORs(),
                     Optional.<String>absent());
         }
 
         private LayeredArchitecture(Map<String, LayerDefinition> layerDefinitions,
                 Set<LayerDependencySpecification> dependencySpecifications,
+                PredicateAggregator<Dependency> irrelevantDependenciesPredicate,
                 Optional<String> overriddenDescription) {
             this.layerDefinitions = layerDefinitions;
             this.dependencySpecifications = dependencySpecifications;
+            this.irrelevantDependenciesPredicate = irrelevantDependenciesPredicate;
             this.overriddenDescription = overriddenDescription;
         }
 
@@ -138,12 +152,21 @@ public final class Architectures {
                 packagesOfAllowedAccessors.addAll(packagesOfOwnLayer);
 
                 EvaluationResult partial = classes().that().resideInAnyPackage(toArray(packagesOfOwnLayer))
-                        .should(onlyHaveDependentsInAnyPackage(toArray(packagesOfAllowedAccessors)))
+                        .should(onlyHaveDependentsWhere(originPackageMatchesIfDependencyIsRelevant(packagesOfAllowedAccessors)))
                         .evaluate(classes);
 
                 result.add(partial);
             }
             return result;
+        }
+
+        private DescribedPredicate<Dependency> originPackageMatchesIfDependencyIsRelevant(SortedSet<String> packagesOfAllowedAccessors) {
+            DescribedPredicate<Dependency> originPackageMatches =
+                    dependencyOrigin(GET_PACKAGE.is(PackageMatchers.of(toArray(packagesOfAllowedAccessors))));
+
+            return irrelevantDependenciesPredicate.isPresent() ?
+                    originPackageMatches.or(irrelevantDependenciesPredicate.get()) :
+                    originPackageMatches;
         }
 
         @Override
@@ -158,11 +181,27 @@ public final class Architectures {
 
         @Override
         public LayeredArchitecture as(String newDescription) {
-            return new LayeredArchitecture(layerDefinitions, dependencySpecifications, Optional.of(newDescription));
+            return new LayeredArchitecture(
+                    layerDefinitions, dependencySpecifications,
+                    irrelevantDependenciesPredicate, Optional.of(newDescription));
         }
 
+        @PublicAPI(usage = ACCESS)
         public LayeredArchitecture ignoreDependency(Class<?> from, Class<?> to) {
-            return this;
+            return ignoreDependency(equivalentTo(from), equivalentTo(to));
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public LayeredArchitecture ignoreDependency(String from, String to) {
+            return ignoreDependency(name(from), name(to));
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public LayeredArchitecture ignoreDependency(
+                DescribedPredicate<? super JavaClass> from, DescribedPredicate<? super JavaClass> to) {
+            return new LayeredArchitecture(
+                    layerDefinitions, dependencySpecifications,
+                    irrelevantDependenciesPredicate.add(dependency(from, to)), overriddenDescription);
         }
 
         private String[] toArray(Set<String> strings) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -161,6 +161,10 @@ public final class Architectures {
             return new LayeredArchitecture(layerDefinitions, dependencySpecifications, Optional.of(newDescription));
         }
 
+        public LayeredArchitecture ignoreDependency(Class<?> from, Class<?> to) {
+            return this;
+        }
+
         private String[] toArray(Set<String> strings) {
             return strings.toArray(new String[strings.size()]);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -617,6 +617,16 @@ public class Assertions extends org.assertj.core.api.Assertions {
             }
             return this;
         }
+
+        public ConditionEventsAssert haveAtLeastOneViolationMessageMatching(String regex) {
+            Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
+            for (String message : messagesOf(actual.getViolating())) {
+                if (pattern.matcher(message).matches()) {
+                    return this;
+                }
+            }
+            throw new AssertionError(String.format("No message matches pattern '%s'", regex));
+        }
     }
 
     public static class AccessesAssertion {


### PR DESCRIPTION
This enables the possibility to use `layeredArchitecture()...ignoreDependency(..)` to ignore certain known violations.

Resolves: #27 