### PR TITLE
Introduce and use DescribedPredicateAssertion

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
@@ -25,89 +25,96 @@ public class DescribedPredicateTest {
 
     @Test
     public void alwaysTrue_works() {
-        assertThat(alwaysTrue().apply(new Object())).isTrue();
-        assertThat(alwaysTrue().getDescription()).contains("always true");
+        assertThat(alwaysTrue()).accepts(new Object()).hasDescription("always true");
     }
 
     @Test
     public void alwaysFalse_works() {
-        assertThat(alwaysFalse().apply(new Object())).isFalse();
-        assertThat(alwaysFalse().getDescription()).contains("always false");
+        assertThat(alwaysFalse()).rejects(new Object()).hasDescription("always false");
     }
 
     @Test
     public void and_works() {
-        assertThat(alwaysFalse().and(alwaysFalse()).apply(new Object())).isFalse();
-        assertThat(alwaysFalse().and(alwaysTrue()).apply(new Object())).isFalse();
-        assertThat(alwaysTrue().and(alwaysFalse()).apply(new Object())).isFalse();
-        assertThat(alwaysTrue().and(alwaysTrue()).apply(new Object())).isTrue();
+        assertThat(alwaysFalse().and(alwaysFalse())).rejects(new Object());
+        assertThat(alwaysFalse().and(alwaysTrue())).rejects(new Object());
+        assertThat(alwaysTrue().and(alwaysFalse())).rejects(new Object());
+        assertThat(alwaysTrue().and(alwaysTrue())).accepts(new Object());
     }
 
     @Test
     public void or_works() {
-        assertThat(alwaysFalse().or(alwaysFalse()).apply(new Object())).isFalse();
-        assertThat(alwaysFalse().or(alwaysTrue()).apply(new Object())).isTrue();
-        assertThat(alwaysTrue().or(alwaysFalse()).apply(new Object())).isTrue();
-        assertThat(alwaysTrue().or(alwaysTrue()).apply(new Object())).isTrue();
+        assertThat(alwaysFalse().or(alwaysFalse())).rejects(new Object());
+        assertThat(alwaysFalse().or(alwaysTrue())).accepts(new Object());
+        assertThat(alwaysTrue().or(alwaysFalse())).accepts(new Object());
+        assertThat(alwaysTrue().or(alwaysTrue())).accepts(new Object());
     }
 
     @Test
     public void equalTo_works() {
-        assertThat(equalTo(5).apply(4)).isFalse();
-        assertThat(equalTo(5).getDescription()).contains("equal to '5'");
-        assertThat(equalTo(5).apply(5)).isTrue();
-        assertThat(equalTo(5).apply(6)).isFalse();
+        assertThat(equalTo(5))
+                .rejects(4)
+                .hasDescription("equal to '5'")
+                .accepts(5)
+                .rejects(6);
 
         Object object = new Object();
-        assertThat(equalTo(object).apply(object)).isTrue();
+        assertThat(equalTo(object)).accepts(object);
     }
 
     @Test
     public void lessThan_works() {
-        assertThat(lessThan(4).apply(3)).isTrue();
-        assertThat(lessThan(4).getDescription()).contains("less than '4'");
-        assertThat(lessThan(4).apply(4)).isFalse();
-        assertThat(lessThan(4).apply(5)).isFalse();
+        assertThat(lessThan(4))
+                .accepts(3)
+                .hasDescription("less than '4'")
+                .rejects(4)
+                .rejects(5);
 
-        assertThat(lessThan(Foo.SECOND).apply(Foo.FIRST)).isTrue();
-        assertThat(lessThan(Foo.SECOND).apply(Foo.SECOND)).isFalse();
-        assertThat(lessThan(Foo.SECOND).apply(Foo.THIRD)).isFalse();
+        assertThat(lessThan(Foo.SECOND))
+                .accepts(Foo.FIRST)
+                .rejects(Foo.SECOND)
+                .rejects(Foo.THIRD);
     }
 
     @Test
     public void greaterThan_works() {
-        assertThat(greaterThan(5).apply(6)).isTrue();
-        assertThat(greaterThan(5).getDescription()).contains("greater than '5'");
-        assertThat(greaterThan(5).apply(5)).isFalse();
-        assertThat(greaterThan(5).apply(4)).isFalse();
+        assertThat(greaterThan(5))
+                .accepts(6)
+                .hasDescription("greater than '5'")
+                .rejects(5)
+                .rejects(4);
 
-        assertThat(greaterThan(Foo.SECOND).apply(Foo.FIRST)).isFalse();
-        assertThat(greaterThan(Foo.SECOND).apply(Foo.SECOND)).isFalse();
-        assertThat(greaterThan(Foo.SECOND).apply(Foo.THIRD)).isTrue();
+        assertThat(greaterThan(Foo.SECOND))
+                .rejects(Foo.FIRST)
+                .rejects(Foo.SECOND)
+                .accepts(Foo.THIRD);
     }
 
     @Test
     public void lessThanOrEqualTo_works() {
-        assertThat(lessThanOrEqualTo(5).apply(4)).isTrue();
-        assertThat(lessThanOrEqualTo(5).getDescription()).contains("less than or equal to '5'");
-        assertThat(lessThanOrEqualTo(5).apply(5)).isTrue();
-        assertThat(lessThanOrEqualTo(5).apply(6)).isFalse();
+        assertThat(lessThanOrEqualTo(5))
+                .accepts(4)
+                .hasDescription("less than or equal to '5'")
+                .accepts(5)
+                .rejects(6);
 
-        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.FIRST)).isTrue();
-        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.SECOND)).isTrue();
-        assertThat(lessThanOrEqualTo(Foo.SECOND).apply(Foo.THIRD)).isFalse();
+        assertThat(lessThanOrEqualTo(Foo.SECOND))
+                .accepts(Foo.FIRST)
+                .accepts(Foo.SECOND)
+                .rejects(Foo.THIRD);
     }
 
     @Test
     public void greaterThanOrEqualTo_works() {
-        assertThat(greaterThanOrEqualTo(5).apply(6)).isTrue();
-        assertThat(greaterThanOrEqualTo(5).getDescription()).contains("greater than or equal to '5'");
-        assertThat(greaterThanOrEqualTo(5).apply(5)).isTrue();
-        assertThat(greaterThanOrEqualTo(5).apply(4)).isFalse();
+        assertThat(greaterThanOrEqualTo(5))
+                .accepts(6)
+                .hasDescription("greater than or equal to '5'")
+                .accepts(5)
+                .rejects(4);
 
-        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.FIRST)).isFalse();
-        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.SECOND)).isTrue();
-        assertThat(greaterThanOrEqualTo(Foo.SECOND).apply(Foo.THIRD)).isTrue();
+        assertThat(greaterThanOrEqualTo(Foo.SECOND))
+                .rejects(Foo.FIRST)
+                .accepts(Foo.SECOND)
+                .accepts(Foo.THIRD);
     }
 
     @DataProvider
@@ -137,20 +144,21 @@ public class DescribedPredicateTest {
     @Test
     @UseDataProvider("not_scenarios")
     public void not_works(NotScenario scenario) {
-        assertThat(scenario.apply(equalTo(5)).apply(4)).isTrue();
-        assertThat(scenario.apply(equalTo(5)).getDescription()).contains(scenario.expectedPrefix + " equal to '5'");
-        assertThat(scenario.apply(equalTo(5)).apply(5)).isFalse();
-        assertThat(scenario.apply(equalTo(5)).apply(6)).isTrue();
+        assertThat(scenario.apply(equalTo(5)))
+                .accepts(4)
+                .hasDescription(scenario.expectedPrefix + " equal to '5'")
+                .rejects(5)
+                .accepts(6);
 
         Object object = new Object();
-        assertThat(scenario.apply(equalTo(object)).apply(object)).isFalse();
+        assertThat(scenario.apply(equalTo(object))).rejects(object);
     }
 
     @Test
     public void onResultOf_works() {
-        assertThat(equalTo(5).onResultOf(constant(4)).apply(new Object())).isFalse();
-        assertThat(equalTo(5).onResultOf(constant(5)).apply(new Object())).isTrue();
-        assertThat(equalTo(5).onResultOf(constant(6)).apply(new Object())).isFalse();
+        assertThat(equalTo(5).onResultOf(constant(4))).rejects(new Object());
+        assertThat(equalTo(5).onResultOf(constant(5))).accepts(new Object());
+        assertThat(equalTo(5).onResultOf(constant(6))).rejects(new Object());
     }
 
     private Function<Object, Integer> constant(final int integer) {

--- a/archunit/src/test/java/com/tngtech/archunit/base/PackageMatchersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/PackageMatchersTest.java
@@ -2,22 +2,22 @@ package com.tngtech.archunit.base;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class PackageMatchersTest {
     @Test
     public void matches_any_package() {
-        PackageMatchers matchers = PackageMatchers.of("..match..", "..other..");
-
-        assertThat(matchers.apply("foo.match.bar")).isTrue();
-        assertThat(matchers.apply("foo.other.bar")).isTrue();
-        assertThat(matchers.apply("foo.match.other.bar")).isTrue();
-        assertThat(matchers.apply("foo.bar")).isFalse();
-        assertThat(matchers.apply("matc.hother")).isFalse();
+        assertThat(PackageMatchers.of("..match..", "..other.."))
+                .accepts("foo.match.bar")
+                .accepts("foo.other.bar")
+                .accepts("foo.match.other.bar")
+                .rejects("foo.bar")
+                .rejects("matc.hother");
     }
 
     @Test
     public void description() {
-        assertThat(PackageMatchers.of("..foo..", "..bar..").getDescription()).isEqualTo("matches any of ['..foo..', '..bar..']");
+        assertThat(PackageMatchers.of("..foo..", "..bar.."))
+                .hasDescription("matches any of ['..foo..', '..bar..']");
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
@@ -158,26 +158,24 @@ public class AccessTargetTest {
     public void predicate_declaredIn() {
         JavaCall<?> call = simulateCall().from(Origin.class, "call").to(Target.class, "called");
 
-        assertThat(declaredIn(Target.class).apply(call.getTarget()))
-                .as("predicate matches").isTrue();
-        assertThat(declaredIn(Target.class.getName()).apply(call.getTarget()))
-                .as("predicate matches").isTrue();
-        assertThat(declaredIn(equivalentTo(Target.class)).apply(call.getTarget()))
-                .as("predicate matches").isTrue();
+        assertThat(declaredIn(Target.class))
+                .accepts(call.getTarget())
+                .hasDescription("declared in " + Target.class.getName());
+        assertThat(declaredIn(Target.class.getName()))
+                .accepts(call.getTarget())
+                .hasDescription("declared in " + Target.class.getName());;
+        assertThat(declaredIn(equivalentTo(Target.class)))
+                .accepts(call.getTarget());
 
-        assertThat(declaredIn(Origin.class).apply(call.getTarget()))
-                .as("predicate matches").isFalse();
-        assertThat(declaredIn(Origin.class.getName()).apply(call.getTarget()))
-                .as("predicate matches").isFalse();
-        assertThat(declaredIn(equivalentTo(Origin.class)).apply(call.getTarget()))
-                .as("predicate matches").isFalse();
+        assertThat(declaredIn(Origin.class))
+                .rejects(call.getTarget());
+        assertThat(declaredIn(Origin.class.getName()))
+                .rejects(call.getTarget());
+        assertThat(declaredIn(equivalentTo(Origin.class)))
+                .rejects(call.getTarget());
 
-        assertThat(declaredIn(Target.class).getDescription())
-                .as("description").isEqualTo("declared in " + Target.class.getName());
-        assertThat(declaredIn(Target.class.getName()).getDescription())
-                .as("description").isEqualTo("declared in " + Target.class.getName());
-        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")).getDescription())
-                .as("description").isEqualTo("declared in custom");
+        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
+                .hasDescription("declared in custom");
     }
 
     @Test
@@ -191,12 +189,10 @@ public class AccessTargetTest {
 
         simulateCall().from(Origin.class, "call").to(Target.class, "called");
 
-        assertThat(constructor().apply(constructorCall.getTarget()))
-                .as("predicate matches").isTrue();
-        assertThat(constructor().apply(methodCall.getTarget()))
-                .as("predicate matches").isFalse();
-        assertThat(constructor().getDescription())
-                .as("description").isEqualTo("constructor");
+        assertThat(constructor())
+                .accepts(constructorCall.getTarget())
+                .rejects(methodCall.getTarget())
+                .hasDescription("constructor");
     }
 
     private void assertDeclarations(CodeUnitCallTarget target, Class<?>... exceptionTypes) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
@@ -164,8 +164,9 @@ public class AccessTargetTest {
         assertThat(declaredIn(Target.class.getName()))
                 .accepts(call.getTarget())
                 .hasDescription("declared in " + Target.class.getName());;
-        assertThat(declaredIn(equivalentTo(Target.class)))
-                .accepts(call.getTarget());
+        assertThat(declaredIn(equivalentTo(Target.class).as("custom")))
+                .accepts(call.getTarget())
+                .hasDescription("declared in custom");
 
         assertThat(declaredIn(Origin.class))
                 .rejects(call.getTarget());
@@ -173,9 +174,6 @@ public class AccessTargetTest {
                 .rejects(call.getTarget());
         assertThat(declaredIn(equivalentTo(Origin.class)))
                 .rejects(call.getTarget());
-
-        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
-                .hasDescription("declared in custom");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
@@ -12,7 +12,7 @@ import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContex
 import static com.tngtech.archunit.core.domain.TestUtils.newMethodCallBuilder;
 import static com.tngtech.archunit.core.domain.TestUtils.resolvedTargetFrom;
 import static com.tngtech.archunit.core.domain.TestUtils.simulateCall;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class JavaAccessTest {
     @Test
@@ -49,11 +49,12 @@ public class JavaAccessTest {
         DescribedPredicate<JavaAccess<?>> predicate =
                 JavaAccess.Predicates.origin(DescribedPredicate.<JavaCodeUnit>alwaysTrue().as("some text"));
 
-        assertThat(predicate.getDescription()).isEqualTo("origin some text");
-        assertThat(predicate.apply(anyAccess())).as("predicate matches").isTrue();
+        assertThat(predicate)
+                .hasDescription("origin some text")
+                .accepts(anyAccess());
 
         predicate = JavaAccess.Predicates.origin(DescribedPredicate.<JavaCodeUnit>alwaysFalse());
-        assertThat(predicate.apply(anyAccess())).as("predicate matches").isFalse();
+        assertThat(predicate).rejects(anyAccess());
     }
 
     private TestJavaAccess anyAccess() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -468,82 +468,80 @@ public class JavaClassTest {
 
     @Test
     public void predicate_withType() {
-        assertThat(type(Parent.class).apply(importClassWithContext(Parent.class)))
-                .as("type(Parent) matches JavaClass Parent").isTrue();
-        assertThat(type(Parent.class).apply(importClassWithContext(SuperClassWithFieldAndMethod.class)))
-                .as("type(Parent) matches JavaClass SuperClassWithFieldAndMethod").isFalse();
+        assertThat(type(Parent.class))
+                .accepts(importClassWithContext(Parent.class))
+                .rejects(importClassWithContext(SuperClassWithFieldAndMethod.class));
 
-        assertThat(type(System.class).getDescription()).isEqualTo("type java.lang.System");
+        assertThat(type(System.class)).hasDescription("type java.lang.System");
     }
 
     @Test
     public void predicate_simpleName() {
-        assertThat(simpleName(Parent.class.getSimpleName()).apply(importClassWithContext(Parent.class)))
-                .as("simpleName(Parent) matches JavaClass Parent").isTrue();
-        assertThat(simpleName(Parent.class.getSimpleName()).apply(importClassWithContext(SuperClassWithFieldAndMethod.class)))
-                .as("simpleName(Parent) matches JavaClass SuperClassWithFieldAndMethod").isFalse();
+        assertThat(simpleName(Parent.class.getSimpleName()))
+                .accepts(importClassWithContext(Parent.class))
+                .rejects(importClassWithContext(SuperClassWithFieldAndMethod.class));
 
-        assertThat(simpleName("Simple").getDescription()).isEqualTo("simple name 'Simple'");
+        assertThat(simpleName("Simple")).hasDescription("simple name 'Simple'");
     }
 
     @Test
     public void predicate_simpleNameStartingWith() {
         JavaClass input = importClassWithContext(Parent.class);
-        assertThat(simpleNameStartingWith("P").apply(input)).isTrue();
-        assertThat(simpleNameStartingWith("Pa").apply(input)).isTrue();
-        assertThat(simpleNameStartingWith("PA").apply(input)).isFalse();
-        assertThat(simpleNameStartingWith(".P").apply(input)).isFalse();
-        assertThat(simpleNameStartingWith("").apply(input)).isTrue();
+        assertThat(simpleNameStartingWith("P")).accepts(input);
+        assertThat(simpleNameStartingWith("Pa")).accepts(input);
+        assertThat(simpleNameStartingWith("PA")).rejects(input);
+        assertThat(simpleNameStartingWith(".P")).rejects(input);
+        assertThat(simpleNameStartingWith("")).accepts(input);
 
-        assertThat(simpleNameStartingWith("wrong").apply(input)).isFalse();
+        assertThat(simpleNameStartingWith("wrong")).rejects(input);
 
         // Full match test
-        assertThat(simpleNameStartingWith(input.getName()).apply(input)).isFalse();
-        assertThat(simpleNameStartingWith(input.getName().substring(0, 2)).apply(input)).isFalse();
+        assertThat(simpleNameStartingWith(input.getName())).rejects(input);
+        assertThat(simpleNameStartingWith(input.getName().substring(0, 2))).rejects(input);
 
-        assertThat(simpleNameStartingWith("Prefix").getDescription()).isEqualTo("simple name starting with 'Prefix'");
+        assertThat(simpleNameStartingWith("Prefix")).hasDescription("simple name starting with 'Prefix'");
     }
 
     @Test
     public void predicate_simpleNameContaining() {
         JavaClass input = importClassWithContext(Parent.class);
 
-        assertThat(simpleNameContaining("Parent").apply(input)).isTrue();
-        assertThat(simpleNameContaining("Par").apply(input)).isTrue();
-        assertThat(simpleNameContaining("a").apply(input)).isTrue();
-        assertThat(simpleNameContaining("b").apply(input)).isFalse();
-        assertThat(simpleNameContaining("A").apply(input)).isFalse();
-        assertThat(simpleNameContaining("ent").apply(input)).isTrue();
-        assertThat(simpleNameContaining("Pent").apply(input)).isFalse();
-        assertThat(simpleNameContaining("aren").apply(input)).isTrue();
-        assertThat(simpleNameContaining("").apply(input)).isTrue();
+        assertThat(simpleNameContaining("Parent")).accepts(input);
+        assertThat(simpleNameContaining("Par")).accepts(input);
+        assertThat(simpleNameContaining("a")).accepts(input);
+        assertThat(simpleNameContaining("b")).rejects(input);
+        assertThat(simpleNameContaining("A")).rejects(input);
+        assertThat(simpleNameContaining("ent")).accepts(input);
+        assertThat(simpleNameContaining("Pent")).rejects(input);
+        assertThat(simpleNameContaining("aren")).accepts(input);
+        assertThat(simpleNameContaining("")).accepts(input);
 
         // Full match test
-        assertThat(simpleNameContaining(input.getName()).apply(input)).isFalse();
-        assertThat(simpleNameContaining(" ").apply(input)).isFalse();
-        assertThat(simpleNameContaining(".").apply(input)).isFalse();
+        assertThat(simpleNameContaining(input.getName())).rejects(input);
+        assertThat(simpleNameContaining(" ")).rejects(input);
+        assertThat(simpleNameContaining(".")).rejects(input);
 
-        assertThat(simpleNameContaining(".Parent").apply(input)).isFalse();
+        assertThat(simpleNameContaining(".Parent")).rejects(input);
 
-        assertThat(simpleNameContaining("Infix").getDescription()).isEqualTo("simple name containing 'Infix'");
+        assertThat(simpleNameContaining("Infix")).hasDescription("simple name containing 'Infix'");
     }
 
     @Test
     public void predicate_simpleNameEndingWith() {
         JavaClass input = importClassWithContext(Parent.class);
 
-        assertThat(simpleNameEndingWith("Parent").apply(input)).isTrue();
-        assertThat(simpleNameEndingWith("ent").apply(input)).isTrue();
-        assertThat(simpleNameEndingWith("").apply(input)).isTrue();
+        assertThat(simpleNameEndingWith("Parent")).accepts(input);
+        assertThat(simpleNameEndingWith("ent")).accepts(input);
+        assertThat(simpleNameEndingWith("")).accepts(input);
 
         // Full match test
-        assertThat(simpleNameEndingWith(input.getName()).apply(input)).isFalse();
-        assertThat(simpleNameEndingWith(" ").apply(input)).isFalse();
-        assertThat(simpleNameEndingWith(".").apply(input)).isFalse();
+        assertThat(simpleNameEndingWith(input.getName())).rejects(input);
+        assertThat(simpleNameEndingWith(" ")).rejects(input);
+        assertThat(simpleNameEndingWith(".")).rejects(input);
 
-        assertThat(simpleNameEndingWith(".Parent").apply(input)).isFalse();
+        assertThat(simpleNameEndingWith(".Parent")).rejects(input);
 
-        assertThat(simpleNameEndingWith("Suffix").getDescription()).isEqualTo("simple name ending with 'Suffix'");
+        assertThat(simpleNameEndingWith("Suffix")).hasDescription("simple name ending with 'Suffix'");
     }
 
     @Test
@@ -577,7 +575,7 @@ public class JavaClassTest {
                 .to(SuperClassWithFieldAndMethod.class)
                 .isFalse();
 
-        assertThat(assignableFrom(System.class).getDescription()).isEqualTo("assignable from java.lang.System");
+        assertThat(assignableFrom(System.class)).hasDescription("assignable from java.lang.System");
     }
 
     @Test
@@ -611,7 +609,7 @@ public class JavaClassTest {
                 .from(SuperClassWithFieldAndMethod.class)
                 .isTrue();
 
-        assertThat(assignableTo(System.class).getDescription()).isEqualTo("assignable to java.lang.System");
+        assertThat(assignableTo(System.class)).hasDescription("assignable to java.lang.System");
     }
 
     @DataProvider
@@ -628,7 +626,7 @@ public class JavaClassTest {
     @Test
     @UseDataProvider("implement_match_cases")
     public void predicate_implement_matches(DescribedPredicate<JavaClass> expectedMatch) {
-        assertThat(expectedMatch.apply(classWithHierarchy(ArrayList.class))).as("predicate matches").isTrue();
+        assertThat(expectedMatch).accepts(classWithHierarchy(ArrayList.class));
     }
 
     @Test
@@ -661,62 +659,60 @@ public class JavaClassTest {
     @Test
     @UseDataProvider("implement_mismatch_cases")
     public void predicate_implement_mismatches(DescribedPredicate<JavaClass> expectedMismatch) {
-        assertThat(expectedMismatch.apply(classWithHierarchy(ArrayList.class))).as("predicate matches").isFalse();
+        assertThat(expectedMismatch).rejects(classWithHierarchy(ArrayList.class));
     }
 
     @Test
     public void predicate_implement_descriptions() {
-        assertThat(implement(List.class).getDescription()).isEqualTo("implement " + List.class.getName());
-        assertThat(implement(List.class.getName()).getDescription()).isEqualTo("implement " + List.class.getName());
-        assertThat(implement(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")).getDescription())
-                .isEqualTo("implement custom");
+        assertThat(implement(List.class)).hasDescription("implement " + List.class.getName());
+        assertThat(implement(List.class.getName())).hasDescription("implement " + List.class.getName());
+        assertThat(implement(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
+                .hasDescription("implement custom");
     }
 
     @Test
     public void predicate_interfaces() {
-        assertThat(INTERFACES.apply(importClassWithContext(Serializable.class))).as("Predicate matches").isTrue();
-        assertThat(INTERFACES.apply(importClassWithContext(Object.class))).as("Predicate matches").isFalse();
-        assertThat(INTERFACES.getDescription()).isEqualTo("interfaces");
+        assertThat(INTERFACES)
+                .accepts(importClassWithContext(Serializable.class))
+                .rejects(importClassWithContext(Object.class))
+                .hasDescription("interfaces");
     }
 
     @Test
     public void predicate_reside_in_a_package() {
         JavaClass clazz = fakeClassWithPackage("some.arbitrary.pkg");
 
-        assertThat(resideInAPackage("some..pkg").apply(clazz)).as("package matches").isTrue();
+        assertThat(resideInAPackage("some..pkg")).accepts(clazz);
 
         clazz = fakeClassWithPackage("wrong.arbitrary.pkg");
 
-        assertThat(resideInAPackage("some..pkg").apply(clazz)).as("package matches").isFalse();
+        assertThat(resideInAPackage("some..pkg")).rejects(clazz);
 
-        assertThat(resideInAPackage("..any..").getDescription())
-                .isEqualTo("reside in a package '..any..'");
+        assertThat(resideInAPackage("..any..")).hasDescription("reside in a package '..any..'");
     }
 
     @Test
     public void predicate_reside_in_any_package() {
         JavaClass clazz = fakeClassWithPackage("some.arbitrary.pkg");
 
-        assertThat(resideInAnyPackage("any.thing", "some..pkg").apply(clazz)).as("package matches").isTrue();
+        assertThat(resideInAnyPackage("any.thing", "some..pkg")).accepts(clazz);
 
         clazz = fakeClassWithPackage("wrong.arbitrary.pkg");
 
-        assertThat(resideInAnyPackage("any.thing", "some..pkg").apply(clazz)).as("package matches").isFalse();
+        assertThat(resideInAnyPackage("any.thing", "some..pkg")).rejects(clazz);
 
-        assertThat(resideInAnyPackage("any.thing", "..any..").getDescription())
-                .isEqualTo("reside in any package ['any.thing', '..any..']");
+        assertThat(resideInAnyPackage("any.thing", "..any..")).hasDescription("reside in any package ['any.thing', '..any..']");
     }
 
     @Test
     public void predicate_equivalentTo() {
         JavaClass javaClass = importClasses(SuperClassWithFieldAndMethod.class, Parent.class).get(SuperClassWithFieldAndMethod.class);
 
-        assertThat(equivalentTo(SuperClassWithFieldAndMethod.class).apply(javaClass))
-                .as("predicate matches").isTrue();
-        assertThat(equivalentTo(Parent.class).apply(javaClass))
-                .as("predicate matches").isFalse();
-        assertThat(equivalentTo(Parent.class).getDescription())
-                .as("description").isEqualTo("equivalent to " + Parent.class.getName());
+        assertThat(equivalentTo(SuperClassWithFieldAndMethod.class))
+                .accepts(javaClass);
+        assertThat(equivalentTo(Parent.class))
+                .rejects(javaClass)
+                .hasDescription("equivalent to " + Parent.class.getName());
     }
 
     private JavaClass classWithHierarchy(Class<?> clazz) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -664,8 +664,10 @@ public class JavaClassTest {
 
     @Test
     public void predicate_implement_descriptions() {
-        assertThat(implement(List.class)).hasDescription("implement " + List.class.getName());
-        assertThat(implement(List.class.getName())).hasDescription("implement " + List.class.getName());
+        assertThat(implement(List.class))
+                .hasDescription("implement " + List.class.getName());
+        assertThat(implement(List.class.getName()))
+                .hasDescription("implement " + List.class.getName());
         assertThat(implement(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
                 .hasDescription("implement custom");
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldAccessTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldAccessTest.java
@@ -19,9 +19,10 @@ import static com.tngtech.archunit.core.domain.JavaFieldAccess.Predicates.access
 import static com.tngtech.archunit.core.domain.JavaFieldAccess.Predicates.target;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
-import static org.assertj.core.api.Assertions.assertThat;
+
 
 @RunWith(DataProviderRunner.class)
 public class JavaFieldAccessTest {
@@ -82,24 +83,21 @@ public class JavaFieldAccessTest {
     @Test
     @UseDataProvider("accessTypes")
     public void predicate_access_type(AccessType accessType) throws Exception {
-        assertThat(accessType(accessType).apply(stringFieldAccess(accessType)))
-                .as("Predicate matches").isTrue();
-        assertThat(accessType(accessType).apply(stringFieldAccess(not(accessType))))
-                .as("Predicate matches").isFalse();
-
-        assertThat(accessType(accessType).getDescription())
-                .as("Predicate description").isEqualTo("access type " + accessType);
+        assertThat(accessType(accessType))
+                .accepts(stringFieldAccess(accessType))
+                .rejects(stringFieldAccess(not(accessType)))
+                .hasDescription("access type " + accessType);
     }
 
     @Test
     public void predicate_field_access_target_by_predicate() throws Exception {
-        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue())
-                .apply(stringFieldAccess(GET))).as("Predicate matches").isTrue();
-        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysFalse())
-                .apply(stringFieldAccess(GET))).as("Predicate matches").isFalse();
+        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue()))
+                .accepts(stringFieldAccess(GET));
+        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysFalse()))
+                .rejects(stringFieldAccess(GET));
 
-        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue().as("any message"))
-                .getDescription()).as("description").isEqualTo("target any message");
+        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue().as("any message")))
+                .hasDescription("target any message");
     }
 
     private AccessType not(AccessType accessType) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldAccessTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldAccessTest.java
@@ -93,10 +93,8 @@ public class JavaFieldAccessTest {
     public void predicate_field_access_target_by_predicate() throws Exception {
         assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue()))
                 .accepts(stringFieldAccess(GET));
-        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysFalse()))
-                .rejects(stringFieldAccess(GET));
-
-        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysTrue().as("any message")))
+        assertThat(target(DescribedPredicate.<FieldAccessTarget>alwaysFalse().as("any message")))
+                .rejects(stringFieldAccess(GET))
                 .hasDescription("target any message");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
@@ -80,14 +80,13 @@ public class JavaMemberTest {
         assertThat(declaredIn(SomeClass.class.getName()))
                 .accepts(field)
                 .hasDescription("declared in " + SomeClass.class.getName());
-        assertThat(declaredIn(equivalentTo(SomeClass.class))).accepts(field);
+        assertThat(declaredIn(equivalentTo(SomeClass.class).as("custom")))
+                .accepts(field)
+                .hasDescription("declared in custom");
 
         assertThat(declaredIn(getClass())).rejects(field);
         assertThat(declaredIn(getClass().getName())).rejects(field);
         assertThat(declaredIn(equivalentTo(getClass()))).rejects(field);
-
-        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
-                .hasDescription("declared in custom");
     }
 
     private static JavaField importField(Class<?> owner, String name) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaMemberTest.java
@@ -9,7 +9,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo
 import static com.tngtech.archunit.core.domain.JavaMember.Predicates.declaredIn;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class JavaMemberTest {
     @Test
@@ -74,26 +74,20 @@ public class JavaMemberTest {
     public void predicate_declaredIn() {
         JavaField field = importField(SomeClass.class, "someField");
 
-        assertThat(declaredIn(SomeClass.class).apply(field))
-                .as("predicate matches").isTrue();
-        assertThat(declaredIn(SomeClass.class.getName()).apply(field))
-                .as("predicate matches").isTrue();
-        assertThat(declaredIn(equivalentTo(SomeClass.class)).apply(field))
-                .as("predicate matches").isTrue();
+        assertThat(declaredIn(SomeClass.class))
+                .accepts(field)
+                .hasDescription("declared in " + SomeClass.class.getName());
+        assertThat(declaredIn(SomeClass.class.getName()))
+                .accepts(field)
+                .hasDescription("declared in " + SomeClass.class.getName());
+        assertThat(declaredIn(equivalentTo(SomeClass.class))).accepts(field);
 
-        assertThat(declaredIn(getClass()).apply(field))
-                .as("predicate matches").isFalse();
-        assertThat(declaredIn(getClass().getName()).apply(field))
-                .as("predicate matches").isFalse();
-        assertThat(declaredIn(equivalentTo(getClass())).apply(field))
-                .as("predicate matches").isFalse();
+        assertThat(declaredIn(getClass())).rejects(field);
+        assertThat(declaredIn(getClass().getName())).rejects(field);
+        assertThat(declaredIn(equivalentTo(getClass()))).rejects(field);
 
-        assertThat(declaredIn(SomeClass.class).getDescription())
-                .as("description").isEqualTo("declared in " + SomeClass.class.getName());
-        assertThat(declaredIn(SomeClass.class.getName()).getDescription())
-                .as("description").isEqualTo("declared in " + SomeClass.class.getName());
-        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")).getDescription())
-                .as("description").isEqualTo("declared in custom");
+        assertThat(declaredIn(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
+                .hasDescription("declared in custom");
     }
 
     private static JavaField importField(Class<?> owner, String name) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
@@ -16,8 +16,8 @@ import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class CanBeAnnotatedTest {
     @Rule
@@ -25,33 +25,26 @@ public class CanBeAnnotatedTest {
 
     @Test
     public void matches_annotation_by_type() {
-        assertThat(annotatedWith(RuntimeRetentionAnnotation.class).apply(importClassWithContext(AnnotatedClass.class)))
-                .as("annotated class matches").isTrue();
-        assertThat(annotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(importClassWithContext(AnnotatedClass.class)))
-                .as("annotated class matches").isTrue();
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class))
+                .accepts(importClassWithContext(AnnotatedClass.class))
+                .rejects(importClassWithContext(Object.class));
+        assertThat(annotatedWith(RuntimeRetentionAnnotation.class.getName()))
+                .accepts(importClassWithContext(AnnotatedClass.class))
+                .rejects(importClassWithContext(Object.class));
 
-        assertThat(annotatedWith(RuntimeRetentionAnnotation.class).apply(importClassWithContext(Object.class)))
-                .as("annotated class matches").isFalse();
-        assertThat(annotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(importClassWithContext(Object.class)))
-                .as("annotated class matches").isFalse();
-
-        assertThat(annotatedWith(Rule.class).getDescription())
-                .isEqualTo("annotated with @Rule");
-        assertThat(annotatedWith(Rule.class.getName()).getDescription())
-                .isEqualTo("annotated with @Rule");
+        assertThat(annotatedWith(Rule.class)).hasDescription("annotated with @Rule");
+        assertThat(annotatedWith(Rule.class.getName())).hasDescription("annotated with @Rule");
     }
 
     @Test
     public void matches_annotation_by_predicate() {
-        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue())
-                .apply(importClassWithContext(AnnotatedClass.class)))
-                .as("annotated class matches").isTrue();
-        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse())
-                .apply(importClassWithContext(AnnotatedClass.class)))
-                .as("annotated class matches").isFalse();
+        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .accepts(importClassWithContext(AnnotatedClass.class));
+        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
+                .rejects(importClassWithContext(AnnotatedClass.class));
 
-        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")).getDescription())
-                .isEqualTo("annotated with Something");
+        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")))
+                .hasDescription("annotated with Something");
     }
 
     /**
@@ -71,33 +64,28 @@ public class CanBeAnnotatedTest {
     public void matches_meta_annotation_by_type() {
         JavaClasses classes = importClassesWithContext(MetaAnnotatedClass.class, Object.class, MetaRuntimeRetentionAnnotation.class);
 
-        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class).apply(classes.get(MetaAnnotatedClass.class)))
-                .as("meta-annotated class matches").isTrue();
-        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(classes.get(MetaAnnotatedClass.class)))
-                .as("meta-annotated class matches").isTrue();
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class))
+                .accepts(classes.get(MetaAnnotatedClass.class))
+                .rejects(classes.get(Object.class));
+        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class.getName()))
+                .accepts(classes.get(MetaAnnotatedClass.class))
+                .rejects(classes.get(Object.class));
 
-        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class).apply(classes.get(Object.class)))
-                .as("meta-annotated class matches").isFalse();
-        assertThat(metaAnnotatedWith(RuntimeRetentionAnnotation.class.getName()).apply(classes.get(Object.class)))
-                .as("meta-annotated class matches").isFalse();
-
-        assertThat(metaAnnotatedWith(Rule.class).getDescription())
-                .isEqualTo("meta-annotated with @Rule");
-        assertThat(metaAnnotatedWith(Rule.class.getName()).getDescription())
-                .isEqualTo("meta-annotated with @Rule");
+        assertThat(metaAnnotatedWith(Rule.class)).hasDescription("meta-annotated with @Rule");
+        assertThat(metaAnnotatedWith(Rule.class.getName())).hasDescription("meta-annotated with @Rule");
     }
 
     @Test
     public void matches_meta_annotation_by_predicate() {
         JavaClass clazz = importClassesWithContext(MetaAnnotatedClass.class, MetaRuntimeRetentionAnnotation.class).get(MetaAnnotatedClass.class);
 
-        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()).apply(clazz))
-                .as("meta-annotated class matches").isTrue();
-        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()).apply(clazz))
-                .as("meta-annotated class matches").isFalse();
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
+                .accepts(clazz);
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
+                .rejects(clazz);
 
-        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")).getDescription())
-                .isEqualTo("meta-annotated with Something");
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")))
+                .hasDescription("meta-annotated with Something");
     }
 
     /**

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotatedTest.java
@@ -40,10 +40,8 @@ public class CanBeAnnotatedTest {
     public void matches_annotation_by_predicate() {
         assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
                 .accepts(importClassWithContext(AnnotatedClass.class));
-        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
-                .rejects(importClassWithContext(AnnotatedClass.class));
-
-        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")))
+        assertThat(annotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse().as("Something")))
+                .rejects(importClassWithContext(AnnotatedClass.class))
                 .hasDescription("annotated with Something");
     }
 
@@ -81,10 +79,8 @@ public class CanBeAnnotatedTest {
 
         assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue()))
                 .accepts(clazz);
-        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse()))
-                .rejects(clazz);
-
-        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysTrue().as("Something")))
+        assertThat(metaAnnotatedWith(DescribedPredicate.<JavaAnnotation>alwaysFalse().as("Something")))
+                .rejects(clazz)
                 .hasDescription("meta-annotated with Something");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasModifiersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasModifiersTest.java
@@ -7,16 +7,15 @@ import com.tngtech.archunit.core.domain.JavaModifier;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class HasModifiersTest {
     @Test
     public void modifier_predicate() {
-        assertThat(modifier(JavaModifier.PRIVATE).apply(hasModifiers(JavaModifier.PRIVATE, JavaModifier.STATIC)))
-                .as("Predicate matches").isTrue();
-        assertThat(modifier(JavaModifier.PRIVATE).apply(hasModifiers(JavaModifier.PUBLIC, JavaModifier.STATIC)))
-                .as("Predicate matches").isFalse();
-        assertThat(modifier(JavaModifier.PRIVATE).getDescription()).isEqualTo("modifier PRIVATE");
+        assertThat(modifier(JavaModifier.PRIVATE))
+                .accepts(hasModifiers(JavaModifier.PRIVATE, JavaModifier.STATIC))
+                .rejects(hasModifiers(JavaModifier.PUBLIC, JavaModifier.STATIC))
+                .hasDescription("modifier PRIVATE");
     }
 
     private static HasModifiers hasModifiers(final JavaModifier... modifiers) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -20,16 +20,16 @@ public class HasNameTest {
         assertMatches("com.tngtech.SomeClass", ".*Clas").isFalse();
         assertMatches("com.tngtech.SomeClass", ".*\\.S.*s").isTrue();
 
-        assertThat(nameMatching(".*foo").getDescription()).isEqualTo("name matching '.*foo'");
+        assertThat(nameMatching(".*foo")).hasDescription("name matching '.*foo'");
     }
 
     @Test
     public void match_against_name() {
-        assertThat(name("some.Foo").apply(newHasName("some.Foo"))).isTrue();
-        assertThat(name("some.Foo").apply(newHasName("some.Fo"))).isFalse();
-        assertThat(name("Foo").apply(newHasName("some.Foo"))).isFalse();
-
-        assertThat(name("some.Foo").getDescription()).isEqualTo("name 'some.Foo'");
+        assertThat(name("some.Foo"))
+                .accepts(newHasName("some.Foo"))
+                .rejects(newHasName("some.Fo"))
+                .hasDescription("name 'some.Foo'");
+        assertThat(name("Foo")).rejects(newHasName("some.Foo"));
     }
 
     private AbstractBooleanAssert assertMatches(String input, String regex) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
@@ -12,10 +12,10 @@ public class HasOwnerTest {
     public void predicate_with_owner() {
         HasOwner<String> hasOwner = hasOwner("owner");
 
-        assertThat(With.owner(startsWith("o")).apply(hasOwner)).as("predicate matches").isTrue();
-        assertThat(With.owner(startsWith("w")).apply(hasOwner)).as("predicate matches").isFalse();
+        assertThat(With.owner(startsWith("o"))).accepts(hasOwner);
+        assertThat(With.owner(startsWith("w"))).rejects(hasOwner);
 
-        assertThat(With.owner(startsWith("foo")).getDescription()).isEqualTo("owner starts with foo");
+        assertThat(With.owner(startsWith("foo"))).hasDescription("owner starts with foo");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
@@ -14,7 +14,6 @@ public class HasOwnerTest {
 
         assertThat(With.owner(startsWith("o"))).accepts(hasOwner);
         assertThat(With.owner(startsWith("w"))).rejects(hasOwner);
-
         assertThat(With.owner(startsWith("foo"))).hasDescription("owner starts with foo");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
@@ -56,16 +56,16 @@ public class HasParameterTypesTest {
     public void predicate_on_parameters_by_Predicate() {
         HasParameterTypes hasParameterTypes = newHasParameterTypes(String.class, Serializable.class);
 
-        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysTrue())).accepts(hasParameterTypes);
-        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse())).rejects(hasParameterTypes);
-
+        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysTrue()))
+                .accepts(hasParameterTypes);
         assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse().as("some text")))
+                .rejects(hasParameterTypes)
                 .hasDescription("raw parameter types some text");
 
-        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysTrue())).accepts(hasParameterTypes);
-        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse())).rejects(hasParameterTypes);
-
+        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysTrue()))
+                .accepts(hasParameterTypes);
         assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse().as("some text")))
+                .rejects(hasParameterTypes)
                 .hasDescription("parameter types some text");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
@@ -11,70 +11,62 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.TestUtils.javaClassList;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.parameterTypes;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.rawParameterTypes;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class HasParameterTypesTest {
     @Test
     public void predicate_on_parameters_by_Class() {
         HasParameterTypes hasParameterTypes = newHasParameterTypes(String.class, Serializable.class);
 
-        assertThat(rawParameterTypes(String.class, Serializable.class).apply(hasParameterTypes)).as("predicate matches").isTrue();
-        assertThat(rawParameterTypes(String.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(Serializable.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(Object.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(String.class, Serializable.class).getDescription())
-                .isEqualTo("raw parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(rawParameterTypes(String.class, Serializable.class))
+                .accepts(hasParameterTypes)
+                .hasDescription("raw parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(rawParameterTypes(String.class)).rejects(hasParameterTypes);
+        assertThat(rawParameterTypes(Serializable.class)).rejects(hasParameterTypes);
+        assertThat(rawParameterTypes(Object.class)).rejects(hasParameterTypes);
 
-        assertThat(parameterTypes(String.class, Serializable.class).apply(hasParameterTypes)).as("predicate matches").isTrue();
-        assertThat(parameterTypes(String.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(parameterTypes(Serializable.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(parameterTypes(Object.class).apply(hasParameterTypes)).as("predicate matches").isFalse();
-        assertThat(parameterTypes(String.class, Serializable.class).getDescription())
-                .isEqualTo("parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(parameterTypes(String.class, Serializable.class))
+                .accepts(hasParameterTypes)
+                .hasDescription("parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(parameterTypes(String.class)).rejects(hasParameterTypes);
+        assertThat(parameterTypes(Serializable.class)).rejects(hasParameterTypes);
+        assertThat(parameterTypes(Object.class)).rejects(hasParameterTypes);
     }
 
     @Test
     public void predicate_on_parameters_by_String() {
         HasParameterTypes hasParameterTypes = newHasParameterTypes(String.class, Serializable.class);
 
-        assertThat(rawParameterTypes(String.class.getName(), Serializable.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isTrue();
-        assertThat(rawParameterTypes(String.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(Serializable.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(Object.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(rawParameterTypes(String.class.getName(), Serializable.class.getName()).getDescription())
-                .isEqualTo("raw parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(rawParameterTypes(String.class.getName(), Serializable.class.getName()))
+                .accepts(hasParameterTypes)
+                .hasDescription("raw parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(rawParameterTypes(String.class.getName())).rejects(hasParameterTypes);
+        assertThat(rawParameterTypes(Serializable.class.getName())).rejects(hasParameterTypes);
+        assertThat(rawParameterTypes(Object.class.getName())).rejects(hasParameterTypes);
 
-        assertThat(parameterTypes(String.class.getName(), Serializable.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isTrue();
-        assertThat(parameterTypes(String.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(parameterTypes(Serializable.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(parameterTypes(Object.class.getName()).apply(hasParameterTypes))
-                .as("predicate matches").isFalse();
-        assertThat(parameterTypes(String.class.getName(), Serializable.class.getName()).getDescription())
-                .isEqualTo("parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(parameterTypes(String.class.getName(), Serializable.class.getName()))
+                .accepts(hasParameterTypes)
+                .hasDescription("parameter types [java.lang.String, java.io.Serializable]");
+        assertThat(parameterTypes(String.class.getName())).rejects(hasParameterTypes);
+        assertThat(parameterTypes(Serializable.class.getName())).rejects(hasParameterTypes);
+        assertThat(parameterTypes(Object.class.getName())).rejects(hasParameterTypes);
     }
 
     @Test
     public void predicate_on_parameters_by_Predicate() {
         HasParameterTypes hasParameterTypes = newHasParameterTypes(String.class, Serializable.class);
 
-        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysTrue()).apply(hasParameterTypes)).isTrue();
-        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse()).apply(hasParameterTypes)).isFalse();
+        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysTrue())).accepts(hasParameterTypes);
+        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse())).rejects(hasParameterTypes);
 
-        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse().as("some text")).getDescription())
-                .isEqualTo("raw parameter types some text");
+        assertThat(rawParameterTypes(DescribedPredicate.<List<JavaClass>>alwaysFalse().as("some text")))
+                .hasDescription("raw parameter types some text");
 
-        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysTrue()).apply(hasParameterTypes)).isTrue();
-        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse()).apply(hasParameterTypes)).isFalse();
+        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysTrue())).accepts(hasParameterTypes);
+        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse())).rejects(hasParameterTypes);
 
-        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse().as("some text")).getDescription())
-                .isEqualTo("parameter types some text");
+        assertThat(parameterTypes(DescribedPredicate.<JavaClassList>alwaysFalse().as("some text")))
+                .hasDescription("parameter types some text");
     }
 
     private HasParameterTypes newHasParameterTypes(final Class<?>... parameters) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
@@ -7,54 +7,57 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.returnType;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class HasReturnTypeTest {
     @Test
     public void predicate_on_return_type_by_Class() {
         HasReturnType hasReturnTypeString = newHasReturnType(importClassWithContext(String.class));
 
-        assertThat(rawReturnType(String.class).apply(hasReturnTypeString)).as("predicate matches").isTrue();
-        assertThat(rawReturnType(Object.class).apply(hasReturnTypeString)).as("predicate matches").isFalse();
-        assertThat(rawReturnType(String.class).getDescription()).isEqualTo("raw return type java.lang.String");
+        assertThat(rawReturnType(String.class))
+                .accepts(hasReturnTypeString)
+                .hasDescription("raw return type java.lang.String");
+        assertThat(rawReturnType(Object.class)).rejects(hasReturnTypeString);
 
-        assertThat(returnType(String.class).apply(hasReturnTypeString)).as("predicate matches").isTrue();
-        assertThat(returnType(Object.class).apply(hasReturnTypeString)).as("predicate matches").isFalse();
-        assertThat(returnType(String.class).getDescription()).isEqualTo("return type java.lang.String");
+        assertThat(returnType(String.class))
+                .accepts(hasReturnTypeString)
+                .hasDescription("return type java.lang.String");
+        assertThat(returnType(Object.class)).rejects(hasReturnTypeString);
     }
 
     @Test
     public void predicate_on_return_type_by_String() {
         HasReturnType hasReturnTypeString = newHasReturnType(importClassWithContext(String.class));
 
-        assertThat(rawReturnType(String.class.getName()).apply(hasReturnTypeString)).as("predicate matches").isTrue();
-        assertThat(rawReturnType(String.class.getSimpleName()).apply(hasReturnTypeString)).as("predicate matches").isFalse();
-        assertThat(rawReturnType(Object.class.getName()).apply(hasReturnTypeString)).as("predicate matches").isFalse();
+        assertThat(rawReturnType(String.class.getName()))
+                .accepts(hasReturnTypeString)
+                .hasDescription("raw return type java.lang.String");
+        assertThat(rawReturnType(String.class.getSimpleName())).rejects(hasReturnTypeString);
+        assertThat(rawReturnType(Object.class.getName())).rejects(hasReturnTypeString);
 
-        assertThat(rawReturnType(String.class.getName()).getDescription()).isEqualTo("raw return type java.lang.String");
 
-        assertThat(returnType(String.class.getName()).apply(hasReturnTypeString)).as("predicate matches").isTrue();
-        assertThat(returnType(String.class.getSimpleName()).apply(hasReturnTypeString)).as("predicate matches").isFalse();
-        assertThat(returnType(Object.class.getName()).apply(hasReturnTypeString)).as("predicate matches").isFalse();
-
-        assertThat(returnType(String.class.getName()).getDescription()).isEqualTo("return type java.lang.String");
+        assertThat(returnType(String.class.getName()))
+                .accepts(hasReturnTypeString)
+                .hasDescription("return type java.lang.String");
+        assertThat(returnType(String.class.getSimpleName())).rejects(hasReturnTypeString);
+        assertThat(returnType(Object.class.getName())).rejects(hasReturnTypeString);
     }
 
     @Test
     public void predicate_on_return_type_by_Predicate() {
         HasReturnType hasReturnTypeString = newHasReturnType(importClassWithContext(String.class));
 
-        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysTrue()).apply(hasReturnTypeString)).isTrue();
-        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse()).apply(hasReturnTypeString)).isFalse();
+        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysTrue())).accepts(hasReturnTypeString);
+        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse())).rejects(hasReturnTypeString);
 
-        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")).getDescription())
-                .isEqualTo("raw return type some text");
+        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")))
+                .hasDescription("raw return type some text");
 
-        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysTrue()).apply(hasReturnTypeString)).isTrue();
-        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse()).apply(hasReturnTypeString)).isFalse();
+        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysTrue())).accepts(hasReturnTypeString);
+        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse())).rejects(hasReturnTypeString);
 
-        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")).getDescription())
-                .isEqualTo("return type some text");
+        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")))
+                .hasDescription("return type some text");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
@@ -47,16 +47,16 @@ public class HasReturnTypeTest {
     public void predicate_on_return_type_by_Predicate() {
         HasReturnType hasReturnTypeString = newHasReturnType(importClassWithContext(String.class));
 
-        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysTrue())).accepts(hasReturnTypeString);
-        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse())).rejects(hasReturnTypeString);
-
+        assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysTrue()))
+                .accepts(hasReturnTypeString);
         assertThat(rawReturnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")))
+                .rejects(hasReturnTypeString)
                 .hasDescription("raw return type some text");
 
-        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysTrue())).accepts(hasReturnTypeString);
-        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse())).rejects(hasReturnTypeString);
-
+        assertThat(returnType(DescribedPredicate.<JavaClass>alwaysTrue()))
+                .accepts(hasReturnTypeString);
         assertThat(returnType(DescribedPredicate.<JavaClass>alwaysFalse().as("some text")))
+                .rejects(hasReturnTypeString)
                 .hasDescription("return type some text");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
@@ -66,9 +66,8 @@ public class HasThrowsClauseTest {
 
         assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysTrue()))
                 .accepts(hasThrowsClause);
-        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse()))
-                .rejects(hasThrowsClause);
         assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse().as("some text")))
+                .rejects(hasThrowsClause)
                 .hasDescription("throws types some text");
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
@@ -13,8 +13,8 @@ import org.junit.runner.RunWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.core.domain.TestUtils.throwsClause;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(DataProviderRunner.class)
 public class HasThrowsClauseTest {
@@ -22,31 +22,24 @@ public class HasThrowsClauseTest {
     public void predicate_throwsClauseWithTypes_by_type() {
         HasThrowsClause<?> hasThrowsClause = newHasThrowsClause(FirstException.class, SecondException.class);
 
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class, SecondException.class).apply(hasThrowsClause))
-                .as("predicate matches")
-                .isTrue();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class).apply(hasThrowsClause)).as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(SecondException.class).apply(hasThrowsClause)).as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(Object.class).apply(hasThrowsClause)).as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class, SecondException.class).getDescription())
-                .isEqualTo(String.format("throws types [%s, %s]", FirstException.class.getName(), SecondException.class.getName()));
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class, SecondException.class))
+                .accepts(hasThrowsClause)
+                .hasDescription(String.format("throws types [%s, %s]", FirstException.class.getName(), SecondException.class.getName()));
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class)).rejects(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(SecondException.class)).rejects(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(Object.class)).rejects(hasThrowsClause);
     }
 
     @Test
     public void predicate_throwsClauseWithTypes_by_type_name() {
         HasThrowsClause<?> hasThrowsClause = newHasThrowsClause(FirstException.class, SecondException.class);
 
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class.getName(), SecondException.class.getName())
-                .apply(hasThrowsClause))
-                .as("predicate matches").isTrue();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class.getName()).apply(hasThrowsClause))
-                .as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(SecondException.class.getName()).apply(hasThrowsClause))
-                .as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(Object.class.getName()).apply(hasThrowsClause))
-                .as("predicate matches").isFalse();
-        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class.getName(), SecondException.class.getName()).getDescription())
-                .isEqualTo(String.format("throws types [%s, %s]", FirstException.class.getName(), SecondException.class.getName()));
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class.getName(), SecondException.class.getName()))
+                .accepts(hasThrowsClause)
+                .hasDescription(String.format("throws types [%s, %s]", FirstException.class.getName(), SecondException.class.getName()));
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(FirstException.class.getName())).rejects(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(SecondException.class.getName())).rejects(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClauseWithTypes(Object.class.getName())).rejects(hasThrowsClause);
     }
 
     @DataProvider
@@ -61,25 +54,22 @@ public class HasThrowsClauseTest {
     @Test
     @UseDataProvider("containing_type_cases")
     public void predicate_containing_type(DescribedPredicate<HasThrowsClause<?>> predicate) {
-        assertThat(predicate.apply(newHasThrowsClause(FirstException.class, SecondException.class)))
-                .as("predicate matches").isTrue();
-
-        assertThat(predicate.apply(newHasThrowsClause(IOException.class, SecondException.class)))
-                .as("predicate matches").isFalse();
-
-        assertThat(predicate.getDescription()).as("predicate description")
-                .isEqualTo("throws clause containing type " + FirstException.class.getName());
+        assertThat(predicate)
+                .accepts(newHasThrowsClause(FirstException.class, SecondException.class))
+                .rejects(newHasThrowsClause(IOException.class, SecondException.class))
+                .hasDescription("throws clause containing type " + FirstException.class.getName());
     }
 
     @Test
     public void predicate_on_parameters_by_Predicate() {
         HasThrowsClause<?> hasThrowsClause = newHasThrowsClause(FirstException.class, SecondException.class);
 
-        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysTrue()).apply(hasThrowsClause)).isTrue();
-        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse()).apply(hasThrowsClause)).isFalse();
-
-        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse().as("some text")).getDescription())
-                .isEqualTo("throws types some text");
+        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysTrue()))
+                .accepts(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse()))
+                .rejects(hasThrowsClause);
+        assertThat(HasThrowsClause.Predicates.throwsClause(DescribedPredicate.<ThrowsClause<?>>alwaysFalse().as("some text")))
+                .hasDescription("throws types some text");
     }
 
     @SafeVarargs

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasTypeTest.java
@@ -33,20 +33,21 @@ public class HasTypeTest {
         HasType matchingField = newHasType(String.class);
         HasType nonmatchingField = newHasType(Object.class);
 
-        assertThat(predicate.apply(matchingField)).as("predicate matches").isTrue();
-        assertThat(predicate.apply(nonmatchingField)).as("predicate matches").isFalse();
+        assertThat(predicate)
+                .accepts(matchingField)
+                .rejects(nonmatchingField);
     }
 
     @Test
     public void predicate_description() {
-        assertThat(HasType.Predicates.rawType(String.class).getDescription()).isEqualTo("raw type " + String.class.getName());
-        assertThat(HasType.Predicates.rawType(String.class.getName()).getDescription()).isEqualTo("raw type " + String.class.getName());
-        assertThat(HasType.Predicates.rawType(equivalentTo(String.class)).getDescription())
-                .isEqualTo("raw type equivalent to " + String.class.getName());
+        assertThat(HasType.Predicates.rawType(String.class)).hasDescription("raw type " + String.class.getName());
+        assertThat(HasType.Predicates.rawType(String.class.getName())).hasDescription("raw type " + String.class.getName());
+        assertThat(HasType.Predicates.rawType(equivalentTo(String.class)))
+                .hasDescription("raw type equivalent to " + String.class.getName());
 
-        assertThat(HasType.Predicates.type(String.class).getDescription()).isEqualTo("type " + String.class.getName());
-        assertThat(HasType.Predicates.type(String.class.getName()).getDescription()).isEqualTo("type " + String.class.getName());
-        assertThat(HasType.Predicates.type(equivalentTo(String.class)).getDescription()).isEqualTo("type equivalent to " + String.class.getName());
+        assertThat(HasType.Predicates.type(String.class)).hasDescription("type " + String.class.getName());
+        assertThat(HasType.Predicates.type(String.class.getName())).hasDescription("type " + String.class.getName());
+        assertThat(HasType.Predicates.type(equivalentTo(String.class))).hasDescription("type equivalent to " + String.class.getName());
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
@@ -52,6 +53,7 @@ import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.lang.CollectsLines;
 import com.tngtech.archunit.lang.ConditionEvent;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -88,6 +90,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static <T> org.assertj.guava.api.OptionalAssert<T> assertThat(Optional<T> optional) {
         return org.assertj.guava.api.Assertions.assertThat(com.google.common.base.Optional.fromNullable(optional.orNull()));
+    }
+
+    public static <T> DescribedPredicateAssertion<T> assertThat(DescribedPredicate<T> predicate) {
+        return new DescribedPredicateAssertion<>(predicate);
     }
 
     public static JavaClassAssertion assertThat(JavaClass javaClass) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DescribedPredicateAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DescribedPredicateAssertion.java
@@ -1,0 +1,33 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DescribedPredicateAssertion<T> extends AbstractObjectAssert<DescribedPredicateAssertion<T>, DescribedPredicate<T>> {
+
+    public DescribedPredicateAssertion(DescribedPredicate<T> predicate) {
+        super(predicate, DescribedPredicateAssertion.class);
+    }
+
+    public DescribedPredicateAssertion<T> accepts(T value) {
+        assertThatPredicateAppliesTo(value).isTrue();
+        return this;
+    }
+
+    public DescribedPredicateAssertion<T> rejects(T value) {
+        assertThatPredicateAppliesTo(value).isFalse();
+        return this;
+    }
+
+    private AbstractBooleanAssert<?> assertThatPredicateAppliesTo(T value) {
+        return assertThat(actual.apply(value)).as("predicate <%s> matches <%s>", actual, value);
+    }
+
+    public DescribedPredicateAssertion<T> hasDescription(String description) {
+        assertThat(actual.getDescription()).as("description of predicate <%s>", actual).isEqualTo(description);
+        return this;
+    }
+}


### PR DESCRIPTION
This does not add a feature to the ArchUnit library, but simplifies its internal tests.

DescribedPredicateAssertion allows to encapsulate

            assertThat(predicate.apply(value1)).as("predicate matches").isTrue();
            assertThat(predicate.apply(value2)).as("predicate matches").isFalse();
            assertThat(predicate.getDescription())).as("description").isEqualTo(description);

in

            assertThat(predicate).accepts(value1).rejects(value2).hasDescription(description);

I've created the pull request for the current `add_member_syntax` branch (where it has been developed), but its actually not related to Issue 38.
You could thus probably also merge it to `master` after `add_member_syntax` has been merged.