### PR TITLE
Improve Kotlin support

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/CodingRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/CodingRulesTest.java
@@ -20,16 +20,16 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 public class CodingRulesTest {
 
     @ArchTest
-    public static final ArchRule NO_ACCESS_TO_STANDARD_STREAMS = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+    private final ArchRule NO_ACCESS_TO_STANDARD_STREAMS = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
     @ArchTest
-    public static void no_access_to_standard_streams_as_method(JavaClasses classes) {
+    private void no_access_to_standard_streams_as_method(JavaClasses classes) {
         noClasses().should(ACCESS_STANDARD_STREAMS).check(classes);
     }
 
     @ArchTest
-    public static final ArchRule NO_GENERIC_EXCEPTIONS = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+    private final ArchRule NO_GENERIC_EXCEPTIONS = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
 
     @ArchTest
-    public static final ArchRule NO_JAVA_UTIL_LOGGING = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+    private final ArchRule NO_JAVA_UTIL_LOGGING = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 }

--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleSetsTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleSetsTest.java
@@ -12,8 +12,8 @@ import org.junit.runner.RunWith;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
 public class RuleSetsTest {
     @ArchTest
-    public static final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    private final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
 
     @ArchTest
-    public static final ArchRules CYCLIC_DEPENDENCY_RULES = ArchRules.in(CyclicDependencyRulesTest.class);
+    private final ArchRules CYCLIC_DEPENDENCY_RULES = ArchRules.in(CyclicDependencyRulesTest.class);
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/CodingRulesTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/CodingRulesTest.java
@@ -17,16 +17,16 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 public class CodingRulesTest {
 
     @ArchTest
-    static final ArchRule NO_ACCESS_TO_STANDARD_STREAMS = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+    private final ArchRule NO_ACCESS_TO_STANDARD_STREAMS = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
     @ArchTest
-    static void no_access_to_standard_streams_as_method(JavaClasses classes) {
+    private void no_access_to_standard_streams_as_method(JavaClasses classes) {
         noClasses().should(ACCESS_STANDARD_STREAMS).check(classes);
     }
 
     @ArchTest
-    static final ArchRule NO_GENERIC_EXCEPTIONS = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+    private final ArchRule NO_GENERIC_EXCEPTIONS = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
 
     @ArchTest
-    static final ArchRule NO_JAVA_UTIL_LOGGING = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+    private final ArchRule NO_JAVA_UTIL_LOGGING = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleSetsTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleSetsTest.java
@@ -9,8 +9,8 @@ import com.tngtech.archunit.junit.ArchTest;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
 class RuleSetsTest {
     @ArchTest
-    static final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    private final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
 
     @ArchTest
-    static final ArchRules CYCLIC_DEPENDENCY_RULES = ArchRules.in(CyclicDependencyRulesTest.class);
+    private final ArchRules CYCLIC_DEPENDENCY_RULES = ArchRules.in(CyclicDependencyRulesTest.class);
 }

--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -86,3 +86,5 @@ ext.configureJUnitArchive = { configureDependencies ->
 }
 
 this.with addCleanThirdPartyTask
+
+javadoc.enabled = false

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleDeclaration.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleDeclaration.java
@@ -26,9 +26,9 @@ import java.util.Set;
 import com.google.common.collect.ImmutableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.tngtech.archunit.junit.ArchTestExecution.getValue;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllFields;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllMethods;
-import static com.tngtech.archunit.junit.ReflectionUtils.getValue;
 import static com.tngtech.archunit.junit.ReflectionUtils.withAnnotation;
 
 abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
@@ -87,7 +87,7 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
     }
 
     private static ArchRules getArchRulesIn(Field field) {
-        ArchRules value = getValue(field, null);
+        ArchRules value = getValue(field);
         return checkNotNull(value, "Field %s.%s is not initialized",
                 field.getDeclaringClass().getName(), field.getName());
     }

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
@@ -15,33 +15,28 @@
  */
 package com.tngtech.archunit.junit;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.Description;
 
-import static com.tngtech.archunit.junit.ReflectionUtils.getValue;
-
 class ArchRuleExecution extends ArchTestExecution {
     private final Field ruleField;
-    private final ArchRule rule;
 
     ArchRuleExecution(Class<?> testClass, Field ruleField, boolean ignore) {
         super(testClass, ignore);
 
-        validateStatic(ruleField);
         ArchTestInitializationException.check(ArchRule.class.isAssignableFrom(ruleField.getType()),
                 "Rule field %s.%s to check must be of type %s",
                 testClass.getSimpleName(), ruleField.getName(), ArchRule.class.getSimpleName());
 
-        this.ruleField = validateStatic(ruleField);
-        rule = getValue(ruleField, null);
+        this.ruleField = ruleField;
     }
 
     @Override
     Result evaluateOn(JavaClasses classes) {
+        ArchRule rule = getValue(ruleField);
         try {
             rule.check(classes);
         } catch (Exception | AssertionError e) {
@@ -58,10 +53,5 @@ class ArchRuleExecution extends ArchTestExecution {
     @Override
     String getName() {
         return ruleField.getName();
-    }
-
-    @Override
-    <T extends Annotation> T getAnnotation(Class<T> type) {
-        return ruleField.getAnnotation(type);
     }
 }

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
@@ -15,14 +15,16 @@
  */
 package com.tngtech.archunit.junit;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Member;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import com.tngtech.archunit.base.ArchUnitException.ReflectionException;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
+
+import static com.tngtech.archunit.junit.ReflectionUtils.newInstanceOf;
 
 abstract class ArchTestExecution {
     final Class<?> testClass;
@@ -31,13 +33,6 @@ abstract class ArchTestExecution {
     ArchTestExecution(Class<?> testClass, boolean ignore) {
         this.testClass = testClass;
         this.ignore = ignore;
-    }
-
-    static <T extends Member> T validateStatic(T member) {
-        ArchTestInitializationException.check(
-                Modifier.isStatic(member.getModifiers()),
-                "With @%s annotated members must be static", ArchTest.class.getSimpleName());
-        return member;
     }
 
     abstract Result evaluateOn(JavaClasses classes);
@@ -51,10 +46,20 @@ abstract class ArchTestExecution {
 
     abstract String getName();
 
-    abstract <T extends Annotation> T getAnnotation(Class<T> type);
-
     boolean ignore() {
         return ignore;
+    }
+
+    static <T> T getValue(Field field) {
+        try {
+            if (Modifier.isStatic(field.getModifiers())) {
+                return ReflectionUtils.getValue(field, null);
+            } else {
+                return ReflectionUtils.getValue(field, newInstanceOf(field.getDeclaringClass()));
+            }
+        } catch (ReflectionException e) {
+            throw new ArchTestInitializationException(e.getCause());
+        }
     }
 
     abstract static class Result {

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestExecution.java
@@ -16,15 +16,14 @@
 package com.tngtech.archunit.junit;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
-import com.tngtech.archunit.base.ArchUnitException.ReflectionException;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
-import static com.tngtech.archunit.junit.ReflectionUtils.newInstanceOf;
+import static com.tngtech.archunit.junit.ArchTestInitializationException.WRAP_CAUSE;
+import static com.tngtech.archunit.junit.ReflectionUtils.getValueOrThrowException;
 
 abstract class ArchTestExecution {
     final Class<?> testClass;
@@ -51,15 +50,7 @@ abstract class ArchTestExecution {
     }
 
     static <T> T getValue(Field field) {
-        try {
-            if (Modifier.isStatic(field.getModifiers())) {
-                return ReflectionUtils.getValue(field, null);
-            } else {
-                return ReflectionUtils.getValue(field, newInstanceOf(field.getDeclaringClass()));
-            }
-        } catch (ReflectionException e) {
-            throw new ArchTestInitializationException(e.getCause());
-        }
+        return getValueOrThrowException(field, WRAP_CAUSE);
     }
 
     abstract static class Result {

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -15,7 +15,6 @@
  */
 package com.tngtech.archunit.junit;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
@@ -30,7 +29,7 @@ class ArchTestMethodExecution extends ArchTestExecution {
 
     ArchTestMethodExecution(Class<?> testClass, Method testMethod, boolean ignore) {
         super(testClass, ignore);
-        this.testMethod = validateStatic(testMethod);
+        this.testMethod = testMethod;
     }
 
     @Override
@@ -49,6 +48,7 @@ class ArchTestMethodExecution extends ArchTestExecution {
                 "Methods annotated with @%s must have exactly one parameter of type %s",
                 ArchTest.class.getSimpleName(), JavaClasses.class.getSimpleName());
 
+        testMethod.setAccessible(true);
         new FrameworkMethod(testMethod).invokeExplosively(newInstanceOf(testClass), classes);
     }
 
@@ -62,8 +62,4 @@ class ArchTestMethodExecution extends ArchTestExecution {
         return testMethod.getName();
     }
 
-    @Override
-    <T extends Annotation> T getAnnotation(Class<T> type) {
-        return testMethod.getAnnotation(type);
-    }
 }

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -20,9 +20,8 @@ import java.util.Arrays;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.runner.Description;
-import org.junit.runners.model.FrameworkMethod;
 
-import static com.tngtech.archunit.junit.ReflectionUtils.newInstanceOf;
+import static com.tngtech.archunit.junit.ReflectionUtils.invokeMethod;
 
 class ArchTestMethodExecution extends ArchTestExecution {
     private final Method testMethod;
@@ -42,14 +41,13 @@ class ArchTestMethodExecution extends ArchTestExecution {
         }
     }
 
-    private void executeTestMethod(JavaClasses classes) throws Throwable {
+    private void executeTestMethod(JavaClasses classes) {
         ArchTestInitializationException.check(
                 Arrays.equals(testMethod.getParameterTypes(), new Class<?>[]{JavaClasses.class}),
                 "Methods annotated with @%s must have exactly one parameter of type %s",
                 ArchTest.class.getSimpleName(), JavaClasses.class.getSimpleName());
 
-        testMethod.setAccessible(true);
-        new FrameworkMethod(testMethod).invokeExplosively(newInstanceOf(testClass), classes);
+        invokeMethod(testMethod, classes);
     }
 
     @Override

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
@@ -40,8 +40,7 @@ import org.junit.runners.model.Statement;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.junit.ArchRuleDeclaration.elementShouldBeIgnored;
 import static com.tngtech.archunit.junit.ArchRuleDeclaration.toDeclarations;
-import static com.tngtech.archunit.junit.ArchTestExecution.validateStatic;
-import static com.tngtech.archunit.junit.ReflectionUtils.getValue;
+import static com.tngtech.archunit.junit.ArchTestExecution.getValue;
 
 /**
  * Evaluates {@link ArchRule ArchRules} against the classes inside of the packages specified via
@@ -127,8 +126,7 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
     }
 
     private ArchRules getArchRules(Field field) {
-        validateStatic(field);
-        return getValue(field, null);
+        return getValue(field);
     }
 
     private Collection<ArchTestExecution> findArchRuleMethods() {

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
@@ -18,13 +18,13 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
+import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.ArchTestWithPrivateInstanceField.PRIVATE_RULE_FIELD_NAME;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTest.RULE_ONE_IN_IGNORED_TEST;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTest.RULE_TWO_IN_IGNORED_TEST;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.FAILING_FIELD_NAME;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.IGNORED_FIELD_NAME;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.SATISFIED_FIELD_NAME;
 import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.WrongArchTestWrongFieldType.NO_RULE_AT_ALL_FIELD_NAME;
-import static com.tngtech.archunit.junit.ArchUnitRunnerRunsRuleFieldsTest.WrongArchTestWrongModifier.WRONG_MODIFIER_FIELD_NAME;
 import static com.tngtech.archunit.junit.ArchUnitRunnerTestUtils.BE_SATISFIED;
 import static com.tngtech.archunit.junit.ArchUnitRunnerTestUtils.NEVER_BE_SATISFIED;
 import static com.tngtech.archunit.junit.ArchUnitRunnerTestUtils.newRunnerFor;
@@ -97,13 +97,16 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     }
 
     @Test
-    public void should_fail_on_wrong_field_visibility() {
-        ArchUnitRunner runner = newRunnerFor(WrongArchTestWrongModifier.class, cache);
+    public void should_allow_instance_fields_of_all_visibility() {
+        ArchUnitRunner runner = newRunnerFor(ArchTestWithPrivateInstanceField.class, cache);
 
-        thrown.expectMessage("With @" + ArchTest.class.getSimpleName() +
-                " annotated members must be static");
+        runner.runChild(ArchUnitRunnerTestUtils.getRule(PRIVATE_RULE_FIELD_NAME, runner), runNotifier);
 
-        runner.runChild(ArchUnitRunnerTestUtils.getRule(WRONG_MODIFIER_FIELD_NAME, runner), runNotifier);
+        verify(runNotifier, never()).fireTestFailure(any(Failure.class));
+        verify(runNotifier).fireTestFinished(descriptionCaptor.capture());
+
+        assertThat(descriptionCaptor.getAllValues()).extractingResultOf("getMethodName")
+                .contains(PRIVATE_RULE_FIELD_NAME);
     }
 
     @Test
@@ -174,11 +177,11 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     }
 
     @AnalyzeClasses(packages = "some.pkg")
-    public static class WrongArchTestWrongModifier {
-        static final String WRONG_MODIFIER_FIELD_NAME = "ruleWithWrongModifier";
+    public static class ArchTestWithPrivateInstanceField {
+        static final String PRIVATE_RULE_FIELD_NAME = "privateField";
 
         @ArchTest
-        private ArchRule ruleWithWrongModifier = all(classes()).should(BE_SATISFIED);
+        private ArchRule privateField = all(classes()).should(BE_SATISFIED);
     }
 
     @AnalyzeClasses(packages = "some.pkg")

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleSetsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleSetsTest.java
@@ -215,7 +215,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
         static final String someOtherMethodRuleName = "someOtherMethodRule";
 
         @ArchTest
-        public static final ArchRules rules = ArchRules.in(ArchTestWithRuleSet.class);
+        final ArchRules rules = ArchRules.in(ArchTestWithRuleSet.class);
 
         @ArchTest
         public static void someOtherMethodRule(JavaClasses classes) {
@@ -225,7 +225,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithRuleSet {
         @ArchTest
-        public static final ArchRules rules = ArchRules.in(Rules.class);
+        final ArchRules rules = ArchRules.in(Rules.class);
     }
 
     @AnalyzeClasses(packages = "some.pkg")

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ClassWithPrivateTests.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ClassWithPrivateTests.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.junit.testexamples;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "some.dummy.package")
+public class ClassWithPrivateTests {
+    @ArchTest
+    private final ArchRule privateRuleField = RuleThatFails.on(UnwantedClass.CLASS_VIOLATING_RULES);
+
+    @ArchTest
+    private void privateRuleMethod(JavaClasses classes) {
+        RuleThatFails.on(UnwantedClass.CLASS_VIOLATING_RULES).check(classes);
+    }
+
+    public static final String PRIVATE_RULE_FIELD_NAME = "privateRuleField";
+    public static final String PRIVATE_RULE_METHOD_NAME = "privateRuleMethod";
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/LibraryWithPrivateTests.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/LibraryWithPrivateTests.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.junit.testexamples;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchRules;
+import com.tngtech.archunit.junit.ArchTest;
+
+@AnalyzeClasses(packages = "some.dummy.package")
+public class LibraryWithPrivateTests {
+    @ArchTest
+    private final ArchRules privateRulesField = ArchRules.in(SubRules.class);
+
+    public static final String PRIVATE_RULES_FIELD_NAME = "privateRulesField";
+
+    public static class SubRules {
+        @ArchTest
+        private final ArchRules privateRulesField = ArchRules.in(ClassWithPrivateTests.class);
+
+        public static final String PRIVATE_RULES_FIELD_NAME = "privateRulesField";
+    }
+}

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestInitializationException.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ArchTestInitializationException.java
@@ -1,9 +1,8 @@
 package com.tngtech.archunit.junit;
 
-import com.tngtech.archunit.Internal;
+import com.tngtech.archunit.base.Function;
 
-@Internal
-public class ArchTestInitializationException extends RuntimeException {
+class ArchTestInitializationException extends RuntimeException {
     private ArchTestInitializationException(String message, Object... args) {
         super(String.format(message, args));
     }
@@ -16,9 +15,16 @@ public class ArchTestInitializationException extends RuntimeException {
         super(String.format(message, args), cause);
     }
 
-    public static void check(boolean condition, String message, Object... args) {
+    static void check(boolean condition, String message, Object... args) {
         if (!condition) {
             throw new ArchTestInitializationException(message, args);
         }
     }
+
+    static final Function<Throwable, ArchTestInitializationException> WRAP_CAUSE = new Function<Throwable, ArchTestInitializationException>() {
+        @Override
+        public ArchTestInitializationException apply(Throwable throwable) {
+            return new ArchTestInitializationException(throwable);
+        }
+    };
 }

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ReflectionUtils.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ReflectionUtils.java
@@ -19,7 +19,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +31,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.ArchUnitException.ReflectionException;
+import com.tngtech.archunit.base.Function;
 
 import static com.google.common.collect.Collections2.filter;
 
@@ -86,13 +89,52 @@ class ReflectionUtils {
     }
 
     @SuppressWarnings("unchecked") // callers must know, what they do here, we can't make this compile safe anyway
-    static <T> T getValue(Field field, Object owner) {
+    private static <T> T getValue(Field field, Object owner) {
         try {
             field.setAccessible(true);
             return (T) field.get(owner);
         } catch (IllegalAccessException e) {
             throw new ReflectionException(e);
         }
+    }
+
+    static <T> T getValueOrThrowException(Field field, Function<Throwable, ? extends RuntimeException> exceptionConverter) {
+        try {
+            if (Modifier.isStatic(field.getModifiers())) {
+                return getValue(field, null);
+            } else {
+                return getValue(field, newInstanceOf(field.getDeclaringClass()));
+            }
+        } catch (ReflectionException e) {
+            throw exceptionConverter.apply(e.getCause());
+        }
+    }
+
+    static <T> T invokeMethod(Method method, Object... args) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            return invoke(null, method, args);
+        } else {
+            return invoke(newInstanceOf(method.getDeclaringClass()), method, args);
+        }
+    }
+
+    @SuppressWarnings("unchecked") // callers must know, what they do here, we can't make this compile safe anyway
+    private static <T> T invoke(Object owner, Method method, Object... args) {
+        method.setAccessible(true);
+        try {
+            return (T) method.invoke(owner, args);
+        } catch (IllegalAccessException e) {
+            throw new ReflectionException(e);
+        } catch (InvocationTargetException e) {
+            ReflectionUtils.<RuntimeException>rethrowUnchecked(e.getTargetException());
+            return null; // will never be reached
+        }
+    }
+
+    // Certified Hack(TM) to rethrow any exception unchecked. Uses a hole in the JLS with respect to Generics.
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void rethrowUnchecked(Throwable throwable) throws T {
+        throw (T) throwable;
     }
 
     private abstract static class Collector<T> {

--- a/archunit-maven-test/verification/TestResultTest.java
+++ b/archunit-maven-test/verification/TestResultTest.java
@@ -1,6 +1,7 @@
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.xml.sax.SAXException;
 
 import static com.tngtech.archunit.thirdparty.com.google.common.base.Preconditions.checkState;
+import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.joox.JOOX.$;
@@ -324,8 +326,19 @@ public class TestResultTest {
         private static <T> T getValue(Field field, Object owner) {
             try {
                 field.setAccessible(true);
+                owner = owner == null && !isStatic(field.getModifiers()) ? newInstanceOf(field.getDeclaringClass()) : owner;
                 return (T) field.get(owner);
             } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Object newInstanceOf(Class<?> clazz) {
+            try {
+                Constructor<?> constructor = clazz.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                return constructor.newInstance();
+            } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -91,7 +91,7 @@ class JavaClassProcessor extends ClassVisitor {
 
     @Override
     public void visitSource(String source, String debug) {
-        if (source != null) {
+        if (!importAborted() && source != null) {
             javaClassBuilder.withSourceFileName(source);
         }
     }

--- a/docs/userguide/003_Getting_Started.adoc
+++ b/docs/userguide/003_Getting_Started.adoc
@@ -74,18 +74,18 @@ public void Services_should_only_be_accessed_by_Controllers() {
 }
 ----
 
-=== Using JUnit 4
+=== Using JUnit 4 or JUnit 5
 
 While ArchUnit can be used with any unit testing framework, it provides extended support
-for writing tests with JUnit 4. The main advantage is automatic caching of imported
-classes between tests (of the same classes), as well as reduction of boilerplate code.
+for writing tests with JUnit 4 and JUnit 5. The main advantage is automatic caching of imported
+classes between tests (of the same imported classes), as well as reduction of boilerplate code.
 
-To use the JUnit 4 support, declare ArchUnit's `ArchUnitRunner`, declare the classes
+To use the JUnit support, declare ArchUnit's `ArchUnitRunner` (only JUnit 4), declare the classes
 to import via `@AnalyzeClasses` and add the respective rules as fields:
 
 [source,java,options="nowrap"]
 ----
-@RunWith(ArchUnitRunner.class)
+@RunWith(ArchUnitRunner.class) // Remove this line for JUnit 5!!
 @AnalyzeClasses(packages = "com.mycompany.myapp")
 public class MyArchitectureTest {
 
@@ -97,26 +97,27 @@ public class MyArchitectureTest {
 }
 ----
 
-The `ArchUnitRunner` will automatically import (or reuse) the specified classes and
+The JUnit test support will automatically import (or reuse) the specified classes and
 evaluate any rule annotated with `@ArchTest` against those classes.
 
-For further information on how to use the JUnit 4 support refer to <<JUnit Support>>.
+For further information on how to use the JUnit support refer to <<JUnit Support>>.
 
-=== Using JUnit 4 with Kotlin
+=== Using JUnit support with Kotlin
 
-As Kotlin removed the `static` keyword from the language, you need to use both a companion object
-and a Java-specific annotation:
+Using the JUnit support with Kotlin is quite similar to Java:
 
 [source,kotlin,options="nowrap"]
 ----
-@RunWith(ArchUnitRunner::class)
-@AnalyzeClasses(packages = ["com.mycompany.myapp"])
+@RunWith(ArchUnitRunner::class) // Remove this line for JUnit 5!!
+@AnalyzeClasses(packagesOf = [MyArchitectureTest::class])
 class MyArchitectureTest {
+    @ArchTest
+    val rule_as_field = ArchRuleDefinition.noClasses().should()...
 
-    companion object {
-        @ArchTest @JvmField val myRule = classes()
-            .that().resideInAPackage("..service..")
-            .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..")
+    @ArchTest
+    fun rule_as_method(classes: JavaClasses) {
+        ArchRule rule = ArchRuleDefinition.noClasses().should()...
+        rule.check(classes)
     }
 }
 ----

--- a/docs/userguide/html/000_Index.html
+++ b/docs/userguide/html/000_Index.html
@@ -467,8 +467,8 @@ h4 {
 <ul class="sectlevel2">
 <li><a href="#_importing_classes">3.1. Importing Classes</a></li>
 <li><a href="#_asserting_architectural_constraints">3.2. Asserting (Architectural) Constraints</a></li>
-<li><a href="#_using_junit_4">3.3. Using JUnit 4</a></li>
-<li><a href="#_using_junit_4_with_kotlin">3.4. Using JUnit 4 with Kotlin</a></li>
+<li><a href="#_using_junit_4_or_junit_5">3.3. Using JUnit 4 or JUnit 5</a></li>
+<li><a href="#_using_junit_support_with_kotlin">3.4. Using JUnit support with Kotlin</a></li>
 </ul>
 </li>
 <li><a href="#_what_to_check">4. What to Check</a>
@@ -798,19 +798,19 @@ public void Services_should_only_be_accessed_by_Controllers() {
 </div>
 </div>
 <div class="sect2">
-<h3 id="_using_junit_4"><a class="anchor" href="#_using_junit_4"></a>3.3. Using JUnit 4</h3>
+<h3 id="_using_junit_4_or_junit_5"><a class="anchor" href="#_using_junit_4_or_junit_5"></a>3.3. Using JUnit 4 or JUnit 5</h3>
 <div class="paragraph">
 <p>While ArchUnit can be used with any unit testing framework, it provides extended support
-for writing tests with JUnit 4. The main advantage is automatic caching of imported
-classes between tests (of the same classes), as well as reduction of boilerplate code.</p>
+for writing tests with JUnit 4 and JUnit 5. The main advantage is automatic caching of imported
+classes between tests (of the same imported classes), as well as reduction of boilerplate code.</p>
 </div>
 <div class="paragraph">
-<p>To use the JUnit 4 support, declare ArchUnit&#8217;s <code>ArchUnitRunner</code>, declare the classes
+<p>To use the JUnit support, declare ArchUnit&#8217;s <code>ArchUnitRunner</code> (only JUnit 4), declare the classes
 to import via <code>@AnalyzeClasses</code> and add the respective rules as fields:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-java hljs" data-lang="java">@RunWith(ArchUnitRunner.class)
+<pre class="highlightjs highlight nowrap"><code class="language-java hljs" data-lang="java">@RunWith(ArchUnitRunner.class) // Remove this line for JUnit 5!!
 @AnalyzeClasses(packages = "com.mycompany.myapp")
 public class MyArchitectureTest {
 
@@ -823,29 +823,30 @@ public class MyArchitectureTest {
 </div>
 </div>
 <div class="paragraph">
-<p>The <code>ArchUnitRunner</code> will automatically import (or reuse) the specified classes and
+<p>The JUnit test support will automatically import (or reuse) the specified classes and
 evaluate any rule annotated with <code>@ArchTest</code> against those classes.</p>
 </div>
 <div class="paragraph">
-<p>For further information on how to use the JUnit 4 support refer to <a href="#_junit_support">JUnit Support</a>.</p>
+<p>For further information on how to use the JUnit support refer to <a href="#_junit_support">JUnit Support</a>.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_using_junit_4_with_kotlin"><a class="anchor" href="#_using_junit_4_with_kotlin"></a>3.4. Using JUnit 4 with Kotlin</h3>
+<h3 id="_using_junit_support_with_kotlin"><a class="anchor" href="#_using_junit_support_with_kotlin"></a>3.4. Using JUnit support with Kotlin</h3>
 <div class="paragraph">
-<p>As Kotlin removed the <code>static</code> keyword from the language, you need to use both a companion object
-and a Java-specific annotation:</p>
+<p>Using the JUnit support with Kotlin is quite similar to Java:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-kotlin hljs" data-lang="kotlin">@RunWith(ArchUnitRunner::class)
-@AnalyzeClasses(packages = ["com.mycompany.myapp"])
+<pre class="highlightjs highlight nowrap"><code class="language-kotlin hljs" data-lang="kotlin">@RunWith(ArchUnitRunner::class) // Remove this line for JUnit 5!!
+@AnalyzeClasses(packagesOf = [MyArchitectureTest::class])
 class MyArchitectureTest {
+    @ArchTest
+    val rule_as_field = ArchRuleDefinition.noClasses().should()...
 
-    companion object {
-        @ArchTest @JvmField val myRule = classes()
-            .that().resideInAPackage("..service..")
-            .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..")
+    @ArchTest
+    fun rule_as_method(classes: JavaClasses) {
+        ArchRule rule = ArchRuleDefinition.noClasses().should()...
+        rule.check(classes)
     }
 }</code></pre>
 </div>
@@ -863,7 +864,7 @@ class MyArchitectureTest {
 <h3 id="_package_dependency_checks"><a class="anchor" href="#_package_dependency_checks"></a>4.1. Package Dependency Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="package-deps-no-access.png" alt="package deps no access" width="438" height="77">
+<img src="package-deps-no-access.png" alt="package deps no access" width="461" height="76">
 </div>
 </div>
 <div class="listingblock">
@@ -874,7 +875,7 @@ class MyArchitectureTest {
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="package-deps-only-access.png" alt="package deps only access" width="463" height="338">
+<img src="package-deps-only-access.png" alt="package deps only access" width="496" height="334">
 </div>
 </div>
 <div class="listingblock">
@@ -888,7 +889,7 @@ class MyArchitectureTest {
 <h3 id="_class_dependency_checks"><a class="anchor" href="#_class_dependency_checks"></a>4.2. Class Dependency Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="class-naming-deps.png" alt="class naming deps" width="316" height="215">
+<img src="class-naming-deps.png" alt="class naming deps" width="334" height="214">
 </div>
 </div>
 <div class="listingblock">
@@ -902,7 +903,7 @@ class MyArchitectureTest {
 <h3 id="_class_and_package_containment_checks"><a class="anchor" href="#_class_and_package_containment_checks"></a>4.3. Class and Package Containment Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="class-package-contain.png" alt="class package contain" width="333" height="205">
+<img src="class-package-contain.png" alt="class package contain" width="348" height="203">
 </div>
 </div>
 <div class="listingblock">
@@ -916,7 +917,7 @@ class MyArchitectureTest {
 <h3 id="_inheritance_checks"><a class="anchor" href="#_inheritance_checks"></a>4.4. Inheritance Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="inheritance-naming-check.png" alt="inheritance naming check" width="447" height="231">
+<img src="inheritance-naming-check.png" alt="inheritance naming check" width="478" height="225">
 </div>
 </div>
 <div class="listingblock">
@@ -927,7 +928,7 @@ class MyArchitectureTest {
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="inheritance-access-check.png" alt="inheritance access check" width="544" height="269">
+<img src="inheritance-access-check.png" alt="inheritance access check" width="579" height="267">
 </div>
 </div>
 <div class="listingblock">
@@ -941,7 +942,7 @@ class MyArchitectureTest {
 <h3 id="_annotation_checks"><a class="anchor" href="#_annotation_checks"></a>4.5. Annotation Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="inheritance-annotation-check.png" alt="inheritance annotation check" width="555" height="223">
+<img src="inheritance-annotation-check.png" alt="inheritance annotation check" width="597" height="220">
 </div>
 </div>
 <div class="listingblock">
@@ -955,7 +956,7 @@ class MyArchitectureTest {
 <h3 id="_layer_checks"><a class="anchor" href="#_layer_checks"></a>4.6. Layer Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="layer-check.png" alt="layer check" width="629" height="603">
+<img src="layer-check.png" alt="layer check" width="653" height="598">
 </div>
 </div>
 <div class="listingblock">
@@ -975,7 +976,7 @@ class MyArchitectureTest {
 <h3 id="_cycle_checks"><a class="anchor" href="#_cycle_checks"></a>4.7. Cycle Checks</h3>
 <div class="imageblock">
 <div class="content">
-<img src="cycle-check.png" alt="cycle check" width="730" height="401">
+<img src="cycle-check.png" alt="cycle check" width="759" height="398">
 </div>
 </div>
 <div class="listingblock">
@@ -1178,7 +1179,7 @@ like this:</p>
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="domain-overview.png" alt="domain overview" width="932" height="445">
+<img src="domain-overview.png" alt="domain overview" width="985" height="442">
 </div>
 </div>
 <div class="paragraph">
@@ -1207,7 +1208,7 @@ inheritance is not completely straight forward. Consider for example</p>
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="resolution-example.png" alt="resolution example" width="358" height="189">
+<img src="resolution-example.png" alt="resolution example" width="377" height="188">
 </div>
 </div>
 <div class="paragraph">
@@ -1222,7 +1223,7 @@ The situation looks roughly like</p>
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="resolution-overview.png" alt="resolution overview" width="503" height="319">
+<img src="resolution-overview.png" alt="resolution overview" width="544" height="317">
 </div>
 </div>
 <div class="paragraph">
@@ -1242,7 +1243,7 @@ cases, for example:</p>
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="diamond-example.png" alt="diamond example" width="459" height="228">
+<img src="diamond-example.png" alt="diamond example" width="514" height="223">
 </div>
 </div>
 <div class="paragraph">
@@ -1574,7 +1575,7 @@ a more generic API, that controls the types of objects that our concept targets.
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="import-vs-lang.png" alt="import vs lang" width="666" height="84">
+<img src="import-vs-lang.png" alt="import vs lang" width="723" height="80">
 </div>
 </div>
 <div class="paragraph">
@@ -1780,7 +1781,7 @@ The way this works is to use the respective package identifiers (compare
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="simple-plantuml-archrule-example.png" alt="simple plantuml archrule example" width="150" height="189">
+<img src="simple-plantuml-archrule-example.png" alt="simple plantuml archrule example" width="160" height="184">
 </div>
 </div>
 <div class="listingblock">


### PR DESCRIPTION
This PR removes the constraint that `@ArchTest` fields/methods must have a certain visibility or modifier. I.e. it is now possible to just write

```
@ArchTest
private final ArchRule rule = classes()...
```

and the JUnit support (both 4 and 5) will pick it up and process it. Thus with Kotlin it's now possible to just write

```
class MyTest {
    @ArchTest val rule = classes()...
}
```

and the test will work without any companion object or further bloat. Also source file links are now correct. Before ArchUnit naively assumed sources would always be `.java` files, which broke the links in violations for IntelliJ. Now violations are reported correctly (`violation in (SomeClass.kt:123)`) and the link brings you to the violation.

Resolves: #77