### PR TITLE
Make CanOverrideDescription consistent

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanOverrideDescription.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanOverrideDescription.java
@@ -20,6 +20,13 @@ import com.tngtech.archunit.PublicAPI;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public interface CanOverrideDescription<SELF> {
+    /**
+     * Allows to adjust the description of this object. Note that this method will not modify the current object,
+     * but instead return a new object with adjusted description.
+     *
+     * @param newDescription The description the result of this method will hold
+     * @return A <b>new</b> equivalent object with adjusted description
+     */
     @PublicAPI(usage = ACCESS)
     SELF as(String newDescription);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
@@ -30,6 +30,7 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.properties.CanOverrideDescription;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public final class Slice extends ForwardingSet<JavaClass> implements HasDescription, CanOverrideDescription<Slice> {
@@ -38,12 +39,18 @@ public final class Slice extends ForwardingSet<JavaClass> implements HasDescript
     private final Set<JavaClass> classes;
 
     private Slice(List<String> matchingGroups, Set<JavaClass> classes) {
-        this.matchingGroups = matchingGroups;
-        this.description = new Description("Slice " + Joiner.on(" - ").join(ascendingCaptures(matchingGroups)));
+        this(matchingGroups,
+                new Description("Slice " + Joiner.on(" - ").join(ascendingCaptures(matchingGroups))),
+                classes);
+    }
+
+    private Slice(List<String> matchingGroups, Description description, Set<JavaClass> classes) {
+        this.matchingGroups = checkNotNull(matchingGroups);
+        this.description = checkNotNull(description);
         this.classes = ImmutableSet.copyOf(classes);
     }
 
-    private List<String> ascendingCaptures(List<String> matchingGroups) {
+    private static List<String> ascendingCaptures(List<String> matchingGroups) {
         List<String> result = new ArrayList<>();
         for (int i = 1; i <= matchingGroups.size(); i++) {
             result.add("$" + i);
@@ -72,8 +79,7 @@ public final class Slice extends ForwardingSet<JavaClass> implements HasDescript
      */
     @Override
     public Slice as(String pattern) {
-        description = new Description(pattern);
-        return this;
+        return new Slice(matchingGroups, new Description(pattern), classes);
     }
 
     @PublicAPI(usage = ACCESS)


### PR DESCRIPTION
In most places `as(..)` returns a new object, in some places though (`Slice`) the original object is modified. This is inconsistent behavior to most other parts of ArchUnit and should thus be corrected.
In theory this is a breaking change, however the direct use of this API is highly unlikely since it is not part of the slice rules API.