### PR TITLE
Extend slice creation

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/CyclicDependencyRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/CyclicDependencyRulesTest.java
@@ -8,6 +8,8 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.dependencies.SliceAssignment;
+import com.tngtech.archunit.library.dependencies.SliceIdentifier;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -54,4 +56,30 @@ public class CyclicDependencyRulesTest {
                     .should().beFreeOfCycles()
                     .ignoreDependency(SliceOneCallingConstructorInSliceTwoAndMethodInSliceThree.class, ClassCallingConstructorInSliceFive.class)
                     .ignoreDependency(resideInAPackage("..slice4.."), DescribedPredicate.<JavaClass>alwaysTrue());
+
+    @ArchTest
+    public static final ArchRule no_cycles_in_freely_customized_slices =
+            slices().assignedFrom(inComplexSliceOneOrTwo())
+                    .namingSlices("$1[$2]")
+                    .should().beFreeOfCycles();
+
+    private static SliceAssignment inComplexSliceOneOrTwo() {
+        return new SliceAssignment() {
+            @Override
+            public String getDescription() {
+                return "complex slice one or two";
+            }
+
+            @Override
+            public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
+                if (javaClass.getPackageName().contains("complexcycles.slice1")) {
+                    return SliceIdentifier.of("Complex-Cycle", "One");
+                }
+                if (javaClass.getPackageName().contains("complexcycles.slice2")) {
+                    return SliceIdentifier.of("Complex-Cycle", "Two");
+                }
+                return SliceIdentifier.ignore();
+            }
+        };
+    }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -443,12 +443,19 @@ class ExamplesIntegrationTest {
                 .by(cycleFromComplexSlice1To2())
                 .by(cycleFromComplexSlice1To2To3To5())
 
+                .ofRule("slices assigned from complex slice one or two should be free of cycles")
+                .by(cycleFromComplexSlice1To2("Complex-Cycle[One]", "Complex-Cycle[Two]"))
+
                 .toDynamicTests();
     }
 
     private static CyclicErrorMatcher cycleFromComplexSlice1To2() {
+        return cycleFromComplexSlice1To2("slice1 of complexcycles", "slice2 of complexcycles");
+    }
+
+    private static CyclicErrorMatcher cycleFromComplexSlice1To2(String sliceOneDescription, String sliceTwoDescription) {
         return cycle()
-                .from("slice1 of complexcycles")
+                .from(sliceOneDescription)
                 .by(callFromMethod(ClassOfMinimalCycleCallingSliceTwo.class, "callSliceTwo")
                         .toMethod(ClassOfMinimalCycleCallingSliceOne.class, "callSliceOne")
                         .inLine(9))
@@ -457,7 +464,7 @@ class ExamplesIntegrationTest {
                 .by(callFromMethod(SliceOneCallingConstructorInSliceTwoAndMethodInSliceThree.class, "callSliceTwo")
                         .toConstructor(InstantiatedClassInSliceTwo.class)
                         .inLine(10))
-                .from("slice2 of complexcycles")
+                .from(sliceTwoDescription)
                 .by(inheritanceFrom(SliceTwoInheritingFromSliceOne.class)
                         .extending(SliceOneCallingConstructorInSliceTwoAndMethodInSliceThree.class))
                 .by(field(ClassOfMinimalCycleCallingSliceOne.class, "classInSliceOne")

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
@@ -33,6 +33,19 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * A collection of {@link JavaClass JavaClasses} modelling some domain aspect of a code basis. This is conceptually
+ * a cut through a code base according to business logic. Take for example
+ * <pre><code>
+ * com.mycompany.myapp.order
+ * com.mycompany.myapp.customer
+ * com.mycompany.myapp.user
+ * com.mycompany.myapp.authorization
+ * </code></pre>
+ * The top level packages under 'myapp' could be considered slices according to different domain aspects.<br>
+ * Thus there could be a slice 'Order' housing all the classes from the {@code order} package, a slice 'Customer'
+ * housing all the classes from the {@code customer} package and so on.
+ */
 public final class Slice extends ForwardingSet<JavaClass> implements HasDescription, CanOverrideDescription<Slice> {
     private final List<String> matchingGroups;
     private Description description;

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceAssignment.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceAssignment.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.library.dependencies;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+
+import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+
+/**
+ * A mapping {@link JavaClass} -&gt; {@link SliceIdentifier} which defines how to partition
+ * a set of {@link JavaClasses} into {@link Slices}. All classes that are mapped to the same
+ * {@link SliceIdentifier} will belong to the same {@link Slice}.<br>
+ * A {@link SliceAssignment} must provide a description to be used for the rule text of a rule
+ * formed via {@link SlicesRuleDefinition}.
+ */
+@PublicAPI(usage = INHERITANCE)
+public interface SliceAssignment extends HasDescription {
+    SliceIdentifier getIdentifierOf(JavaClass javaClass);
+}

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.library.dependencies;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+/**
+ * An unique identifier of a {@link Slice}. All {@link JavaClasses} that are assigned to the same
+ * {@link SliceIdentifier} are considered to belong to the same {@link Slice}.<br>
+ * A {@link SliceIdentifier} consists of textual parts. Two {@link SliceIdentifier} are considered to
+ * be equal if and only if their parts are equal. The parts can also be referred to from
+ * {@link Slices#namingSlices(String)} via '{@code $x}' where '{@code x}' is the number of the part.
+ */
+public final class SliceIdentifier {
+    private final List<String> parts;
+
+    private SliceIdentifier(List<String> parts) {
+        this.parts = ImmutableList.copyOf(parts);
+    }
+
+    List<String> getParts() {
+        return parts;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parts);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SliceIdentifier other = (SliceIdentifier) obj;
+        return Objects.equals(this.parts, other.parts);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + parts;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static SliceIdentifier of(String... parts) {
+        return of(ImmutableList.copyOf(parts));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static SliceIdentifier of(List<String> parts) {
+        checkNotNull(parts, "Supplied parts may not be null");
+        checkArgument(!parts.isEmpty(),
+                "Parts of a %s must not be empty. Use %s.ignore() to ignore a %s",
+                SliceIdentifier.class.getSimpleName(), SliceIdentifier.class.getSimpleName(), JavaClass.class.getSimpleName());
+
+        return new SliceIdentifier(parts);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static SliceIdentifier ignore() {
+        return new SliceIdentifier(Collections.<String>emptyList());
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SlicesRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SlicesRuleDefinition.java
@@ -16,15 +16,38 @@
 package com.tngtech.archunit.library.dependencies;
 
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.Priority;
 import com.tngtech.archunit.library.dependencies.syntax.GivenSlices;
+import com.tngtech.archunit.library.dependencies.syntax.SlicesShould;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Allows to specify {@link ArchRule ArchRules} for "slices" of a code base. A slice is conceptually
+ * a cut through a code base according to business logic. Take for example
+ * <pre><code>
+ * com.mycompany.myapp.order
+ * com.mycompany.myapp.customer
+ * com.mycompany.myapp.user
+ * com.mycompany.myapp.authorization
+ * </code></pre>
+ * The top level packages under 'myapp' are composed according to different domain aspects. It is
+ * good practice, to keep such packages free of cycles, which is one capability that this class
+ * provides.<br>
+ * Consider
+ * <pre><code>
+ * {@link #slices() slices()}.{@link Slices#matching(String) matching("..myapp.(*)..")}.{@link GivenSlices#should() should()}.{@link SlicesShould#beFreeOfCycles() beFreeOfCycles()}
+ * </code></pre>
+ * Then this rule will assert, that the four slices of 'myapp' are free of cycles.
+ */
 public final class SlicesRuleDefinition {
     private SlicesRuleDefinition() {
     }
 
+    /**
+     * Entry point into {@link SlicesRuleDefinition}
+     */
     @PublicAPI(usage = ACCESS)
     public static Creator slices() {
         return new Creator();
@@ -34,9 +57,20 @@ public final class SlicesRuleDefinition {
         private Creator() {
         }
 
+        /**
+         * @see Slices#matching(String)
+         */
         @PublicAPI(usage = ACCESS)
         public GivenSlices matching(String packageIdentifier) {
             return new GivenSlicesInternal(Priority.MEDIUM, Slices.matching(packageIdentifier));
+        }
+
+        /**
+         * @see Slices#assignedFrom(SliceAssignment)
+         */
+        @PublicAPI(usage = ACCESS)
+        public GivenSlices assignedFrom(SliceAssignment assignment) {
+            return new GivenSlicesInternal(Priority.MEDIUM, Slices.assignedFrom(assignment));
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceIdentifierTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceIdentifierTest.java
@@ -1,0 +1,47 @@
+package com.tngtech.archunit.library.dependencies;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SliceIdentifierTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void rejects_null() {
+        thrown.expect(NullPointerException.class);
+
+        SliceIdentifier.of((String[]) null);
+    }
+
+    @Test
+    public void rejects_null_list() {
+        thrown.expect(NullPointerException.class);
+
+        SliceIdentifier.of((List<String>) null);
+    }
+
+    @Test
+    public void rejects_empty_parts() {
+        expectEmptyPartsException();
+
+        SliceIdentifier.of();
+    }
+
+    @Test
+    public void rejects_empty_parts_list() {
+        expectEmptyPartsException();
+
+        SliceIdentifier.of(Collections.<String>emptyList());
+    }
+
+    private void expectEmptyPartsException() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("empty");
+        thrown.expectMessage("Use SliceIdentifier.ignore() to ignore a JavaClass");
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
@@ -1,5 +1,7 @@
 package com.tngtech.archunit.library.dependencies;
 
+import java.io.File;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -7,16 +9,21 @@ import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.DescribedIterable;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.TestUtils;
+import com.tngtech.archunit.testutil.Assertions;
 import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.domain.TestUtils.dependencyFrom;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.simulateCall;
+import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SlicesTest {
@@ -28,6 +35,20 @@ public class SlicesTest {
         assertThat(Slices.matching("(**)").transform(classes)).hasSize(3);
         assertThat(Slices.matching("java.(**)").transform(classes)).hasSize(3);
         assertThat(Slices.matching("java.(*).(*)").transform(classes)).hasSize(1);
+    }
+
+    @Test
+    public void matching_description() {
+        JavaClasses classes = importClassesWithContext(Object.class);
+
+        Slices.Transformer transformer = Slices.matching("java.(*)..");
+        assertThat(transformer.getDescription()).isEqualTo("slices matching 'java.(*)..'");
+
+        Slices slices = transformer.transform(classes);
+        assertThat(slices.getDescription()).isEqualTo("slices matching 'java.(*)..'");
+
+        slices = transformer.that(DescribedPredicate.<Slice>alwaysTrue().as("changed")).transform(classes);
+        assertThat(slices.getDescription()).isEqualTo("slices matching 'java.(*)..' that changed");
     }
 
     @Test
@@ -68,5 +89,56 @@ public class SlicesTest {
         Slices slices = Slices.matching("java.(*)..").transform(ImmutableSet.of(first, second));
 
         assertThat(slices).extractingResultOf("getDescription").containsOnly("Slice lang", "Slice util");
+    }
+
+    @Test
+    public void slices_from_identifier() {
+        Slices slices = Slices.assignedFrom(assignmentOfJavaLangAndUtil("some description"))
+                .namingSlices("Any $1 - $2")
+                .transform(importClassesWithContext(Object.class, Number.class, List.class, Collection.class, File.class));
+
+        assertThat(slices.getDescription()).isEqualTo("slices assigned from some description");
+        assertThat(slices).extractingResultOf("getDescription").containsOnly("Any Lang - $2", "Any Adjusted - Util");
+        assertThat(slices).hasSize(2);
+        assertThatClasses(getSliceOf(Object.class, slices)).contain(Number.class);
+        assertThatClasses(getSliceOf(List.class, slices)).contain(Collection.class);
+        Assertions.assertThat(tryGetSliceOf(File.class, slices))
+                .as("Slice of class java.io.File (which should be missing from the assignment)")
+                .isAbsent();
+    }
+
+    private Slice getSliceOf(Class<?> clazz, Slices slices) {
+        return tryGetSliceOf(clazz, slices).get();
+    }
+
+    private Optional<Slice> tryGetSliceOf(Class<?> clazz, Slices slices) {
+        for (Slice slice : slices) {
+            for (JavaClass javaClass : slice) {
+                if (javaClass.isEquivalentTo(clazz)) {
+                    return Optional.of(slice);
+                }
+            }
+        }
+        return Optional.absent();
+    }
+
+    private SliceAssignment assignmentOfJavaLangAndUtil(final String description) {
+        return new SliceAssignment() {
+            @Override
+            public String getDescription() {
+                return description;
+            }
+
+            @Override
+            public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
+                if (javaClass.getPackageName().startsWith("java.lang")) {
+                    return SliceIdentifier.of("Lang");
+                }
+                if (javaClass.getPackageName().startsWith("java.util")) {
+                    return SliceIdentifier.of("Adjusted", "Util");
+                }
+                return SliceIdentifier.ignore();
+            }
+        };
     }
 }

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -44,6 +44,39 @@ SlicesRuleDefinition.slices().matching("..myapp.(**)").should().notDependOnEachO
 SlicesRuleDefinition.slices().matching("..myapp.(**).service..").should().notDependOnEachOther()
 ----
 
+If this constraint is too rigid, e.g. in legacy applications where the package structure is rather
+inconsistent, it is possible to further customize the slice creation. This can be done by specifying
+a mapping of `JavaClass` to `SliceIdentifier` where classes with the same `SliceIdentifier` will
+be sorted into the same slice. Consider this example:
+
+[source,java,options="nowrap"]
+----
+SliceAssignment legacyPackageStructure = new SliceAssignment() {
+    // this will specify which classes belong together in the same slice
+    @Override
+    public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
+        if (javaClass.getPackageName().startsWith("com.oldapp")) {
+            return SliceIdentifier.of("Legacy");
+        }
+        if (javaClass.getName().contains(".esb.")) {
+            return SliceIdentifier.of("ESB");
+        }
+        // ... further custom mappings
+
+        // if the class does not match anything, we ignore it
+        return SliceIdentifier.ignore();
+    }
+
+    // this will be part of the rule description if the test fails
+    @Override
+    public String getDescription() {
+        return "legacy package structure";
+    }
+};
+
+SlicesRuleDefinition.slices().assignedFrom(legacyPackageStructure).should().beFreeOfCycles()
+----
+
 === General Coding Rules
 
 The Library API also offers a small set of coding rules that might be useful in various projects.

--- a/docs/userguide/html/000_Index.html
+++ b/docs/userguide/html/000_Index.html
@@ -1763,6 +1763,40 @@ SlicesRuleDefinition.slices().matching("..myapp.(**)").should().notDependOnEachO
 SlicesRuleDefinition.slices().matching("..myapp.(**).service..").should().notDependOnEachOther()</code></pre>
 </div>
 </div>
+<div class="paragraph">
+<p>If this constraint is too rigid, e.g. in legacy applications where the package structure is rather
+inconsistent, it is possible to further customize the slice creation. This can be done by specifying
+a mapping of <code>JavaClass</code> to <code>SliceIdentifier</code> where classes with the same <code>SliceIdentifier</code> will
+be sorted into the same slice. Consider this example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-java hljs" data-lang="java">SliceAssignment legacyPackageStructure = new SliceAssignment() {
+    // this will specify which classes belong together in the same slice
+    @Override
+    public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
+        if (javaClass.getPackageName().startsWith("com.oldapp")) {
+            return SliceIdentifier.of("Legacy");
+        }
+        if (javaClass.getName().contains(".esb.")) {
+            return SliceIdentifier.of("ESB");
+        }
+        // ... further custom mappings
+
+        // if the class does not match anything, we ignore it
+        return SliceIdentifier.ignore();
+    }
+
+    // this will be part of the rule description if the test fails
+    @Override
+    public String getDescription() {
+        return "legacy package structure";
+    }
+};
+
+SlicesRuleDefinition.slices().assignedFrom(legacyPackageStructure).should().beFreeOfCycles()</code></pre>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_general_coding_rules"><a class="anchor" href="#_general_coding_rules"></a>8.3. General Coding Rules</h3>


### PR DESCRIPTION
In legacy projects it is often necessary to further customize the way slices are created (more than simple package matching like '..myapp.(*)..').
This PR extends the slices API to freely create slices by defining a custom mapping from `JavaClass` to `SliceIdentifier` where two classes mapped to the same identifier will end up in the same slice.