### PR TITLE
Adds theClass(..), noClass(..), should().be(..) and should().notBe(..)

### DIFF
--- a/archunit-example/src/main/java/com/tngtech/archunit/example/EvilCoreAccessor.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/EvilCoreAccessor.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.example;
+
+import com.tngtech.archunit.example.core.VeryCentralCore;
+
+@SuppressWarnings("unused")
+public class EvilCoreAccessor {
+    void iShouldNotAccessCore() {
+        new VeryCentralCore().doCoreStuff();
+    }
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/SomeOtherBusinessInterface.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/SomeOtherBusinessInterface.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.example;
+
+public interface SomeOtherBusinessInterface {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/controller/WronglyAnnotated.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/controller/WronglyAnnotated.java
@@ -1,7 +1,9 @@
 package com.tngtech.archunit.example.controller;
 
 import com.tngtech.archunit.example.MyController;
+import com.tngtech.archunit.example.core.HighSecurity;
 
+@HighSecurity
 @MyController
 public class WronglyAnnotated {
 }

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/core/AnotherGoodCoreSatellite.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/core/AnotherGoodCoreSatellite.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.example.core;
+
+@SuppressWarnings("unused")
+public class AnotherGoodCoreSatellite implements CoreSatellite {
+    VeryCentralCore centralCore;
+
+    void iAlsoMayAccessCore() {
+        centralCore.doCoreStuff();
+    }
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/core/CoreSatellite.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/core/CoreSatellite.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.example.core;
+
+public interface CoreSatellite {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/core/GoodCoreSatellite.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/core/GoodCoreSatellite.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.example.core;
+
+@SuppressWarnings("unused")
+public class GoodCoreSatellite implements CoreSatellite {
+    VeryCentralCore centralCore;
+
+    void iMayAccessCore() {
+        centralCore.doCoreStuff();
+    }
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/core/HighSecurity.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/core/HighSecurity.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.example.core;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+public @interface HighSecurity {
+}

--- a/archunit-example/src/main/java/com/tngtech/archunit/example/core/VeryCentralCore.java
+++ b/archunit-example/src/main/java/com/tngtech/archunit/example/core/VeryCentralCore.java
@@ -1,0 +1,17 @@
+package com.tngtech.archunit.example.core;
+
+import com.tngtech.archunit.example.SomeOtherBusinessInterface;
+import com.tngtech.archunit.example.web.AnnotatedController;
+
+@HighSecurity
+@SuppressWarnings("unused")
+public class VeryCentralCore implements SomeOtherBusinessInterface {
+    public static final String DO_CORE_STUFF_METHOD_NAME = "doCoreStuff";
+
+    public void doCoreStuff() {
+    }
+
+    void coreDoingIllegalStuff() {
+        new AnnotatedController();
+    }
+}

--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SingleClassTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/SingleClassTest.java
@@ -1,0 +1,50 @@
+package com.tngtech.archunit.exampletest;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.example.ClassViolatingCodingRules;
+import com.tngtech.archunit.example.SomeOtherBusinessInterface;
+import com.tngtech.archunit.example.core.CoreSatellite;
+import com.tngtech.archunit.example.core.HighSecurity;
+import com.tngtech.archunit.example.core.VeryCentralCore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClass;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.theClass;
+
+@Category(Example.class)
+public class SingleClassTest {
+    private static final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
+
+    @Test
+    public void core_should_only_be_accessed_by_satellites() {
+        theClass(VeryCentralCore.class)
+                .should().onlyBeAccessed().byClassesThat().implement(CoreSatellite.class)
+                .check(classes);
+    }
+
+    @Test
+    public void core_should_only_access_classes_in_core_itself() {
+        noClass(VeryCentralCore.class)
+                .should().accessClassesThat().resideOutsideOfPackages("..core..", "java..")
+                .check(classes);
+    }
+
+    @Test
+    public void the_only_class_with_high_security_is_central_core() {
+        classes()
+                .that().areAnnotatedWith(HighSecurity.class)
+                .should().be(VeryCentralCore.class)
+                .check(classes);
+    }
+
+    @Test
+    public void central_core_should_not_implement_some_business_interface() {
+        classes()
+                .that().implement(SomeOtherBusinessInterface.class)
+                .should().notBe(VeryCentralCore.class)
+                .check(classes);
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SingleClassIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/SingleClassIntegrationTest.java
@@ -1,0 +1,68 @@
+package com.tngtech.archunit.integration;
+
+import com.tngtech.archunit.example.EvilCoreAccessor;
+import com.tngtech.archunit.example.SomeOtherBusinessInterface;
+import com.tngtech.archunit.example.controller.WronglyAnnotated;
+import com.tngtech.archunit.example.core.CoreSatellite;
+import com.tngtech.archunit.example.core.HighSecurity;
+import com.tngtech.archunit.example.core.VeryCentralCore;
+import com.tngtech.archunit.example.web.AnnotatedController;
+import com.tngtech.archunit.exampletest.SingleClassTest;
+import com.tngtech.archunit.junit.ExpectedViolation;
+import org.junit.Rule;
+
+import static com.tngtech.archunit.example.core.VeryCentralCore.DO_CORE_STUFF_METHOD_NAME;
+import static com.tngtech.archunit.junit.ExpectedAccess.callFrom;
+import static com.tngtech.archunit.junit.ExpectedClass.javaClass;
+
+public class SingleClassIntegrationTest extends SingleClassTest {
+    @Rule
+    public final ExpectedViolation expectedViolation = ExpectedViolation.none();
+
+    @Override
+    public void core_should_only_be_accessed_by_satellites() {
+        expectedViolation
+                .ofRule(String.format("the class %s should only be accessed by classes that implement %s",
+                        VeryCentralCore.class.getName(), CoreSatellite.class.getName()))
+                .by(callFrom(EvilCoreAccessor.class, "iShouldNotAccessCore")
+                        .toConstructor(VeryCentralCore.class)
+                        .inLine(8))
+                .by(callFrom(EvilCoreAccessor.class, "iShouldNotAccessCore")
+                        .toMethod(VeryCentralCore.class, DO_CORE_STUFF_METHOD_NAME)
+                        .inLine(8));
+
+        super.core_should_only_be_accessed_by_satellites();
+    }
+
+    @Override
+    public void core_should_only_access_classes_in_core_itself() {
+        expectedViolation
+                .ofRule(String.format("no class %s should access classes that reside outside of packages ['..core..', 'java..']",
+                        VeryCentralCore.class.getName()))
+                .by(callFrom(VeryCentralCore.class, "coreDoingIllegalStuff")
+                        .toConstructor(AnnotatedController.class)
+                        .inLine(15));
+
+        super.core_should_only_access_classes_in_core_itself();
+    }
+
+    @Override
+    public void the_only_class_with_high_security_is_central_core() {
+        expectedViolation
+                .ofRule(String.format("classes that are annotated with @%s should be %s",
+                        HighSecurity.class.getSimpleName(), VeryCentralCore.class.getName()))
+                .by(javaClass(WronglyAnnotated.class).notBeing(VeryCentralCore.class));
+
+        super.the_only_class_with_high_security_is_central_core();
+    }
+
+    @Override
+    public void central_core_should_not_implement_some_business_interface() {
+        expectedViolation
+                .ofRule(String.format("classes that implement %s should not be %s",
+                        SomeOtherBusinessInterface.class.getName(), VeryCentralCore.class.getName()))
+                .by(javaClass(VeryCentralCore.class).being(VeryCentralCore.class));
+
+        super.central_core_should_not_implement_some_business_interface();
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedClass.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedClass.java
@@ -1,0 +1,29 @@
+package com.tngtech.archunit.junit;
+
+public class ExpectedClass {
+    public static Creator javaClass(Class<?> clazz) {
+        return new Creator(clazz);
+    }
+
+    public static class Creator {
+        private final Class<?> clazz;
+
+        private Creator(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        public ExpectedMessage notBeing(Class<?> desiredClass) {
+            String expectedMessage = String.format(
+                    "class %s is not %s in (%s.java:0)",
+                    clazz.getName(), desiredClass.getName(), clazz.getSimpleName());
+            return new ExpectedMessage(expectedMessage);
+        }
+
+        public ExpectedMessage being(Class<?> desiredClass) {
+            String expectedMessage = String.format(
+                    "class %s is %s in (%s.java:0)",
+                    clazz.getName(), desiredClass.getName(), clazz.getSimpleName());
+            return new ExpectedMessage(expectedMessage);
+        }
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedLocation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedLocation.java
@@ -14,7 +14,7 @@ public class ExpectedLocation {
 
         public ExpectedMessage notResidingIn(String packageIdentifier) {
             String expectedMessage = String.format(
-                    "Class %s doesn't reside in a package '%s' in (%s.java:0)",
+                    "class %s doesn't reside in a package '%s' in (%s.java:0)",
                     clazz.getName(), packageIdentifier, clazz.getSimpleName());
             return new ExpectedMessage(expectedMessage);
         }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/junit/ExpectedViolation.java
@@ -123,7 +123,7 @@ public class ExpectedViolation implements TestRule, ExpectsViolations {
         }
 
         public MessageAssertionChain.Link notMatching(String packageIdentifier) {
-            return containsLine("Class %s doesn't reside in a package '%s' in (%s.java:0)",
+            return containsLine("class %s doesn't reside in a package '%s' in (%s.java:0)",
                     clazz.getName(), packageIdentifier, clazz.getSimpleName());
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -65,7 +65,6 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nam
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.parameterTypes;
-import static com.tngtech.archunit.lang.conditions.ArchPredicates.be;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static java.util.Arrays.asList;
 
@@ -276,6 +275,33 @@ public final class ArchConditions {
                 .as(ownerName + "." + fieldName);
     }
 
+    public static ArchCondition<JavaClass> be(final Class<?> clazz) {
+        return be(clazz.getName());
+    }
+
+    public static ArchCondition<JavaClass> notBe(final Class<?> clazz) {
+        return not(be(clazz));
+    }
+
+    public static ArchCondition<JavaClass> be(final String className) {
+        return new ArchCondition<JavaClass>("be " + className) {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                boolean itemEquivalentToClazz = javaClass.getName().equals(className);
+                String message = String.format("class %s %s %s in %s",
+                        javaClass.getName(),
+                        itemEquivalentToClazz ? "is" : "is not",
+                        className,
+                        formatLocation(javaClass, 0));
+                events.add(new SimpleConditionEvent(javaClass, itemEquivalentToClazz, message));
+            }
+        };
+    }
+
+    public static ArchCondition<JavaClass> notBe(final String className) {
+        return not(be(className));
+    }
+
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveFullyQualifiedName(final String name) {
         final DescribedPredicate<HasName> haveFullyQualifiedName = have(fullyQualifiedName(name));
@@ -442,7 +468,7 @@ public final class ArchConditions {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = resideInAPackage.apply(item);
-                String message = String.format("Class %s %s %s in %s",
+                String message = String.format("class %s %s %s in %s",
                         item.getName(),
                         satisfied ? "does" : "doesn't",
                         resideInAPackage.getDescription(),
@@ -578,7 +604,7 @@ public final class ArchConditions {
     }
 
     private static ArchCondition<JavaClass> createAnnotatedCondition(final DescribedPredicate<CanBeAnnotated> annotatedWith) {
-        return new ArchCondition<JavaClass>(be(annotatedWith).getDescription()) {
+        return new ArchCondition<JavaClass>(ArchPredicates.be(annotatedWith).getDescription()) {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = annotatedWith.apply(item);
@@ -720,7 +746,7 @@ public final class ArchConditions {
     }
 
     private static ArchCondition<JavaClass> createAssignableCondition(final DescribedPredicate<JavaClass> assignable) {
-        return new ArchCondition<JavaClass>(be(assignable).getDescription()) {
+        return new ArchCondition<JavaClass>(ArchPredicates.be(assignable).getDescription()) {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
                 boolean satisfied = assignable.apply(item);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -275,14 +275,17 @@ public final class ArchConditions {
                 .as(ownerName + "." + fieldName);
     }
 
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> be(final Class<?> clazz) {
         return be(clazz.getName());
     }
 
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBe(final Class<?> clazz) {
         return not(be(clazz));
     }
 
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> be(final String className) {
         return new ArchCondition<JavaClass>("be " + className) {
             @Override
@@ -298,6 +301,7 @@ public final class ArchConditions {
         };
     }
 
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBe(final String className) {
         return not(be(className));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
@@ -70,18 +70,22 @@ public final class ArchRuleDefinition {
         return priority(MEDIUM).noClasses();
     }
 
+    @PublicAPI(usage = ACCESS)
     public static GivenClass theClass(Class<?> clazz) {
         return priority(MEDIUM).theClass(clazz);
     }
 
+    @PublicAPI(usage = ACCESS)
     public static GivenClass theClass(String className) {
         return priority(MEDIUM).theClass(className);
     }
 
+    @PublicAPI(usage = ACCESS)
     public static GivenClass noClass(Class<?> clazz) {
         return priority(MEDIUM).noClass(clazz);
     }
 
+    @PublicAPI(usage = ACCESS)
     public static GivenClass noClass(String className) {
         return priority(MEDIUM).noClass(className);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
@@ -17,19 +17,23 @@ package com.tngtech.archunit.lang.syntax;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.Function;
+import com.tngtech.archunit.base.Function.Functions;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.AbstractClassesTransformer;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ClassesTransformer;
 import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.syntax.elements.GivenClass;
 import com.tngtech.archunit.lang.syntax.elements.GivenClasses;
 import com.tngtech.archunit.lang.syntax.elements.GivenObjects;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.lang.Priority.MEDIUM;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.never;
+import static java.util.Collections.singleton;
 
 public final class ArchRuleDefinition {
     private ArchRuleDefinition() {
@@ -64,6 +68,22 @@ public final class ArchRuleDefinition {
     @PublicAPI(usage = ACCESS)
     public static GivenClasses noClasses() {
         return priority(MEDIUM).noClasses();
+    }
+
+    public static GivenClass theClass(Class<?> clazz) {
+        return priority(MEDIUM).theClass(clazz);
+    }
+
+    public static GivenClass theClass(String className) {
+        return priority(MEDIUM).theClass(className);
+    }
+
+    public static GivenClass noClass(Class<?> clazz) {
+        return priority(MEDIUM).noClass(clazz);
+    }
+
+    public static GivenClass noClass(String className) {
+        return priority(MEDIUM).noClass(className);
     }
 
     public static final class Creator {
@@ -109,6 +129,37 @@ public final class ArchRuleDefinition {
                     priority,
                     classesTransformer.as("no " + classesTransformer.getDescription()),
                     ArchRuleDefinition.<TYPE>negateCondition());
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public GivenClass theClass(final Class<?> clazz) {
+            return theClass(clazz.getName());
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public GivenClass theClass(final String className) {
+            ClassesTransformer<JavaClass> theClass = theClassTransformer(className);
+            return new GivenClassInternal(priority, theClass, Functions.<ArchCondition<JavaClass>>identity());
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public GivenClass noClass(final Class<?> clazz) {
+            return noClass(clazz.getName());
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public GivenClass noClass(final String className) {
+            ClassesTransformer<JavaClass> noClass = theClassTransformer(className).as("no class " + className);
+            return new GivenClassInternal(priority, noClass, ArchRuleDefinition.<JavaClass>negateCondition());
+        }
+
+        private ClassesTransformer<JavaClass> theClassTransformer(final String className) {
+            return new AbstractClassesTransformer<JavaClass>("the class " + className) {
+                @Override
+                public Iterable<JavaClass> doTransform(JavaClasses classes) {
+                    return singleton(classes.get(className));
+                }
+            };
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -59,6 +59,23 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
         super(classesTransformer, priority, conditionAggregator, prepareCondition);
     }
 
+    public ClassesShouldConjunction be(final Class<?> clazz) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.be(clazz)));
+    }
+
+    public ClassesShouldConjunction notBe(final Class<?> clazz) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBe(clazz)));
+    }
+
+    @Override
+    public ClassesShouldConjunction be(String className) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.be(className)));
+    }
+
+    public ClassesShouldConjunction notBe(String className) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBe(className)));
+    }
+
     @Override
     public ClassesShouldConjunction haveFullyQualifiedName(final String name) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.haveFullyQualifiedName(name)));

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -59,10 +59,12 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
         super(classesTransformer, priority, conditionAggregator, prepareCondition);
     }
 
+    @Override
     public ClassesShouldConjunction be(final Class<?> clazz) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.be(clazz)));
     }
 
+    @Override
     public ClassesShouldConjunction notBe(final Class<?> clazz) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBe(clazz)));
     }
@@ -72,6 +74,7 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.be(className)));
     }
 
+    @Override
     public ClassesShouldConjunction notBe(String className) {
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBe(className)));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassInternal.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.syntax;
+
+import com.tngtech.archunit.base.Function;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ClassesTransformer;
+import com.tngtech.archunit.lang.Priority;
+import com.tngtech.archunit.lang.syntax.elements.ClassesShould;
+import com.tngtech.archunit.lang.syntax.elements.ClassesShouldConjunction;
+import com.tngtech.archunit.lang.syntax.elements.GivenClass;
+
+class GivenClassInternal implements GivenClass {
+    private final Priority priority;
+    private final ClassesTransformer<JavaClass> classesTransformer;
+    private final Function<ArchCondition<JavaClass>, ArchCondition<JavaClass>> prepareCondition;
+
+    GivenClassInternal(Priority priority, ClassesTransformer<JavaClass> classesTransformer,
+            Function<ArchCondition<JavaClass>, ArchCondition<JavaClass>> prepareCondition) {
+        this.priority = priority;
+        this.classesTransformer = classesTransformer;
+        this.prepareCondition = prepareCondition;
+    }
+
+    @Override
+    public ClassesShould should() {
+        return new ClassesShouldInternal(classesTransformer, priority, prepareCondition);
+    }
+
+    @Override
+    public ClassesShouldConjunction should(ArchCondition<JavaClass> condition) {
+        return new ClassesShouldInternal(classesTransformer, priority, condition, prepareCondition);
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -827,6 +827,7 @@ public interface ClassesShould {
      * @param className the name of the only class that should be matched.
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
+    @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction be(String className);
 
     /**
@@ -835,5 +836,6 @@ public interface ClassesShould {
      * @param className the name of the class that should not be matched.
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
+    @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBe(String className);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -802,4 +802,38 @@ public interface ClassesShould {
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeInterfaces();
+
+    /**
+     * Asserts that the rule matches exactly the given class.
+     *
+     * @param clazz the only class the should be matched
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction be(Class<?> clazz);
+
+    /**
+     * Asserts that the rule does not match the given class.
+     *
+     * @param clazz the class that should not be matched
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBe(Class<?> clazz);
+
+    /**
+     * Asserts that the rule matches exactly the class with the given fully qualified class name.
+     *
+     * @param className the name of the only class that should be matched.
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    ClassesShouldConjunction be(String className);
+
+    /**
+     * Asserts that the rule does not match the class with the given fully qualified class name.
+     *
+     * @param className the name of the class that should not be matched.
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    ClassesShouldConjunction notBe(String className);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
@@ -15,11 +15,16 @@
  */
 package com.tngtech.archunit.lang.syntax.elements;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
 
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
 public interface GivenClass {
+    @PublicAPI(usage = ACCESS)
     ClassesShould should();
 
+    @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction should(ArchCondition<JavaClass> condition);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.syntax.elements;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+
+public interface GivenClass {
+    ClassesShould should();
+
+    ClassesShouldConjunction should(ArchCondition<JavaClass> condition);
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -29,7 +29,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
-import com.tngtech.archunit.lang.syntax.elements.testclasses.RightNamedClass;
+import com.tngtech.archunit.lang.syntax.elements.testclasses.SomeClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.WrongNamedClass;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -68,7 +68,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(DataProviderRunner.class)
 public class ClassesShouldTest {
-    private static final String FAILURE_REPORT_NEWLINE_MARKER = "#";
+    static final String FAILURE_REPORT_NEWLINE_MARKER = "#";
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
@@ -76,23 +76,23 @@ public class ClassesShouldTest {
     @DataProvider
     public static Object[][] haveFullyQualifiedName_rules() {
         return $$(
-                $(classes().should().haveFullyQualifiedName(RightNamedClass.class.getName())),
-                $(classes().should(ArchConditions.haveFullyQualifiedName(RightNamedClass.class.getName())))
+                $(classes().should().haveFullyQualifiedName(SomeClass.class.getName())),
+                $(classes().should(ArchConditions.haveFullyQualifiedName(SomeClass.class.getName())))
         );
     }
 
     @Test
     @UseDataProvider("haveFullyQualifiedName_rules")
     public void haveFullyQualifiedName(ArchRule rule) {
-        EvaluationResult result = rule.evaluate(importClasses(RightNamedClass.class, WrongNamedClass.class));
+        EvaluationResult result = rule.evaluate(importClasses(SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains(String.format("classes should have fully qualified name '%s'", RightNamedClass.class.getName()))
+                .contains(String.format("classes should have fully qualified name '%s'", SomeClass.class.getName()))
                 .containsPattern(String.format("class %s doesn't have fully qualified name '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
-                        quote(RightNamedClass.class.getName()),
+                        quote(SomeClass.class.getName()),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotMatch(String.format(".*%s .*name.*", quote(RightNamedClass.class.getName())));
+                .doesNotMatch(String.format(".*%s .*name.*", quote(SomeClass.class.getName())));
     }
 
     @DataProvider
@@ -107,19 +107,19 @@ public class ClassesShouldTest {
     @UseDataProvider("notHaveFullyQualifiedName_rules")
     public void notHaveFullyQualifiedName(ArchRule rule) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should not have fully qualified name '%s'", WrongNamedClass.class.getName()))
                 .contains(String.format("%s has fully qualified name '%s'", WrongNamedClass.class.getName(), WrongNamedClass.class.getName()))
-                .doesNotContain(String.format("%s .*name", RightNamedClass.class.getName()));
+                .doesNotContain(String.format("%s .*name", SomeClass.class.getName()));
     }
 
     @DataProvider
     public static Object[][] haveSimpleName_rules() {
         return $$(
-                $(classes().should().haveSimpleName(RightNamedClass.class.getSimpleName())),
-                $(classes().should(ArchConditions.haveSimpleName(RightNamedClass.class.getSimpleName())))
+                $(classes().should().haveSimpleName(SomeClass.class.getSimpleName())),
+                $(classes().should(ArchConditions.haveSimpleName(SomeClass.class.getSimpleName())))
         );
     }
 
@@ -127,15 +127,15 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleName_rules")
     public void haveSimpleName(ArchRule rule) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains(String.format("classes should have simple name '%s'", RightNamedClass.class.getSimpleName()))
+                .contains(String.format("classes should have simple name '%s'", SomeClass.class.getSimpleName()))
                 .containsPattern(String.format("class %s doesn't have simple name '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
-                        quote(RightNamedClass.class.getSimpleName()),
+                        quote(SomeClass.class.getSimpleName()),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotMatch(String.format(".*class %s .*simple name.*", RightNamedClass.class.getSimpleName()));
+                .doesNotMatch(String.format(".*class %s .*simple name.*", SomeClass.class.getSimpleName()));
     }
 
     @DataProvider
@@ -150,7 +150,7 @@ public class ClassesShouldTest {
     @UseDataProvider("notHaveSimpleName_rules")
     public void notHaveSimpleName(ArchRule rule) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should not have simple name '%s'", WrongNamedClass.class.getSimpleName()))
@@ -158,12 +158,12 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(WrongNamedClass.class.getSimpleName()),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotMatch(String.format(".*class %s .*simple name.*", RightNamedClass.class.getSimpleName()));
+                .doesNotMatch(String.format(".*class %s .*simple name.*", SomeClass.class.getSimpleName()));
     }
 
     @DataProvider
     public static Object[][] haveNameMatching_rules() {
-        String regex = containsPartOfRegex(RightNamedClass.class.getSimpleName());
+        String regex = containsPartOfRegex(SomeClass.class.getSimpleName());
         return $$(
                 $(classes().should().haveNameMatching(regex), regex),
                 $(classes().should(ArchConditions.haveNameMatching(regex)), regex)
@@ -174,7 +174,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveNameMatching_rules")
     public void haveNameMatching(ArchRule rule, String regex) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have name matching '%s'", regex))
@@ -182,7 +182,7 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(regex),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(String.format("%s", RightNamedClass.class.getSimpleName()));
+                .doesNotContain(String.format("%s", SomeClass.class.getSimpleName()));
     }
 
     @DataProvider
@@ -198,7 +198,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveNameNotMatching_rules")
     public void haveNameNotMatching(ArchRule rule, String regex) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have name not matching '%s'", regex))
@@ -206,12 +206,12 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(regex),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(String.format("%s", RightNamedClass.class.getSimpleName()));
+                .doesNotContain(String.format("%s", SomeClass.class.getSimpleName()));
     }
 
     @DataProvider
     public static Object[][] haveSimpleNameStartingWith_rules() {
-        String simpleName = RightNamedClass.class.getSimpleName();
+        String simpleName = SomeClass.class.getSimpleName();
         String prefix = simpleName.substring(0, simpleName.length() - 1);
         return $$(
                 $(classes().should().haveSimpleNameStartingWith(prefix), prefix),
@@ -223,7 +223,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameStartingWith_rules")
     public void haveSimpleNameStartingWith(ArchRule rule, String prefix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name starting with '%s'", prefix))
@@ -231,12 +231,12 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(prefix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
     public static Object[][] haveSimpleNameContaining_rules() {
-        String simpleName = RightNamedClass.class.getSimpleName();
+        String simpleName = SomeClass.class.getSimpleName();
         String infix = simpleName.substring(1, simpleName.length() - 1);
         return $$(
                 $(classes().should().haveSimpleNameContaining(infix), infix),
@@ -248,7 +248,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameContaining_rules")
     public void haveSimpleNameContaining(ArchRule rule, String infix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name containing '%s'", infix))
@@ -256,7 +256,7 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(infix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
@@ -273,7 +273,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameNotContaining_rules")
     public void haveSimpleNameNotContaining(ArchRule rule, String infix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not containing '%s'", infix))
@@ -281,7 +281,7 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(infix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
@@ -298,7 +298,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameNotStartingWith_rules")
     public void haveSimpleNameNotStartingWith(ArchRule rule, String prefix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not starting with '%s'", prefix))
@@ -306,12 +306,12 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(prefix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
     public static Object[][] haveSimpleNameEndingWith_rules() {
-        String simpleName = RightNamedClass.class.getSimpleName();
+        String simpleName = SomeClass.class.getSimpleName();
         String suffix = simpleName.substring(1, simpleName.length());
         return $$(
                 $(classes().should().haveSimpleNameEndingWith(suffix), suffix),
@@ -323,7 +323,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameEndingWith_rules")
     public void haveSimpleNameEndingWith(ArchRule rule, String suffix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name ending with '%s'", suffix))
@@ -331,7 +331,7 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(suffix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
@@ -348,7 +348,7 @@ public class ClassesShouldTest {
     @UseDataProvider("haveSimpleNameNotEndingWith_rules")
     public void haveSimpleNameNotEndingWith(ArchRule rule, String suffix) {
         EvaluationResult result = rule.evaluate(importClasses(
-                RightNamedClass.class, WrongNamedClass.class));
+                SomeClass.class, WrongNamedClass.class));
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not ending with '%s'", suffix))
@@ -356,7 +356,7 @@ public class ClassesShouldTest {
                         quote(WrongNamedClass.class.getName()),
                         quote(suffix),
                         locationPattern(WrongNamedClass.class)))
-                .doesNotContain(RightNamedClass.class.getName());
+                .doesNotContain(SomeClass.class.getName());
     }
 
     @DataProvider
@@ -1149,11 +1149,57 @@ public class ClassesShouldTest {
                 .doesNotMatch(String.format(".*class %s .* interface.*", quote(satisfied.getName())));
     }
 
+    @DataProvider
+    public static Object[][] beClass_rules() {
+        return $$(
+                $(classes().should().be(String.class), String.class, Collection.class),
+                $(classes().should().be(String.class.getName()), String.class, Collection.class),
+                $(classes().should(ArchConditions.be(String.class)), String.class, Collection.class),
+                $(classes().should(ArchConditions.be(String.class.getName())), String.class, Collection.class));
+    }
+
+    @Test
+    @UseDataProvider("beClass_rules")
+    public void beClass(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be " + satisfied.getName())
+                .containsPattern(String.format("class %s is not %s in %s",
+                        quote(violated.getName()),
+                        quote(satisfied.getName()),
+                        locationPattern(violated)))
+                .doesNotMatch(String.format(".*class %s .* is .*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeClass_rules() {
+        return $$(
+                $(classes().should().notBe(Collection.class), String.class, Collection.class),
+                $(classes().should().notBe(Collection.class.getName()), String.class, Collection.class),
+                $(classes().should(ArchConditions.notBe(Collection.class)), String.class, Collection.class),
+                $(classes().should(ArchConditions.notBe(Collection.class.getName())), String.class, Collection.class));
+    }
+
+    @Test
+    @UseDataProvider("notBeClass_rules")
+    public void notBeClass(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be " + violated.getName())
+                .containsPattern(String.format("class %s is %s in %s",
+                        quote(violated.getName()),
+                        quote(violated.getName()),
+                        locationPattern(violated)))
+                .doesNotMatch(String.format(".*class %s .* is .*", quote(satisfied.getName())));
+    }
+
     static String locationPattern(Class<?> clazz) {
         return String.format("\\(%s.java:0\\)", quote(clazz.getSimpleName()));
     }
 
-    private String singleLineFailureReportOf(EvaluationResult result) {
+    static String singleLineFailureReportOf(EvaluationResult result) {
         return result.getFailureReport().toString().replaceAll("\\r?\\n", FAILURE_REPORT_NEWLINE_MARKER);
     }
 
@@ -1166,7 +1212,7 @@ public class ClassesShouldTest {
         };
     }
 
-    private static String containsPartOfRegex(String fullString) {
+    static String containsPartOfRegex(String fullString) {
         return String.format(".*%s.*", fullString.substring(1, fullString.length() - 1));
     }
 
@@ -1194,7 +1240,7 @@ public class ClassesShouldTest {
         return JavaCall.Predicates.target(owner(type(type))).as("target is " + type.getSimpleName());
     }
 
-    private static DescribedPredicate<JavaAccess<?>> accessTargetIs(Class<?> type) {
+    static DescribedPredicate<JavaAccess<?>> accessTargetIs(Class<?> type) {
         return JavaAccess.Predicates.target(owner(type(type))).as("target is " + type.getSimpleName());
     }
 
@@ -1233,7 +1279,7 @@ public class ClassesShouldTest {
         }
     }
 
-    private Pattern accessesFieldRegex(Class<?> origin, String accessType, Class<?> targetClass, String fieldName) {
+    static Pattern accessesFieldRegex(Class<?> origin, String accessType, Class<?> targetClass, String fieldName) {
         String originAccesses = String.format("%s[^%s]* %s", quote(origin.getName()), FAILURE_REPORT_NEWLINE_MARKER, accessType);
         String target = String.format("[^%s]*%s\\.%s", FAILURE_REPORT_NEWLINE_MARKER, quote(targetClass.getName()), fieldName);
         return Pattern.compile(String.format(".*%s field %s.*", originAccesses, target));
@@ -1280,6 +1326,7 @@ public class ClassesShouldTest {
         }
     }
 
+    @SuppressWarnings("ConstantConditions")
     private static class ClassAccessingWrongField {
         ClassAccessingField classAccessingField;
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
@@ -1,0 +1,1424 @@
+package com.tngtech.archunit.lang.syntax.elements;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Joiner;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.RuntimeRetentionAnnotation;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
+import com.tngtech.archunit.lang.syntax.elements.testclasses.SomeClass;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
+import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClass;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.theClass;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.FAILURE_REPORT_NEWLINE_MARKER;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.accessTargetIs;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.accessesFieldRegex;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.containsPartOfRegex;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.locationPattern;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.singleLineFailureReportOf;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static java.util.regex.Pattern.quote;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class GivenClassShouldTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private static final String ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX = "[^" + FAILURE_REPORT_NEWLINE_MARKER + "]*";
+
+    @DataProvider
+    public static Object[][] theClass_should_haveFullyQualifiedName_rules() {
+        return $$(
+                $(theClass(SomeClass.class).should().haveFullyQualifiedName(SomeClass.class.getName()),
+                        theClass(SomeClass.class).should().notHaveFullyQualifiedName(SomeClass.class.getName())),
+                $(theClass(SomeClass.class).should(ArchConditions.haveFullyQualifiedName(SomeClass.class.getName())),
+                        theClass(SomeClass.class).should(ArchConditions.notHaveFullyQualifiedName(SomeClass.class.getName()))),
+                $(theClass(SomeClass.class.getName()).should().haveFullyQualifiedName(SomeClass.class.getName()),
+                        theClass(SomeClass.class.getName()).should().notHaveFullyQualifiedName(SomeClass.class.getName())),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveFullyQualifiedName(SomeClass.class.getName())),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.notHaveFullyQualifiedName(SomeClass.class.getName())))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveFullyQualifiedName_rules")
+    public void theClass_should_haveFullyQualifiedName(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have fully qualified name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getName())
+                .haveFailingRuleText("the class %s should not have fully qualified name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getName())
+                .containFailureDetail(
+                        String.format("class %s has fully qualified name '%s' in %s",
+                                quote(SomeClass.class.getName()),
+                                quote(SomeClass.class.getName()),
+                                locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveFullyQualifiedName_rules() {
+        return $$(
+                $(noClass(SomeClass.class).should().notHaveFullyQualifiedName(SomeClass.class.getName()),
+                        noClass(SomeClass.class).should().haveFullyQualifiedName(SomeClass.class.getName())),
+                $(noClass(SomeClass.class).should(ArchConditions.notHaveFullyQualifiedName(SomeClass.class.getName())),
+                        noClass(SomeClass.class).should(ArchConditions.haveFullyQualifiedName(SomeClass.class.getName()))),
+                $(noClass(SomeClass.class.getName()).should().notHaveFullyQualifiedName(SomeClass.class.getName()),
+                        noClass(SomeClass.class.getName()).should().haveFullyQualifiedName(SomeClass.class.getName())),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.notHaveFullyQualifiedName(SomeClass.class.getName())),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveFullyQualifiedName(SomeClass.class.getName())))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveFullyQualifiedName_rules")
+    public void noClass_should_haveFullyQualifiedName(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not have fully qualified name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getName())
+                .haveFailingRuleText("no class %s should have fully qualified name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getName())
+                .containFailureDetail(String.format("class %s has fully qualified name '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(SomeClass.class.getName()),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveSimpleName_rules() {
+        return $$(
+                $(theClass(SomeClass.class).should().haveSimpleName(SomeClass.class.getSimpleName()),
+                        theClass(SomeClass.class).should().notHaveSimpleName(SomeClass.class.getSimpleName())),
+                $(theClass(SomeClass.class).should(ArchConditions.haveSimpleName(SomeClass.class.getSimpleName())),
+                        theClass(SomeClass.class).should(ArchConditions.notHaveSimpleName(SomeClass.class.getSimpleName()))),
+                $(theClass(SomeClass.class.getName()).should().haveSimpleName(SomeClass.class.getSimpleName()),
+                        theClass(SomeClass.class.getName()).should().notHaveSimpleName(SomeClass.class.getSimpleName())),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleName(SomeClass.class.getSimpleName())),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.notHaveSimpleName(SomeClass.class.getSimpleName())))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveSimpleName_rules")
+    public void haveSimpleName(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have simple name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getSimpleName())
+                .haveFailingRuleText("the class %s should not have simple name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getSimpleName())
+                .containFailureDetail(String.format("class %s has simple name '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(SomeClass.class.getSimpleName()),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getSimpleName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveSimpleName_rules() {
+        return $$(
+                $(noClass(SomeClass.class).should().notHaveSimpleName(SomeClass.class.getSimpleName()),
+                        noClass(SomeClass.class).should().haveSimpleName(SomeClass.class.getSimpleName())),
+                $(noClass(SomeClass.class).should(ArchConditions.notHaveSimpleName(SomeClass.class.getSimpleName())),
+                        noClass(SomeClass.class).should(ArchConditions.haveSimpleName(SomeClass.class.getSimpleName()))),
+                $(noClass(SomeClass.class.getName()).should().notHaveSimpleName(SomeClass.class.getSimpleName()),
+                        noClass(SomeClass.class.getName()).should().haveSimpleName(SomeClass.class.getSimpleName())),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.notHaveSimpleName(SomeClass.class.getSimpleName())),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleName(SomeClass.class.getSimpleName())))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveSimpleName_rules")
+    public void noClass_should_haveSimpleName(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not have simple name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getSimpleName())
+                .haveFailingRuleText("no class %s should have simple name '%s'",
+                        SomeClass.class.getName(), SomeClass.class.getSimpleName())
+                .containFailureDetail(String.format("class %s has simple name '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(SomeClass.class.getSimpleName()),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getSimpleName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveNameMatching_rules() {
+        String regex = containsPartOfRegex(SomeClass.class.getSimpleName());
+        return $$(
+                $(theClass(SomeClass.class).should().haveNameMatching(regex),
+                        theClass(SomeClass.class).should().haveNameNotMatching(regex)),
+                $(theClass(SomeClass.class).should(ArchConditions.haveNameMatching(regex)),
+                        theClass(SomeClass.class).should(ArchConditions.haveNameNotMatching(regex))),
+                $(theClass(SomeClass.class.getName()).should().haveNameMatching(regex),
+                        theClass(SomeClass.class.getName()).should().haveNameNotMatching(regex)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveNameMatching(regex)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.haveNameNotMatching(regex)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveNameMatching_rules")
+    public void theClass_should_haveNameMatching(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String regex = containsPartOfRegex(SomeClass.class.getSimpleName());
+
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have name matching '%s'",
+                        SomeClass.class.getName(), regex)
+                .haveFailingRuleText("the class %s should have name not matching '%s'",
+                        SomeClass.class.getName(), regex)
+                .containFailureDetail(String.format("class %s matches '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(regex),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(regex));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveNameMatching_rules() {
+        String regex = containsPartOfRegex(SomeClass.class.getSimpleName());
+        return $$(
+                $(noClass(SomeClass.class).should().haveNameNotMatching(regex),
+                        noClass(SomeClass.class).should().haveNameMatching(regex)),
+                $(noClass(SomeClass.class).should(ArchConditions.haveNameNotMatching(regex)),
+                        noClass(SomeClass.class).should(ArchConditions.haveNameMatching(regex))),
+                $(noClass(SomeClass.class.getName()).should().haveNameNotMatching(regex),
+                        noClass(SomeClass.class.getName()).should().haveNameMatching(regex)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.haveNameNotMatching(regex)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveNameMatching(regex)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveNameMatching_rules")
+    public void noClass_should_haveNameMatching(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String regex = containsPartOfRegex(SomeClass.class.getSimpleName());
+
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should have name not matching '%s'",
+                        SomeClass.class.getName(), regex)
+                .haveFailingRuleText("no class %s should have name matching '%s'",
+                        SomeClass.class.getName(), regex)
+                .containFailureDetail(String.format("class %s matches '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(regex),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(regex));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveSimpleNameStartingWith_rules() {
+        String simpleName = SomeClass.class.getSimpleName();
+        String prefix = simpleName.substring(0, simpleName.length() - 1);
+        return $$(
+                $(theClass(SomeClass.class).should().haveSimpleNameStartingWith(prefix),
+                        theClass(SomeClass.class).should().haveSimpleNameNotStartingWith(prefix)),
+                $(theClass(SomeClass.class).should(ArchConditions.haveSimpleNameStartingWith(prefix)),
+                        theClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotStartingWith(prefix))),
+                $(theClass(SomeClass.class.getName()).should().haveSimpleNameStartingWith(prefix),
+                        theClass(SomeClass.class.getName()).should().haveSimpleNameNotStartingWith(prefix)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameStartingWith(prefix)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotStartingWith(prefix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveSimpleNameStartingWith_rules")
+    public void theClass_should_haveSimpleNameStartingWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String prefix = simpleName.substring(0, simpleName.length() - 1);
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have simple name starting with '%s'",
+                        SomeClass.class.getName(), prefix)
+                .haveFailingRuleText("the class %s should have simple name not starting with '%s'",
+                        SomeClass.class.getName(), prefix)
+                .containFailureDetail(String.format("simple name of %s starts with '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(prefix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveSimpleNameStartingWith_rules() {
+
+        String simpleName = SomeClass.class.getSimpleName();
+        String prefix = simpleName.substring(0, simpleName.length() - 1);
+        return $$(
+                $(noClass(SomeClass.class).should().haveSimpleNameNotStartingWith(prefix),
+                        noClass(SomeClass.class).should().haveSimpleNameStartingWith(prefix)),
+                $(noClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotStartingWith(prefix)),
+                        noClass(SomeClass.class).should(ArchConditions.haveSimpleNameStartingWith(prefix))),
+                $(noClass(SomeClass.class.getName()).should().haveSimpleNameNotStartingWith(prefix),
+                        noClass(SomeClass.class.getName()).should().haveSimpleNameStartingWith(prefix)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotStartingWith(prefix)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameStartingWith(prefix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveSimpleNameStartingWith_rules")
+    public void noClass_should_haveSimpleNameStartingWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String prefix = simpleName.substring(0, simpleName.length() - 1);
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should have simple name not starting with '%s'",
+                        SomeClass.class.getName(), prefix)
+                .haveFailingRuleText("no class %s should have simple name starting with '%s'",
+                        SomeClass.class.getName(), prefix)
+                .containFailureDetail(String.format("simple name of %s starts with '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(prefix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveSimpleNameContaining_rules() {
+        String simpleName = SomeClass.class.getSimpleName();
+        String infix = simpleName.substring(1, simpleName.length() - 1);
+
+        return $$(
+                $(theClass(SomeClass.class).should().haveSimpleNameContaining(infix),
+                        theClass(SomeClass.class).should().haveSimpleNameNotContaining(infix)),
+                $(theClass(SomeClass.class).should(ArchConditions.haveSimpleNameContaining(infix)),
+                        theClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotContaining(infix))),
+                $(theClass(SomeClass.class.getName()).should().haveSimpleNameContaining(infix),
+                        theClass(SomeClass.class.getName()).should().haveSimpleNameNotContaining(infix)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameContaining(infix)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotContaining(infix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveSimpleNameContaining_rules")
+    public void theClass_should_haveSimpleNameContaining(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String infix = simpleName.substring(1, simpleName.length() - 1);
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have simple name containing '%s'",
+                        SomeClass.class.getName(), infix)
+                .haveFailingRuleText("the class %s should have simple name not containing '%s'",
+                        SomeClass.class.getName(), infix)
+                .containFailureDetail(String.format("simple name of %s contains '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(infix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveSimpleNameContaining_rules() {
+
+        String simpleName = SomeClass.class.getSimpleName();
+        String infix = simpleName.substring(1, simpleName.length() - 1);
+        return $$(
+                $(noClass(SomeClass.class).should().haveSimpleNameNotContaining(infix),
+                        noClass(SomeClass.class).should().haveSimpleNameContaining(infix)),
+                $(noClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotContaining(infix)),
+                        noClass(SomeClass.class).should(ArchConditions.haveSimpleNameContaining(infix))),
+                $(noClass(SomeClass.class.getName()).should().haveSimpleNameNotContaining(infix),
+                        noClass(SomeClass.class.getName()).should().haveSimpleNameContaining(infix)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotContaining(infix)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameContaining(infix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveSimpleNameContaining_rules")
+    public void noClass_should_haveSimpleNameContaining(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String infix = simpleName.substring(1, simpleName.length() - 1);
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should have simple name not containing '%s'",
+                        SomeClass.class.getName(), infix)
+                .haveFailingRuleText("no class %s should have simple name containing '%s'",
+                        SomeClass.class.getName(), infix)
+                .containFailureDetail(String.format("simple name of %s contains '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(infix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveSimpleNameEndingWith_rules() {
+        String simpleName = SomeClass.class.getSimpleName();
+        String suffix = simpleName.substring(1, simpleName.length());
+
+        return $$(
+                $(theClass(SomeClass.class).should().haveSimpleNameEndingWith(suffix),
+                        theClass(SomeClass.class).should().haveSimpleNameNotEndingWith(suffix)),
+                $(theClass(SomeClass.class).should(ArchConditions.haveSimpleNameEndingWith(suffix)),
+                        theClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotEndingWith(suffix))),
+                $(theClass(SomeClass.class.getName()).should().haveSimpleNameEndingWith(suffix),
+                        theClass(SomeClass.class.getName()).should().haveSimpleNameNotEndingWith(suffix)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameEndingWith(suffix)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotEndingWith(suffix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveSimpleNameEndingWith_rules")
+    public void theClass_should_haveSimpleNameEndingWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String suffix = simpleName.substring(1, simpleName.length());
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have simple name ending with '%s'",
+                        SomeClass.class.getName(), suffix)
+                .haveFailingRuleText("the class %s should have simple name not ending with '%s'",
+                        SomeClass.class.getName(), suffix)
+                .containFailureDetail(String.format("simple name of %s ends with '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(suffix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveSimpleNameEndingWith_rules() {
+
+        String simpleName = SomeClass.class.getSimpleName();
+        String suffix = simpleName.substring(1, simpleName.length());
+        return $$(
+                $(noClass(SomeClass.class).should().haveSimpleNameNotEndingWith(suffix),
+                        noClass(SomeClass.class).should().haveSimpleNameEndingWith(suffix)),
+                $(noClass(SomeClass.class).should(ArchConditions.haveSimpleNameNotEndingWith(suffix)),
+                        noClass(SomeClass.class).should(ArchConditions.haveSimpleNameEndingWith(suffix))),
+                $(noClass(SomeClass.class.getName()).should().haveSimpleNameNotEndingWith(suffix),
+                        noClass(SomeClass.class.getName()).should().haveSimpleNameEndingWith(suffix)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameNotEndingWith(suffix)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.haveSimpleNameEndingWith(suffix)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveSimpleNameEndingWith_rules")
+    public void noClass_should_haveSimpleNameEndingWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String simpleName = SomeClass.class.getSimpleName();
+        String suffix = simpleName.substring(1, simpleName.length());
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should have simple name not ending with '%s'",
+                        SomeClass.class.getName(), suffix)
+                .haveFailingRuleText("no class %s should have simple name ending with '%s'",
+                        SomeClass.class.getName(), suffix)
+                .containFailureDetail(String.format("simple name of %s ends with '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(suffix),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_resideInAPackage_rules() {
+        String thePackage = SomeClass.class.getPackage().getName();
+        return $$(
+                $(theClass(SomeClass.class).should().resideInAPackage(thePackage),
+                        theClass(SomeClass.class).should().resideOutsideOfPackage(thePackage)),
+                $(theClass(SomeClass.class).should(ArchConditions.resideInAPackage(thePackage)),
+                        theClass(SomeClass.class).should(ArchConditions.resideOutsideOfPackage(thePackage))),
+                $(theClass(SomeClass.class.getName()).should().resideInAPackage(thePackage),
+                        theClass(SomeClass.class.getName()).should().resideOutsideOfPackage(thePackage)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.resideInAPackage(thePackage)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.resideOutsideOfPackage(thePackage)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_resideInAPackage_rules")
+    public void theClass_should_resideInAPackage(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String thePackage = SomeClass.class.getPackage().getName();
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should reside in a package '%s'",
+                        SomeClass.class.getName(), thePackage)
+                .haveFailingRuleText("the class %s should reside outside of package '%s'",
+                        SomeClass.class.getName(), thePackage)
+                .containFailureDetail(String.format("class %s doesn't reside outside of package '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(thePackage),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_resideInAPackage_rules() {
+        String thePackage = SomeClass.class.getPackage().getName();
+        return $$(
+                $(noClass(SomeClass.class).should().resideOutsideOfPackage(thePackage),
+                        noClass(SomeClass.class).should().resideInAPackage(thePackage)),
+                $(noClass(SomeClass.class).should(ArchConditions.resideOutsideOfPackage(thePackage)),
+                        noClass(SomeClass.class).should(ArchConditions.resideInAPackage(thePackage))),
+                $(noClass(SomeClass.class.getName()).should().resideOutsideOfPackage(thePackage),
+                        noClass(SomeClass.class.getName()).should().resideInAPackage(thePackage)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.resideOutsideOfPackage(thePackage)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.resideInAPackage(thePackage)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_resideInAPackage_rules")
+    public void noClass_should_resideInAPackage(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String thePackage = SomeClass.class.getPackage().getName();
+
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should reside outside of package '%s'",
+                        SomeClass.class.getName(), thePackage)
+                .haveFailingRuleText("no class %s should reside in a package '%s'",
+                        SomeClass.class.getName(), thePackage)
+                .containFailureDetail(String.format("class %s does reside in a package '%s' in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(thePackage),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_resideInAnyPackage_rules() {
+
+        String firstPackage = SomeClass.class.getPackage().getName();
+        String secondPackage = Object.class.getPackage().getName();
+        return $$(
+                $(theClass(SomeClass.class).should().resideInAnyPackage(firstPackage, secondPackage),
+                        theClass(SomeClass.class).should().resideOutsideOfPackages(firstPackage, secondPackage)),
+                $(theClass(SomeClass.class).should(ArchConditions.resideInAnyPackage(firstPackage, secondPackage)),
+                        theClass(SomeClass.class).should(ArchConditions.resideOutsideOfPackages(firstPackage, secondPackage))),
+                $(theClass(SomeClass.class.getName()).should().resideInAnyPackage(firstPackage, secondPackage),
+                        theClass(SomeClass.class.getName()).should().resideOutsideOfPackages(firstPackage, secondPackage)),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.resideInAnyPackage(firstPackage, secondPackage)),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.resideOutsideOfPackages(firstPackage, secondPackage)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_resideInAnyPackage_rules")
+    public void theClass_should_resideInAnyPackage(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String firstPackage = SomeClass.class.getPackage().getName();
+        String secondPackage = Object.class.getPackage().getName();
+        String[] packageIdentifiers = {firstPackage, secondPackage};
+
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should reside in any package ['%s']",
+                        SomeClass.class.getName(),
+                        Joiner.on("', '").join(packageIdentifiers))
+                .haveFailingRuleText("the class %s should reside outside of packages ['%s']",
+                        SomeClass.class.getName(),
+                        Joiner.on("', '").join(packageIdentifiers))
+                .containFailureDetail(String.format("class %s doesn't reside outside of packages \\['%s'\\] in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(Joiner.on("', '").join(packageIdentifiers)),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_resideInAnyPackage_rules() {
+        String firstPackage = SomeClass.class.getPackage().getName();
+        String secondPackage = Object.class.getPackage().getName();
+
+        return $$(
+                $(noClass(SomeClass.class).should().resideOutsideOfPackages(firstPackage, secondPackage),
+                        noClass(SomeClass.class).should().resideInAnyPackage(firstPackage, secondPackage)),
+                $(noClass(SomeClass.class).should(ArchConditions.resideOutsideOfPackages(firstPackage, secondPackage)),
+                        noClass(SomeClass.class).should(ArchConditions.resideInAnyPackage(firstPackage, secondPackage))),
+                $(noClass(SomeClass.class.getName()).should().resideOutsideOfPackages(firstPackage, secondPackage),
+                        noClass(SomeClass.class.getName()).should().resideInAnyPackage(firstPackage, secondPackage)),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.resideOutsideOfPackages(firstPackage, secondPackage)),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.resideInAnyPackage(firstPackage, secondPackage)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_resideInAnyPackage_rules")
+    public void noClass_should_resideInAnyPackage(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        String firstPackage = SomeClass.class.getPackage().getName();
+        String secondPackage = Object.class.getPackage().getName();
+        String[] packageIdentifiers = {firstPackage, secondPackage};
+
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should reside outside of packages ['%s']",
+                        SomeClass.class.getName(),
+                        Joiner.on("', '").join(packageIdentifiers))
+                .haveFailingRuleText("no class %s should reside in any package ['%s']",
+                        SomeClass.class.getName(),
+                        Joiner.on("', '").join(packageIdentifiers))
+                .containFailureDetail(String.format("class %s does reside in any package \\['%s'\\] in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(Joiner.on("', '").join(packageIdentifiers)),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_bePublic_rules() {
+        return $$(
+                $(theClass(SomeClass.class).should().bePublic(),
+                        theClass(SomeClass.class).should().notBePublic()),
+                $(theClass(SomeClass.class).should(ArchConditions.bePublic()),
+                        theClass(SomeClass.class).should(ArchConditions.notBePublic())),
+                $(theClass(SomeClass.class.getName()).should().bePublic(),
+                        theClass(SomeClass.class.getName()).should().notBePublic()),
+                $(theClass(SomeClass.class.getName()).should(ArchConditions.bePublic()),
+                        theClass(SomeClass.class.getName()).should(ArchConditions.notBePublic()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_bePublic_rules")
+    public void theClass_should_bePublic(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should be public",
+                        SomeClass.class.getName())
+                .haveFailingRuleText("the class %s should not be public",
+                        SomeClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_bePublic_rules() {
+        return $$(
+                $(noClass(SomeClass.class).should().notBePublic(),
+                        noClass(SomeClass.class).should().bePublic()),
+                $(noClass(SomeClass.class).should(ArchConditions.notBePublic()),
+                        noClass(SomeClass.class).should(ArchConditions.bePublic())),
+                $(noClass(SomeClass.class.getName()).should().notBePublic(),
+                        noClass(SomeClass.class.getName()).should().bePublic()),
+                $(noClass(SomeClass.class.getName()).should(ArchConditions.notBePublic()),
+                        noClass(SomeClass.class.getName()).should(ArchConditions.bePublic()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_bePublic_rules")
+    public void noClass_should_bePublic(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not be public",
+                        SomeClass.class.getName())
+                .haveFailingRuleText("no class %s should be public",
+                        SomeClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(SomeClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(SomeClass.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_bePrivate_rules() {
+        return $$(
+                $(theClass(PrivateClass.class).should().bePrivate(),
+                        theClass(PrivateClass.class).should().notBePrivate()),
+                $(theClass(PrivateClass.class).should(ArchConditions.bePrivate()),
+                        theClass(PrivateClass.class).should(ArchConditions.notBePrivate())),
+                $(theClass(PrivateClass.class.getName()).should().bePrivate(),
+                        theClass(PrivateClass.class.getName()).should().notBePrivate()),
+                $(theClass(PrivateClass.class.getName()).should(ArchConditions.bePrivate()),
+                        theClass(PrivateClass.class.getName()).should(ArchConditions.notBePrivate()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_bePrivate_rules")
+    public void theClass_should_bePrivate(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PrivateClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should be private",
+                        PrivateClass.class.getName())
+                .haveFailingRuleText("the class %s should not be private",
+                        PrivateClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(PrivateClass.class.getName()),
+                        quote(JavaModifier.PRIVATE.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_bePrivate_rules() {
+        return $$(
+                $(noClass(PrivateClass.class).should().notBePrivate(),
+                        noClass(PrivateClass.class).should().bePrivate()),
+                $(noClass(PrivateClass.class).should(ArchConditions.notBePrivate()),
+                        noClass(PrivateClass.class).should(ArchConditions.bePrivate())),
+                $(noClass(PrivateClass.class.getName()).should().notBePrivate(),
+                        noClass(PrivateClass.class.getName()).should().bePrivate()),
+                $(noClass(PrivateClass.class.getName()).should(ArchConditions.notBePrivate()),
+                        noClass(PrivateClass.class.getName()).should(ArchConditions.bePrivate()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_bePrivate_rules")
+    public void noClass_should_bePrivate(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PrivateClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not be private",
+                        PrivateClass.class.getName())
+                .haveFailingRuleText("no class %s should be private",
+                        PrivateClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(PrivateClass.class.getName()),
+                        quote(JavaModifier.PRIVATE.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_beProtected_rules() {
+        return $$(
+                $(theClass(ProtectedClass.class).should().beProtected(),
+                        theClass(ProtectedClass.class).should().notBeProtected()),
+                $(theClass(ProtectedClass.class).should(ArchConditions.beProtected()),
+                        theClass(ProtectedClass.class).should(ArchConditions.notBeProtected())),
+                $(theClass(ProtectedClass.class.getName()).should().beProtected(),
+                        theClass(ProtectedClass.class.getName()).should().notBeProtected()),
+                $(theClass(ProtectedClass.class.getName()).should(ArchConditions.beProtected()),
+                        theClass(ProtectedClass.class.getName()).should(ArchConditions.notBeProtected()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_beProtected_rules")
+    public void theClass_should_beProtected(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ProtectedClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should be protected",
+                        ProtectedClass.class.getName())
+                .haveFailingRuleText("the class %s should not be protected",
+                        ProtectedClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(ProtectedClass.class.getName()),
+                        quote(JavaModifier.PROTECTED.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_beProtected_rules() {
+        return $$(
+                $(noClass(ProtectedClass.class).should().notBeProtected(),
+                        noClass(ProtectedClass.class).should().beProtected()),
+                $(noClass(ProtectedClass.class).should(ArchConditions.notBeProtected()),
+                        noClass(ProtectedClass.class).should(ArchConditions.beProtected())),
+                $(noClass(ProtectedClass.class.getName()).should().notBeProtected(),
+                        noClass(ProtectedClass.class.getName()).should().beProtected()),
+                $(noClass(ProtectedClass.class.getName()).should(ArchConditions.notBeProtected()),
+                        noClass(ProtectedClass.class.getName()).should(ArchConditions.beProtected()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_beProtected_rules")
+    public void noClass_should_beProtected(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ProtectedClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not be protected",
+                        ProtectedClass.class.getName())
+                .haveFailingRuleText("no class %s should be protected",
+                        ProtectedClass.class.getName())
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(ProtectedClass.class.getName()),
+                        quote(JavaModifier.PROTECTED.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_bePackagePrivate_rules() {
+        return $$(
+                $(theClass(PackagePrivateClass.class).should().bePackagePrivate(),
+                        theClass(PackagePrivateClass.class).should().notBePackagePrivate()),
+                $(theClass(PackagePrivateClass.class).should(ArchConditions.bePackagePrivate()),
+                        theClass(PackagePrivateClass.class).should(ArchConditions.notBePackagePrivate())),
+                $(theClass(PackagePrivateClass.class.getName()).should().bePackagePrivate(),
+                        theClass(PackagePrivateClass.class.getName()).should().notBePackagePrivate()),
+                $(theClass(PackagePrivateClass.class.getName()).should(ArchConditions.bePackagePrivate()),
+                        theClass(PackagePrivateClass.class.getName()).should(ArchConditions.notBePackagePrivate()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_bePackagePrivate_rules")
+    public void theClass_should_bePackagePrivate(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PackagePrivateClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should be package private",
+                        PackagePrivateClass.class.getName())
+                .haveFailingRuleText("the class %s should not be package private",
+                        PackagePrivateClass.class.getName())
+                .containFailureDetail(String.format("class %s doesn't have modifier %s in %s "
+                                + "and class %s doesn't have modifier %s in %s "
+                                + "and class %s doesn't have modifier %s in %s",
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PRIVATE.name()),
+                        locationPattern(GivenClassShouldTest.class),
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PROTECTED.name()),
+                        locationPattern(GivenClassShouldTest.class),
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_bePackagePrivate_rules() {
+        return $$(
+                $(noClass(PackagePrivateClass.class).should().notBePackagePrivate(),
+                        noClass(PackagePrivateClass.class).should().bePackagePrivate()),
+                $(noClass(PackagePrivateClass.class).should(ArchConditions.notBePackagePrivate()),
+                        noClass(PackagePrivateClass.class).should(ArchConditions.bePackagePrivate())),
+                $(noClass(PackagePrivateClass.class.getName()).should().notBePackagePrivate(),
+                        noClass(PackagePrivateClass.class.getName()).should().bePackagePrivate()),
+                $(noClass(PackagePrivateClass.class.getName()).should(ArchConditions.notBePackagePrivate()),
+                        noClass(PackagePrivateClass.class.getName()).should(ArchConditions.bePackagePrivate()))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_bePackagePrivate_rules")
+    public void noClass_should_bePackagePrivate(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PackagePrivateClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not be package private",
+                        PackagePrivateClass.class.getName())
+                .haveFailingRuleText("no class %s should be package private",
+                        PackagePrivateClass.class.getName())
+                .containFailureDetail(String.format("class %s doesn't have modifier %s in %s "
+                                + "and class %s doesn't have modifier %s in %s "
+                                + "and class %s doesn't have modifier %s in %s",
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PRIVATE.name()),
+                        locationPattern(GivenClassShouldTest.class),
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PROTECTED.name()),
+                        locationPattern(GivenClassShouldTest.class),
+                        quote(PackagePrivateClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_haveModifier_public_rules() {
+        return $$(
+                $(theClass(PublicClass.class).should().haveModifier(PUBLIC),
+                        theClass(PublicClass.class).should().notHaveModifier(PUBLIC)),
+                $(theClass(PublicClass.class).should(ArchConditions.haveModifier(PUBLIC)),
+                        theClass(PublicClass.class).should(ArchConditions.notHaveModifier(PUBLIC))),
+                $(theClass(PublicClass.class.getName()).should().haveModifier(PUBLIC),
+                        theClass(PublicClass.class.getName()).should().notHaveModifier(PUBLIC)),
+                $(theClass(PublicClass.class.getName()).should(ArchConditions.haveModifier(PUBLIC)),
+                        theClass(PublicClass.class.getName()).should(ArchConditions.notHaveModifier(PUBLIC)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_haveModifier_public_rules")
+    public void theClass_should_haveModifier_public(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PublicClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should have modifier %s",
+                        PublicClass.class.getName(), PUBLIC)
+                .haveFailingRuleText("the class %s should not have modifier %s",
+                        PublicClass.class.getName(), PUBLIC)
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(PublicClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_haveModifier_public_rules() {
+        return $$(
+                $(noClass(PublicClass.class).should().notHaveModifier(PUBLIC),
+                        noClass(PublicClass.class).should().haveModifier(PUBLIC)),
+                $(noClass(PublicClass.class).should(ArchConditions.notHaveModifier(PUBLIC)),
+                        noClass(PublicClass.class).should(ArchConditions.haveModifier(PUBLIC))),
+                $(noClass(PublicClass.class.getName()).should().notHaveModifier(PUBLIC),
+                        noClass(PublicClass.class.getName()).should().haveModifier(PUBLIC)),
+                $(noClass(PublicClass.class.getName()).should(ArchConditions.notHaveModifier(PUBLIC)),
+                        noClass(PublicClass.class.getName()).should(ArchConditions.haveModifier(PUBLIC)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_haveModifier_public_rules")
+    public void noClass_should_haveModifier_public(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, PublicClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not have modifier %s",
+                        PublicClass.class.getName(), PUBLIC)
+                .haveFailingRuleText("no class %s should have modifier %s",
+                        PublicClass.class.getName(), PUBLIC)
+                .containFailureDetail(String.format("class %s has modifier %s in %s",
+                        quote(PublicClass.class.getName()),
+                        quote(JavaModifier.PUBLIC.name()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_beAnnotatedWith_rules() {
+        return $$(
+                $(theClass(SomeAnnotatedClass.class).should().beAnnotatedWith(RuntimeRetentionAnnotation.class),
+                        theClass(SomeAnnotatedClass.class).should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                $(theClass(SomeAnnotatedClass.class).should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                        theClass(SomeAnnotatedClass.class).should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class))),
+                $(theClass(SomeAnnotatedClass.class.getName()).should().beAnnotatedWith(RuntimeRetentionAnnotation.class),
+                        theClass(SomeAnnotatedClass.class.getName()).should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                $(theClass(SomeAnnotatedClass.class.getName()).should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                        theClass(SomeAnnotatedClass.class.getName()).should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_beAnnotatedWith_rules")
+    public void theClass_should_beAnnotatedWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeAnnotatedClass.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should be annotated with @%s",
+                        SomeAnnotatedClass.class.getName(), RuntimeRetentionAnnotation.class.getSimpleName())
+                .haveFailingRuleText("the class %s should not be annotated with @%s",
+                        SomeAnnotatedClass.class.getName(), RuntimeRetentionAnnotation.class.getSimpleName())
+                .containFailureDetail(String.format("class %s is annotated with @%s in %s",
+                        quote(SomeAnnotatedClass.class.getName()),
+                        quote(RuntimeRetentionAnnotation.class.getSimpleName()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_beAnnotatedWith_rules() {
+        return $$(
+                $(noClass(SomeAnnotatedClass.class).should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class),
+                        noClass(SomeAnnotatedClass.class).should().beAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                $(noClass(SomeAnnotatedClass.class).should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                        noClass(SomeAnnotatedClass.class).should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class))),
+                $(noClass(SomeAnnotatedClass.class.getName()).should().notBeAnnotatedWith(RuntimeRetentionAnnotation.class),
+                        noClass(SomeAnnotatedClass.class.getName()).should().beAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                $(noClass(SomeAnnotatedClass.class.getName()).should(ArchConditions.notBeAnnotatedWith(RuntimeRetentionAnnotation.class)),
+                        noClass(SomeAnnotatedClass.class.getName()).should(ArchConditions.beAnnotatedWith(RuntimeRetentionAnnotation.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_beAnnotatedWith_rules")
+    public void noClass_should_beAnnotatedWith(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, SomeAnnotatedClass.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not be annotated with @%s",
+                        SomeAnnotatedClass.class.getName(), RuntimeRetentionAnnotation.class.getSimpleName())
+                .haveFailingRuleText("no class %s should be annotated with @%s",
+                        SomeAnnotatedClass.class.getName(), RuntimeRetentionAnnotation.class.getSimpleName())
+                .containFailureDetail(String.format("class %s is annotated with @%s in %s",
+                        quote(SomeAnnotatedClass.class.getName()),
+                        quote(RuntimeRetentionAnnotation.class.getSimpleName()),
+                        locationPattern(GivenClassShouldTest.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_implement_rules() {
+        return $$(
+                $(theClass(ArrayList.class).should().implement(Collection.class),
+                        theClass(ArrayList.class).should().notImplement(Collection.class)),
+                $(theClass(ArrayList.class).should(ArchConditions.implement(Collection.class)),
+                        theClass(ArrayList.class).should(ArchConditions.notImplement(Collection.class))),
+                $(theClass(ArrayList.class.getName()).should().implement(Collection.class),
+                        theClass(ArrayList.class.getName()).should().notImplement(Collection.class)),
+                $(theClass(ArrayList.class.getName()).should(ArchConditions.implement(Collection.class)),
+                        theClass(ArrayList.class.getName()).should(ArchConditions.notImplement(Collection.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_implement_rules")
+    public void theClass_should_implement(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ArrayList.class, Object.class)
+                .haveSuccessfulRuleText("the class %s should implement %s",
+                        ArrayList.class.getName(), Collection.class.getName())
+                .haveFailingRuleText("the class %s should not implement %s",
+                        ArrayList.class.getName(), Collection.class.getName())
+                .containFailureDetail(String.format("class %s implements %s in %s",
+                        quote(ArrayList.class.getName()),
+                        quote(Collection.class.getName()),
+                        locationPattern(ArrayList.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_implement_rules() {
+        return $$(
+                $(noClass(ArrayList.class).should().notImplement(Collection.class),
+                        noClass(ArrayList.class).should().implement(Collection.class)),
+                $(noClass(ArrayList.class).should(ArchConditions.notImplement(Collection.class)),
+                        noClass(ArrayList.class).should(ArchConditions.implement(Collection.class))),
+                $(noClass(ArrayList.class.getName()).should().notImplement(Collection.class),
+                        noClass(ArrayList.class.getName()).should().implement(Collection.class)),
+                $(noClass(ArrayList.class.getName()).should(ArchConditions.notImplement(Collection.class)),
+                        noClass(ArrayList.class.getName()).should(ArchConditions.implement(Collection.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_implement_rules")
+    public void noClass_should_implement(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ArrayList.class, Object.class)
+                .haveSuccessfulRuleText("no class %s should not implement %s",
+                        ArrayList.class.getName(), Collection.class.getName())
+                .haveFailingRuleText("no class %s should implement %s",
+                        ArrayList.class.getName(), Collection.class.getName())
+                .containFailureDetail(String.format("class %s implements %s in %s",
+                        quote(ArrayList.class.getName()),
+                        quote(Collection.class.getName()),
+                        locationPattern(ArrayList.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_beAssignableTo_rules() {
+        return $$(
+                $(theClass(List.class).should().beAssignableTo(Collection.class),
+                        theClass(List.class).should().notBeAssignableTo(Collection.class)),
+                $(theClass(List.class).should(ArchConditions.beAssignableTo(Collection.class)),
+                        theClass(List.class).should(ArchConditions.notBeAssignableTo(Collection.class))),
+                $(theClass(List.class.getName()).should().beAssignableTo(Collection.class),
+                        theClass(List.class.getName()).should().notBeAssignableTo(Collection.class)),
+                $(theClass(List.class.getName()).should(ArchConditions.beAssignableTo(Collection.class)),
+                        theClass(List.class.getName()).should(ArchConditions.notBeAssignableTo(Collection.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_beAssignableTo_rules")
+    public void theClass_should_beAssignableTo(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, List.class, Collection.class)
+                .haveSuccessfulRuleText("the class %s should be assignable to %s",
+                        List.class.getName(), Collection.class.getName())
+                .haveFailingRuleText("the class %s should not be assignable to %s",
+                        List.class.getName(), Collection.class.getName())
+                .containFailureDetail(String.format("class %s is assignable to %s in %s",
+                        quote(List.class.getName()),
+                        quote(Collection.class.getName()),
+                        locationPattern(List.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_beAssignableTo_rules() {
+        return $$(
+                $(noClass(List.class).should().notBeAssignableTo(Collection.class),
+                        noClass(List.class).should().beAssignableTo(Collection.class)),
+                $(noClass(List.class).should(ArchConditions.notBeAssignableTo(Collection.class)),
+                        noClass(List.class).should(ArchConditions.beAssignableTo(Collection.class))),
+                $(noClass(List.class.getName()).should().notBeAssignableTo(Collection.class),
+                        noClass(List.class.getName()).should().beAssignableTo(Collection.class)),
+                $(noClass(List.class.getName()).should(ArchConditions.notBeAssignableTo(Collection.class)),
+                        noClass(List.class.getName()).should(ArchConditions.beAssignableTo(Collection.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_beAssignableTo_rules")
+    public void noClass_should_beAssignableTo(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, List.class, Collection.class)
+                .haveSuccessfulRuleText("no class %s should not be assignable to %s",
+                        List.class.getName(), Collection.class.getName())
+                .haveFailingRuleText("no class %s should be assignable to %s",
+                        List.class.getName(), Collection.class.getName())
+                .containFailureDetail(String.format("class %s is assignable to %s in %s",
+                        quote(List.class.getName()),
+                        quote(Collection.class.getName()),
+                        locationPattern(List.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_beAssignableFrom_rules() {
+        return $$(
+                $(theClass(Collection.class).should().beAssignableFrom(List.class),
+                        theClass(Collection.class).should().notBeAssignableFrom(List.class)),
+                $(theClass(Collection.class).should(ArchConditions.beAssignableFrom(List.class)),
+                        theClass(Collection.class).should(ArchConditions.notBeAssignableFrom(List.class))),
+                $(theClass(Collection.class.getName()).should().beAssignableFrom(List.class),
+                        theClass(Collection.class.getName()).should().notBeAssignableFrom(List.class)),
+                $(theClass(Collection.class.getName()).should(ArchConditions.beAssignableFrom(List.class)),
+                        theClass(Collection.class.getName()).should(ArchConditions.notBeAssignableFrom(List.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_beAssignableFrom_rules")
+    public void theClass_should_beAssignableFrom(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, Collection.class, List.class)
+                .haveSuccessfulRuleText("the class %s should be assignable from %s",
+                        Collection.class.getName(), List.class.getName())
+                .haveFailingRuleText("the class %s should not be assignable from %s",
+                        Collection.class.getName(), List.class.getName())
+                .containFailureDetail(String.format("class %s is assignable from %s in %s",
+                        quote(Collection.class.getName()),
+                        quote(List.class.getName()),
+                        locationPattern(Collection.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_beAssignableFrom_rules() {
+        return $$(
+                $(noClass(Collection.class).should().notBeAssignableFrom(List.class),
+                        noClass(Collection.class).should().beAssignableFrom(List.class)),
+                $(noClass(Collection.class).should(ArchConditions.notBeAssignableFrom(List.class)),
+                        noClass(Collection.class).should(ArchConditions.beAssignableFrom(List.class))),
+                $(noClass(Collection.class.getName()).should().notBeAssignableFrom(List.class),
+                        noClass(Collection.class.getName()).should().beAssignableFrom(List.class)),
+                $(noClass(Collection.class.getName()).should(ArchConditions.notBeAssignableFrom(List.class)),
+                        noClass(Collection.class.getName()).should(ArchConditions.beAssignableFrom(List.class)))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_beAssignableFrom_rules")
+    public void noClass_should_beAssignableFrom(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, Collection.class, List.class)
+                .haveSuccessfulRuleText("no class %s should not be assignable from %s",
+                        Collection.class.getName(), List.class.getName())
+                .haveFailingRuleText("no class %s should be assignable from %s",
+                        Collection.class.getName(), List.class.getName())
+                .containFailureDetail(String.format("class %s is assignable from %s in %s",
+                        quote(Collection.class.getName()),
+                        quote(List.class.getName()),
+                        locationPattern(Collection.class)))
+                .doNotContainFailureDetail(quote(Object.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_getField_rules() {
+        return $$(
+                $(theClass(ClassAccessingField.class).should().getField(ClassWithField.class, "field"),
+                        theClass(ClassAccessingWrongField.class).should().getField(ClassWithField.class, "field")),
+                $(theClass(ClassAccessingField.class).should(ArchConditions.getField(ClassWithField.class, "field")),
+                        theClass(ClassAccessingWrongField.class).should(ArchConditions.getField(ClassWithField.class, "field"))),
+                $(theClass(ClassAccessingField.class.getName()).should().getField(ClassWithField.class, "field"),
+                        theClass(ClassAccessingWrongField.class.getName()).should().getField(ClassWithField.class, "field")),
+                $(theClass(ClassAccessingField.class.getName()).should(ArchConditions.getField(ClassWithField.class, "field")),
+                        theClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.getField(ClassWithField.class, "field")))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_getField_rules")
+    public void theClass_should_getField(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("the class %s should get field %s.%s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .haveFailingRuleText("the class %s should get field %s.%s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingWrongField.class, "gets",
+                        ClassAccessingWrongField.class, "classAccessingField"))
+                .doNotContainFailureDetail(quote(ClassAccessingField.class.getName()) + ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX + "get");
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_getField_rules() {
+        return $$(
+                $(noClass(ClassAccessingWrongField.class).should().getField(ClassWithField.class, "field"),
+                        noClass(ClassAccessingField.class).should().getField(ClassWithField.class, "field")),
+                $(noClass(ClassAccessingWrongField.class).should(ArchConditions.getField(ClassWithField.class, "field")),
+                        noClass(ClassAccessingField.class).should(ArchConditions.getField(ClassWithField.class, "field"))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should().getField(ClassWithField.class, "field"),
+                        noClass(ClassAccessingField.class.getName()).should().getField(ClassWithField.class, "field")),
+                $(noClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.getField(ClassWithField.class, "field")),
+                        noClass(ClassAccessingField.class.getName()).should(ArchConditions.getField(ClassWithField.class, "field")))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_getField_rules")
+    public void noClass_should_getField(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("no class %s should get field %s.%s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .haveFailingRuleText("no class %s should get field %s.%s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingField.class, "gets",
+                        ClassWithField.class, "field"))
+                .doNotContainFailureDetail(quote(ClassAccessingWrongField.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_accessField_rules() {
+        return $$(
+                $(theClass(ClassAccessingField.class).should().accessField(ClassWithField.class, "field"),
+                        theClass(ClassAccessingWrongField.class).should().accessField(ClassWithField.class, "field")),
+                $(theClass(ClassAccessingField.class).should(ArchConditions.accessField(ClassWithField.class, "field")),
+                        theClass(ClassAccessingWrongField.class).should(ArchConditions.accessField(ClassWithField.class, "field"))),
+                $(theClass(ClassAccessingField.class.getName()).should().accessField(ClassWithField.class, "field"),
+                        theClass(ClassAccessingWrongField.class.getName()).should().accessField(ClassWithField.class, "field")),
+                $(theClass(ClassAccessingField.class.getName()).should(ArchConditions.accessField(ClassWithField.class, "field")),
+                        theClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.accessField(ClassWithField.class, "field")))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_accessField_rules")
+    public void theClass_should_accessField(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("the class %s should access field %s.%s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .haveFailingRuleText("the class %s should access field %s.%s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingWrongField.class, "accesses",
+                        ClassAccessingWrongField.class, "classAccessingField"))
+                .doNotContainFailureDetail(quote(ClassAccessingField.class.getName()) + ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX + "accesses");
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_accessField_rules() {
+        return $$(
+                $(noClass(ClassAccessingWrongField.class).should().accessField(ClassWithField.class, "field"),
+                        noClass(ClassAccessingField.class).should().accessField(ClassWithField.class, "field")),
+                $(noClass(ClassAccessingWrongField.class).should(ArchConditions.accessField(ClassWithField.class, "field")),
+                        noClass(ClassAccessingField.class).should(ArchConditions.accessField(ClassWithField.class, "field"))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should().accessField(ClassWithField.class, "field"),
+                        noClass(ClassAccessingField.class.getName()).should().accessField(ClassWithField.class, "field")),
+                $(noClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.accessField(ClassWithField.class, "field")),
+                        noClass(ClassAccessingField.class.getName()).should(ArchConditions.accessField(ClassWithField.class, "field")))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_accessField_rules")
+    public void noClass_should_accessField(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("no class %s should access field %s.%s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .haveFailingRuleText("no class %s should access field %s.%s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName(), "field")
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingField.class, "accesses",
+                        ClassWithField.class, "field"))
+                .doNotContainFailureDetail(quote(ClassAccessingWrongField.class.getName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_getFieldWhere_rules() {
+        return $$(
+                $(theClass(ClassAccessingField.class).should().getFieldWhere(accessTargetIs(ClassWithField.class)),
+                        theClass(ClassAccessingWrongField.class).should().getFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(theClass(ClassAccessingField.class).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))),
+                        theClass(ClassAccessingWrongField.class).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class)))),
+                $(theClass(ClassAccessingField.class.getName()).should().getFieldWhere(accessTargetIs(ClassWithField.class)),
+                        theClass(ClassAccessingWrongField.class.getName()).should().getFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(theClass(ClassAccessingField.class.getName()).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))),
+                        theClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_getFieldWhere_rules")
+    public void theClass_should_getFieldWhere(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("the class %s should get field where target is %s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName())
+                .haveFailingRuleText("the class %s should get field where target is %s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName())
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingWrongField.class, "gets",
+                        ClassAccessingWrongField.class, "classAccessingField"))
+                .doNotContainFailureDetail(quote(ClassAccessingField.class.getSimpleName()) + ".*accesses");
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_getFieldWhere_rules() {
+        return $$(
+                $(noClass(ClassAccessingWrongField.class).should().getFieldWhere(accessTargetIs(ClassWithField.class)),
+                        noClass(ClassAccessingField.class).should().getFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(noClass(ClassAccessingWrongField.class).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))),
+                        noClass(ClassAccessingField.class).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class)))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should().getFieldWhere(accessTargetIs(ClassWithField.class)),
+                        noClass(ClassAccessingField.class.getName()).should().getFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))),
+                        noClass(ClassAccessingField.class.getName()).should(ArchConditions.getFieldWhere(accessTargetIs(ClassWithField.class))))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_getFieldWhere_rules")
+    public void noClass_should_getFieldWhere(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("no class %s should get field where target is %s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName())
+                .haveFailingRuleText("no class %s should get field where target is %s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName())
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingField.class, "gets",
+                        ClassWithField.class, "field"))
+                .doNotContainFailureDetail(quote(ClassAccessingWrongField.class.getSimpleName()));
+    }
+
+    @DataProvider
+    public static Object[][] theClass_should_accessFieldWhere_rules() {
+        return $$(
+                $(theClass(ClassAccessingField.class).should().accessFieldWhere(accessTargetIs(ClassWithField.class)),
+                        theClass(ClassAccessingWrongField.class).should().accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(theClass(ClassAccessingField.class).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                        theClass(ClassAccessingWrongField.class).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class)))),
+                $(theClass(ClassAccessingField.class.getName()).should().accessFieldWhere(accessTargetIs(ClassWithField.class)),
+                        theClass(ClassAccessingWrongField.class.getName()).should().accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(theClass(ClassAccessingField.class.getName()).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                        theClass(ClassAccessingWrongField.class.getName())
+                                .should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))))
+        );
+    }
+
+    @Test
+    @UseDataProvider("theClass_should_accessFieldWhere_rules")
+    public void theClass_should_accessFieldWhere(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("the class %s should access field where target is %s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName())
+                .haveFailingRuleText("the class %s should access field where target is %s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName())
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingWrongField.class, "accesses",
+                        ClassAccessingWrongField.class, "classAccessingField"))
+                .doNotContainFailureDetail(quote(ClassAccessingField.class.getSimpleName()) + ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX + "accesses");
+    }
+
+    @DataProvider
+    public static Object[][] noClass_should_accessFieldWhere_rules() {
+        return $$(
+                $(noClass(ClassAccessingWrongField.class).should().accessFieldWhere(accessTargetIs(ClassWithField.class)),
+                        noClass(ClassAccessingField.class).should().accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(noClass(ClassAccessingWrongField.class).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                        noClass(ClassAccessingField.class).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class)))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should().accessFieldWhere(accessTargetIs(ClassWithField.class)),
+                        noClass(ClassAccessingField.class.getName()).should().accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                $(noClass(ClassAccessingWrongField.class.getName()).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))),
+                        noClass(ClassAccessingField.class.getName()).should(ArchConditions.accessFieldWhere(accessTargetIs(ClassWithField.class))))
+        );
+    }
+
+    @Test
+    @UseDataProvider("noClass_should_accessFieldWhere_rules")
+    public void noClass_should_accessFieldWhere(ArchRule satisfiedRule, ArchRule unsatisfiedRule) {
+        assertThatRules(satisfiedRule, unsatisfiedRule, ClassWithField.class, ClassAccessingWrongField.class, ClassAccessingField.class)
+                .haveSuccessfulRuleText("no class %s should access field where target is %s",
+                        ClassAccessingWrongField.class.getName(), ClassWithField.class.getSimpleName())
+                .haveFailingRuleText("no class %s should access field where target is %s",
+                        ClassAccessingField.class.getName(), ClassWithField.class.getSimpleName())
+                .containFailureDetail(accessesFieldRegex(
+                        ClassAccessingField.class, "accesses",
+                        ClassWithField.class, "field"))
+                .doNotContainFailureDetail(quote(ClassAccessingWrongField.class.getName()));
+    }
+
+    private RuleEvaluationAsserter assertThatRules(ArchRule satisfiedRule, ArchRule unsatisfiedRule, Class<?>... classesToImport) {
+        return new RuleEvaluationAsserter(satisfiedRule, unsatisfiedRule, classesToImport);
+    }
+
+    private static class RuleEvaluationAsserter {
+        private final ArchRule satisfiedRule;
+        private final ArchRule unsatisfiedRule;
+        private EvaluationResult satisfiedResult;
+        private final EvaluationResult unsatisfiedResult;
+
+        RuleEvaluationAsserter(ArchRule satisfiedRule, ArchRule unsatisfiedRule, Class<?>... classesToImport) {
+            this.satisfiedRule = satisfiedRule;
+            this.unsatisfiedRule = unsatisfiedRule;
+            JavaClasses classes = importClasses(classesToImport);
+            satisfiedResult = satisfiedRule.evaluate(classes);
+            unsatisfiedResult = unsatisfiedRule.evaluate(classes);
+        }
+
+        RuleEvaluationAsserter haveSuccessfulRuleText(String descriptionTemplate, Object... args) {
+            assertThat(satisfiedRule.getDescription()).isEqualTo(String.format(descriptionTemplate, args));
+            assertNoViolation(satisfiedResult);
+            return this;
+        }
+
+        RuleEvaluationAsserter haveFailingRuleText(String descriptionTemplate, Object... args) {
+            String description = String.format(descriptionTemplate, args);
+            assertThat(unsatisfiedRule.getDescription()).isEqualTo(description);
+            assertThat(singleLineFailureReportOf(unsatisfiedResult)).contains(description);
+            return this;
+        }
+
+        RuleEvaluationAsserter containFailureDetail(String detailPattern) {
+            return containFailureDetail(Pattern.compile(detailPattern));
+        }
+
+        RuleEvaluationAsserter containFailureDetail(Pattern detailPattern) {
+            assertThat(singleLineFailureReportOf(unsatisfiedResult)).containsPattern(detailPattern);
+            return this;
+        }
+
+        void doNotContainFailureDetail(String detailPattern) {
+            String anyLineThatContainsThePattern = ".*" + FAILURE_REPORT_NEWLINE_MARKER
+                    + ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX + detailPattern + ANY_NUMBER_OF_NON_NEWLINE_CHARS_REGEX
+                    + FAILURE_REPORT_NEWLINE_MARKER + ".*";
+            assertThat(singleLineFailureReportOf(unsatisfiedResult)).doesNotMatch(anyLineThatContainsThePattern);
+        }
+    }
+
+    private static void assertNoViolation(EvaluationResult result) {
+        assertThat(result.hasViolation()).as("result has violation").isFalse();
+    }
+
+    private static class ClassWithField {
+        String field;
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassAccessingField {
+        ClassWithField classWithField;
+
+        String access() {
+            classWithField.field = "new";
+            return classWithField.field;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassAccessingWrongField {
+        ClassAccessingField classAccessingField;
+
+        @SuppressWarnings("ConstantConditions")
+        ClassWithField wrongAccess() {
+            classAccessingField.classWithField = null;
+            return classAccessingField.classWithField;
+        }
+    }
+
+    public static class PublicClass {
+    }
+
+    protected static class ProtectedClass {
+    }
+
+    static class PackagePrivateClass {
+    }
+
+    private static class PrivateClass {
+    }
+
+    @RuntimeRetentionAnnotation
+    private static class SomeAnnotatedClass {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/SomeClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/SomeClass.java
@@ -1,4 +1,4 @@
 package com.tngtech.archunit.lang.syntax.elements.testclasses;
 
-public class RightNamedClass {
+public class SomeClass {
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
@@ -318,6 +318,8 @@ public abstract class RandomSyntaxTestBase {
                         } else if (methodName.toLowerCase().contains("assign")
                                 || methodName.toLowerCase().contains("implement")) {
                             return new Parameter("some.Type", "some.Type");
+                        } else if (methodName.equals("be") || methodName.equals("notBe")) {
+                            return new Parameter("some.Type", "some.Type");
                         } else {
                             return new Parameter("string", "'string'");
                         }


### PR DESCRIPTION
Extended the syntax to offer an ArchRuleDefinition.theClass(..) and noClass(..) entry point to create rules based on a specific class. Also added should().be(..) and should().notBe().

Issue: #60
Signed-off-by: Michael Sherman <msherman32@gatech.edu>