### PR TITLE
Add documentation for Kotlin

### DIFF
--- a/docs/userguide/003_Getting_Started.adoc
+++ b/docs/userguide/003_Getting_Started.adoc
@@ -101,3 +101,22 @@ The `ArchUnitRunner` will automatically import (or reuse) the specified classes 
 evaluate any rule annotated with `@ArchTest` against those classes.
 
 For further information on how to use the JUnit 4 support refer to <<JUnit Support>>.
+
+=== Using JUnit 4 with Kotlin
+
+As Kotlin removed the `static` keyword from the language, you need to use both a companion object
+and a Java-specific annotation:
+
+[source,kotlin,options="nowrap"]
+----
+@RunWith(ArchUnitRunner::class)
+@AnalyzeClasses(packages = ["com.mycompany.myapp"])
+class MyArchitectureTest {
+
+    companion object {
+        @ArchTest @JvmField val myRule = classes()
+            .that().resideInAPackage("..service..")
+            .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..")
+		}
+}
+----


### PR DESCRIPTION
Using ArchUnit with Kotlin works mostly out of the box, but there are
some syntax changes (aka workarounds) necessary. Now they're documented.

I hereby agree to the terms of the ArchUnit Contributor License Agreement.