### PR TITLE
README improvements

### DIFF
--- a/archunit-example/README.md
+++ b/archunit-example/README.md
@@ -1,19 +1,20 @@
 # ArchUnit Examples
 
-This module houses some examples to illustrate how to use ArchUnit. All example
-rules you can find within `example/test` refer to classes from `example/main`.
-These tests are all designed to fail, to demonstrate how production code could violate
-typical architectural constraints (like layer dependencies).
+This module houses some examples
+* to illustrate how to use ArchUnit, and
+* providing input for the `archunit-integration-test` at the same time.
 
-All tests are marked with `@Category(Example.class)`, to run them with the regular
-Gradle build, add the property `example`, e.g.
+The [example rules within `example/test`](src/test/java/com/tngtech/archunit/exampletest)
+are applied to classes from [`example/main`](src/main/java/com/tngtech/archunit/example/),
+which are designed to break the architectural concepts (like layer dependencies, etc.).
+This demonstrates how ArchUnit detects such violations.
 
+In order to execute those tests (marked with `@Category(Example.class)`, excluded from the regular build),
+simply add the property `example` to the Gradle build:
 ```
 ../gradlew clean build -P example
 ```
 
-Otherwise the tests can be run directly from any IDE.
+Alternatively, the tests can also be run directly from any IDE, of course.
 
-Note that the example rules within this module also serve as input to
-`archunit-integration-test`, to continuously ensure the expected behavior of the example
-rules.
+Happy exploring!

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/CodingRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/CodingRulesTest.java
@@ -3,7 +3,6 @@ package com.tngtech.archunit.exampletest;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.example.ClassViolatingCodingRules;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -15,12 +14,8 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 
 @Category(Example.class)
 public class CodingRulesTest {
-    private JavaClasses classes;
 
-    @Before
-    public void setUp() throws Exception {
-        classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
-    }
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
 
     @Test
     public void classes_should_not_access_standard_streams_defined_by_hand() {

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/DaoRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/DaoRulesTest.java
@@ -7,7 +7,6 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.example.persistence.first.InWrongPackageDao;
 import com.tngtech.archunit.example.persistence.second.dao.OtherDao;
 import com.tngtech.archunit.example.service.ServiceViolatingDaoRules;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -15,12 +14,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
 @Category(Example.class)
 public class DaoRulesTest {
-    private JavaClasses classes;
 
-    @Before
-    public void setUp() throws Exception {
-        classes = new ClassFileImporter().importPackagesOf(InWrongPackageDao.class, OtherDao.class, ServiceViolatingDaoRules.class);
-    }
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(InWrongPackageDao.class, OtherDao.class, ServiceViolatingDaoRules.class);
 
     @Test
     public void DAOs_must_reside_in_a_dao_package() {

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
@@ -3,7 +3,6 @@ package com.tngtech.archunit.exampletest;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.example.ClassViolatingCodingRules;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -12,12 +11,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 @Category(Example.class)
 public class LayerDependencyRulesTest {
-    private JavaClasses classes;
 
-    @Before
-    public void setUp() throws Exception {
-        classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
-    }
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
 
     @Test
     public void services_should_not_access_controllers() {

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SessionBeanRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SessionBeanRulesTest.java
@@ -22,7 +22,6 @@ import com.tngtech.archunit.example.ClassViolatingSessionBeanRules;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -37,12 +36,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 @Category(Example.class)
 public class SessionBeanRulesTest {
-    private JavaClasses classes;
 
-    @Before
-    public void setUp() throws Exception {
-        classes = new ClassFileImporter().importPackagesOf(ClassViolatingSessionBeanRules.class);
-    }
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingSessionBeanRules.class);
 
     @Test
     public void stateless_session_beans_should_not_have_state() {

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/ThirdPartyRulesTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/ThirdPartyRulesTest.java
@@ -9,7 +9,6 @@ import com.tngtech.archunit.example.ClassViolatingThirdPartyRules;
 import com.tngtech.archunit.example.thirdparty.ThirdPartyClassWithProblem;
 import com.tngtech.archunit.example.thirdparty.ThirdPartyClassWorkaroundFactory;
 import com.tngtech.archunit.lang.ArchCondition;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -33,12 +32,7 @@ public class ThirdPartyRulesTest {
                     " and its subclasses, but instead use " +
                     ThirdPartyClassWorkaroundFactory.class.getSimpleName();
 
-    private JavaClasses classes;
-
-    @Before
-    public void setUp() throws Exception {
-        classes = new ClassFileImporter().importPackagesOf(ClassViolatingThirdPartyRules.class);
-    }
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingThirdPartyRules.class);
 
     @Test
     public void third_party_class_should_only_be_instantiated_via_workaround() {


### PR DESCRIPTION
#### improved README.md
* streamlined 'TL;DR' section and added dependency line for gradle (for copy & paste convenience)
* simplified `Getting started' example (@Before-method is not needed and only distracts from ArchUnit example)
* concluded 'Getting started' section with link to archunit-example (which helps getting started, but not every reader might arrive at the last 'Where to look next' section)
* simplified 'Extending ArchUnit' section (also rephrasing 'one has to do' -> 'it can be done')
* streamlined 'License' section (while the reason for redistributing ASM & Guava might not be that relevant within this section, their actual licence might however be)
* added link to 'Where to look next' section (to guide the readers)
    
archunit-example/README.md:
* added links to the directories containing example rules and 'production' code (to keep the reader attracted)

#### examples import classes directly in field initialization instead of @Before method

----
> - [x] I hereby agree to the terms of the ArchUnit Contributor License Agreement.