### PR TITLE
Fixed sample code for Kotlin

### DIFF
--- a/docs/userguide/003_Getting_Started.adoc
+++ b/docs/userguide/003_Getting_Started.adoc
@@ -116,7 +116,7 @@ class MyArchitectureTest {
 
     @ArchTest
     fun rule_as_method(classes: JavaClasses) {
-        ArchRule rule = ArchRuleDefinition.noClasses().should()...
+        val rule = ArchRuleDefinition.noClasses().should()...
         rule.check(classes)
     }
 }


### PR DESCRIPTION
Hi. 
I was reading ArchUnit user guide and found that sample code for kotlin had wrong syntax.
```
ArchRule rule = ArchRuleDefinition.noClasses().should()...
```
This PR fixed this.