### PR TITLE
Use Maven Surefire 2.22.0 in example installation

### DIFF
--- a/docs/userguide/002_Installation.adoc
+++ b/docs/userguide/002_Installation.adoc
@@ -46,7 +46,7 @@ A typical Maven configuration could look like this:
         ...
         <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.21.0</version>
+            <version>2.22.0</version>
             <dependencies>
                 <dependency>
                     <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
2.21.0 has some issue when using fork mode and other bugs. They are fixed in 2.22.0.