### PR TITLE
Add support for meta-annotations

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -146,6 +146,31 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         });
     }
 
+    @Override
+    public boolean isMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return isMetaAnnotatedWith(annotationType.getName());
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(final String annotationTypeName) {
+        return anyMember(new Predicate<JavaMember>() {
+            @Override
+            public boolean apply(JavaMember input) {
+                return input.isMetaAnnotatedWith(annotationTypeName);
+            }
+        });
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(final DescribedPredicate<? super JavaAnnotation> predicate) {
+        return anyMember(new Predicate<JavaMember>() {
+            @Override
+            public boolean apply(JavaMember input) {
+                return input.isMetaAnnotatedWith(predicate);
+            }
+        });
+    }
+
     private boolean anyMember(Predicate<JavaMember> predicate) {
         for (final JavaMember member : resolve()) {
             if (predicate.apply(member)) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -147,6 +147,26 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         return CanBeAnnotated.Utils.isAnnotatedWith(annotations.get().values(), predicate);
     }
 
+    @Override
+    public boolean isMetaAnnotatedWith(Class<? extends Annotation> type) {
+        return isMetaAnnotatedWith(type.getName());
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(String typeName) {
+        for (JavaAnnotation annotation : annotations.get().values()) {
+            if (annotation.getType().isAnnotatedWith(typeName) || annotation.getType().isMetaAnnotatedWith(typeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return CanBeAnnotated.Utils.isMetaAnnotatedWith(annotations.get().values(), predicate);
+    }
+
     /**
      * @param type A given annotation type to match {@link JavaAnnotation JavaAnnotations} against
      * @return An {@link Annotation} of the given annotation type

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -105,6 +105,26 @@ public abstract class JavaMember implements
     }
 
     @Override
+    public boolean isMetaAnnotatedWith(Class<? extends Annotation> type) {
+        return isMetaAnnotatedWith(type.getName());
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(String typeName) {
+        for (JavaAnnotation annotation : annotations.get().values()) {
+            if (annotation.getType().isAnnotatedWith(typeName) || annotation.getType().isMetaAnnotatedWith(typeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return CanBeAnnotated.Utils.isMetaAnnotatedWith(annotations.get().values(), predicate);
+    }
+
+    @Override
     public JavaClass getOwner() {
         return owner;
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -547,6 +547,36 @@ public final class ArchConditions {
         return not(beAnnotatedWith(predicate));
     }
 
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beMetaAnnotatedWith(Class<? extends Annotation> type) {
+        return createAnnotatedCondition(HasAnnotations.Predicates.metaAnnotatedWith(type));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeMetaAnnotatedWith(Class<? extends Annotation> type) {
+        return not(beMetaAnnotatedWith(type));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beMetaAnnotatedWith(String typeName) {
+        return createAnnotatedCondition(HasAnnotations.Predicates.metaAnnotatedWith(typeName));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeMetaAnnotatedWith(String typeName) {
+        return not(beMetaAnnotatedWith(typeName));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beMetaAnnotatedWith(final DescribedPredicate<? super JavaAnnotation> predicate) {
+        return createAnnotatedCondition(HasAnnotations.Predicates.metaAnnotatedWith(predicate));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return not(beMetaAnnotatedWith(predicate));
+    }
+
     private static ArchCondition<JavaClass> createAnnotatedCondition(final DescribedPredicate<CanBeAnnotated> annotatedWith) {
         return new ArchCondition<JavaClass>(be(annotatedWith).getDescription()) {
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -220,6 +220,36 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldConjunction beMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.beMetaAnnotatedWith(annotationType)));
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBeMetaAnnotatedWith(annotationType)));
+    }
+
+    @Override
+    public ClassesShouldConjunction beMetaAnnotatedWith(String annotationTypeName) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.beMetaAnnotatedWith(annotationTypeName)));
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeMetaAnnotatedWith(String annotationTypeName) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBeMetaAnnotatedWith(annotationTypeName)));
+    }
+
+    @Override
+    public ClassesShouldConjunction beMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.beMetaAnnotatedWith(predicate)));
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBeMetaAnnotatedWith(predicate)));
+    }
+
+    @Override
     public ClassesShouldConjunction implement(Class<?> type) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.implement(type)));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldThatInternal.java
@@ -37,6 +37,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameCo
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
@@ -108,6 +109,36 @@ class ClassesShouldThatInternal implements ClassesShouldThat, ClassesShouldConju
     @Override
     public ClassesShouldConjunction areNotAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
         return shouldWith(are(not(annotatedWith(predicate))));
+    }
+
+    @Override
+    public ClassesShouldConjunction areMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return shouldWith(are(metaAnnotatedWith(annotationType)));
+    }
+
+    @Override
+    public ClassesShouldConjunction areNotMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return shouldWith(are(not(metaAnnotatedWith(annotationType))));
+    }
+
+    @Override
+    public ClassesShouldConjunction areMetaAnnotatedWith(String annotationTypeName) {
+        return shouldWith(are(metaAnnotatedWith(annotationTypeName)));
+    }
+
+    @Override
+    public ClassesShouldConjunction areNotMetaAnnotatedWith(String annotationTypeName) {
+        return shouldWith(are(not(metaAnnotatedWith(annotationTypeName))));
+    }
+
+    @Override
+    public ClassesShouldConjunction areMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return shouldWith(are(metaAnnotatedWith(predicate)));
+    }
+
+    @Override
+    public ClassesShouldConjunction areNotMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return shouldWith(are(not(metaAnnotatedWith(predicate))));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesThatInternal.java
@@ -31,6 +31,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameCo
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
@@ -92,6 +93,36 @@ class GivenClassesThatInternal implements GivenClassesThat {
     @Override
     public GivenClassesConjunction areNotAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
         return givenWith(are(not(annotatedWith(predicate))));
+    }
+
+    @Override
+    public GivenClassesConjunction areMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return givenWith(are(metaAnnotatedWith(annotationType)));
+    }
+
+    @Override
+    public GivenClassesConjunction areNotMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return givenWith(are(not(metaAnnotatedWith(annotationType))));
+    }
+
+    @Override
+    public GivenClassesConjunction areMetaAnnotatedWith(String annotationTypeName) {
+        return givenWith(are(metaAnnotatedWith(annotationTypeName)));
+    }
+
+    @Override
+    public GivenClassesConjunction areNotMetaAnnotatedWith(String annotationTypeName) {
+        return givenWith(are(not(metaAnnotatedWith(annotationTypeName))));
+    }
+
+    @Override
+    public GivenClassesConjunction areMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return givenWith(are(metaAnnotatedWith(predicate)));
+    }
+
+    @Override
+    public GivenClassesConjunction areNotMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate) {
+        return givenWith(are(not(metaAnnotatedWith(predicate))));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -319,6 +319,66 @@ public interface ClassesShould {
     ClassesShouldConjunction notBeAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
 
     /**
+     * Asserts that classes are meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationType Specific type of {@link Annotation}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beMetaAnnotatedWith(Class<? extends Annotation> annotationType);
+
+    /**
+     * Asserts that classes are not meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationType Specific type of {@link Annotation}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeMetaAnnotatedWith(Class<? extends Annotation> annotationType);
+
+    /**
+     * Asserts that classes are meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationTypeName Fully qualified class name of a specific type of {@link Annotation}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beMetaAnnotatedWith(String annotationTypeName);
+
+    /**
+     * Asserts that classes are not meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationTypeName Fully qualified class name of a specific type of {@link Annotation}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeMetaAnnotatedWith(String annotationTypeName);
+
+    /**
+     * Asserts that classes are meta-annotated with a certain annotation, where matching meta-annotations are
+     * determined by the supplied predicate. A meta-annotation is an annotation that is declared on another annotation.
+     *
+     * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
+
+    /**
+     * Asserts that classes are not meta-annotated with a certain annotation, where matching meta-annotations are
+     * determined by the supplied predicate. A meta-annotation is an annotation that is declared on another annotation.
+     *
+     * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
+
+    /**
      * Asserts that classes implement a certain interface.
      *
      * @param type An interface imported classes should implement

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -309,6 +309,68 @@ public interface ClassesThat<CONJUNCTION> {
     CONJUNCTION areNotAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
 
     /**
+     * Matches classes meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationType Specific type of {@link Annotation}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areMetaAnnotatedWith(Class<? extends Annotation> annotationType);
+
+    /**
+     * Matches classes not meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationType Specific type of {@link Annotation}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotMetaAnnotatedWith(Class<? extends Annotation> annotationType);
+
+    /**
+     * Matches classes meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationTypeName Fully qualified class name of a specific type of {@link Annotation}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areMetaAnnotatedWith(String annotationTypeName);
+
+    /**
+     * Matches classes not meta-annotated with a certain type of annotation. A meta-annotation is
+     * an annotation that is declared on another annotation.
+     *
+     * @param annotationTypeName Fully qualified class name of a specific type of {@link Annotation}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotMetaAnnotatedWith(String annotationTypeName);
+
+    /**
+     * Matches classes meta-annotated with a certain annotation, where matching meta-annotations are
+     * determined by the supplied predicate.  A meta-annotation is an annotation that is declared on
+     * another annotation.
+     *
+     * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
+
+    /**
+     * Matches classes not meta-annotated with a certain annotation, where matching meta-annotations are
+     * determined by the supplied predicate.  A meta-annotation is an annotation that is declared on
+     * another annotation.
+     *
+     * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation> predicate);
+
+    /**
      * Matches classes that implement a certain interface.
      *
      * @param type An interface type matching classes must implement

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.AccessTarget.Predicates.constructor;
 import static com.tngtech.archunit.core.domain.AccessTarget.Predicates.declaredIn;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.simulateCall;
 import static com.tngtech.archunit.core.domain.TestUtils.withinImportedClasses;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +63,61 @@ public class AccessTargetTest {
                 .isFalse();
         assertThat(call.getTarget().isAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
                 .as("target is annotated with anything")
+                .isFalse();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_type_on_resolved_target() {
+        JavaClasses classes = importClassesWithContext(Origin.class, Target.class, QueriedAnnotation.class);
+        JavaCall<?> call = simulateCall().from(classes.get(Origin.class), "call").to(classes.get(Target.class).getMethod("called"));
+
+        assertThat(call.getTarget().isMetaAnnotatedWith(QueriedAnnotation.class))
+                .as("target is meta-annotated with @" + QueriedAnnotation.class.getSimpleName())
+                .isFalse();
+        assertThat(call.getTarget().isMetaAnnotatedWith(Retention.class))
+                .as("target is meta-annotated with @" + Retention.class.getSimpleName())
+                .isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_typeName_on_resolved_target() {
+        JavaClasses classes = importClassesWithContext(Origin.class, Target.class, QueriedAnnotation.class);
+        JavaCall<?> call = simulateCall().from(classes.get(Origin.class), "call").to(classes.get(Target.class).getMethod("called"));
+
+        assertThat(call.getTarget().isMetaAnnotatedWith(QueriedAnnotation.class.getName()))
+                .as("target is meta-annotated with @" + QueriedAnnotation.class.getSimpleName())
+                .isFalse();
+        assertThat(call.getTarget().isMetaAnnotatedWith(Retention.class.getName()))
+                .as("target is meta-annotated with @" + Retention.class.getSimpleName())
+                .isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_predicate_on_resolved_target() {
+        JavaClasses classes = importClassesWithContext(Origin.class, Target.class, QueriedAnnotation.class);
+        JavaCall<?> call = simulateCall().from(classes.get(Origin.class), "call").to(classes.get(Target.class).getMethod("called"));
+
+        assertThat(call.getTarget().isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .as("target is meta-annotated with anything")
+                .isTrue();
+        assertThat(call.getTarget().isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
+                .as("target is meta-annotated with nothing")
+                .isFalse();
+    }
+
+    @Test
+    public void meta_annotated_on_unresolved_target() {
+        JavaClasses classes = importClassesWithContext(Origin.class, Target.class, QueriedAnnotation.class);
+        JavaCall<?> call = simulateCall().from(classes.get(Origin.class), "call").toUnresolved(Target.class, "called");
+
+        assertThat(call.getTarget().isMetaAnnotatedWith(Retention.class))
+                .as("target is meta-annotated with @" + Retention.class.getSimpleName())
+                .isFalse();
+        assertThat(call.getTarget().isMetaAnnotatedWith(Retention.class.getName()))
+                .as("target is meta-annotated with @" + Retention.class.getSimpleName())
+                .isFalse();
+        assertThat(call.getTarget().isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .as("target is meta-annotated with anything")
                 .isFalse();
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -168,12 +168,44 @@ public class JavaClassTest {
     }
 
     @Test
-    public void predicate_isAnnotatedWith() {
+    public void isAnnotatedWith_predicate() {
         assertThat(importClassWithContext(Parent.class)
                 .isAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
                 .as("predicate matches").isTrue();
         assertThat(importClassWithContext(Parent.class)
                 .isAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
+                .as("predicate matches").isFalse();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_type() {
+        JavaClass clazz = importClassesWithContext(Parent.class, SomeAnnotation.class).get(Parent.class);
+
+        assertThat(clazz.isMetaAnnotatedWith(SomeAnnotation.class))
+                .as("Parent is meta-annotated with @" + SomeAnnotation.class.getSimpleName()).isFalse();
+        assertThat(clazz.isMetaAnnotatedWith(Retention.class))
+                .as("Parent is meta-annotated with @" + Retention.class.getSimpleName()).isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_typeName() {
+        JavaClass clazz = importClassesWithContext(Parent.class, SomeAnnotation.class).get(Parent.class);
+
+        assertThat(clazz.isMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .as("Parent is meta-annotated with @" + SomeAnnotation.class.getSimpleName()).isFalse();
+        assertThat(clazz.isMetaAnnotatedWith(Retention.class.getName()))
+                .as("Parent is meta-annotated with @" + Retention.class.getSimpleName()).isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_predicate() {
+        JavaClass clazz = importClassesWithContext(Parent.class, SomeAnnotation.class).get(Parent.class);
+
+        assertThat(clazz
+                .isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .as("predicate matches").isTrue();
+        assertThat(clazz
+                .isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
                 .as("predicate matches").isFalse();
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.core.domain.JavaMember.Predicates.declaredIn;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
+import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JavaMemberTest {
@@ -34,6 +35,38 @@ public class JavaMemberTest {
                 .as("predicate matches").isTrue();
         assertThat(importField(SomeClass.class, "someField")
                 .isAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
+                .as("predicate matches").isFalse();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_type() {
+        JavaClass clazz = importClassesWithContext(SomeClass.class, Deprecated.class).get(SomeClass.class);
+
+        assertThat(clazz.getField("someField").isMetaAnnotatedWith(Deprecated.class))
+                .as("field is meta-annotated with @Deprecated").isFalse();
+        assertThat(clazz.getField("someField").isMetaAnnotatedWith(Retention.class))
+                .as("field is meta-annotated with @Retention").isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_typeName() {
+        JavaClass clazz = importClassesWithContext(SomeClass.class, Deprecated.class).get(SomeClass.class);
+
+        assertThat(clazz.getField("someField").isMetaAnnotatedWith(Deprecated.class.getName()))
+                .as("field is meta-annotated with @Deprecated").isFalse();
+        assertThat(clazz.getField("someField").isMetaAnnotatedWith(Retention.class.getName()))
+                .as("field is meta-annotated with @Retention").isTrue();
+    }
+
+    @Test
+    public void isMetaAnnotatedWith_predicate() {
+        JavaClass clazz = importClassesWithContext(SomeClass.class, Deprecated.class).get(SomeClass.class);
+
+        assertThat(clazz.getField("someField")
+                .isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .as("predicate matches").isTrue();
+        assertThat(clazz.getField("someField")
+                .isMetaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
                 .as("predicate matches").isFalse();
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
@@ -6,12 +6,16 @@ import java.lang.annotation.RetentionPolicy;
 import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
+import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,6 +67,52 @@ public class CanBeAnnotatedTest {
         annotatedWith(SourceRetentionAnnotation.class);
     }
 
+    @Test
+    public void matches_meta_annotation_by_type() {
+        JavaClasses classes = importClassesWithContext(MetaAnnotatedClass.class, Object.class, MetaRuntimeRetentionAnnotation.class);
+
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class).apply(classes.get(MetaAnnotatedClass.class)))
+                .as("meta-annotated class matches").isTrue();
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(classes.get(MetaAnnotatedClass.class)))
+                .as("meta-annotated class matches").isTrue();
+
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class).apply(classes.get(Object.class)))
+                .as("meta-annotated class matches").isFalse();
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(classes.get(Object.class)))
+                .as("meta-annotated class matches").isFalse();
+
+        assertThat(metaAnnotatedWith(Rule.class).getDescription())
+                .isEqualTo("meta-annotated with @Rule");
+        assertThat(metaAnnotatedWith(Rule.class.getName()).getDescription())
+                .isEqualTo("meta-annotated with @Rule");
+    }
+
+    @Test
+    public void matches_meta_annotation_by_predicate() {
+        JavaClass clazz = importClassesWithContext(MetaAnnotatedClass.class, MetaRuntimeRetentionAnnotation.class).get(MetaAnnotatedClass.class);
+
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()).apply(clazz))
+                .as("meta-annotated class matches").isTrue();
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()).apply(clazz))
+                .as("meta-annotated class matches").isFalse();
+
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")).getDescription())
+                .isEqualTo("meta-annotated with Something");
+    }
+
+    /**
+     * Since ArchUnit checks bytecode, it's very likely wrong API usage to look for an annotation with @Retention(SOURCE)
+     */
+    @Test
+    public void metaAnnotatedWith_Retention_Source_is_rejected() {
+        metaAnnotatedWith(RuntimeRetentionAnnotation.class);
+        metaAnnotatedWith(ClassRetentionAnnotation.class);
+        metaAnnotatedWith(DefaultClassRetentionAnnotation.class);
+
+        expectInvalidSyntaxUsageForRetentionSource(thrown);
+        metaAnnotatedWith(SourceRetentionAnnotation.class);
+    }
+
     public static void expectInvalidSyntaxUsageForRetentionSource(ExpectedException thrown) {
         thrown.expect(InvalidSyntaxUsageException.class);
         thrown.expectMessage(Retention.class.getSimpleName());
@@ -87,5 +137,14 @@ public class CanBeAnnotatedTest {
 
     @RuntimeRetentionAnnotation
     private static class AnnotatedClass {
+    }
+
+    @Retention(RUNTIME)
+    @RuntimeRetentionAnnotation
+    public @interface MetaRuntimeRetentionAnnotation {
+    }
+
+    @MetaRuntimeRetentionAnnotation
+    private static class MetaAnnotatedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/RandomClassesSyntaxTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/RandomClassesSyntaxTest.java
@@ -10,7 +10,8 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 public class RandomClassesSyntaxTest extends RandomSyntaxTestBase {
     @DataProvider
     public static List<List<?>> random_rules() {
-        return RandomSyntaxTestBase.createRandomRules(givenClassesSeed());
+        return RandomSyntaxTestBase.createRandomRules(givenClassesSeed(),
+                new SingleStringReplacement("meta annotated", "meta-annotated"));
     }
 
     private static RandomSyntaxSeed<GivenClasses> givenClassesSeed() {
@@ -18,6 +19,33 @@ public class RandomClassesSyntaxTest extends RandomSyntaxTestBase {
             return new RandomSyntaxSeed<>(GivenClasses.class, ArchRuleDefinition.classes(), "classes");
         } else {
             return new RandomSyntaxSeed<>(GivenClasses.class, ArchRuleDefinition.noClasses(), "no classes");
+        }
+    }
+
+    private static class SingleStringReplacement implements DescriptionReplacement {
+
+        private final String search;
+
+        private final String replacement;
+
+        private SingleStringReplacement(String search, String replacement) {
+            this.search = search;
+            this.replacement = replacement;
+        }
+
+        @Override
+        public boolean applyTo(String currentToken, List<String> currentDescription) {
+            if (currentToken.contains(search)) {
+                currentDescription.add(currentToken.replace(search, replacement));
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{/" + search + "/" + replacement + "/}";
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -337,6 +337,56 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void areMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterResultOf(classes().that().areMetaAnnotatedWith(SomeAnnotation.class))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(MetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotMetaAnnotatedWith(SomeAnnotation.class))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterResultOf(classes().that().areMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(MetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.then(GET_NAME).is(equalTo(SomeAnnotation.class.getName()));
+        List<JavaClass> classes = filterResultOf(classes().that().areMetaAnnotatedWith(hasNamePredicate))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(MetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.then(GET_NAME).is(equalTo(SomeAnnotation.class.getName()));
+        List<JavaClass> classes = filterResultOf(classes().that().areNotMetaAnnotatedWith(hasNamePredicate))
+                .on(MetaAnnotatedClass.class, AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(AnnotatedClass.class, SimpleClass.class, MetaAnnotatedAnnotation.class);
+    }
+
+    @Test
     public void implement_type() {
         List<JavaClass> classes = filterResultOf(classes().that().implement(Collection.class))
                 .on(ArrayList.class, List.class, Iterable.class);
@@ -624,6 +674,11 @@ public class GivenClassesThatTest {
     private @interface SomeAnnotation {
     }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @SomeAnnotation
+    private @interface MetaAnnotatedAnnotation {
+    }
+
     private static class SimpleClass {
     }
 
@@ -640,5 +695,9 @@ public class GivenClassesThatTest {
 
     @SomeAnnotation
     private static class AnnotatedClass {
+    }
+
+    @MetaAnnotatedAnnotation
+    private static class MetaAnnotatedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
@@ -330,6 +330,68 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
+    public void areMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areMetaAnnotatedWith(SomeAnnotation.class))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingMetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingMetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areMetaAnnotatedWith(hasNamePredicate))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThat(getOnlyElement(classes)).matches(ClassAccessingMetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(hasNamePredicate))
+                .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
     public void implement_type() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClasses().should().accessClassesThat().implement(Collection.class))
@@ -615,6 +677,13 @@ public class ShouldAccessClassesThatTest {
         }
     }
 
+    private static class ClassAccessingMetaAnnotatedClass {
+        @SuppressWarnings("unused")
+        void call() {
+            new MetaAnnotatedClass();
+        }
+    }
+
     private static class SimpleClass {
     }
 
@@ -636,7 +705,16 @@ public class ShouldAccessClassesThatTest {
     private @interface SomeAnnotation {
     }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @SomeAnnotation
+    private @interface MetaAnnotatedAnnotation {
+    }
+
     @SomeAnnotation
     private static class AnnotatedClass {
+    }
+
+    @MetaAnnotatedAnnotation
+    private static class MetaAnnotatedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
@@ -413,6 +413,83 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
+    public void areMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(SomeAnnotation.class))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                SimpleClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_type() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                SimpleClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_typeName() {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class);
+    }
+
+    @Test
+    public void areMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(hasNamePredicate))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                SimpleClass.class, ClassAccessingSimpleClass.class);
+    }
+
+    @Test
+    public void areNotMetaAnnotatedWith_predicate() {
+        DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(hasNamePredicate))
+                .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
+                        ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
+                        SimpleClass.class, ClassAccessingSimpleClass.class,
+                        MetaAnnotatedAnnotation.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class);
+    }
+
+    @Test
     public void implement_type() {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classes().should().onlyBeAccessed().byClassesThat().implement(SomeInterface.class))
@@ -694,6 +771,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     private static class ClassBeingAccessedByAnnotatedClass {
     }
 
+    private static class ClassBeingAccessedByMetaAnnotatedClass {
+    }
+
     private static class SimpleClass {
     }
 
@@ -725,10 +805,22 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     private @interface SomeAnnotation {
     }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @SomeAnnotation
+    private @interface MetaAnnotatedAnnotation {
+    }
+
     @SomeAnnotation
     private static class AnnotatedClass {
         void call() {
             new ClassBeingAccessedByAnnotatedClass();
+        }
+    }
+
+    @MetaAnnotatedAnnotation
+    private static class MetaAnnotatedClass {
+        void call() {
+            new ClassBeingAccessedByMetaAnnotatedClass();
         }
     }
 


### PR DESCRIPTION
Now it is possible to call
```
  classes().that().areMetaAnnotatedWith(...)
  classes().that().areNotMetaAnnotatedWith(...)
```
and
```
  classes().should().beMetaAnnotatedWith(...)
  classes().should().notBeMetaAnnotatedWith(...)
```

I hereby agree to the terms of the ArchUnit Contributor License Agreement.

Resolves #57