### PR TITLE
@ArchIgnore annotation allows to specify a reason why the test is ignored

### DIFF
--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchIgnore.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchIgnore.java
@@ -30,4 +30,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({TYPE, FIELD, METHOD})
 @Retention(RUNTIME)
 public @interface ArchIgnore {
+    /** documents why the test is ignored */
+    String reason() default "";
 }


### PR DESCRIPTION
Since `@ArchIgnore` corresponds to `@org.junit.Ignore`, it might also be useful to be able to add a reason when an `@ArchTest` is ignored.

---
> I hereby agree to the terms of the ArchUnit Contributor License Agreement.