### PR TITLE
fixed class hierarchy resolution

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -128,7 +128,7 @@ class ClassGraphCreator implements ImportContext {
 
     private void resolveInheritance(String currentTypeName, Function<JavaClass, Set<String>> inheritanceStrategy) {
         for (String parent : inheritanceStrategy.apply(classes.getOrResolve(currentTypeName))) {
-            resolveInheritance(parent, interfaceStrategy);
+            resolveInheritance(parent, inheritanceStrategy);
         }
     }
 


### PR DESCRIPTION
Hi,
I encountered a problem with the resolution of type hierarchies, where a base class in a quite deep hierarchy from a framework was not resolved correctly. 
I debugged this a lot and think this change should fix it. It seems quite obvious to me that this is wrong, so I decided to just provide a minimal pull request. It's obvious because resolving only the interfaces for a superclass does not add its own superclass-hierarchy to the context. So, it can happen that not the whole hierarchy is resolved.
I would also provide a test case for that, but unfortunately I'm not able to git push at work. I did this change with github's online editor. I can also not build/test this here, so please excuse that I did not completely follow the contribution guidelines. Maybe you can just see this as a bug report with a solution suggestion.