### PR TITLE
Support condition to check how many classes have matched

### DIFF
--- a/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/RestrictNumberOfClassesWithACertainPropertyTest.java
+++ b/archunit-example/src/test/java/com/tngtech/archunit/exampletest/junit/RestrictNumberOfClassesWithACertainPropertyTest.java
@@ -1,0 +1,26 @@
+package com.tngtech.archunit.exampletest.junit;
+
+import com.tngtech.archunit.example.SomeBusinessInterface;
+import com.tngtech.archunit.example.SomeOtherBusinessInterface;
+import com.tngtech.archunit.exampletest.Example;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.base.DescribedPredicate.lessThanOrEqualTo;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@Category(Example.class)
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "com.tngtech.archunit.example")
+public class RestrictNumberOfClassesWithACertainPropertyTest {
+    @ArchTest
+    public static final ArchRule no_new_classes_should_implement_SomeBusinessInterface =
+            classes().that().implement(SomeBusinessInterface.class)
+                    .should().containNumberOfElements(lessThanOrEqualTo(1))
+                    .because("from now on new classes should implement "
+                            + SomeOtherBusinessInterface.class.getName());
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/RestrictNumberOfClassesWithACertainPropertyIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/junit/RestrictNumberOfClassesWithACertainPropertyIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.tngtech.archunit.integration.junit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.tngtech.archunit.example.ClassViolatingSessionBeanRules;
+import com.tngtech.archunit.example.SecondBeanImplementingSomeBusinessInterface;
+import com.tngtech.archunit.example.SomeBusinessInterface;
+import com.tngtech.archunit.example.SomeOtherBusinessInterface;
+import com.tngtech.archunit.exampletest.junit.RestrictNumberOfClassesWithACertainPropertyTest;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.CalledByArchUnitIntegrationTestRunner;
+import com.tngtech.archunit.junit.ExpectsViolations;
+import com.tngtech.archunit.junit.MessageAssertionChain;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+
+@RunWith(ArchUnitIntegrationTestRunner.class)
+@AnalyzeClasses(packages = "com.tngtech.archunit.example")
+public class RestrictNumberOfClassesWithACertainPropertyIntegrationTest {
+    @ArchTest
+    @ExpectedViolationFrom(location = RestrictNumberOfClassesWithACertainPropertyIntegrationTest.class, method = "expectViolationFromTooManyClasses")
+    public static final ArchRule no_new_classes_should_implement_SomeBusinessInterface =
+            RestrictNumberOfClassesWithACertainPropertyTest.no_new_classes_should_implement_SomeBusinessInterface;
+
+    @CalledByArchUnitIntegrationTestRunner
+    static void expectViolationFromTooManyClasses(ExpectsViolations expectViolations) {
+        expectViolations.ofRule(
+                String.format("classes that implement %s should contain number of elements less than or equal to '1', "
+                                + "because from now on new classes should implement %s",
+                        SomeBusinessInterface.class.getName(), SomeOtherBusinessInterface.class.getName()))
+                .by(classesContaining(ClassViolatingSessionBeanRules.class, SecondBeanImplementingSomeBusinessInterface.class));
+    }
+
+    private static MessageAssertionChain.Link classesContaining(final Class<?>... classes) {
+        final String expectedLine = String.format("there is/are %d element(s) in classes %s", classes.length, namesOf(classes));
+        return new MessageAssertionChain.Link() {
+            @Override
+            public Result filterMatching(List<String> lines) {
+                List<String> rest = new ArrayList<>();
+                for (String line : lines) {
+                    if (!line.equals(expectedLine)) {
+                        rest.add(line);
+                    }
+                }
+                boolean matches = (rest.size() == lines.size() - 1);
+                return new Result(matches, rest, String.format("No line matched '%s'", expectedLine));
+            }
+
+            @Override
+            public String getDescription() {
+                return "classes containing " + namesOf(classes);
+            }
+        };
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -98,6 +98,22 @@ public abstract class DescribedPredicate<T> {
         return new EqualToPredicate<>(object);
     }
 
+    public static <T extends Comparable<T>> DescribedPredicate<T> lessThan(final T value) {
+        return new LessThanPredicate<>(value);
+    }
+
+    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThan(final T value) {
+        return new GreaterThanPredicate<>(value);
+    }
+
+    public static <T extends Comparable<T>> DescribedPredicate<T> lessThanOrEqualTo(final T value) {
+        return new LessThanOrEqualToPredicate<>(value);
+    }
+
+    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThanOrEqualTo(final T value) {
+        return new GreaterThanOrEqualToPredicate<>(value);
+    }
+
     public static <T> DescribedPredicate<T> doesnt(final DescribedPredicate<T> predicate) {
         return not(predicate).as("doesn't %s", predicate.getDescription());
     }
@@ -187,16 +203,72 @@ public abstract class DescribedPredicate<T> {
     }
 
     private static class EqualToPredicate<T> extends DescribedPredicate<T> {
-        private final T object;
+        private final T value;
 
-        EqualToPredicate(T object) {
-            super("equal to '%s'", object);
-            this.object = checkNotNull(object);
+        EqualToPredicate(T value) {
+            super("equal to '%s'", value);
+            this.value = checkNotNull(value);
         }
 
         @Override
         public boolean apply(T input) {
-            return object.equals(input);
+            return value.equals(input);
+        }
+    }
+
+    private static class LessThanPredicate<T extends Comparable<T>> extends DescribedPredicate<T> {
+        private final T value;
+
+        LessThanPredicate(T value) {
+            super("less than '%s'", value);
+            this.value = checkNotNull(value);
+        }
+
+        @Override
+        public boolean apply(T input) {
+            return input.compareTo(value) < 0;
+        }
+    }
+
+    private static class GreaterThanPredicate<T extends Comparable<T>> extends DescribedPredicate<T> {
+        private final T value;
+
+        GreaterThanPredicate(T value) {
+            super("greater than '%s'", value);
+            this.value = checkNotNull(value);
+        }
+
+        @Override
+        public boolean apply(T input) {
+            return input.compareTo(value) > 0;
+        }
+    }
+
+    private static class LessThanOrEqualToPredicate<T extends Comparable<T>> extends DescribedPredicate<T> {
+        private final T value;
+
+        LessThanOrEqualToPredicate(T value) {
+            super("less than or equal to '%s'", value);
+            this.value = checkNotNull(value);
+        }
+
+        @Override
+        public boolean apply(T input) {
+            return input.compareTo(value) <= 0;
+        }
+    }
+
+    private static class GreaterThanOrEqualToPredicate<T extends Comparable<T>> extends DescribedPredicate<T> {
+        private final T value;
+
+        GreaterThanOrEqualToPredicate(T value) {
+            super("greater than or equal to '%s'", value);
+            this.value = checkNotNull(value);
+        }
+
+        @Override
+        public boolean apply(T input) {
+            return input.compareTo(value) >= 0;
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/base/Guava.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Guava.java
@@ -15,7 +15,6 @@
  */
 package com.tngtech.archunit.base;
 
-import java.util.Collection;
 import java.util.Map;
 
 import com.google.common.base.Predicate;
@@ -48,14 +47,6 @@ public final class Guava {
     public static final class Iterables {
         public static <T> Iterable<T> filter(Iterable<T> iterable, DescribedPredicate<? super T> predicate) {
             return com.google.common.collect.Iterables.filter(iterable, toGuava(predicate));
-        }
-
-        public static int size(Iterable<?> iterable) {
-            return com.google.common.collect.Iterables.size(iterable);
-        }
-
-        public static String toString(Iterable<?> iterable) {
-            return com.google.common.collect.Iterables.toString(iterable);
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/base/Guava.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Guava.java
@@ -15,6 +15,7 @@
  */
 package com.tngtech.archunit.base;
 
+import java.util.Collection;
 import java.util.Map;
 
 import com.google.common.base.Predicate;
@@ -47,6 +48,14 @@ public final class Guava {
     public static final class Iterables {
         public static <T> Iterable<T> filter(Iterable<T> iterable, DescribedPredicate<? super T> predicate) {
             return com.google.common.collect.Iterables.filter(iterable, toGuava(predicate));
+        }
+
+        public static int size(Iterable<?> iterable) {
+            return com.google.common.collect.Iterables.size(iterable);
+        }
+
+        public static String toString(Iterable<?> iterable) {
+            return com.google.common.collect.Iterables.toString(iterable);
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -16,18 +16,15 @@
 package com.tngtech.archunit.lang.conditions;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.List;
 
 import com.google.common.base.Joiner;
 import com.tngtech.archunit.Internal;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.base.Guava;
 import com.tngtech.archunit.base.PackageMatcher;
 import com.tngtech.archunit.base.PackageMatchers;
 import com.tngtech.archunit.core.domain.AccessTarget;
@@ -785,24 +782,23 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> containNumberOfElements(final DescribedPredicate<Integer> predicate) {
         return new ArchCondition<JavaClass>("contain number of elements " + predicate.getDescription()) {
-            private Iterable<JavaClass> allObjectsToTest;
-
-            @Override
-            public void init(Iterable<JavaClass> allObjectsToTest) {
-                this.allObjectsToTest = allObjectsToTest;
-            }
+            private SortedSet<String> allClassNames = new TreeSet<>();
 
             @Override
             public void check(JavaClass item, ConditionEvents events) {
-                // no-op, classes checked at finish method
+                allClassNames.add(item.getName());
             }
 
             @Override
             public void finish(ConditionEvents events) {
-                final int size = Guava.Iterables.size(allObjectsToTest);
-                final boolean conditionSatisfied = predicate.apply(size);
-                final String message = String.format("there is/are %d element(s) in classes %s", size, Guava.Iterables.toString(allObjectsToTest));
+                int size = allClassNames.size();
+                boolean conditionSatisfied = predicate.apply(size);
+                String message = String.format("there is/are %d element(s) in classes %s", size, join(allClassNames));
                 events.add(new SimpleConditionEvent(size, conditionSatisfied, message));
+            }
+
+            private String join(SortedSet<String> strings) {
+                return "[" + Joiner.on(", ").join(strings) + "]";
             }
         };
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -479,6 +479,11 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
         return copyWithNewCondition(conditionAggregator.add(ArchConditions.notBeInterfaces()));
     }
 
+    @Override
+    public ClassesShouldConjunction containNumberOfElements(DescribedPredicate<Integer> predicate) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.containNumberOfElements(predicate)));
+    }
+
     ClassesShouldInternal copyWithNewCondition(ArchCondition<JavaClass> newCondition) {
         return new ClassesShouldInternal(classesTransformer, priority, newCondition, prepareCondition);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -846,4 +846,12 @@ public interface ClassesShould {
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBe(String className);
+
+    /**
+     * Asserts that number of matched elements conforms supplied predicated.
+     *
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction containNumberOfElements(DescribedPredicate<Integer> predicate);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -848,7 +848,7 @@ public interface ClassesShould {
     ClassesShouldConjunction notBe(String className);
 
     /**
-     * Asserts that number of matched elements conforms supplied predicated.
+     * Asserts that the number of classes checked by this rule conforms to the supplied predicate.
      *
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */

--- a/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
@@ -11,6 +11,10 @@ import static com.tngtech.archunit.base.DescribedPredicate.alwaysTrue;
 import static com.tngtech.archunit.base.DescribedPredicate.doesnt;
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThan;
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
+import static com.tngtech.archunit.base.DescribedPredicate.lessThan;
+import static com.tngtech.archunit.base.DescribedPredicate.lessThanOrEqualTo;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
@@ -56,6 +60,54 @@ public class DescribedPredicateTest {
 
         Object object = new Object();
         assertThat(equalTo(object).apply(object)).isTrue();
+    }
+
+    @Test
+    public void lessThan_works() {
+        assertThat(lessThan(4).apply(3)).isTrue();
+        assertThat(lessThan(4).getDescription()).contains("less than '4'");
+        assertThat(lessThan(4).apply(4)).isFalse();
+        assertThat(lessThan(4).apply(5)).isFalse();
+
+        assertThat(lessThan(Foo.SECOND).apply(Foo.FIRST)).isTrue();
+        assertThat(lessThan(Foo.SECOND).apply(Foo.SECOND)).isFalse();
+        assertThat(lessThan(Foo.SECOND).apply(Foo.THIRD)).isFalse();
+    }
+
+    @Test
+    public void greaterThan_works() {
+        assertThat(greaterThan(5).apply(6)).isTrue();
+        assertThat(greaterThan(5).getDescription()).contains("greater than '5'");
+        assertThat(greaterThan(5).apply(5)).isFalse();
+        assertThat(greaterThan(5).apply(4)).isFalse();
+
+        assertThat(greaterThan(Foo.SECOND).apply(Foo.FIRST)).isFalse();
+        assertThat(greaterThan(Foo.SECOND).apply(Foo.SECOND)).isFalse();
+        assertThat(greaterThan(Foo.SECOND).apply(Foo.THIRD)).isTrue();
+    }
+
+    @Test
+    public void lessThanOrEqualTo_works() {
+        assertThat(lessThanOrEqualTo(5).apply(4)).isTrue();
+        assertThat(lessThanOrEqualTo(5).getDescription()).contains("less than or equal to '5'");
+        assertThat(lessThanOrEqualTo(5).apply(5)).isTrue();
+        assertThat(lessThanOrEqualTo(5).apply(6)).isFalse();
+
+        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.FIRST)).isTrue();
+        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.SECOND)).isTrue();
+        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.THIRD)).isFalse();
+    }
+
+    @Test
+    public void greaterThanOrEqualTo_works() {
+        assertThat(greaterThanOrEqualTo(5).apply(6)).isTrue();
+        assertThat(greaterThanOrEqualTo(5).getDescription()).contains("greater than or equal to '5'");
+        assertThat(greaterThanOrEqualTo(5).apply(5)).isTrue();
+        assertThat(greaterThanOrEqualTo(5).apply(4)).isFalse();
+
+        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.FIRST)).isFalse();
+        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.SECOND)).isTrue();
+        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.THIRD)).isTrue();
     }
 
     @DataProvider
@@ -123,5 +175,9 @@ public class DescribedPredicateTest {
         public String toString() {
             return expectedPrefix;
         }
+    }
+
+    enum Foo {
+        FIRST, SECOND, THIRD
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -39,6 +39,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThan;
+import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
+import static com.tngtech.archunit.base.DescribedPredicate.lessThan;
+import static com.tngtech.archunit.base.DescribedPredicate.lessThanOrEqualTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaClassTest.expectInvalidSyntaxUsageForClassInsteadOfInterface;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
@@ -1127,6 +1132,32 @@ public class ClassesShouldTest {
                         quote(violated.getName()),
                         locationPattern(violated)))
                 .doesNotMatch(String.format(".*class %s .* interface.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] containNumberOfElements_rules() {
+        return $$(
+                $(equalTo(999)),
+                $(lessThan(0)),
+                $(lessThan(1)),
+                $(lessThan(2)),
+                $(greaterThan(2)),
+                $(greaterThan(3)),
+                $(greaterThan(999)),
+                $(lessThanOrEqualTo(0)),
+                $(lessThanOrEqualTo(1)),
+                $(greaterThanOrEqualTo(3)),
+                $(greaterThanOrEqualTo(999)));
+    }
+
+    @Test
+    @UseDataProvider("containNumberOfElements_rules")
+    public void haveMatchedFound(DescribedPredicate<Integer> predicate) {
+        EvaluationResult result = classes().should().containNumberOfElements(predicate).evaluate(importClasses(String.class, Integer.class));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("contain number of elements")
+                .contains("there is/are 2 element(s) in classes [JavaClass{name='java.lang.String'}, JavaClass{name='java.lang.Integer'}]");
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1152,12 +1152,12 @@ public class ClassesShouldTest {
 
     @Test
     @UseDataProvider("containNumberOfElements_rules")
-    public void haveMatchedFound(DescribedPredicate<Integer> predicate) {
+    public void containNumberOfElements(DescribedPredicate<Integer> predicate) {
         EvaluationResult result = classes().should().containNumberOfElements(predicate).evaluate(importClasses(String.class, Integer.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .contains("contain number of elements")
-                .contains("there is/are 2 element(s) in classes [JavaClass{name='java.lang.String'}, JavaClass{name='java.lang.Integer'}]");
+                .contains("contain number of elements " + predicate.getDescription())
+                .contains("there is/are 2 element(s) in classes [java.lang.Integer, java.lang.String]");
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
@@ -60,13 +60,22 @@ public abstract class RandomSyntaxTestBase {
         assertThat(archRule.getDescription()).as("description of constructed ArchRule").isEqualTo(expectedDescription);
 
         archRule.evaluate(importClassesWithContext());
-        archRule.check(importClassesWithContext());
+        assertCheckEitherPassesOrThrowsAssertionError(archRule);
 
         ArchRule overriddenText = archRule.as("overridden rule text");
         assertThat(overriddenText.getDescription()).isEqualTo("overridden rule text");
         assertThat(overriddenText.evaluate(
                 importClassesWithContext()).getFailureReport().toString()).contains(
                 "overridden rule text");
+    }
+
+    private void assertCheckEitherPassesOrThrowsAssertionError(ArchRule archRule) {
+        try {
+            archRule.check(importClassesWithContext());
+            // it is okay if this passes
+        } catch (AssertionError e) {
+            // it is also okay, if this throws an AssertionError, but no other exception must be thrown
+        }
     }
 
     private static class SyntaxSpec<T> {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
@@ -358,7 +358,12 @@ public abstract class RandomSyntaxTestBase {
                 .add(new SpecificParameterProvider(DescribedPredicate.class) {
                     @Override
                     Parameter get(String methodName, TypeToken<?> type) {
-                        return new Parameter(DescribedPredicate.alwaysTrue().as("custom predicate"), "custom predicate");
+                        if ("containNumberOfElements".equals(methodName)) {
+                            final DescribedPredicate<Integer> predicate = DescribedPredicate.lessThan(123);
+                            return new Parameter(predicate, predicate.getDescription());
+                        } else {
+                            return new Parameter(DescribedPredicate.alwaysTrue().as("custom predicate"), "custom predicate");
+                        }
                     }
                 })
                 .add(new SpecificParameterProvider(ArchCondition.class) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
@@ -358,12 +358,7 @@ public abstract class RandomSyntaxTestBase {
                 .add(new SpecificParameterProvider(DescribedPredicate.class) {
                     @Override
                     Parameter get(String methodName, TypeToken<?> type) {
-                        if ("containNumberOfElements".equals(methodName)) {
-                            final DescribedPredicate<Integer> predicate = DescribedPredicate.lessThan(123);
-                            return new Parameter(predicate, predicate.getDescription());
-                        } else {
-                            return new Parameter(DescribedPredicate.alwaysTrue().as("custom predicate"), "custom predicate");
-                        }
+                        return new Parameter(DescribedPredicate.alwaysTrue().as("custom predicate"), "custom predicate");
                     }
                 })
                 .add(new SpecificParameterProvider(ArchCondition.class) {


### PR DESCRIPTION
Hi,
pls take a look this proposal. I did not find rule that I can use to match how many classes has been matched to detect if state of code changed dramatically.
To have something similar to following code snippet.
I am not sure about DSL wording.
Thx
Ivos

```
noClasses().that()
  .haveNameMatching("foo\\.Bar.*")
  .should()
  .haveMatchedCount(123)
  .andShould()
  .accessClassesThat()
  .resideInAPackage("sapho.service..");```