### PR TITLE
Fix deprecated Gradle wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ ext {
     currentScriptRootOf = { it.buildscript.sourceFile.parentFile }
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.7'
 }
 


### PR DESCRIPTION
As of Gradle 4.8 defining custom wrappers is deprecated ([release notes](https://docs.gradle.org/4.8/release-notes.html)) and will be removed in 5.0 as shown in the [build log](https://api.travis-ci.org/v3/job/477026981/log.txt) at the end:

```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/4.10.2/userguide/command_line_interface.html#sec:command_line_warnings
```

This is the fix suggested in the release notes.