### PR TITLE
Fixed missing `apple.security` to SecurityTest. Resolves #67

### DIFF
--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
@@ -27,7 +27,7 @@ public class SecurityTest {
     @Test
     public void only_security_infrastructure_should_use_java_security_on_whole_classpath() {
         ArchRule rule = classes().that().resideInAPackage("java.security.cert..")
-                .should().onlyBeAccessed().byAnyPackage("..example.security..", "java..", "..sun..", "javax..");
+                .should().onlyBeAccessed().byAnyPackage("..example.security..", "java..", "..sun..", "javax..", "apple.security..");
 
         JavaClasses classes = new ClassFileImporter().importClasspath(onlyAppAndRuntime());
 

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SecurityIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SecurityIntegrationTest.java
@@ -29,7 +29,7 @@ public class SecurityIntegrationTest extends SecurityTest {
     @Override
     public void only_security_infrastructure_should_use_java_security_on_whole_classpath() {
         expectViolationFromWrongSecurityCheck("classes that reside in a package 'java.security.cert..' "
-                + "should only be accessed by any package ['..example.security..', 'java..', '..sun..', 'javax..']");
+                + "should only be accessed by any package ['..example.security..', 'java..', '..sun..', 'javax..', 'apple.security..']");
 
         super.only_security_infrastructure_should_use_java_security_on_whole_classpath();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.UrlEscapers;
 import com.tngtech.archunit.Internal;
 import com.tngtech.archunit.base.ArchUnitException.LocationException;
 import com.tngtech.archunit.base.Optional;
@@ -96,9 +97,12 @@ interface UrlSource extends Iterable<URL> {
 
         private static Optional<URL> newUrl(String protocol, String path) {
             try {
-                return Optional.of(new URL(protocol + "://" + path));
+                return Optional.of(new URL(protocol + "://" + UrlEscapers.urlFragmentEscaper().escape(path)));
             } catch (MalformedURLException e) {
                 LOG.warn("Cannot parse URL from path " + path, e);
+                return Optional.absent();
+            } catch (IllegalArgumentException e){
+                LOG.warn("Cannot escape fragments from path " + path, e);
                 return Optional.absent();
             }
         }


### PR DESCRIPTION
Also fixes a problem related to running JUnit Tests from IntelliJ on Mac systems. IntelliJ resides in a folder `IntelliJ App` (mind the space)  which executes the JUnit tests and adds therefore its own Jars to the classpath. When converted from an URL into an URI we recieve an illegal character exception. The fix was to UrlEscape the path variable within the `newUrl` method.

I hereby agree to the terms of the ArchUnit Contributor License Agreement.