### PR TITLE
Supports running on Java Early Access versions

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/PluginLoader.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/PluginLoader.java
@@ -150,7 +150,7 @@ public class PluginLoader<T> {
         };
 
         private static final Ordering<JavaVersion> FROM_NEWEST_TO_OLDEST_ORDERING = Ordering.explicit(JAVA_9);
-        private static final Pattern VERSION_PATTERN = Pattern.compile("([^.]+).*");
+        private static final Pattern VERSION_PATTERN = Pattern.compile("([^.-]+).*");
 
         public abstract boolean isLessOrEqualThan(String version);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/PluginLoader.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/PluginLoader.java
@@ -150,7 +150,7 @@ public class PluginLoader<T> {
         };
 
         private static final Ordering<JavaVersion> FROM_NEWEST_TO_OLDEST_ORDERING = Ordering.explicit(JAVA_9);
-        private static final Pattern VERSION_PATTERN = Pattern.compile("([^.-]+).*");
+        private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+).*");
 
         public abstract boolean isLessOrEqualThan(String version);
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/PluginLoaderTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/PluginLoaderTest.java
@@ -27,6 +27,9 @@ public class PluginLoaderTest {
 
         System.setProperty("java.version", "9.0.1");
         assertThat(loadsArrayListForJava9FallbackHashSet().load()).isInstanceOf(ArrayList.class);
+
+        System.setProperty("java.version", "11-ea");
+        assertThat(loadsArrayListForJava9FallbackHashSet().load()).isInstanceOf(ArrayList.class);
     }
 
     // PluginLoader memoizes the loaded plugin


### PR DESCRIPTION
I'm trying to run my unit tests on an Early Access version of Java 11 (gotta be prepared 😉), and my ArchUnit test fails while attempting to parse the version string:
```
java.lang.ExceptionInInitializerError
Caused by: java.lang.NumberFormatException: For input string: "11-ea"
````
This PR should fix that.