### PR TITLE
#114: Expose if JavaClass is an array

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -149,6 +149,11 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
     }
 
     @PublicAPI(usage = ACCESS)
+    public boolean isArray() {
+        return javaType.isArray();
+    }
+
+    @PublicAPI(usage = ACCESS)
     public boolean isInnerClass() {
         return enclosingClass.isPresent();
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.core.domain.testobjects.AhavingMembersOfTypeB;
 import com.tngtech.archunit.core.domain.testobjects.AllPrimitiveDependencies;
 import com.tngtech.archunit.core.domain.testobjects.B;
 import com.tngtech.archunit.core.domain.testobjects.InterfaceForA;
+import com.tngtech.archunit.core.domain.testobjects.IsArrayTestClass;
 import com.tngtech.archunit.core.domain.testobjects.SuperA;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -65,6 +66,20 @@ import static org.mockito.Mockito.when;
 public class JavaClassTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void finds_array_type() {
+        JavaMethod method = importClassWithContext(IsArrayTestClass.class).getMethod("anArray");
+
+        assertThat(method.getReturnType().isArray()).isTrue();
+    }
+
+    @Test
+    public void finds_non_array_type() {
+        JavaMethod method = importClassWithContext(IsArrayTestClass.class).getMethod("notAnArray");
+
+        assertThat(method.getReturnType().isArray()).isFalse();
+    }
 
     @Test
     public void finds_fields_and_methods() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/IsArrayTestClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/IsArrayTestClass.java
@@ -1,0 +1,12 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+public class IsArrayTestClass {
+
+    public Object[] anArray() {
+        return null;
+    }
+
+    public Object notAnArray() {
+        return null;
+    }
+}


### PR DESCRIPTION
This commit partially resolves #114 by adding a `isArray` method to `JavaClass`. 

Getting the return type of the array as mentioned by @wolfs in the issue is a different story as it  probably requires a more "gerneral" kind of api - not just related to arrays (e.g what should such a method return? A simple String or a more powerful kind of abstraction?)

Thanks for looking at this and for your awesome work 👍 