### PR TITLE
Issue #41

### DIFF
--- a/archunit-example/src/main/java/com/tngtech/archunit/example/AbstractController.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/AbstractController.java
@@ -1,7 +1,9 @@
 package com.tngtech.archunit.example;
 
+import com.tngtech.archunit.example.web.InheritedControllerImpl;
+
 /**
- * For demo purpose only, see
+ * For demo purpose only, see {@link InheritedControllerImpl}
  */
 public abstract class AbstractController {
 

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/AbstractController.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/AbstractController.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.example;
+
+/**
+ * For demo purpose only, see
+ */
+public abstract class AbstractController {
+
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/SomeControllerAnnotation.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/SomeControllerAnnotation.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SomeControllerAnnotation {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/controller/SomeGuiController.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/controller/SomeGuiController.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.example.controller;
+
+public class SomeGuiController {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/web/AnnotatedController.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/web/AnnotatedController.java
@@ -1,0 +1,12 @@
+package com.tngtech.archunit.example.web;
+
+import com.tngtech.archunit.example.SomeControllerAnnotation;
+
+@SomeControllerAnnotation
+public class AnnotatedController {
+
+    public void foo() {
+        // bar
+    }
+
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/web/InheritedControllerImpl.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/web/InheritedControllerImpl.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.example.web;
+
+import com.tngtech.archunit.example.AbstractController;
+
+public class InheritedControllerImpl extends AbstractController {
+
+
+}

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/InterfaceRules.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/InterfaceRules.java
@@ -24,6 +24,16 @@ public class InterfaceRules {
     }
 
     @Test
+    public void interfaces_should_not_have_the_word_interface_in_the_name_alternative2() {
+        JavaClasses classes = new ClassFileImporter().importClasses(
+                SomeBusinessInterface.class,
+                SomeDao.class
+        );
+
+        noClasses().that().areInterfaces().should().haveSimpleNameContaining("Interface").check(classes);
+    }
+
+    @Test
     public void interfaces_must_not_be_placed_in_implementation_packages() {
         JavaClasses classes = new ClassFileImporter().importPackagesOf(SomeInterfacePlacedInTheWrongPackage.class);
 

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/NamingConventionTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/NamingConventionTest.java
@@ -1,0 +1,45 @@
+package com.tngtech.archunit.exampletest.junit;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.example.AbstractController;
+import com.tngtech.archunit.example.SomeControllerAnnotation;
+import com.tngtech.archunit.exampletest.Example;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@Category(Example.class)
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "com.tngtech.archunit.example")
+public class NamingConventionTest {
+
+    @ArchTest
+    public static void services_should_be_prefixed(JavaClasses javaClasses) {
+        classes().
+                that().resideInAPackage("..service..")
+                .should().haveSimpleNameStartingWith("Service")
+                .check(javaClasses);
+    }
+
+    @ArchTest
+    public static void controllers_should_not_have_Gui_in_name(JavaClasses javaClasses) {
+        classes().
+                that().resideInAPackage("..controller..")
+                .should().haveSimpleNameNotContaining("Gui")
+                .check(javaClasses);
+    }
+
+    @ArchTest
+    public static void controllers_should_be_suffixed(JavaClasses javaClasses) {
+        classes().
+                that().resideInAPackage("..controller..")
+                .or().areAnnotatedWith(SomeControllerAnnotation.class)
+                .or().areAssignableTo(AbstractController.class)
+                .should().haveSimpleNameEndingWith("Controller")
+                .check(javaClasses);
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/InterfaceRulesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/InterfaceRulesIntegrationTest.java
@@ -24,6 +24,15 @@ public class InterfaceRulesIntegrationTest extends InterfaceRules {
 
     @Test
     @Override
+    public void interfaces_should_not_have_the_word_interface_in_the_name_alternative2() {
+        expectedViolation.ofRule("no classes that are interfaces should have simple name containing 'Interface'")
+                .by(clazz(SomeBusinessInterface.class).havingNameContaining("Interface"));
+
+        super.interfaces_should_not_have_the_word_interface_in_the_name_alternative2();
+    }
+
+    @Test
+    @Override
     public void interfaces_must_not_be_placed_in_implementation_packages() {
         expectedViolation.ofRule("no classes that reside in a package '..impl..' should be interfaces")
                 .by(clazz(SomeInterfacePlacedInTheWrongPackage.class).beingAnInterface());

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -143,6 +143,10 @@ public class ExpectedViolation implements TestRule, ExpectsViolations {
             return containsLine("class %s matches '%s'", clazz.getName(), regex);
         }
 
+        public MessageAssertionChain.Link havingNameContaining(String infix) {
+            return containsLine("simple name of %s contains '%s'", clazz.getName(), infix);
+        }
+
         public MessageAssertionChain.Link beingAnInterface() {
             return containsLine("class %s is an interface", clazz.getName());
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -795,6 +795,16 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         }
 
         @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<JavaClass> simpleNameContaining(final String infix) {
+            return new DescribedPredicate<JavaClass>(String.format("simple name containing '%s'", infix)) {
+                @Override
+                public boolean apply(JavaClass input) {
+                    return input.getSimpleName().contains(infix);
+                }
+            };
+        }
+
+        @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> simpleNameEndingWith(final String suffix) {
             return new DescribedPredicate<JavaClass>(String.format("simple name ending with '%s'", suffix)) {
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -53,6 +53,7 @@ import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyO
 import static com.tngtech.archunit.core.domain.Formatters.ensureSimpleName;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
@@ -345,6 +346,27 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> haveSimpleNameNotStartingWith(String prefix) {
         return not(haveSimpleNameStartingWith(prefix)).as("have simple name not starting with '%s'", prefix);
     }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveSimpleNameContaining(final String infix) {
+        final DescribedPredicate<JavaClass> predicate = have(simpleNameContaining(infix));
+
+        return new ArchCondition<JavaClass>(predicate.getDescription()) {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean satisfied = predicate.apply(item);
+                String dynInfix = satisfied ? "contains" : "doesn't contain";
+                String message = String.format("simple name of %s %s '%s'", item.getName(), dynInfix, infix);
+                events.add(new SimpleConditionEvent(item, satisfied, message));
+            }
+        };
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveSimpleNameNotContaining(final String infix) {
+        return not(haveSimpleNameContaining(infix)).as("have simple name not containing '%s'", infix);
+    }
+
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameEndingWith(final String suffix) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -90,6 +90,16 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldConjunction haveSimpleNameContaining(String infix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleNameContaining(infix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameNotContaining(String infix) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleNameNotContaining(infix)));
+    }
+
+    @Override
     public ClassesShouldConjunction haveSimpleNameEndingWith(String suffix) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveSimpleNameEndingWith(suffix)));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
@@ -33,6 +33,9 @@ import com.tngtech.archunit.lang.syntax.elements.ClassesShouldThat;
 
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
@@ -45,13 +48,13 @@ class ClassesShouldThatInternal implements ClassesShouldThat, ClassesShouldConju
     private final FinishedRule finishedRule = new FinishedRule();
 
     ClassesShouldThatInternal(ClassesShouldInternal classesShould,
-            Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>> createCondition) {
+                              Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>> createCondition) {
         this(classesShould, new PredicateAggregator<JavaClass>(), createCondition);
     }
 
     private ClassesShouldThatInternal(ClassesShouldInternal classesShould,
-            PredicateAggregator<JavaClass> predicateAggregator,
-            Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>> createCondition) {
+                                      PredicateAggregator<JavaClass> predicateAggregator,
+                                      Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>> createCondition) {
         this.classesShould = classesShould;
         this.predicateAggregator = predicateAggregator;
         this.createCondition = createCondition;
@@ -145,6 +148,36 @@ class ClassesShouldThatInternal implements ClassesShouldThat, ClassesShouldConju
     @Override
     public ClassesShouldConjunction haveNameNotMatching(String regex) {
         return shouldWith(ClassesThatPredicates.haveNameNotMatching(regex));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameStartingWith(String prefix) {
+        return shouldWith(have(simpleNameStartingWith(prefix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameNotStartingWith(String prefix) {
+        return shouldWith(ClassesThatPredicates.haveSimpleNameNotStartingWith(prefix));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameContaining(String infix) {
+        return shouldWith(have(simpleNameContaining(infix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameNotContaining(String infix) {
+        return shouldWith(ClassesThatPredicates.haveSimpleNameNotContaining(infix));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameEndingWith(String suffix) {
+        return shouldWith(have(simpleNameEndingWith(suffix)));
+    }
+
+    @Override
+    public ClassesShouldConjunction haveSimpleNameNotEndingWith(String suffix) {
+        return shouldWith(ClassesThatPredicates.haveSimpleNameNotEndingWith(suffix));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatPredicates.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatPredicates.java
@@ -24,6 +24,9 @@ import com.tngtech.archunit.core.domain.properties.HasName;
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.JavaModifier.PROTECTED;
 import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
@@ -35,6 +38,18 @@ import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 class ClassesThatPredicates {
     static DescribedPredicate<HasName> haveNameNotMatching(String regex) {
         return have(not(nameMatching(regex)).as("name not matching '%s'", regex));
+    }
+
+    static DescribedPredicate<JavaClass> haveSimpleNameNotStartingWith(String prefix) {
+        return have(not(simpleNameStartingWith(prefix)).as("simple name not starting with '%s'", prefix));
+    }
+
+    static DescribedPredicate<JavaClass> haveSimpleNameNotContaining(String infix) {
+        return have(not(simpleNameContaining(infix)).as("simple name not containing '%s'", infix));
+    }
+
+    public static DescribedPredicate<JavaClass> haveSimpleNameNotEndingWith(String suffix) {
+        return have(not(simpleNameEndingWith(suffix)).as("simple name not ending with '%s'", suffix));
     }
 
     static DescribedPredicate<HasModifiers> arePublic() {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
@@ -15,6 +15,7 @@
  */
 package com.tngtech.archunit.lang.syntax;
 
+import java.io.CharArrayReader;
 import java.lang.annotation.Annotation;
 
 import com.tngtech.archunit.base.DescribedPredicate;
@@ -26,7 +27,7 @@ import com.tngtech.archunit.lang.syntax.elements.GivenClassesThat;
 
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.*;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
@@ -119,6 +120,36 @@ class GivenClassesThatInternal implements GivenClassesThat {
     @Override
     public GivenClassesConjunction dontImplement(DescribedPredicate<? super JavaClass> predicate) {
         return givenWith(dont(JavaClass.Predicates.implement(predicate)));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameStartingWith(String prefix) {
+        return givenWith(have(simpleNameStartingWith(prefix)));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameNotStartingWith(String prefix) {
+        return givenWith(ClassesThatPredicates.haveSimpleNameNotStartingWith(prefix));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameContaining(String infix) {
+        return givenWith(have(simpleNameContaining(infix)));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameNotContaining(String infix) {
+        return givenWith(ClassesThatPredicates.haveSimpleNameNotContaining(infix));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameEndingWith(String suffix) {
+        return givenWith(have(simpleNameEndingWith(suffix)));
+    }
+
+    @Override
+    public GivenClassesConjunction haveSimpleNameNotEndingWith(String suffix) {
+        return givenWith(ClassesThatPredicates.haveSimpleNameNotEndingWith(suffix));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -93,6 +93,24 @@ public interface ClassesShould {
     ClassesShouldConjunction haveSimpleNameNotStartingWith(String prefix);
 
     /**
+     * Asserts that classes' simple class names contain the specified sequence of char values.
+     *
+     * @param infix the String to search for
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveSimpleNameContaining(String infix);
+
+    /**
+     * Asserts that classes' simple class names do not contain the specified sequence of char values.
+     *
+     * @param infix the String to search for
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction haveSimpleNameNotContaining(String infix);
+
+    /**
      * Asserts that classes' simple class names end with a given suffix.
      *
      * @param suffix A suffix the simple class name should end with

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -93,18 +93,18 @@ public interface ClassesShould {
     ClassesShouldConjunction haveSimpleNameNotStartingWith(String prefix);
 
     /**
-     * Asserts that classes' simple class names contain the specified sequence of char values.
+     * Asserts that classes' simple class names contain the specified infix string.
      *
-     * @param infix the String to search for
+     * @param infix the infix string to search for
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction haveSimpleNameContaining(String infix);
 
     /**
-     * Asserts that classes' simple class names do not contain the specified sequence of char values.
+     * Asserts that classes' simple class names do not contain the specified infix string.
      *
-     * @param infix the String to search for
+     * @param infix the infix string to search for
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -83,6 +83,62 @@ public interface ClassesThat<CONJUNCTION> {
     CONJUNCTION haveNameNotMatching(String regex);
 
     /**
+     * Matches classes with a simple class name starting with a given prefix.
+     *
+     * @param prefix A prefix the simple class name should start with
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameStartingWith(String prefix);
+
+    /**
+     * Matches classes with a simple class name not starting with a given prefix.
+     *
+     * @param prefix A prefix the simple class name should not start with
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameNotStartingWith(String prefix);
+
+    /**
+     * Matches classes with a simple class name containing the specified
+     * sequence of char values.
+     *
+     * @param infix the String to search for
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameContaining(String infix);
+
+    /**
+     * Matches classes with a simple class name not containing the specified
+     * sequence of char values.
+     *
+     * @param infix the String to search for
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameNotContaining(String infix);
+
+    /**
+     * Matches classes with a simple class name ending with a given suffix.
+     *
+     * @param suffix A suffix the simple class name should not end with
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameEndingWith(String suffix);
+
+    /**
+     * Matches classes with a simple class name not ending with a given suffix.
+     *
+     * @param suffix A suffix the simple class name should not end with
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveSimpleNameNotEndingWith(String suffix);
+
+    /**
      * Matches classes residing in a package matching the supplied package identifier.
      *
      * @param packageIdentifier A string identifying packages, for details see {@link PackageMatcher}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -101,20 +101,18 @@ public interface ClassesThat<CONJUNCTION> {
     CONJUNCTION haveSimpleNameNotStartingWith(String prefix);
 
     /**
-     * Matches classes with a simple class name containing the specified
-     * sequence of char values.
+     * Matches classes with a simple class name containing the specified infix string.
      *
-     * @param infix the String to search for
+     * @param infix the infix string to search for
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
     CONJUNCTION haveSimpleNameContaining(String infix);
 
     /**
-     * Matches classes with a simple class name not containing the specified
-     * sequence of char values.
+     * Matches classes with a simple class name not containing the specified infix string.
      *
-     * @param infix the String to search for
+     * @param infix the infix string to search for
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -35,6 +35,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.implement;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
@@ -380,6 +381,26 @@ public class JavaClassTest {
         assertThat(simpleNameStartingWith(input.getName().substring(0, 2)).apply(input)).isFalse();
 
         assertThat(simpleNameStartingWith("Prefix").getDescription()).isEqualTo("simple name starting with 'Prefix'");
+    }
+
+    @Test
+    public void predicate_simpleNameContaining() {
+        JavaClass input = importClassWithContext(Parent.class);
+
+        assertThat(simpleNameContaining("Parent").apply(input)).isTrue();
+        assertThat(simpleNameContaining("Par").apply(input)).isTrue();
+        assertThat(simpleNameContaining("ent").apply(input)).isTrue();
+        assertThat(simpleNameContaining("aren").apply(input)).isTrue();
+        assertThat(simpleNameContaining("").apply(input)).isTrue();
+
+        // Full match test
+        assertThat(simpleNameContaining(input.getName()).apply(input)).isFalse();
+        assertThat(simpleNameContaining(" ").apply(input)).isFalse();
+        assertThat(simpleNameContaining(".").apply(input)).isFalse();
+
+        assertThat(simpleNameContaining(".Parent").apply(input)).isFalse();
+
+        assertThat(simpleNameContaining("Infix").getDescription()).isEqualTo("simple name containing 'Infix'");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -211,6 +211,52 @@ public class ClassesShouldTest {
     }
 
     @DataProvider
+    public static Object[][] haveSimpleNameContaining_rules() {
+        String simpleName = RightNamedClass.class.getSimpleName();
+        String prefix = simpleName.substring(1, simpleName.length() - 1);
+        return $$(
+                $(classes().should().haveSimpleNameContaining(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleNameContaining(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveSimpleNameContaining_rules")
+    public void haveSimpleNameContaining(ArchRule rule, String prefix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have simple name containing '%s'", prefix))
+                .contains(String.format("simple name of %s doesn't contain '%s'",
+                        WrongNamedClass.class.getName(), prefix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+    @DataProvider
+    public static Object[][] haveSimpleNameNotContaining_rules() {
+        String simpleName = WrongNamedClass.class.getSimpleName();
+        String prefix = simpleName.substring(1, simpleName.length() - 1);
+        return $$(
+                $(classes().should().haveSimpleNameNotContaining(prefix), prefix),
+                $(classes().should(ArchConditions.haveSimpleNameNotContaining(prefix)), prefix)
+        );
+    }
+
+    @Test
+    @UseDataProvider("haveSimpleNameNotContaining_rules")
+    public void haveSimpleNameNotContaining(ArchRule rule, String prefix) {
+        EvaluationResult result = rule.evaluate(importClasses(
+                RightNamedClass.class, WrongNamedClass.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains(String.format("classes should have simple name not containing '%s'", prefix))
+                .contains(String.format("simple name of %s contains '%s'",
+                        WrongNamedClass.class.getName(), prefix))
+                .doesNotContain(RightNamedClass.class.getName());
+    }
+
+    @DataProvider
     public static Object[][] haveSimpleNameNotStartingWith_rules() {
         String simpleName = WrongNamedClass.class.getSimpleName();
         String prefix = simpleName.substring(0, simpleName.length() - 1);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -3,6 +3,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Constructor;
+import java.text.AttributedString;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,6 +84,54 @@ public class GivenClassesThatTest {
                 .on(List.class, String.class, Iterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(String.class, Iterable.class);
+    }
+
+    @Test
+    public void haveSimpleNameStartingWith() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameStartingWith("String"))
+                .on(AttributedString.class, String.class, StringBuilder.class, Iterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(String.class, StringBuilder.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotStartingWith() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameNotStartingWith("String"))
+                .on(AttributedString.class, String.class, StringBuilder.class, Iterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(AttributedString.class, Iterable.class);
+    }
+
+    @Test
+    public void haveSimpleNameContaining() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameContaining("rin"))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(String.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotContaining() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameNotContaining("rin"))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Iterable.class);
+    }
+
+    @Test
+    public void haveSimpleNameEndingWith() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameEndingWith("String"))
+                .on(String.class, AttributedString.class, StringBuilder.class);
+
+        assertThatClasses(classes).matchInAnyOrder(String.class, AttributedString.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotEndingWith() throws Exception {
+        List<JavaClass> classes = filterResultOf(classes().that().haveSimpleNameNotEndingWith("String"))
+                .on(String.class, AttributedString.class, StringBuilder.class);
+
+        assertThatClasses(classes).matchInAnyOrder(StringBuilder.class);
     }
 
     @Test
@@ -486,12 +535,24 @@ public class GivenClassesThatTest {
         assertThatClasses(classes).matchInAnyOrder(Collection.class, Iterable.class);
     }
 
-    private DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
-        return GET_NAME.is(equalTo(type.getName()));
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface SomeAnnotation {
     }
 
-    private Evaluator filterResultOf(GivenClassesConjunction givenClasses) {
-        return new Evaluator(givenClasses);
+    private static class SimpleClass {
+    }
+
+    private static class PrivateClass {
+    }
+
+    static class PackagePrivateClass {
+    }
+
+    protected static class ProtectedClass {
+    }
+
+    @SomeAnnotation
+    private static class AnnotatedClass {
     }
 
     private class Evaluator {
@@ -516,23 +577,11 @@ public class GivenClassesThatTest {
         }
     }
 
-    private static class SimpleClass {
+    private DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
+        return GET_NAME.is(equalTo(type.getName()));
     }
 
-    private static class PrivateClass {
-    }
-
-    static class PackagePrivateClass {
-    }
-
-    protected static class ProtectedClass {
-    }
-
-    @Retention(RetentionPolicy.RUNTIME)
-    private @interface SomeAnnotation {
-    }
-
-    @SomeAnnotation
-    private static class AnnotatedClass {
+    private Evaluator filterResultOf(GivenClassesConjunction givenClasses) {
+        return new Evaluator(givenClasses);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
@@ -89,6 +89,60 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
+    public void haveSimpleNameStartingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameStartingWith("Lis"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotStartingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameNotStartingWith("Lis"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
+    }
+
+    @Test
+    public void haveSimpleNameContaining() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameContaining("is"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotContaining() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameNotContaining("is"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
+    }
+
+    @Test
+    public void haveSimpleNameEndingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameEndingWith("ist"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotEndingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().haveSimpleNameNotEndingWith("ist"))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
+    }
+
+    @Test
     public void resideInAPackage() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClasses().should().accessClassesThat().resideInAPackage("..tngtech.."))

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
@@ -108,6 +108,81 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
+    public void haveSimpleNameStartingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameStartingWith("Fo"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByBar.class, Bar.class,
+                ClassAccessedByBaz.class, Baz.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotStartingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotStartingWith("Fo"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByFoo.class, Foo.class);
+    }
+
+    @Test
+    public void haveSimpleNameContaining() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameContaining("o"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByBar.class, Bar.class,
+                ClassAccessedByBaz.class, Baz.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotContaining() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotContaining("o"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByFoo.class, Foo.class);
+    }
+
+    @Test
+    public void haveSimpleNameEndingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameEndingWith("oo"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByBar.class, Bar.class,
+                ClassAccessedByBaz.class, Baz.class);
+    }
+
+    @Test
+    public void haveSimpleNameNotEndingWith() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotEndingWith("oo"))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByFoo.class, Foo.class);
+    }
+
+    @Test
     public void resideInAPackage() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classes().should().onlyBeAccessed().byClassesThat().resideInAPackage("..access.."))


### PR DESCRIPTION
Hi,

this PR implements everything that should be required in order to resolve #41.
Please review the changes. I was unsure whether to call the negation methods `haveXyzNot` or `notHave` as you suggested, since I had already started naming the methods `haveSimpleNamingNotEndingWith` and it was merged like that. I have no problems with renaming all methods respectively if wanted.

Stef

I hereby agree to the terms of the ArchUnit Contributor License Agreement.