### PR TITLE
Add syntax fails on invalid args

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/base/ArchUnitException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/ArchUnitException.java
@@ -104,4 +104,11 @@ public class ArchUnitException extends RuntimeException {
             return new ClassResolverConfigurationException(message, cause);
         }
     }
+
+    @Internal
+    public static class InvalidSyntaxUsageException extends ArchUnitException {
+        public InvalidSyntaxUsageException(String message) {
+            super(message);
+        }
+    }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
@@ -856,6 +857,10 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> implement(final Class<?> type) {
+            if (!type.isInterface()) {
+                throw new InvalidSyntaxUsageException(String.format(
+                        "implement(type) can only ever be true, if type is an interface, but type %s is not", type.getName()));
+            }
             return implement(type.getName());
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
@@ -1,11 +1,14 @@
 package com.tngtech.archunit.core.domain.properties;
 
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
+import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
@@ -13,16 +16,19 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CanBeAnnotatedTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void matches_annotation_by_type() {
-        assertThat(annotatedWith(SomeAnnotation.class).apply(importClassWithContext(AnnotatedClass.class)))
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class).apply(importClassWithContext(AnnotatedClass.class)))
                 .as("annotated class matches").isTrue();
-        assertThat(annotatedWith(SomeAnnotation.class.getName()).apply(importClassWithContext(AnnotatedClass.class)))
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(importClassWithContext(AnnotatedClass.class)))
                 .as("annotated class matches").isTrue();
 
-        assertThat(annotatedWith(SomeAnnotation.class).apply(importClassWithContext(Object.class)))
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class).apply(importClassWithContext(Object.class)))
                 .as("annotated class matches").isFalse();
-        assertThat(annotatedWith(SomeAnnotation.class.getName()).apply(importClassWithContext(Object.class)))
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(importClassWithContext(Object.class)))
                 .as("annotated class matches").isFalse();
 
         assertThat(annotatedWith(Rule.class).getDescription())
@@ -44,11 +50,42 @@ public class CanBeAnnotatedTest {
                 .isEqualTo("annotated with Something");
     }
 
-    @Retention(RUNTIME)
-    @interface SomeAnnotation {
+    /**
+     * Since ArchUnit checks bytecode, it's very likely wrong API usage to look for an annotation with @Retention(SOURCE)
+     */
+    @Test
+    public void annotatedWith_Retention_Source_is_rejected() {
+        annotatedWith(RuntimeRetentionAnnotation.class);
+        annotatedWith(ClassRetentionAnnotation.class);
+        annotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        annotatedWith(SourceRetentionAnnotation.class);
     }
 
-    @SomeAnnotation
+    public static void expectInvalidSyntaxUsageForRetentionSource(ExpectedException thrown) {
+        thrown.expect(InvalidSyntaxUsageException.class);
+        thrown.expectMessage(Retention.class.getSimpleName());
+        thrown.expectMessage(RetentionPolicy.SOURCE.name());
+        thrown.expectMessage("useless");
+    }
+
+    @Retention(RUNTIME)
+    public @interface RuntimeRetentionAnnotation {
+    }
+
+    @Retention(RetentionPolicy.CLASS)
+    public @interface ClassRetentionAnnotation {
+    }
+
+    public @interface DefaultClassRetentionAnnotation {
+    }
+
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface SourceRetentionAnnotation {
+    }
+
+    @RuntimeRetentionAnnotation
     private static class AnnotatedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1,5 +1,6 @@
 package com.tngtech.archunit.lang.syntax.elements;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
+import static com.tngtech.archunit.core.domain.JavaClassTest.expectInvalidSyntaxUsageForClassInsteadOfInterface;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.JavaModifier.PROTECTED;
@@ -664,11 +666,19 @@ public class ClassesShouldTest {
                 .doesNotMatch(String.format(".*class %s .* implement.*", quote(satisfied.getName())));
     }
 
+    @Test
+    public void implement_rejects_non_interface_types() {
+        classes().should().implement(Serializable.class);
+
+        expectInvalidSyntaxUsageForClassInsteadOfInterface(thrown, AbstractList.class);
+        classes().should().implement(AbstractList.class);
+    }
+
     @DataProvider
     public static List<List<?>> implement_not_satisfied_rules() {
         return ImmutableList.<List<?>>builder()
                 .addAll(implementNotSatisfiedCases(Collection.class, List.class))
-                .addAll(implementNotSatisfiedCases(AbstractList.class, ArrayList.class))
+                .addAll(implementNotSatisfiedCases(Set.class, ArrayList.class))
                 .build();
     }
 
@@ -719,6 +729,14 @@ public class ClassesShouldTest {
                 .contains(String.format("classes should not implement %s", Collection.class.getName()))
                 .contains(String.format("class %s implements %s", violated.getName(), Collection.class.getName()))
                 .doesNotMatch(String.format(".*class %s .* implement.*", quote(satisfied.getName())));
+    }
+
+    @Test
+    public void notImplement_rejects_non_interface_types() {
+        classes().should().notImplement(Serializable.class);
+
+        expectInvalidSyntaxUsageForClassInsteadOfInterface(thrown, AbstractList.class);
+        classes().should().notImplement(AbstractList.class);
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1,8 +1,6 @@
 package com.tngtech.archunit.lang.syntax.elements;
 
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,6 +19,11 @@ import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.ClassRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.DefaultClassRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.RuntimeRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.SourceRetentionAnnotation;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
@@ -28,7 +31,9 @@ import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
@@ -38,6 +43,7 @@ import static com.tngtech.archunit.core.domain.JavaModifier.PROTECTED;
 import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
 import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
 import static com.tngtech.archunit.core.domain.TestUtils.importHierarchies;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.expectInvalidSyntaxUsageForRetentionSource;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.bePackagePrivate;
@@ -59,6 +65,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(DataProviderRunner.class)
 public class ClassesShouldTest {
     private static final String FAILURE_REPORT_NEWLINE_MARKER = "#";
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @DataProvider
     public static Object[][] haveFullyQualifiedName_rules() {
@@ -554,17 +563,17 @@ public class ClassesShouldTest {
     @DataProvider
     public static Object[][] annotated_rules() {
         return $$(
-                $(classes().should().beAnnotatedWith(SomeAnnotation.class),
+                $(classes().should().beAnnotatedWith(RuntimeRetentionAnnotation.class),
                         SomeAnnotatedClass.class, String.class),
-                $(classes().should(ArchConditions.beAnnotatedWith(SomeAnnotation.class)),
+                $(classes().should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class)),
                         SomeAnnotatedClass.class, String.class),
-                $(classes().should().beAnnotatedWith(SomeAnnotation.class.getName()),
+                $(classes().should().beAnnotatedWith(RuntimeRetentionAnnotation.class.getName()),
                         SomeAnnotatedClass.class, String.class),
-                $(classes().should(ArchConditions.beAnnotatedWith(SomeAnnotation.class.getName())),
+                $(classes().should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class.getName())),
                         SomeAnnotatedClass.class, String.class),
-                $(classes().should().beAnnotatedWith(annotation(SomeAnnotation.class)),
+                $(classes().should().beAnnotatedWith(annotation(RuntimeRetentionAnnotation.class)),
                         SomeAnnotatedClass.class, String.class),
-                $(classes().should(ArchConditions.beAnnotatedWith(annotation(SomeAnnotation.class))),
+                $(classes().should(ArchConditions.beAnnotatedWith(annotation(RuntimeRetentionAnnotation.class))),
                         SomeAnnotatedClass.class, String.class));
     }
 
@@ -574,26 +583,39 @@ public class ClassesShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(correctClass, wrongClass));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains(String.format("classes should be annotated with @%s", SomeAnnotation.class.getSimpleName()))
+                .contains(String.format("classes should be annotated with @%s", RuntimeRetentionAnnotation.class.getSimpleName()))
                 .contains(String.format("class %s is not annotated with @%s",
-                        wrongClass.getName(), SomeAnnotation.class.getSimpleName()))
+                        wrongClass.getName(), RuntimeRetentionAnnotation.class.getSimpleName()))
                 .doesNotMatch(String.format(".*%s.*annotated.*", quote(correctClass.getName())));
+    }
+
+    /**
+     * Compare {@link CanBeAnnotatedTest#annotatedWith_Retention_Source_is_rejected}
+     */
+    @Test
+    public void beAnnotatedWith_Retention_Source_is_rejected() {
+        classes().should().beAnnotatedWith(RuntimeRetentionAnnotation.class);
+        classes().should().beAnnotatedWith(ClassRetentionAnnotation.class);
+        classes().should().beAnnotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        classes().should().beAnnotatedWith(SourceRetentionAnnotation.class);
     }
 
     @DataProvider
     public static Object[][] notAnnotated_rules() {
         return $$(
-                $(classes().should().notBeAnnotatedWith(SomeAnnotation.class),
+                $(classes().should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class),
                         String.class, SomeAnnotatedClass.class),
-                $(classes().should(ArchConditions.notBeAnnotatedWith(SomeAnnotation.class)),
+                $(classes().should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class)),
                         String.class, SomeAnnotatedClass.class),
-                $(classes().should().notBeAnnotatedWith(SomeAnnotation.class.getName()),
+                $(classes().should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class.getName()),
                         String.class, SomeAnnotatedClass.class),
-                $(classes().should(ArchConditions.notBeAnnotatedWith(SomeAnnotation.class.getName())),
+                $(classes().should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class.getName())),
                         String.class, SomeAnnotatedClass.class),
-                $(classes().should().notBeAnnotatedWith(annotation(SomeAnnotation.class)),
+                $(classes().should().notBeAnnotatedWith(annotation(RuntimeRetentionAnnotation.class)),
                         String.class, SomeAnnotatedClass.class),
-                $(classes().should(ArchConditions.notBeAnnotatedWith(annotation(SomeAnnotation.class))),
+                $(classes().should(ArchConditions.notBeAnnotatedWith(annotation(RuntimeRetentionAnnotation.class))),
                         String.class, SomeAnnotatedClass.class));
     }
 
@@ -603,10 +625,23 @@ public class ClassesShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(correctClass, wrongClass));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains("classes should not be annotated with @" + SomeAnnotation.class.getSimpleName())
+                .contains("classes should not be annotated with @" + RuntimeRetentionAnnotation.class.getSimpleName())
                 .contains(String.format("class %s is annotated with @%s",
-                        wrongClass.getName(), SomeAnnotation.class.getSimpleName()))
+                        wrongClass.getName(), RuntimeRetentionAnnotation.class.getSimpleName()))
                 .doesNotMatch(String.format(".*%s.*annotated.*", quote(correctClass.getName())));
+    }
+
+    /**
+     * Compare {@link CanBeAnnotatedTest#annotatedWith_Retention_Source_is_rejected}
+     */
+    @Test
+    public void notBeAnnotatedWith_Retention_Source_is_rejected() {
+        classes().should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class);
+        classes().should().notBeAnnotatedWith(ClassRetentionAnnotation.class);
+        classes().should().notBeAnnotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        classes().should().notBeAnnotatedWith(SourceRetentionAnnotation.class);
     }
 
     @DataProvider
@@ -1272,11 +1307,7 @@ public class ClassesShouldTest {
     private static class PrivateClass {
     }
 
-    @Retention(RetentionPolicy.RUNTIME)
-    private @interface SomeAnnotation {
-    }
-
-    @SomeAnnotation
+    @RuntimeRetentionAnnotation
     private static class SomeAnnotatedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -1,5 +1,6 @@
 package com.tngtech.archunit.lang.syntax.elements;
 
+import java.io.Serializable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Constructor;
@@ -8,6 +9,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -29,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
+import static com.tngtech.archunit.core.domain.JavaClassTest.expectInvalidSyntaxUsageForClassInsteadOfInterface;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.expectInvalidSyntaxUsageForRetentionSource;
@@ -340,10 +343,18 @@ public class GivenClassesThatTest {
 
         assertThat(getOnlyElement(classes)).matches(ArrayList.class);
 
-        classes = filterResultOf(classes().that().implement(AbstractList.class))
+        classes = filterResultOf(classes().that().implement(Set.class))
                 .on(ArrayList.class, List.class, Iterable.class);
 
         assertThat(classes).isEmpty();
+    }
+
+    @Test
+    public void implement_rejects_non_interface_types() {
+        classes().that().implement(Serializable.class);
+
+        expectInvalidSyntaxUsageForClassInsteadOfInterface(thrown, AbstractList.class);
+        classes().that().implement(AbstractList.class);
     }
 
     @Test
@@ -352,6 +363,14 @@ public class GivenClassesThatTest {
                 .on(ArrayList.class, List.class, Iterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(List.class, Iterable.class);
+    }
+
+    @Test
+    public void dontImplement_rejects_non_interface_types() {
+        classes().that().dontImplement(Serializable.class);
+
+        expectInvalidSyntaxUsageForClassInsteadOfInterface(thrown, AbstractList.class);
+        classes().that().dontImplement(AbstractList.class);
     }
 
     @Test
@@ -611,9 +630,11 @@ public class GivenClassesThatTest {
     private static class PrivateClass {
     }
 
+    @SuppressWarnings("WeakerAccess")
     static class PackagePrivateClass {
     }
 
+    @SuppressWarnings("WeakerAccess")
     protected static class ProtectedClass {
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -12,11 +12,18 @@ import java.util.List;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.ClassRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.DefaultClassRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.RuntimeRetentionAnnotation;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.SourceRetentionAnnotation;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -24,6 +31,7 @@ import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleName;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.expectInvalidSyntaxUsageForRetentionSource;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
@@ -37,6 +45,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 public class GivenClassesThatTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void haveFullyQualifiedName() {
@@ -255,12 +265,38 @@ public class GivenClassesThatTest {
         assertThat(getOnlyElement(classes)).matches(AnnotatedClass.class);
     }
 
+    /**
+     * Compare {@link CanBeAnnotatedTest#annotatedWith_Retention_Source_is_rejected}
+     */
+    @Test
+    public void annotatedWith_Retention_Source_is_rejected() {
+        classes().that().areAnnotatedWith(RuntimeRetentionAnnotation.class);
+        classes().that().areAnnotatedWith(ClassRetentionAnnotation.class);
+        classes().that().areAnnotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        classes().that().areAnnotatedWith(SourceRetentionAnnotation.class);
+    }
+
     @Test
     public void areNotAnnotatedWith_type() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotAnnotatedWith(SomeAnnotation.class))
                 .on(AnnotatedClass.class, SimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(SimpleClass.class);
+    }
+
+    /**
+     * Compare {@link CanBeAnnotatedTest#annotatedWith_Retention_Source_is_rejected}
+     */
+    @Test
+    public void notAnnotatedWith_Retention_Source_is_rejected() {
+        classes().that().areNotAnnotatedWith(RuntimeRetentionAnnotation.class);
+        classes().that().areNotAnnotatedWith(ClassRetentionAnnotation.class);
+        classes().that().areNotAnnotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        classes().that().areNotAnnotatedWith(SourceRetentionAnnotation.class);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
@@ -532,72 +532,84 @@ public class ShouldAccessClassesThatTest {
     }
 
     private static class ClassAccessingList {
-        void call(List list) {
+        @SuppressWarnings("unused")
+        void call(List<?> list) {
             list.size();
         }
     }
 
     private static class ClassAccessingArrayList {
-        void call(ArrayList list) {
+        @SuppressWarnings("unused")
+        void call(ArrayList<?> list) {
             list.size();
         }
     }
 
     private static class ClassAccessingString {
+        @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
         void call() {
             "string".length();
         }
     }
 
     private static class ClassAccessingCollection {
-        void call(Collection collection) {
+        @SuppressWarnings("unused")
+        void call(Collection<?> collection) {
             collection.size();
         }
     }
 
     private static class ClassAccessingIterable {
-        void call(Iterable iterable) {
+        @SuppressWarnings("unused")
+        void call(Iterable<?> iterable) {
             iterable.iterator();
         }
     }
 
     private static class ClassAccessingConstructor {
+        @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
         void call(Constructor<?> constructor) {
             constructor.getModifiers();
         }
     }
 
     private static class ClassAccessingSimpleClass {
+        @SuppressWarnings("unused")
         void call() {
             new SimpleClass();
         }
     }
 
     private static class ClassAccessingPrivateClass {
+        @SuppressWarnings("unused")
         void call() {
             new PrivateClass();
         }
     }
 
     private static class ClassAccessingPackagePrivateClass {
+        @SuppressWarnings("unused")
         void call() {
             new PackagePrivateClass();
         }
     }
 
     private static class ClassAccessingProtectedClass {
+        @SuppressWarnings("unused")
         void call() {
             new ProtectedClass();
         }
     }
 
     private static class ClassAccessingPublicClass {
+        @SuppressWarnings("unused")
         void call() {
             new PublicClass();
         }
     }
 
     private static class ClassAccessingAnnotatedClass {
+        @SuppressWarnings("unused")
         void call() {
             new AnnotatedClass();
         }
@@ -612,9 +624,11 @@ public class ShouldAccessClassesThatTest {
     static class PackagePrivateClass {
     }
 
+    @SuppressWarnings("WeakerAccess")
     protected static class ProtectedClass {
     }
 
+    @SuppressWarnings("WeakerAccess")
     public static class PublicClass {
     }
 


### PR DESCRIPTION
Adds some sanity checks to syntax methods accepting types (i.e. if we can determine, that an argument makes no sense, like `annotatedWith(annotationWithRetentionSource)` or `implement(concreteType)`)

Resolves #48 