### PR TITLE
Extend rules api with dependency conditions

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/LayerDependencyRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/LayerDependencyRulesTest.java
@@ -15,6 +15,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
 public class LayerDependencyRulesTest {
 
+    // 'access' catches only violations by real accesses, i.e. accessing a field, calling a method; compare 'dependOn' further down
+
     @ArchTest
     public static final ArchRule services_should_not_access_controllers =
             noClasses().that().resideInAPackage("..service..")
@@ -29,4 +31,17 @@ public class LayerDependencyRulesTest {
     public static final ArchRule services_should_only_be_accessed_by_controllers_or_other_services =
             classes().that().resideInAPackage("..service..")
                     .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..");
+
+    // 'dependOn' catches a wider variety of violations, e.g. having fields of type, having method parameters of type, extending type ...
+
+    @ArchTest
+    public static final ArchRule services_should_not_depend_on_controllers =
+            noClasses().that().resideInAPackage("..service..")
+                    .should().dependOnClassesThat().resideInAPackage("..controller..");
+
+    @ArchTest
+    public static final ArchRule persistence_should_not_depend_on_services =
+            noClasses().that().resideInAPackage("..persistence..")
+                    .should().dependOnClassesThat().resideInAPackage("..service..");
+
 }

--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/LayerDependencyRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/LayerDependencyRulesTest.java
@@ -44,4 +44,9 @@ public class LayerDependencyRulesTest {
             noClasses().that().resideInAPackage("..persistence..")
                     .should().dependOnClassesThat().resideInAPackage("..service..");
 
+    @ArchTest
+    public static final ArchRule services_should_only_be_depended_on_by_controllers_or_other_services =
+            classes().that().resideInAPackage("..service..")
+                    .should().onlyHaveDependentClassesThat().resideInAnyPackage("..controller..", "..service..");
+
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/LayerDependencyRulesTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/LayerDependencyRulesTest.java
@@ -41,4 +41,9 @@ public class LayerDependencyRulesTest {
             noClasses().that().resideInAPackage("..persistence..")
                     .should().dependOnClassesThat().resideInAPackage("..service..");
 
+    @ArchTest
+    static final ArchRule services_should_only_be_depended_on_by_controllers_or_other_services =
+            classes().that().resideInAPackage("..service..")
+                    .should().onlyHaveDependentClassesThat().resideInAnyPackage("..controller..", "..service..");
+
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/LayerDependencyRulesTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/LayerDependencyRulesTest.java
@@ -12,6 +12,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example")
 public class LayerDependencyRulesTest {
 
+    // 'access' catches only violations by real accesses, i.e. accessing a field, calling a method; compare 'dependOn' further down
+
     @ArchTest
     static final ArchRule services_should_not_access_controllers =
             noClasses().that().resideInAPackage("..service..")
@@ -26,4 +28,17 @@ public class LayerDependencyRulesTest {
     static final ArchRule services_should_only_be_accessed_by_controllers_or_other_services =
             classes().that().resideInAPackage("..service..")
                     .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..");
+
+    // 'dependOn' catches a wider variety of violations, e.g. having fields of type, having method parameters of type, extending type ...
+
+    @ArchTest
+    static final ArchRule services_should_not_depend_on_controllers =
+            noClasses().that().resideInAPackage("..service..")
+                    .should().dependOnClassesThat().resideInAPackage("..controller..");
+
+    @ArchTest
+    static final ArchRule persistence_should_not_depend_on_services =
+            noClasses().that().resideInAPackage("..persistence..")
+                    .should().dependOnClassesThat().resideInAPackage("..service..");
+
 }

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/service/ServiceViolatingLayerRules.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/service/ServiceViolatingLayerRules.java
@@ -1,6 +1,7 @@
 package com.tngtech.archunit.example.service;
 
 import com.tngtech.archunit.example.MyService;
+import com.tngtech.archunit.example.controller.SomeGuiController;
 import com.tngtech.archunit.example.controller.one.UseCaseOneTwoController;
 import com.tngtech.archunit.example.controller.two.UseCaseTwoController;
 
@@ -8,6 +9,7 @@ import com.tngtech.archunit.example.controller.two.UseCaseTwoController;
 public class ServiceViolatingLayerRules {
     public static final String illegalAccessToController = "illegalAccessToController";
     public static final String doSomething = "doSomething";
+    public static final String dependentMethod = "dependentMethod";
 
     void illegalAccessToController() {
         System.out.println(UseCaseOneTwoController.someString);
@@ -16,5 +18,9 @@ public class ServiceViolatingLayerRules {
     }
 
     public void doSomething() {
+    }
+
+    public SomeGuiController dependentMethod(UseCaseTwoController otherController) {
+        return null;
     }
 }

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
@@ -14,6 +14,8 @@ public class LayerDependencyRulesTest {
 
     private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
 
+    // 'access' catches only violations by real accesses, i.e. accessing a field, calling a method; compare 'dependOn' further down
+
     @Test
     public void services_should_not_access_controllers() {
         noClasses().that().resideInAPackage("..service..")
@@ -30,5 +32,19 @@ public class LayerDependencyRulesTest {
     public void services_should_only_be_accessed_by_controllers_or_other_services() {
         classes().that().resideInAPackage("..service..")
                 .should().onlyBeAccessed().byAnyPackage("..controller..", "..service..").check(classes);
+    }
+
+    // 'dependOn' catches a wider variety of violations, e.g. having fields of type, having method parameters of type, extending type ...
+
+    @Test
+    public void services_should_not_depend_on_controllers() {
+        noClasses().that().resideInAPackage("..service..")
+                .should().dependOnClassesThat().resideInAPackage("..controller..").check(classes);
+    }
+
+    @Test
+    public void persistence_should_not_depend_on_services() {
+        noClasses().that().resideInAPackage("..persistence..")
+                .should().dependOnClassesThat().resideInAPackage("..service..").check(classes);
     }
 }

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/LayerDependencyRulesTest.java
@@ -47,4 +47,11 @@ public class LayerDependencyRulesTest {
         noClasses().that().resideInAPackage("..persistence..")
                 .should().dependOnClassesThat().resideInAPackage("..service..").check(classes);
     }
+
+    @Test
+    public void services_should_only_be_depended_on_by_controllers_or_other_services() {
+        classes().that().resideInAPackage("..service..")
+                .should().onlyHaveDependentClassesThat().resideInAnyPackage("..controller..", "..service..").check(classes);
+    }
+
 }

--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -22,3 +22,7 @@ dependencies {
 
     testRuntime project(path: ':archunit-junit5-engine')
 }
+
+test {
+    useJUnitPlatform()
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -497,6 +497,19 @@ class ExamplesIntegrationTest {
                 .by(field(DaoCallingService.class, "service").ofType(ServiceViolatingLayerRules.class))
                 .by(inheritanceFrom(DaoCallingService.class).implementing(ServiceInterface.class))
 
+                .ofRule("classes that reside in a package '..service..' should " +
+                        "only have dependent classes that reside in any package ['..controller..', '..service..']")
+                .by(callFromMethod(DaoCallingService.class, violateLayerRules)
+                        .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)
+                        .inLine(14).asDependency())
+                .by(callFromMethod(SomeMediator.class, violateLayerRulesIndirectly)
+                        .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)
+                        .inLine(15).asDependency())
+                .by(inheritanceFrom(DaoCallingService.class).implementing(ServiceInterface.class))
+                .by(constructor(SomeMediator.class).withParameter(ServiceViolatingLayerRules.class))
+                .by(field(SomeMediator.class, "service").ofType(ServiceViolatingLayerRules.class))
+                .by(field(DaoCallingService.class, "service").ofType(ServiceViolatingLayerRules.class))
+
                 .toDynamicTests();
     }
 

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -116,6 +116,7 @@ import static com.tngtech.archunit.example.controller.three.UseCaseThreeControll
 import static com.tngtech.archunit.example.controller.two.UseCaseTwoController.doSomethingTwo;
 import static com.tngtech.archunit.example.core.VeryCentralCore.DO_CORE_STUFF_METHOD_NAME;
 import static com.tngtech.archunit.example.persistence.layerviolation.DaoCallingService.violateLayerRules;
+import static com.tngtech.archunit.example.service.ServiceViolatingLayerRules.dependentMethod;
 import static com.tngtech.archunit.example.service.ServiceViolatingLayerRules.illegalAccessToController;
 import static com.tngtech.archunit.testutils.CyclicErrorMatcher.cycle;
 import static com.tngtech.archunit.testutils.ExpectedAccess.callFromConstructor;
@@ -154,7 +155,7 @@ class ExamplesIntegrationTest {
                         .inLine(14))
                 .by(callFromMethod(ServiceViolatingLayerRules.class, "illegalAccessToController")
                         .getting().field(System.class, "out")
-                        .inLine(13))
+                        .inLine(15))
                 .times(2)
 
                 .ofRule("no classes should throw generic exceptions")
@@ -451,13 +452,13 @@ class ExamplesIntegrationTest {
                         "should access classes that reside in a package '..controller..'")
                 .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .getting().field(UseCaseOneTwoController.class, someString)
-                        .inLine(13))
+                        .inLine(15))
                 .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .toConstructor(UseCaseTwoController.class)
-                        .inLine(14))
+                        .inLine(16))
                 .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .toMethod(UseCaseTwoController.class, doSomethingTwo)
-                        .inLine(15))
+                        .inLine(17))
 
                 .ofRule("no classes that reside in a package '..persistence..' should " +
                         "access classes that reside in a package '..service..'")
@@ -473,6 +474,28 @@ class ExamplesIntegrationTest {
                 .by(callFromMethod(SomeMediator.class, violateLayerRulesIndirectly)
                         .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)
                         .inLine(15))
+
+                .ofRule("no classes that reside in a package '..service..' " +
+                        "should depend on classes that reside in a package '..controller..'")
+                .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
+                        .getting().field(UseCaseOneTwoController.class, someString)
+                        .inLine(15).asDependency())
+                .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
+                        .toConstructor(UseCaseTwoController.class)
+                        .inLine(16).asDependency())
+                .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
+                        .toMethod(UseCaseTwoController.class, doSomethingTwo)
+                        .inLine(17).asDependency())
+                .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
+                .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
+
+                .ofRule("no classes that reside in a package '..persistence..' should " +
+                        "depend on classes that reside in a package '..service..'")
+                .by(callFromMethod(DaoCallingService.class, violateLayerRules)
+                        .toMethod(ServiceViolatingLayerRules.class, ServiceViolatingLayerRules.doSomething)
+                        .inLine(14).asDependency())
+                .by(field(DaoCallingService.class, "service").ofType(ServiceViolatingLayerRules.class))
+                .by(inheritanceFrom(DaoCallingService.class).implementing(ServiceInterface.class))
 
                 .toDynamicTests();
     }
@@ -503,18 +526,22 @@ class ExamplesIntegrationTest {
 
                                 .by(callFromMethod(ServiceViolatingLayerRules.class, "illegalAccessToController")
                                         .toConstructor(UseCaseTwoController.class)
-                                        .inLine(14)
+                                        .inLine(16)
                                         .asDependency())
 
                                 .by(callFromMethod(ServiceViolatingLayerRules.class, "illegalAccessToController")
                                         .toMethod(UseCaseTwoController.class, "doSomethingTwo")
-                                        .inLine(15)
+                                        .inLine(17)
                                         .asDependency())
 
                                 .by(callFromMethod(ServiceViolatingLayerRules.class, "illegalAccessToController")
                                         .getting().field(UseCaseOneTwoController.class, "someString")
-                                        .inLine(13)
-                                        .asDependency());
+                                        .inLine(15)
+                                        .asDependency())
+
+                                .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
+
+                                .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class));
 
         ExpectedTestFailures expectedTestFailures = ExpectedTestFailures
                 .forTests(

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -38,6 +38,9 @@ import static com.tngtech.archunit.core.domain.Formatters.formatLocation;
  * <li>a class calls a method of another class</li>
  * <li>a class calls a constructor of another class</li>
  * <li>a class inherits from another class (which is in fact a special case of constructor call)</li>
+ * <li>a class implements an interface</li>
+ * <li>a class has a field with type of another class</li>
+ * <li>a class has a method/constructor with parameter/return type of another class</li>
  * </ul>
  */
 public class Dependency implements HasDescription, Comparable<Dependency> {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -992,6 +992,24 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         @Deprecated
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, String> GET_PACKAGE = GET_PACKAGE_NAME;
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<Dependency>> GET_DIRECT_DEPENDENCIES_FROM_SELF =
+                new ChainableFunction<JavaClass, Set<Dependency>>() {
+                    @Override
+                    public Set<Dependency> apply(JavaClass input) {
+                        return input.getDirectDependenciesFromSelf();
+                    }
+                };
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<Dependency>> GET_DIRECT_DEPENDENCIES_TO_SELF =
+                new ChainableFunction<JavaClass, Set<Dependency>>() {
+                    @Override
+                    public Set<Dependency> apply(JavaClass input) {
+                        return input.getDirectDependenciesToSelf();
+                    }
+                };
     }
 
     public static final class Predicates {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -55,7 +55,6 @@ public interface HasName {
             NameMatchingPredicate(String regex) {
                 super(String.format("name matching '%s'", regex));
                 this.pattern = Pattern.compile(regex);
-                ;
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
@@ -31,12 +31,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 @PublicAPI(usage = ACCESS)
-public final class AllDependenciesCondition extends AllAttributesMatchCondition<Dependency> {
+public final class AnyDependencyCondition extends AnyAttributeMatchesCondition<Dependency> {
     private final DescribedPredicate<? super Dependency> conditionPredicate;
     private final Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies;
     private final DescribedPredicate<Dependency> ignorePredicate;
 
-    AllDependenciesCondition(
+    AnyDependencyCondition(
             String description,
             final DescribedPredicate<? super Dependency> predicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies) {
@@ -44,7 +44,7 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
         this(description, predicate, javaClassToRelevantDependencies, DescribedPredicate.<Dependency>alwaysFalse());
     }
 
-    private AllDependenciesCondition(
+    private AnyDependencyCondition(
             String description,
             final DescribedPredicate<? super Dependency> conditionPredicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies,
@@ -62,8 +62,8 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
     }
 
     @PublicAPI(usage = ACCESS)
-    public AllDependenciesCondition ignoreDependency(DescribedPredicate<Dependency> ignorePredicate) {
-        return new AllDependenciesCondition(getDescription(),
+    public AnyDependencyCondition ignoreDependency(DescribedPredicate<Dependency> ignorePredicate) {
+        return new AnyDependencyCondition(getDescription(),
                 conditionPredicate,
                 javaClassToRelevantDependencies,
                 this.ignorePredicate.or(ignorePredicate));
@@ -71,8 +71,8 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public AllDependenciesCondition as(String description, Object... args) {
-        return new AllDependenciesCondition(
+    public AnyDependencyCondition as(String description, Object... args) {
+        return new AnyDependencyCondition(
                 String.format(description, args),
                 conditionPredicate,
                 javaClassToRelevantDependencies,

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -52,6 +52,7 @@ import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassGet
 import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassSetsFieldCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_ORIGIN_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_TARGET_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyTarget;
@@ -257,10 +258,20 @@ public final class ArchConditions {
     }
 
     /**
-     * @param predicate A predicate identifying relevant dependencies on this class
-     * @return A condition matching {@link JavaClass classes} that have other classes
-     * depending on them (e.g. calling methods of this class)
-     * where the respective dependency is matched by the predicate
+     * @param predicate A predicate specifying allowed dependencies on this class
+     * @return A condition satisfied by {@link JavaClass classes} where all classes
+     * depending on them (e.g. calling methods of this class) are matched by the predicate
+     */
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> onlyHaveDependentClassesThat(DescribedPredicate<? super JavaClass> predicate) {
+        return onlyHaveDependentsWhere(GET_ORIGIN_CLASS.is(predicate))
+                .as("only have dependent classes that " + predicate.getDescription());
+    }
+
+    /**
+     * @param predicate A predicate specifying allowed dependencies on this class
+     * @return A condition satisfied by {@link JavaClass classes} where all {@link Dependency dependencies}
+     * on them (e.g. calling methods of this class) are matched by the predicate
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyHaveDependentsWhere(DescribedPredicate<? super Dependency> predicate) {
@@ -270,7 +281,7 @@ public final class ArchConditions {
 
     /**
      * @param packageIdentifiers Strings identifying packages according to {@link PackageMatcher}
-     * @return A condition matching {@link JavaClass classes} that depend on
+     * @return A condition matching {@link JavaClass classes} that only depend on
      * other classes (e.g. this class calling methods of other classes)
      * with a package matching any of the identifiers
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -465,6 +465,21 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldThat dependOnClassesThat() {
+        return new ClassesShouldThatInternal(this, new Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>>() {
+            @Override
+            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> input) {
+                return ArchConditions.dependOnClassesThat(input);
+            }
+        });
+    }
+
+    @Override
+    public ClassesShouldConjunction dependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.dependOnClassesThat(predicate)));
+    }
+
+    @Override
     public OnlyBeAccessedSpecification<ClassesShouldConjunction> onlyBeAccessed() {
         return new OnlyBeAccessedSpecificationInternal(this);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -453,8 +453,8 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     public ClassesShouldThat accessClassesThat() {
         return new ClassesShouldThatInternal(this, new Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>>() {
             @Override
-            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> input) {
-                return ArchConditions.accessClassesThat(input);
+            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> predicate) {
+                return ArchConditions.accessClassesThat(predicate);
             }
         });
     }
@@ -468,8 +468,8 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     public ClassesShouldThat dependOnClassesThat() {
         return new ClassesShouldThatInternal(this, new Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>>() {
             @Override
-            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> input) {
-                return ArchConditions.dependOnClassesThat(input);
+            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> predicate) {
+                return ArchConditions.dependOnClassesThat(predicate);
             }
         });
     }
@@ -482,6 +482,21 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     @Override
     public OnlyBeAccessedSpecification<ClassesShouldConjunction> onlyBeAccessed() {
         return new OnlyBeAccessedSpecificationInternal(this);
+    }
+
+    @Override
+    public ClassesShouldThat onlyHaveDependentClassesThat() {
+        return new ClassesShouldThatInternal(this, new Function<DescribedPredicate<JavaClass>, ArchCondition<JavaClass>>() {
+            @Override
+            public ArchCondition<JavaClass> apply(DescribedPredicate<JavaClass> predicate) {
+                return ArchConditions.onlyHaveDependentClassesThat(predicate);
+            }
+        });
+    }
+
+    @Override
+    public ClassesShouldConjunction onlyHaveDependentClassesThat(DescribedPredicate<? super JavaClass> predicate) {
+        return copyWithNewCondition(conditionAggregator.add(ArchConditions.onlyHaveDependentClassesThat(predicate)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -821,6 +821,31 @@ public interface ClassesShould {
     @PublicAPI(usage = ACCESS)
     OnlyBeAccessedSpecification<ClassesShouldConjunction> onlyBeAccessed();
 
+    /**
+     * Asserts that only certain classes depend on the classes selected by this rule.<br>
+     * <br>E.g.
+     * <pre><code>
+     * {@link ArchRuleDefinition#classes() classes()}.{@link GivenClasses#should() should()}.{@link #onlyHaveDependentClassesThat()}.{@link ClassesShouldThat#haveFullyQualifiedName(String) haveFullyQualifiedName(String)}
+     * </code></pre>
+     *
+     * @return A syntax element that allows choosing from which classes a dependency to these classes may exist
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldThat onlyHaveDependentClassesThat();
+
+    /**
+     * Asserts that only certain classes depend on the classes selected by this rule.<br>
+     * <br>E.g.
+     * <pre><code>
+     * {@link ArchRuleDefinition#classes() classes()}.{@link GivenClasses#should() should()}.{@link #onlyHaveDependentClassesThat(DescribedPredicate) onlyHaveDependentClassesThat(myPredicate)}
+     * </code></pre>
+     *
+     * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency origin
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction onlyHaveDependentClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
 
     /**
      * Asserts that classes are interfaces.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -785,6 +785,33 @@ public interface ClassesShould {
     ClassesShouldConjunction accessClassesThat(DescribedPredicate<? super JavaClass> predicate);
 
     /**
+     * Asserts that all classes selected by this rule depend on certain classes.<br>
+     * NOTE: This usually makes more sense the negated way, e.g.
+     * <p>
+     * <pre><code>
+     * {@link ArchRuleDefinition#noClasses() noClasses()}.{@link GivenClasses#should() should()}.{@link #dependOnClassesThat()}.{@link ClassesShouldThat#haveFullyQualifiedName(String) haveFullyQualifiedName(String)}
+     * </code></pre>
+     *
+     * @return A syntax element that allows choosing to which classes a dependency should exist
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldThat dependOnClassesThat();
+
+    /**
+     * Asserts that all classes selected by this rule depend on certain classes.<br>
+     * NOTE: This usually makes more sense the negated way, e.g.
+     * <p>
+     * <pre><code>
+     * {@link ArchRuleDefinition#noClasses() noClasses()}.{@link GivenClasses#should() should()}.{@link #dependOnClassesThat(DescribedPredicate) dependOnClassesThat(myPredicate)}
+     * </code></pre>
+     *
+     * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency target
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction dependOnClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
+    /**
      * @return A syntax element that allows restricting how classes should be accessed
      * <br>E.g.
      * <pre><code>

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
@@ -2,9 +2,10 @@ package com.tngtech.archunit.lang.syntax.elements;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.ArchConfiguration;
@@ -14,6 +15,8 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.FailureReport;
 
+import static java.util.regex.Pattern.quote;
+
 class ClassesShouldEvaluator {
     private static String OPTIONAL_ARGS_REGEX = "(?:\\([^)]*\\))?";
     private static String METHOD_OR_FIELD_REGEX = "\\.[\\w<>]+" + OPTIONAL_ARGS_REGEX;
@@ -22,35 +25,50 @@ class ClassesShouldEvaluator {
     private static String SELF_REFERENCE_REGEX = MEMBER_REFERENCE_REGEX + ".*" + SAME_CLASS_BACK_REFERENCE_REGEX;
 
     private final ArchRule rule;
+    private final ClassInReportLineMatcher reportLineMatcher;
 
-    private ClassesShouldEvaluator(ArchRule rule) {
+    private ClassesShouldEvaluator(ArchRule rule, ClassInReportLineMatcher reportLineMatcher) {
         this.rule = rule;
+        this.reportLineMatcher = reportLineMatcher;
     }
 
     static ClassesShouldEvaluator filterClassesAppearingInFailureReport(ArchRule rule) {
-        return new ClassesShouldEvaluator(rule);
+        return new ClassesShouldEvaluator(rule, new ClassContainedInLineMatcher());
     }
 
-    List<JavaClass> on(Class<?>... toCheck) {
+    static ClassesShouldEvaluator filterViolationCausesInFailureReport(ArchRule rule) {
+        return new ClassesShouldEvaluator(rule, new ClassOriginInLineMatcher());
+    }
+
+    Set<JavaClass> on(Class<?>... toCheck) {
         JavaClasses classes = importClasses(toCheck);
-        String report = getRelevantFailures(classes);
-        List<JavaClass> result = new ArrayList<>();
+        List<String> relevantFailures = getRelevantFailures(classes);
+        Set<JavaClass> result = new HashSet<>();
         for (JavaClass clazz : classes) {
-            if (report.contains(clazz.getName())) {
+            if (anyLineMatches(relevantFailures, clazz)) {
                 result.add(clazz);
             }
         }
         return result;
     }
 
-    private String getRelevantFailures(JavaClasses classes) {
+    private boolean anyLineMatches(List<String> relevantFailures, JavaClass clazz) {
+        for (String line : relevantFailures) {
+            if (reportLineMatcher.matches(line, clazz)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> getRelevantFailures(JavaClasses classes) {
         List<String> relevant = new ArrayList<>();
         for (String line : linesIn(rule.evaluate(classes).getFailureReport())) {
             if (!isDefaultConstructor(line) && !isSelfReference(line) && !isExtendsJavaLangAnnotation(line)) {
                 relevant.add(line);
             }
         }
-        return Joiner.on("#").join(relevant);
+        return relevant;
     }
 
     private boolean isDefaultConstructor(String line) {
@@ -79,6 +97,25 @@ class ClassesShouldEvaluator {
             return new ClassFileImporter().importClasses(ImmutableSet.copyOf(classes));
         } finally {
             ArchConfiguration.get().reset();
+        }
+    }
+
+    private abstract static class ClassInReportLineMatcher {
+        abstract boolean matches(String line, JavaClass javaClass);
+    }
+
+    private static class ClassContainedInLineMatcher extends ClassInReportLineMatcher {
+        @Override
+        boolean matches(String line, JavaClass javaClass) {
+            return line.contains(javaClass.getName());
+        }
+    }
+
+    private static class ClassOriginInLineMatcher extends ClassInReportLineMatcher {
+        @Override
+        boolean matches(String line, JavaClass javaClass) {
+            String originPattern = String.format(".*<%s.*(\\w\\.)+\\w.*in \\(.*\\.java.*\\)", quote(javaClass.getName()));
+            return line.matches(originPattern);
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesThatTestsExistTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesThatTestsExistTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ClassesThatTestsExistTest {
     private static final Set<Class<?>> CLASSES_SHOULD_THAT_CONTEXT = ImmutableSet.of(
-            GivenClassesThatTest.class, ShouldAccessClassesThatTest.class, ShouldOnlyBeAccessedByClassesThatTest.class
+            GivenClassesThatTest.class, ShouldClassesThatTest.class, ShouldOnlyByClassesThatTest.class
     );
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldAccessClassesThatTest.java
@@ -1,5 +1,6 @@
 package com.tngtech.archunit.lang.syntax.elements;
 
+import java.io.Serializable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Constructor;
@@ -8,11 +9,17 @@ import java.util.Collection;
 import java.util.List;
 
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasType;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -25,162 +32,186 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldThatEvaluator.filterClassesAppearingInFailureReport;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldEvaluator.filterClassesAppearingInFailureReport;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
+@RunWith(DataProviderRunner.class)
 public class ShouldAccessClassesThatTest {
 
     @Rule
     public final MockitoRule rule = MockitoJUnit.rule();
 
+    @DataProvider
+    public static Object[][] no_classes_should_that_rule_starts() {
+        return testForEach(noClasses().should().accessClassesThat(), noClasses().should().dependOnClassesThat());
+    }
+
     @Test
-    public void haveFullyQualifiedName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveFullyQualifiedName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveFullyQualifiedName(List.class.getName()))
+                noClassesShouldThatRuleStart.haveFullyQualifiedName(List.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void dontHaveFullyQualifiedName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontHaveFullyQualifiedName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().dontHaveFullyQualifiedName(List.class.getName()))
+                noClassesShouldThatRuleStart.dontHaveFullyQualifiedName(List.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void haveSimpleName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleName(List.class.getSimpleName()))
+                noClassesShouldThatRuleStart.haveSimpleName(List.class.getSimpleName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void dontHaveSimpleName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontHaveSimpleName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().dontHaveSimpleName(List.class.getSimpleName()))
+                noClassesShouldThatRuleStart.dontHaveSimpleName(List.class.getSimpleName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void haveNameMatching() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveNameMatching(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveNameMatching(".*\\.List"))
+                noClassesShouldThatRuleStart.haveNameMatching(".*\\.List"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void haveNameNotMatching() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveNameNotMatching(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveNameNotMatching(".*\\.List"))
+                noClassesShouldThatRuleStart.haveNameNotMatching(".*\\.List"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void haveSimpleNameStartingWith() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameStartingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameStartingWith("Lis"))
+                noClassesShouldThatRuleStart.haveSimpleNameStartingWith("Lis"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void haveSimpleNameNotStartingWith() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameNotStartingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameNotStartingWith("Lis"))
+                noClassesShouldThatRuleStart.haveSimpleNameNotStartingWith("Lis"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void haveSimpleNameContaining() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameContaining(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameContaining("is"))
+                noClassesShouldThatRuleStart.haveSimpleNameContaining("is"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void haveSimpleNameNotContaining() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameNotContaining(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameNotContaining("is"))
+                noClassesShouldThatRuleStart.haveSimpleNameNotContaining("is"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void haveSimpleNameEndingWith() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameEndingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameEndingWith("ist"))
+                noClassesShouldThatRuleStart.haveSimpleNameEndingWith("ist"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void haveSimpleNameNotEndingWith() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveSimpleNameNotEndingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().haveSimpleNameNotEndingWith("ist"))
+                noClassesShouldThatRuleStart.haveSimpleNameNotEndingWith("ist"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void resideInAPackage() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void resideInAPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().resideInAPackage("..tngtech.."))
+                noClassesShouldThatRuleStart.resideInAPackage("..tngtech.."))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingPublicClass.class);
     }
 
     @Test
-    public void resideOutsideOfPackage() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void resideOutsideOfPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().resideOutsideOfPackage("..tngtech.."))
+                noClassesShouldThatRuleStart.resideOutsideOfPackage("..tngtech.."))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void resideInAnyPackage() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void resideInAnyPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().resideInAnyPackage("..tngtech..", "java.lang.reflect"))
+                noClassesShouldThatRuleStart.resideInAnyPackage("..tngtech..", "java.lang.reflect"))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingConstructor.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingPublicClass.class, ClassAccessingConstructor.class);
     }
 
     @Test
-    public void resideOutsideOfPackages() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void resideOutsideOfPackages(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().resideOutsideOfPackages("..tngtech..", "java.lang.reflect")
+                noClassesShouldThatRuleStart.resideOutsideOfPackages("..tngtech..", "java.lang.reflect")
         ).on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingConstructor.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class);
     }
 
     @Test
-    public void arePublic() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().arePublic())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void arePublic(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePublic())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -188,8 +219,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotPublic() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().areNotPublic())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotPublic(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPublic())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -198,8 +230,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areProtected() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().areProtected())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areProtected(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areProtected())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -207,8 +240,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotProtected() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().areNotProtected())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotProtected(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotProtected())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -217,8 +251,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void arePackagePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().arePackagePrivate())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void arePackagePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePackagePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -226,8 +261,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotPackagePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().areNotPackagePrivate())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotPackagePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPackagePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -236,8 +272,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void arePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().arePrivate())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void arePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -245,8 +282,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotPrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().areNotPrivate())
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotPrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -255,8 +293,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void haveModifier() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().haveModifier(PRIVATE))
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveModifier(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.haveModifier(PRIVATE))
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -264,8 +303,9 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void dontHaveModifier() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClasses().should().accessClassesThat().dontHaveModifier(PRIVATE))
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontHaveModifier(ClassesShouldThat noClassesShouldThatRuleStart) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.dontHaveModifier(PRIVATE))
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -274,65 +314,72 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areAnnotatedWith_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAnnotatedWith(SomeAnnotation.class))
+                noClassesShouldThatRuleStart.areAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingAnnotatedClass.class);
     }
 
     @Test
-    public void areNotAnnotatedWith_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAnnotatedWith(SomeAnnotation.class))
+                noClassesShouldThatRuleStart.areNotAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingSimpleClass.class);
     }
 
     @Test
-    public void areAnnotatedWith_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAnnotatedWith(SomeAnnotation.class.getName()))
+                noClassesShouldThatRuleStart.areAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingAnnotatedClass.class);
     }
 
     @Test
-    public void areNotAnnotatedWith_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAnnotatedWith(SomeAnnotation.class.getName()))
+                noClassesShouldThatRuleStart.areNotAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingSimpleClass.class);
     }
 
     @Test
-    public void areAnnotatedWith_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAnnotatedWith(hasNamePredicate))
+                noClassesShouldThatRuleStart.areAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingAnnotatedClass.class);
     }
 
     @Test
-    public void areNotAnnotatedWith_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAnnotatedWith(hasNamePredicate))
+                noClassesShouldThatRuleStart.areNotAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingSimpleClass.class);
     }
 
     @Test
-    public void areMetaAnnotatedWith_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areMetaAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areMetaAnnotatedWith(SomeAnnotation.class))
+                noClassesShouldThatRuleStart.areMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -340,9 +387,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotMetaAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class))
+                noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -350,9 +398,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areMetaAnnotatedWith_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areMetaAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                noClassesShouldThatRuleStart.areMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -360,9 +409,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotMetaAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
+                noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -370,10 +420,11 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areMetaAnnotatedWith_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areMetaAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areMetaAnnotatedWith(hasNamePredicate))
+                noClassesShouldThatRuleStart.areMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -381,10 +432,11 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotMetaAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotMetaAnnotatedWith(hasNamePredicate))
+                noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
 
@@ -392,117 +444,130 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void implement_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void implement_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().implement(Collection.class))
+                noClassesShouldThatRuleStart.implement(Collection.class))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingArrayList.class);
     }
 
     @Test
-    public void dontImplement_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontImplement_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().dontImplement(Collection.class))
+                noClassesShouldThatRuleStart.dontImplement(Collection.class))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingList.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void implement_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void implement_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().implement(Collection.class.getName()))
+                noClassesShouldThatRuleStart.implement(Collection.class.getName()))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingArrayList.class);
     }
 
     @Test
-    public void dontImplement_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontImplement_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().dontImplement(Collection.class.getName()))
+                noClassesShouldThatRuleStart.dontImplement(Collection.class.getName()))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingList.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void implement_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void implement_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().implement(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.implement(classWithNameOf(Collection.class)))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingArrayList.class);
     }
 
     @Test
-    public void dontImplement_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void dontImplement_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().dontImplement(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.dontImplement(classWithNameOf(Collection.class)))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingList.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void areAssignableTo_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableTo_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableTo(Collection.class))
+                noClassesShouldThatRuleStart.areAssignableTo(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void areNotAssignableTo_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableTo_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableTo(Collection.class))
+                noClassesShouldThatRuleStart.areNotAssignableTo(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void areAssignableTo_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableTo_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableTo(Collection.class.getName()))
+                noClassesShouldThatRuleStart.areAssignableTo(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void areNotAssignableTo_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableTo_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableTo(Collection.class.getName()))
+                noClassesShouldThatRuleStart.areNotAssignableTo(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void areAssignableTo_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableTo_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableTo(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.areAssignableTo(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThat(getOnlyElement(classes)).matches(ClassAccessingList.class);
     }
 
     @Test
-    public void areNotAssignableTo_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableTo_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableTo(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.areNotAssignableTo(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
     }
 
     @Test
-    public void areAssignableFrom_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableFrom_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableFrom(Collection.class))
+                noClassesShouldThatRuleStart.areAssignableFrom(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -510,9 +575,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_type() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableFrom_type(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableFrom(Collection.class))
+                noClassesShouldThatRuleStart.areNotAssignableFrom(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -520,9 +586,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areAssignableFrom_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableFrom_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableFrom(Collection.class.getName()))
+                noClassesShouldThatRuleStart.areAssignableFrom(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -530,9 +597,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_typeName() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableFrom_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableFrom(Collection.class.getName()))
+                noClassesShouldThatRuleStart.areNotAssignableFrom(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -540,9 +608,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areAssignableFrom_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAssignableFrom_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areAssignableFrom(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.areAssignableFrom(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -550,9 +619,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAssignableFrom_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotAssignableFrom(classWithNameOf(Collection.class)))
+                noClassesShouldThatRuleStart.areNotAssignableFrom(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -560,9 +630,10 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areInterfaces_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areInterfaces_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areInterfaces())
+                noClassesShouldThatRuleStart.areInterfaces())
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
 
@@ -570,26 +641,60 @@ public class ShouldAccessClassesThatTest {
     }
 
     @Test
-    public void areNotInterfaces_predicate() {
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotInterfaces_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat().areNotInterfaces())
+                noClassesShouldThatRuleStart.areNotInterfaces())
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingSimpleClass.class);
     }
 
+    @DataProvider
+    public static Object[][] no_classes_should_predicate_rule_starts() {
+        return testForEach(
+                noClasses().should().accessClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))),
+                noClasses().should().dependOnClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class)))))
+        );
+    }
+
     @Test
-    public void accessClassesThat_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                noClasses().should().accessClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))))
+    @UseDataProvider("no_classes_should_predicate_rule_starts")
+    public void shouldThat_predicate(ArchRule rule) {
+        List<JavaClass> classes = filterClassesAppearingInFailureReport(rule)
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingList.class, ClassAccessingString.class);
     }
 
-    private DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
+    @Test
+    public void dependOnClassesThat_reports_all_dependencies() {
+        Function<ArchRule, List<JavaClass>> filterClassesInFailureReport = new Function<ArchRule, List<JavaClass>>() {
+            @Override
+            public List<JavaClass> apply(ArchRule rule) {
+                return filterClassesAppearingInFailureReport(rule)
+                        .on(ClassHavingFieldOfTypeList.class, ClassHavingMethodParameterOfTypeString.class,
+                                ClassHavingConstructorParameterOfTypeCollection.class, ClassImplementingSerializable.class,
+                                ClassHavingReturnTypeArrayList.class);
+            }
+        };
+
+        List<JavaClass> classes = filterClassesInFailureReport.apply(
+                noClasses().should().dependOnClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))));
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassHavingFieldOfTypeList.class, ClassHavingMethodParameterOfTypeString.class,
+                ClassHavingReturnTypeArrayList.class, ClassImplementingSerializable.class);
+
+        classes = filterClassesInFailureReport.apply(
+                noClasses().should().accessClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))));
+
+        assertThat(classes).isEmpty();
+    }
+
+    private static DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
         return GET_NAME.is(equalTo(type.getName()));
     }
 
@@ -600,10 +705,22 @@ public class ShouldAccessClassesThatTest {
         }
     }
 
+    private static class ClassHavingFieldOfTypeList {
+        @SuppressWarnings("unused")
+        List<?> list;
+    }
+
     private static class ClassAccessingArrayList {
         @SuppressWarnings("unused")
         void call(ArrayList<?> list) {
             list.size();
+        }
+    }
+
+    private static class ClassHavingReturnTypeArrayList {
+        @SuppressWarnings("unused")
+        ArrayList<?> call() {
+            return null;
         }
     }
 
@@ -614,10 +731,22 @@ public class ShouldAccessClassesThatTest {
         }
     }
 
+    private static class ClassHavingMethodParameterOfTypeString {
+        @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
+        void call(String string) {
+        }
+    }
+
     private static class ClassAccessingCollection {
         @SuppressWarnings("unused")
         void call(Collection<?> collection) {
             collection.size();
+        }
+    }
+
+    private static class ClassHavingConstructorParameterOfTypeCollection {
+        @SuppressWarnings("unused")
+        ClassHavingConstructorParameterOfTypeCollection(Collection<?> collection) {
         }
     }
 
@@ -626,6 +755,9 @@ public class ShouldAccessClassesThatTest {
         void call(Iterable<?> iterable) {
             iterable.iterator();
         }
+    }
+
+    private static class ClassImplementingSerializable implements Serializable {
     }
 
     private static class ClassAccessingConstructor {
@@ -690,6 +822,7 @@ public class ShouldAccessClassesThatTest {
     private static class PrivateClass {
     }
 
+    @SuppressWarnings("WeakerAccess")
     static class PackagePrivateClass {
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Function;
@@ -38,20 +39,22 @@ import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
 @RunWith(DataProviderRunner.class)
-public class ShouldAccessClassesThatTest {
+public class ShouldClassesThatTest {
 
     @Rule
     public final MockitoRule rule = MockitoJUnit.rule();
 
     @DataProvider
     public static Object[][] no_classes_should_that_rule_starts() {
-        return testForEach(noClasses().should().accessClassesThat(), noClasses().should().dependOnClassesThat());
+        return testForEach(
+                noClasses().should().accessClassesThat(),
+                noClasses().should().dependOnClassesThat());
     }
 
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveFullyQualifiedName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveFullyQualifiedName(List.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -61,7 +64,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontHaveFullyQualifiedName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.dontHaveFullyQualifiedName(List.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -71,7 +74,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleName(List.class.getSimpleName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -81,7 +84,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontHaveSimpleName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.dontHaveSimpleName(List.class.getSimpleName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -91,7 +94,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveNameMatching(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveNameMatching(".*\\.List"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -101,7 +104,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveNameNotMatching(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveNameNotMatching(".*\\.List"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -111,7 +114,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameStartingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameStartingWith("Lis"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -121,7 +124,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameNotStartingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameNotStartingWith("Lis"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -131,7 +134,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameContaining(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameContaining("is"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -141,7 +144,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameNotContaining(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameNotContaining("is"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -151,7 +154,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameEndingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameEndingWith("ist"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -161,7 +164,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleNameNotEndingWith(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleNameNotEndingWith("ist"))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -171,7 +174,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void resideInAPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.resideInAPackage("..tngtech.."))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -181,7 +184,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void resideOutsideOfPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.resideOutsideOfPackage("..tngtech.."))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -191,7 +194,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void resideInAnyPackage(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.resideInAnyPackage("..tngtech..", "java.lang.reflect"))
                 .on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingConstructor.class);
 
@@ -201,7 +204,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void resideOutsideOfPackages(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.resideOutsideOfPackages("..tngtech..", "java.lang.reflect")
         ).on(ClassAccessingPublicClass.class, ClassAccessingString.class, ClassAccessingConstructor.class);
 
@@ -211,7 +214,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void arePublic(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePublic())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePublic())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -221,7 +224,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotPublic(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPublic())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPublic())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -232,7 +235,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areProtected(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areProtected())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areProtected())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -242,7 +245,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotProtected(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotProtected())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotProtected())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -253,7 +256,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void arePackagePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePackagePrivate())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePackagePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -263,7 +266,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotPackagePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPackagePrivate())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPackagePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -274,7 +277,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void arePrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePrivate())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.arePrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -284,7 +287,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotPrivate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPrivate())
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.areNotPrivate())
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -295,7 +298,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveModifier(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.haveModifier(PRIVATE))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.haveModifier(PRIVATE))
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -305,7 +308,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontHaveModifier(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.dontHaveModifier(PRIVATE))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(noClassesShouldThatRuleStart.dontHaveModifier(PRIVATE))
                 .on(ClassAccessingPublicClass.class, ClassAccessingPrivateClass.class,
                         ClassAccessingPackagePrivateClass.class, ClassAccessingProtectedClass.class);
 
@@ -316,7 +319,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -326,7 +329,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -336,7 +339,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -346,7 +349,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -357,7 +360,7 @@ public class ShouldAccessClassesThatTest {
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -368,7 +371,7 @@ public class ShouldAccessClassesThatTest {
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class);
 
@@ -378,7 +381,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areMetaAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -389,7 +392,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotMetaAnnotatedWith_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -400,7 +403,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areMetaAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -411,7 +414,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotMetaAnnotatedWith_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -423,7 +426,7 @@ public class ShouldAccessClassesThatTest {
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areMetaAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -435,7 +438,7 @@ public class ShouldAccessClassesThatTest {
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotMetaAnnotatedWith_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassAccessingMetaAnnotatedClass.class, ClassAccessingAnnotatedClass.class, ClassAccessingSimpleClass.class,
                         MetaAnnotatedAnnotation.class);
@@ -446,7 +449,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void implement_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.implement(Collection.class))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -456,7 +459,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontImplement_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.dontImplement(Collection.class))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -466,7 +469,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void implement_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.implement(Collection.class.getName()))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -476,7 +479,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontImplement_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.dontImplement(Collection.class.getName()))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -486,7 +489,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void implement_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.implement(classWithNameOf(Collection.class)))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -496,7 +499,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void dontImplement_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.dontImplement(classWithNameOf(Collection.class)))
                 .on(ClassAccessingArrayList.class, ClassAccessingList.class, ClassAccessingIterable.class);
 
@@ -506,7 +509,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableTo_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableTo(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -516,7 +519,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableTo_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableTo(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -526,7 +529,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableTo_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableTo(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -536,7 +539,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableTo_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableTo(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -546,7 +549,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableTo_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableTo(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -556,7 +559,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableTo_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableTo(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
 
@@ -566,7 +569,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableFrom_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableFrom(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -577,7 +580,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableFrom_type(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableFrom(Collection.class))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -588,7 +591,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableFrom_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableFrom(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -599,7 +602,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableFrom_typeName(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableFrom(Collection.class.getName()))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -610,7 +613,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areAssignableFrom_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areAssignableFrom(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -621,7 +624,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotAssignableFrom_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotAssignableFrom(classWithNameOf(Collection.class)))
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
@@ -632,7 +635,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areInterfaces_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areInterfaces())
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
@@ -643,7 +646,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void areNotInterfaces_predicate(ClassesShouldThat noClassesShouldThatRuleStart) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotInterfaces())
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingSimpleClass.class);
@@ -662,7 +665,7 @@ public class ShouldAccessClassesThatTest {
     @Test
     @UseDataProvider("no_classes_should_predicate_rule_starts")
     public void shouldThat_predicate(ArchRule rule) {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(rule)
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(rule)
                 .on(ClassAccessingList.class, ClassAccessingString.class,
                         ClassAccessingCollection.class, ClassAccessingIterable.class);
 
@@ -671,9 +674,9 @@ public class ShouldAccessClassesThatTest {
 
     @Test
     public void dependOnClassesThat_reports_all_dependencies() {
-        Function<ArchRule, List<JavaClass>> filterClassesInFailureReport = new Function<ArchRule, List<JavaClass>>() {
+        Function<ArchRule, Set<JavaClass>> filterClassesInFailureReport = new Function<ArchRule, Set<JavaClass>>() {
             @Override
-            public List<JavaClass> apply(ArchRule rule) {
+            public Set<JavaClass> apply(ArchRule rule) {
                 return filterClassesAppearingInFailureReport(rule)
                         .on(ClassHavingFieldOfTypeList.class, ClassHavingMethodParameterOfTypeString.class,
                                 ClassHavingConstructorParameterOfTypeCollection.class, ClassImplementingSerializable.class,
@@ -681,7 +684,7 @@ public class ShouldAccessClassesThatTest {
             }
         };
 
-        List<JavaClass> classes = filterClassesInFailureReport.apply(
+        Set<JavaClass> classes = filterClassesInFailureReport.apply(
                 noClasses().should().dependOnClassesThat(are(not(assignableFrom(classWithNameOf(Collection.class))))));
 
         assertThatClasses(classes).matchInAnyOrder(

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyBeAccessedByClassesThatTest.java
@@ -26,7 +26,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldThatEvaluator.filterClassesAppearingInFailureReport;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldEvaluator.filterClassesAppearingInFailureReport;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 
 public class ShouldOnlyBeAccessedByClassesThatTest {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -2,19 +2,25 @@ package com.tngtech.archunit.lang.syntax.elements;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.List;
+import java.util.Set;
 
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.access.ClassAccessingOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.accessed.ClassBeingAccessedByOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.anotheraccess.YetAnotherClassAccessingOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.otheraccess.ClassAlsoAccessingOtherClass;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -23,21 +29,36 @@ import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_TYPE;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldEvaluator.filterClassesAppearingInFailureReport;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldEvaluator.filterViolationCausesInFailureReport;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class ShouldOnlyBeAccessedByClassesThatTest {
+@RunWith(DataProviderRunner.class)
+public class ShouldOnlyByClassesThatTest {
 
     @Rule
     public final MockitoRule rule = MockitoJUnit.rule();
 
+    @DataProvider
+    public static Object[][] should_only_be_by_rule_starts() {
+        return testForEach(
+                classes().should().onlyBeAccessed().byClassesThat(),
+                classes().should().onlyHaveDependentClassesThat()
+        );
+    }
+
     @Test
-    public void haveFullyQualifiedName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveFullyQualifiedName(Foo.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveFullyQualifiedName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveFullyQualifiedName(Foo.class.getName()))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -48,9 +69,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontHaveFullyQualifiedName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().dontHaveFullyQualifiedName(Foo.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontHaveFullyQualifiedName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.dontHaveFullyQualifiedName(Foo.class.getName()))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -59,9 +81,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleName(Foo.class.getSimpleName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleName(Foo.class.getSimpleName()))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -72,9 +95,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontHaveSimpleName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().dontHaveSimpleName(Foo.class.getSimpleName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontHaveSimpleName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.dontHaveSimpleName(Foo.class.getSimpleName()))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -83,9 +107,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveNameMatching() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveNameMatching(".*\\$Foo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveNameMatching(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveNameMatching(".*\\$Foo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -96,9 +121,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveNameNotMatching() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveNameNotMatching(".*\\$Foo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveNameNotMatching(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveNameNotMatching(".*\\$Foo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -107,9 +133,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameStartingWith() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameStartingWith("Fo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameStartingWith(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameStartingWith("Fo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -120,9 +147,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameNotStartingWith() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotStartingWith("Fo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameNotStartingWith(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameNotStartingWith("Fo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -132,9 +160,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameContaining() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameContaining("o"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameContaining(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameContaining("o"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -145,9 +174,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameNotContaining() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotContaining("o"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameNotContaining(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameNotContaining("o"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -157,9 +187,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameEndingWith() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameEndingWith("oo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameEndingWith(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameEndingWith("oo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -170,9 +201,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveSimpleNameNotEndingWith() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().haveSimpleNameNotEndingWith("oo"))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveSimpleNameNotEndingWith(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveSimpleNameNotEndingWith("oo"))
                 .on(ClassAccessedByFoo.class, Foo.class,
                         ClassAccessedByBar.class, Bar.class,
                         ClassAccessedByBaz.class, Baz.class);
@@ -182,27 +214,30 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void resideInAPackage() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().resideInAPackage("..access.."))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void resideInAPackage(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.resideInAPackage("..access.."))
                 .on(ClassAccessingOtherClass.class, ClassAlsoAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAlsoAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
     }
 
     @Test
-    public void resideOutsideOfPackage() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().resideOutsideOfPackage("..access.."))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void resideOutsideOfPackage(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.resideOutsideOfPackage("..access.."))
                 .on(ClassAccessingOtherClass.class, ClassAlsoAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
     }
 
     @Test
-    public void resideInAnyPackage() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().resideInAnyPackage("..access..", "..otheraccess.."))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void resideInAnyPackage(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.resideInAnyPackage("..access..", "..otheraccess.."))
                 .on(ClassAccessingOtherClass.class, ClassAlsoAccessingOtherClass.class,
                         YetAnotherClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
@@ -210,9 +245,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void resideOutsideOfPackages() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().resideOutsideOfPackages("..access..", "..otheraccess..")
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void resideOutsideOfPackages(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.resideOutsideOfPackages("..access..", "..otheraccess..")
         ).on(ClassAccessingOtherClass.class, ClassAlsoAccessingOtherClass.class,
                 YetAnotherClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
@@ -221,8 +257,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void arePublic() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().arePublic())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void arePublic(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.arePublic())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -235,8 +272,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotPublic() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().areNotPublic())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotPublic(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.areNotPublic())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -247,8 +285,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areProtected() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().areProtected())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areProtected(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.areProtected())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -261,8 +300,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotProtected() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().areNotProtected())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotProtected(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.areNotProtected())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -273,8 +313,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void arePackagePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().arePackagePrivate())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void arePackagePrivate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.arePackagePrivate())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -287,8 +328,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotPackagePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().areNotPackagePrivate())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotPackagePrivate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.areNotPackagePrivate())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -299,8 +341,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void arePrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().arePrivate())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void arePrivate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.arePrivate())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -313,8 +356,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotPrivate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().areNotPrivate())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotPrivate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.areNotPrivate())
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -325,8 +369,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void haveModifier() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().haveModifier(PRIVATE))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveModifier(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.haveModifier(PRIVATE))
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -339,8 +384,9 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontHaveModifier() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(classes().should().onlyBeAccessed().byClassesThat().dontHaveModifier(PRIVATE))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontHaveModifier(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(classesShouldOnlyBeBy.dontHaveModifier(PRIVATE))
                 .on(ClassAccessedByPublicClass.class, ClassAccessedByPrivateClass.class,
                         ClassAccessedByPackagePrivateClass.class, ClassAccessedByProtectedClass.class,
                         PublicClass.class, PrivateClass.class,
@@ -351,9 +397,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAnnotatedWith_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAnnotatedWith(SomeAnnotation.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnnotatedWith_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnnotatedWith(SomeAnnotation.class))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -361,9 +408,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAnnotatedWith_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAnnotatedWith(SomeAnnotation.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAnnotatedWith_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAnnotatedWith(SomeAnnotation.class))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -371,9 +419,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAnnotatedWith_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAnnotatedWith(SomeAnnotation.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnnotatedWith_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -381,9 +430,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAnnotatedWith_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAnnotatedWith(SomeAnnotation.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAnnotatedWith_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -391,10 +441,11 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAnnotatedWith_predicate() {
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnnotatedWith_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAnnotatedWith(hasNamePredicate))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnnotatedWith(hasNamePredicate))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -402,10 +453,11 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAnnotatedWith_predicate() {
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAnnotatedWith_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAnnotatedWith(hasNamePredicate))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAnnotatedWith(hasNamePredicate))
                 .on(ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -413,9 +465,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areMetaAnnotatedWith_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(SomeAnnotation.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areMetaAnnotatedWith_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -426,9 +479,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotMetaAnnotatedWith_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotMetaAnnotatedWith(SomeAnnotation.class))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -438,9 +492,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areMetaAnnotatedWith_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(SomeAnnotation.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areMetaAnnotatedWith_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -451,9 +506,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotMetaAnnotatedWith_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotMetaAnnotatedWith(SomeAnnotation.class.getName()))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -463,10 +519,11 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areMetaAnnotatedWith_predicate() {
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areMetaAnnotatedWith_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areMetaAnnotatedWith(hasNamePredicate))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -477,10 +534,11 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotMetaAnnotatedWith_predicate() {
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotMetaAnnotatedWith_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
         DescribedPredicate<HasType> hasNamePredicate = GET_TYPE.is(classWithNameOf(SomeAnnotation.class));
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotMetaAnnotatedWith(hasNamePredicate))
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotMetaAnnotatedWith(hasNamePredicate))
                 .on(ClassBeingAccessedByMetaAnnotatedClass.class, MetaAnnotatedClass.class,
                         ClassBeingAccessedByAnnotatedClass.class, AnnotatedClass.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class,
@@ -490,9 +548,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void implement_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().implement(SomeInterface.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void implement_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.implement(SomeInterface.class))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -500,9 +559,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontImplement_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().dontImplement(SomeInterface.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontImplement_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.dontImplement(SomeInterface.class))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -510,9 +570,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void implement_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().implement(SomeInterface.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void implement_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.implement(SomeInterface.class.getName()))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -520,9 +581,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontImplement_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().dontImplement(SomeInterface.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontImplement_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.dontImplement(SomeInterface.class.getName()))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -530,9 +592,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void implement_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().implement(classWithNameOf(SomeInterface.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void implement_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.implement(classWithNameOf(SomeInterface.class)))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -540,9 +603,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void dontImplement_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().dontImplement(classWithNameOf(SomeInterface.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void dontImplement_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.dontImplement(classWithNameOf(SomeInterface.class)))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -550,9 +614,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableTo_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableTo(SomeInterface.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableTo_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableTo(SomeInterface.class))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -560,9 +625,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableTo_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableTo(SomeInterface.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableTo_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableTo(SomeInterface.class))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -570,9 +636,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableTo_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableTo(SomeInterface.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableTo_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableTo(SomeInterface.class.getName()))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -580,9 +647,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableTo_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableTo(SomeInterface.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableTo_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableTo(SomeInterface.class.getName()))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -590,9 +658,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableTo_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableTo(classWithNameOf(SomeInterface.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableTo_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableTo(classWithNameOf(SomeInterface.class)))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -600,9 +669,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableTo_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableTo(classWithNameOf(SomeInterface.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableTo_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableTo(classWithNameOf(SomeInterface.class)))
                 .on(ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class,
                         SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -610,9 +680,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableFrom_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableFrom(ClassExtendingClass.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableFrom_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableFrom(ClassExtendingClass.class))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -620,9 +691,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_type() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableFrom(ClassExtendingClass.class))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableFrom_type(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableFrom(ClassExtendingClass.class))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -631,9 +703,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableFrom_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableFrom(ClassExtendingClass.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableFrom_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableFrom(ClassExtendingClass.class.getName()))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -641,9 +714,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_typeName() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableFrom(ClassExtendingClass.class.getName()))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableFrom_typeName(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableFrom(ClassExtendingClass.class.getName()))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -652,9 +726,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areAssignableFrom_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areAssignableFrom(classWithNameOf(ClassExtendingClass.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAssignableFrom_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAssignableFrom(classWithNameOf(ClassExtendingClass.class)))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -662,9 +737,10 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void areNotAssignableFrom_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotAssignableFrom(classWithNameOf(ClassExtendingClass.class)))
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAssignableFrom_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAssignableFrom(classWithNameOf(ClassExtendingClass.class)))
                 .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
                         ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
 
@@ -673,44 +749,85 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     }
 
     @Test
-    public void byClassesThat_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat(are(not(assignableFrom(classWithNameOf(ClassExtendingClass.class))))))
-                .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
-                        ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
-
-        assertThatClasses(classes).matchInAnyOrder(ClassExtendingClass.class,
-                ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class);
-    }
-
-    @Test
-    public void areInterfaces_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areInterfaces())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areInterfaces_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areInterfaces())
                 .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingSimpleClass.class, SimpleClass.class);
     }
 
     @Test
-    public void areNotInterfaces_predicate() {
-        List<JavaClass> classes = filterClassesAppearingInFailureReport(
-                classes().should().onlyBeAccessed().byClassesThat().areNotInterfaces())
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotInterfaces_predicate(ClassesShouldThat classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotInterfaces())
                 .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByInterface.class, InterfaceAccessingAClass.class);
     }
 
-    @Test
-    public void accesses_by_the_class_itself_are_ignored() {
-        ClassesShouldConjunction rule = classes().should().onlyBeAccessed()
-                .byClassesThat(classWithNameOf(ClassAccessingClassAccessingItself.class));
+    @DataProvider
+    public static Object[][] byClassesThat_predicate_rules() {
+        return testForEach(
+                classes().should().onlyBeAccessed().byClassesThat(are(not(assignableFrom(classWithNameOf(ClassExtendingClass.class))))),
+                classes().should().onlyHaveDependentClassesThat(are(not(assignableFrom(classWithNameOf(ClassExtendingClass.class))))));
+    }
 
+    @Test
+    @UseDataProvider("byClassesThat_predicate_rules")
+    public void classesThat_predicate(ArchRule rule) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(rule)
+                .on(ClassExtendingClass.class, ClassImplementingSomeInterface.class,
+                        ClassBeingAccessedByClassImplementingSomeInterface.class, SimpleClass.class, ClassAccessingSimpleClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassExtendingClass.class,
+                ClassImplementingSomeInterface.class, ClassBeingAccessedByClassImplementingSomeInterface.class);
+    }
+
+    @Test
+    public void onlyHaveDependentClassesThat_reports_all_dependents() {
+        Function<ArchRule, Set<JavaClass>> filterViolationOriginsInFailureReport = new Function<ArchRule, Set<JavaClass>>() {
+            @Override
+            public Set<JavaClass> apply(ArchRule rule) {
+                return filterViolationCausesInFailureReport(rule)
+                        .on(ClassBeingDependedOnByFieldType.class,
+                                ClassDependingViaFieldType.class,
+                                ClassBeingDependedOnByMethodParameterType.class,
+                                ClassDependingViaMethodParameter.class,
+                                InterfaceBeingDependedOnByImplementing.class,
+                                ClassDependingViaImplementing.class);
+            }
+        };
+
+        Set<JavaClass> classes = filterViolationOriginsInFailureReport.apply(
+                classes().should().onlyHaveDependentClassesThat(have(not(nameMatching(".*DependingVia.*")))));
+
+        assertThatClasses(classes).matchInAnyOrder(ClassDependingViaFieldType.class,
+                ClassDependingViaMethodParameter.class, ClassDependingViaImplementing.class);
+
+        classes = filterViolationOriginsInFailureReport.apply(
+                classes().should().onlyBeAccessed().byClassesThat(have(not(nameMatching(".*DependingVia.*")))));
+
+        assertThat(classes).isEmpty();
+    }
+
+    @DataProvider
+    public static Object[][] rule_starts_where_a_class_accesses_itself() {
+        return testForEach(
+                classes().should().onlyBeAccessed().byClassesThat(classWithNameOf(ClassAccessingClassAccessingItself.class)),
+                classes().should().onlyHaveDependentClassesThat(classWithNameOf(ClassAccessingClassAccessingItself.class)));
+    }
+
+    @Test
+    @UseDataProvider("rule_starts_where_a_class_accesses_itself")
+    public void accesses_by_the_class_itself_are_ignored(ArchRule rule) {
         rule.check(new ClassFileImporter().importClasses(
                 ClassAccessingItself.class, ClassAccessingClassAccessingItself.class));
     }
 
-    private DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
+    private static DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
         return GET_NAME.is(equalTo(type.getName()));
     }
 
@@ -719,6 +836,7 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         }
     }
 
+    @SuppressWarnings("unused")
     private static class Foo {
         ClassAccessedByFoo other;
 
@@ -731,6 +849,7 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         String field;
     }
 
+    @SuppressWarnings("unused")
     private static class Bar {
         ClassAccessedByBar other;
 
@@ -744,12 +863,14 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         }
     }
 
+    @SuppressWarnings("unused")
     private static class Baz {
         void call() {
             new ClassAccessedByBaz();
         }
     }
 
+    @SuppressWarnings("unused")
     private static class ClassAccessingSimpleClass {
         void call() {
             new SimpleClass();
@@ -777,24 +898,28 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     private static class SimpleClass {
     }
 
+    @SuppressWarnings("unused")
     private static class PrivateClass {
         void call() {
             new ClassAccessedByPrivateClass();
         }
     }
 
+    @SuppressWarnings("unused")
     static class PackagePrivateClass {
         void call() {
             new ClassAccessedByPackagePrivateClass();
         }
     }
 
+    @SuppressWarnings("unused")
     protected static class ProtectedClass {
         void call() {
             new ClassAccessedByProtectedClass();
         }
     }
 
+    @SuppressWarnings("unused")
     public static class PublicClass {
         void call() {
             new ClassAccessedByPublicClass();
@@ -810,6 +935,7 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     private @interface MetaAnnotatedAnnotation {
     }
 
+    @SuppressWarnings("unused")
     @SomeAnnotation
     private static class AnnotatedClass {
         void call() {
@@ -817,6 +943,7 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         }
     }
 
+    @SuppressWarnings("unused")
     @MetaAnnotatedAnnotation
     private static class MetaAnnotatedClass {
         void call() {
@@ -831,10 +958,12 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         static final Object SOME_CONSTANT = "Some value";
     }
 
+    @SuppressWarnings("unused")
     interface InterfaceAccessingAClass {
         Object SOME_CONSTANT = ClassBeingAccessedByInterface.SOME_CONSTANT;
     }
 
+    @SuppressWarnings("unused")
     private static class ClassImplementingSomeInterface implements SomeInterface {
         void call() {
             new ClassBeingAccessedByClassImplementingSomeInterface();
@@ -847,6 +976,7 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
     private static class ClassBeingAccessedByClassImplementingSomeInterface {
     }
 
+    @SuppressWarnings("unused")
     private static class ClassAccessingItself {
         private String field;
 
@@ -855,9 +985,33 @@ public class ShouldOnlyBeAccessedByClassesThatTest {
         }
     }
 
+    @SuppressWarnings("unused")
     private static class ClassAccessingClassAccessingItself {
         void call() {
             new ClassAccessingItself("foo");
         }
+    }
+
+    private static class ClassBeingDependedOnByFieldType {
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassDependingViaFieldType {
+        ClassBeingDependedOnByFieldType field;
+    }
+
+    private static class ClassBeingDependedOnByMethodParameterType {
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassDependingViaMethodParameter {
+        void foo(ClassBeingDependedOnByMethodParameterType parameter) {
+        }
+    }
+
+    private interface InterfaceBeingDependedOnByImplementing {
+    }
+
+    private static class ClassDependingViaImplementing implements InterfaceBeingDependedOnByImplementing {
     }
 }


### PR DESCRIPTION
Adds `dependOnClassesThat(predicate?)` and `onlyHaveDependentClassesThat(predicate?)` to the rules API.

Resolves: #69