### PR TITLE
Add packages

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -27,10 +27,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
  * @param <T> The type of objects the predicate applies to
  */
 @PublicAPI(usage = INHERITANCE)
-public abstract class DescribedPredicate<T> {
+public abstract class DescribedPredicate<T> implements Predicate<T> {
     private final String description;
-
-    public abstract boolean apply(T input);
 
     public DescribedPredicate(String description, Object... params) {
         checkArgument(description != null, "Description must be set");

--- a/archunit/src/main/java/com/tngtech/archunit/base/Predicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Predicate.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.base;
+
+import com.tngtech.archunit.PublicAPI;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+
+@PublicAPI(usage = INHERITANCE)
+public interface Predicate<T> {
+    boolean apply(T input);
+
+    class Defaults {
+        private Defaults() {
+        }
+
+        @PublicAPI(usage = ACCESS)
+        @SuppressWarnings("unchecked")
+        public static <T> Predicate<T> alwaysTrue() {
+            return (Predicate<T>) ALWAYS_TRUE;
+        }
+
+        @PublicAPI(usage = ACCESS)
+        @SuppressWarnings("unchecked")
+        public static <T> Predicate<T> alwaysFalse() {
+            return (Predicate<T>) ALWAYS_FALSE;
+        }
+
+        private static final Predicate<Object> ALWAYS_TRUE = new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                return true;
+            }
+        };
+
+        private static final Predicate<Object> ALWAYS_FALSE = new Predicate<Object>() {
+            @Override
+            public boolean apply(Object input) {
+                return false;
+            }
+        };
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -63,6 +63,7 @@ import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_
 public class JavaClass implements HasName, HasAnnotations, HasModifiers {
     private final Optional<Source> source;
     private final JavaType javaType;
+    private JavaPackage javaPackage;
     private final boolean isInterface;
     private final boolean isEnum;
     private final Set<JavaModifier> modifiers;
@@ -101,6 +102,7 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         isEnum = builder.isEnum();
         modifiers = checkNotNull(builder.getModifiers());
         reflectSupplier = Suppliers.memoize(new ReflectClassSupplier());
+        javaPackage = JavaPackage.simple(this);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -118,15 +120,13 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
         return javaType.getSimpleName();
     }
 
-    /**
-     * Please use {@link #getPackageName()} instead. This name was chosen poorly since a method 'getPackage' should
-     * have returned an object, not a mere String. This method will be refactored in a future release to return
-     * an object.
-     */
-    @Deprecated
     @PublicAPI(usage = ACCESS)
-    public String getPackage() {
-        return getPackageName();
+    public JavaPackage getPackage() {
+        return javaPackage;
+    }
+
+    void setPackage(JavaPackage javaPackage) {
+        this.javaPackage = checkNotNull(javaPackage);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -1047,14 +1047,13 @@ public class JavaClass implements HasName, HasAnnotations, HasModifiers {
             }
         };
 
-        /**
-         * @deprecated This was named poorly, 'getPackage' should return a real object, not a mere String.
-         * Compare notes on {@link #getPackage()}. This function will be refactored to return an object in a future release.
-         * Use {@link #GET_PACKAGE_NAME} instead.
-         */
-        @Deprecated
         @PublicAPI(usage = ACCESS)
-        public static final ChainableFunction<JavaClass, String> GET_PACKAGE = GET_PACKAGE_NAME;
+        public static final ChainableFunction<JavaClass, JavaPackage> GET_PACKAGE = new ChainableFunction<JavaClass, JavaPackage>() {
+            @Override
+            public JavaPackage apply(JavaClass input) {
+                return input.getPackage();
+            }
+        };
 
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaFieldAccess>> GET_FIELD_ACCESSES_FROM_SELF =

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.ChainableFunction;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.base.Predicate;
+import com.tngtech.archunit.core.domain.properties.HasName;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_SIMPLE_NAME;
+import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
+import static java.util.Collections.singleton;
+
+public final class JavaPackage implements HasName {
+    private final String name;
+    private final String relativeName;
+    private final Set<JavaClass> classes;
+    private final Map<String, JavaPackage> subPackages;
+    private Optional<JavaPackage> parent = Optional.absent();
+
+    private JavaPackage(String name, Set<JavaClass> classes, Map<String, JavaPackage> subPackages) {
+        this.name = checkNotNull(name);
+        relativeName = name.substring(name.lastIndexOf(".") + 1);
+        this.classes = ImmutableSet.copyOf(classes);
+        this.subPackages = ImmutableMap.copyOf(subPackages);
+    }
+
+    /**
+     * @return the (full) name of this package, e.g. {@code com.mycompany.myapp}
+     */
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the (relative) name of this package, e.g. {@code lang} for package {@code java.lang}
+     */
+    @PublicAPI(usage = ACCESS)
+    public String getRelativeName() {
+        return relativeName;
+    }
+
+    /**
+     * @return the parent package, e.g. {@code java} for package {@code java.lang}
+     */
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaPackage> getParent() {
+        return parent;
+    }
+
+    private void setParent(JavaPackage parent) {
+        this.parent = Optional.of(parent);
+    }
+
+    /**
+     * @return all classes directly contained in this package, no classes in sub-packages (compare {@link #getAllClasses()})
+     */
+    @PublicAPI(usage = ACCESS)
+    public Iterable<JavaClass> getClasses() {
+        return classes;
+    }
+
+    /**
+     * @return all classes contained in this package or any sub-package (compare {@link #getClasses()})
+     */
+    @PublicAPI(usage = ACCESS)
+    public Iterable<JavaClass> getAllClasses() {
+        ImmutableSet.Builder<JavaClass> result = ImmutableSet.<JavaClass>builder().addAll(classes);
+        for (JavaPackage subPackage : getSubPackages()) {
+            result.addAll(subPackage.getAllClasses());
+        }
+        return result.build();
+    }
+
+    /**
+     * @return all (direct) sub-packages contained in this package, e.g. {@code [java.lang, java.io, ...]} for package {@code java}
+     * (compare {@link #getAllSubPackages()})
+     */
+    @PublicAPI(usage = ACCESS)
+    public Iterable<JavaPackage> getSubPackages() {
+        return subPackages.values();
+    }
+
+    /**
+     * @return all sub-packages including nested sub-packages contained in this package,
+     * e.g. {@code [java.lang, java.lang.annotation, java.util, java.util.concurrent, ...]} for package {@code java}
+     * (compare {@link #getSubPackages()})
+     */
+    @PublicAPI(usage = ACCESS)
+    public Iterable<JavaPackage> getAllSubPackages() {
+        ImmutableSet.Builder<JavaPackage> result = ImmutableSet.builder();
+        for (JavaPackage subPackage : getSubPackages()) {
+            result.add(subPackage);
+            result.addAll(subPackage.getAllSubPackages());
+        }
+        return result.build();
+    }
+
+    /**
+     * @param clazz a Java {@link Class}
+     * @return true if this package (directly) contains a {@link JavaClass} equivalent to the supplied {@link Class}
+     * @see #getClass(Class)
+     * @see #containsClassWithFullyQualifiedName(String)
+     * @see #containsClassWithSimpleName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public boolean containsClass(Class<?> clazz) {
+        return containsClassWithFullyQualifiedName(clazz.getName());
+    }
+
+    /**
+     * @param clazz A Java class
+     * @return the class if contained in this package, otherwise an Exception is thrown
+     * @see #containsClass(Class)
+     * @see #getClassWithFullyQualifiedName(String)
+     * @see #getClassWithSimpleName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getClass(Class<?> clazz) {
+        return getClassWithFullyQualifiedName(clazz.getName());
+    }
+
+    /**
+     * @param className fully qualified name of a Java class
+     * @return true if this package (directly) contains a {@link JavaClass} with the given fully qualified name
+     * @see #getClassWithFullyQualifiedName(String)
+     * @see #containsClass(Class)
+     * @see #containsClassWithSimpleName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public boolean containsClassWithFullyQualifiedName(String className) {
+        return tryGetClassWithFullyQualifiedName(className).isPresent();
+    }
+
+    /**
+     * @param className fully qualified name of a Java class
+     * @return the class if contained in this package, otherwise an Exception is thrown
+     * @see #containsClassWithFullyQualifiedName(String)
+     * @see #getClass(Class)
+     * @see #getClassWithSimpleName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getClassWithFullyQualifiedName(String className) {
+        return getValue(tryGetClassWithFullyQualifiedName(className),
+                "This package does not contain any class with fully qualified name '%s'", className);
+    }
+
+    private Optional<JavaClass> tryGetClassWithFullyQualifiedName(String className) {
+        return tryGetClassWith(GET_NAME.is(equalTo(className)));
+    }
+
+    /**
+     * @param className simple name of a Java class
+     * @return true if this package (directly) contains a {@link JavaClass} with the given simple name
+     * @see #getClassWithSimpleName(String)
+     * @see #containsClass(Class)
+     * @see #containsClassWithFullyQualifiedName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public boolean containsClassWithSimpleName(String className) {
+        return tryGetClassWithSimpleName(className).isPresent();
+    }
+
+    /**
+     * @param className simple name of a Java class
+     * @return the class if contained in this package, otherwise an Exception is thrown
+     * @see #containsClassWithSimpleName(String)
+     * @see #getClass(Class)
+     * @see #getClassWithFullyQualifiedName(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getClassWithSimpleName(String className) {
+        return getValue(tryGetClassWithSimpleName(className),
+                "This package does not contain any class with simple name '%s'", className);
+    }
+
+    private Optional<JavaClass> tryGetClassWithSimpleName(String className) {
+        return tryGetClassWith(GET_SIMPLE_NAME.is(equalTo(className)));
+    }
+
+    private Optional<JavaClass> tryGetClassWith(DescribedPredicate<? super JavaClass> predicate) {
+        Set<JavaClass> matching = getClassesWith(predicate);
+        return matching.size() == 1 ? Optional.of(getOnlyElement(matching)) : Optional.<JavaClass>absent();
+    }
+
+    private Set<JavaClass> getClassesWith(Predicate<? super JavaClass> predicate) {
+        Set<JavaClass> result = new HashSet<>();
+        for (JavaClass javaClass : classes) {
+            if (predicate.apply(javaClass)) {
+                result.add(javaClass);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @param packageName name of a package, may consist of several parts, e.g. {@code some.subpackage}
+     * @return true if this package contains the supplied (sub-) package
+     * @see #getPackage(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public boolean containsPackage(String packageName) {
+        return tryGetPackage(packageName).isPresent();
+    }
+
+    /**
+     * @param packageName name of a package, may consist of several parts, e.g. {@code some.subpackage}
+     * @return the (sub-) package with the given (relative) name; throws an exception if there is no such package contained
+     * @see #containsPackage(String)
+     */
+    @PublicAPI(usage = ACCESS)
+    public JavaPackage getPackage(String packageName) {
+        return getValue(tryGetPackage(packageName), "This package does not contain any sub package '%s'", packageName);
+    }
+
+    private Optional<JavaPackage> tryGetPackage(String packageName) {
+        Deque<String> packageParts = new LinkedList<>(Splitter.on(".").splitToList(packageName));
+        return tryGetPackage(this, packageParts);
+    }
+
+    private Optional<JavaPackage> tryGetPackage(JavaPackage currentPackage, Deque<String> packageParts) {
+        if (packageParts.isEmpty()) {
+            return Optional.of(currentPackage);
+        }
+
+        String next = packageParts.poll();
+        if (!subPackages.containsKey(next)) {
+            return Optional.absent();
+        }
+        JavaPackage child = subPackages.get(next);
+        return child.tryGetPackage(child, packageParts);
+    }
+
+    private <T> T getValue(Optional<T> optional, String errorMessageTemplate, Object... messageParams) {
+        checkArgument(optional.isPresent(), errorMessageTemplate, messageParams);
+        return optional.get();
+    }
+
+    /**
+     * Traverses the package tree visiting each matching class.
+     * @param predicate determines which classes within the package tree should be visited
+     * @param visitor will receive each class in the package tree matching the given predicate
+     * @see #accept(Predicate, PackageVisitor)
+     */
+    @PublicAPI(usage = ACCESS)
+    public void accept(Predicate<? super JavaClass> predicate, ClassVisitor visitor) {
+        for (JavaClass javaClass : getClassesWith(predicate)) {
+            visitor.visit(javaClass);
+        }
+        for (JavaPackage subPackage : getSubPackages()) {
+            subPackage.accept(predicate, visitor);
+        }
+    }
+
+    /**
+     * Traverses the package tree visiting each matching package.
+     * @param predicate determines which packages within the package tree should be visited
+     * @param visitor will receive each package in the package tree matching the given predicate
+     * @see #accept(Predicate, ClassVisitor)
+     */
+    @PublicAPI(usage = ACCESS)
+    public void accept(Predicate<? super JavaPackage> predicate, PackageVisitor visitor) {
+        if (predicate.apply(this)) {
+            visitor.visit(this);
+        }
+        for (JavaPackage subPackage : getSubPackages()) {
+            subPackage.accept(predicate, visitor);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + getName() + "]";
+    }
+
+    static JavaPackage simple(JavaClass javaClass) {
+        String packageName = javaClass.getPackageName();
+        JavaPackage defaultPackage = JavaPackage.from(singleton(javaClass));
+        return packageName.isEmpty() ? defaultPackage : defaultPackage.getPackage(packageName);
+    }
+
+    static JavaPackage from(Iterable<JavaClass> classes) {
+        return new Tree(classes).toJavaPackage();
+    }
+
+    private static class Tree {
+        private final String packageName;
+        private final Map<String, Tree> subPackageTrees;
+        private final Set<JavaClass> classes = new HashSet<>();
+
+        Tree(Iterable<JavaClass> classes) {
+            this("", classes);
+        }
+
+        private Tree(String packageName, Iterable<JavaClass> classes) {
+            this.packageName = packageName;
+
+            SetMultimap<String, JavaClass> childPackages = HashMultimap.create();
+            for (JavaClass clazz : classes) {
+                if (clazz.getPackageName().equals(packageName)) {
+                    this.classes.add(clazz);
+                } else {
+                    String subPackageName = findSubPackageName(packageName, clazz);
+                    childPackages.put(subPackageName, clazz);
+                }
+            }
+            this.subPackageTrees = createSubTrees(packageName, childPackages);
+        }
+
+        private String findSubPackageName(String packageName, JavaClass clazz) {
+            String packageRest = !packageName.isEmpty()
+                    ? clazz.getPackageName().substring(packageName.length() + 1)
+                    : clazz.getPackageName();
+            int indexOfDot = packageRest.indexOf(".");
+            return indexOfDot > 0 ? packageRest.substring(0, indexOfDot) : packageRest;
+        }
+
+        private Map<String, Tree> createSubTrees(String packageName, SetMultimap<String, JavaClass> childPackages) {
+            Map<String, Tree> result = new HashMap<>();
+            for (Map.Entry<String, Collection<JavaClass>> entry : childPackages.asMap().entrySet()) {
+                String childPackageName = joinSkippingEmpty(packageName, entry.getKey());
+                result.put(entry.getKey(), new Tree(childPackageName, entry.getValue()));
+            }
+            return result;
+        }
+
+        private String joinSkippingEmpty(String first, String second) {
+            return !first.isEmpty() ? first + "." + second : second;
+        }
+
+        JavaPackage toJavaPackage() {
+            JavaPackage result = createJavaPackage();
+            for (JavaPackage subPackage : result.getSubPackages()) {
+                subPackage.setParent(result);
+            }
+            return result;
+        }
+
+        private JavaPackage createJavaPackage() {
+            ImmutableMap.Builder<String, JavaPackage> subPackages = ImmutableMap.builder();
+            for (Map.Entry<String, Tree> entry : subPackageTrees.entrySet()) {
+                subPackages.put(entry.getKey(), entry.getValue().toJavaPackage());
+            }
+            return new JavaPackage(packageName, classes, subPackages.build());
+        }
+    }
+
+    interface ClassVisitor {
+        void visit(JavaClass javaClass);
+    }
+
+    interface PackageVisitor {
+        void visit(JavaPackage javaPackage);
+    }
+
+    public static final class Functions {
+        private Functions() {
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaPackage, String> GET_RELATIVE_NAME =
+                new ChainableFunction<JavaPackage, String>() {
+                    @Override
+                    public String apply(JavaPackage javaPackage) {
+                        return javaPackage.getRelativeName();
+                    }
+                };
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaPackage, Iterable<JavaClass>> GET_CLASSES =
+                new ChainableFunction<JavaPackage, Iterable<JavaClass>>() {
+                    @Override
+                    public Iterable<JavaClass> apply(JavaPackage javaPackage) {
+                        return javaPackage.getClasses();
+                    }
+                };
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaPackage, Iterable<JavaPackage>> GET_SUB_PACKAGES =
+                new ChainableFunction<JavaPackage, Iterable<JavaPackage>>() {
+                    @Override
+                    public Iterable<JavaPackage> apply(JavaPackage javaPackage) {
+                        return javaPackage.getSubPackages();
+                    }
+                };
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/base/PredicateTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/PredicateTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.base;
+
+import org.junit.Test;
+
+import static com.tngtech.archunit.base.Predicate.Defaults.alwaysFalse;
+import static com.tngtech.archunit.base.Predicate.Defaults.alwaysTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PredicateTest {
+
+    @Test
+    public void alwaysTrue_works() {
+        assertThat(alwaysTrue().apply(new Object())).isTrue();
+    }
+
+    @Test
+    public void alwaysFalse_works() {
+        assertThat(alwaysFalse().apply(new Object())).isFalse();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -1,13 +1,11 @@
 package com.tngtech.archunit.core.domain;
 
 import java.io.IOException;
-import java.util.List;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.properties.HasName;
-import org.assertj.core.api.AbstractBooleanAssert;
+import com.tngtech.archunit.testutil.Assertions;
+import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -135,7 +133,7 @@ public class DependencyTest {
     }
 
     private static DependencyAssertion assertThatDependency(Class<?> originClass, Class<?> targetClass) {
-        return new DependencyAssertion(createDependency(originClass, targetClass));
+        return Assertions.assertThatDependency(createDependency(originClass, targetClass));
     }
 
     private static Dependency createDependency(Class<?> originClass, Class<?> targetClass) {
@@ -169,83 +167,4 @@ public class DependencyTest {
         }
     }
 
-    private static class DependencyAssertion {
-        private final Dependency input;
-
-        DependencyAssertion(Dependency input) {
-            this.input = input;
-        }
-
-        DependencyAssertion matches(Class<?> originClass, Class<?> targetClass) {
-            for (AbstractBooleanAssert<?> dependencyAssert : dependencyMatches(originClass, targetClass)) {
-                dependencyAssert.isTrue();
-            }
-            return this;
-        }
-
-        DependencyAssertion doesntMatch(Class<?> originClass, Class<?> targetClass) {
-            for (AbstractBooleanAssert<?> dependencyAssert : dependencyMatches(originClass, targetClass)) {
-                dependencyAssert.isFalse();
-            }
-            return this;
-        }
-
-        private List<AbstractBooleanAssert<?>> dependencyMatches(Class<?> originClass, Class<?> targetClass) {
-            return ImmutableList.of(
-                    assertThat(dependency(originClass, targetClass).apply(input))
-                            .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()),
-                    assertThat(dependency(originClass.getName(), targetClass.getName()).apply(input))
-                            .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()),
-                    assertThat(dependency(
-                            HasName.Predicates.name(originClass.getName()),
-                            HasName.Predicates.name(targetClass.getName())).apply(input))
-                            .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()));
-        }
-
-        DependencyAssertion matchesOrigin(Class<?> originClass) {
-            for (AbstractBooleanAssert<?> dependencyOriginAssert : dependencyMatchesOrigin(originClass)) {
-                dependencyOriginAssert.isTrue();
-            }
-            return this;
-        }
-
-        void doesntMatchOrigin(Class<?> originClass) {
-            for (AbstractBooleanAssert<?> dependencyOriginAssert : dependencyMatchesOrigin(originClass)) {
-                dependencyOriginAssert.isFalse();
-            }
-        }
-
-        private List<AbstractBooleanAssert<?>> dependencyMatchesOrigin(Class<?> originClass) {
-            return ImmutableList.of(
-                    assertThat(dependencyOrigin(originClass).apply(input))
-                            .as("Dependency origin matches '%s.class'", originClass.getSimpleName()),
-                    assertThat(dependencyOrigin(originClass.getName()).apply(input))
-                            .as("Dependency origin matches '%s.class'", originClass.getSimpleName()),
-                    assertThat(dependencyOrigin(HasName.Predicates.name(originClass.getName())).apply(input))
-                            .as("Dependency origin matches '%s.class'", originClass.getSimpleName()));
-        }
-
-        DependencyAssertion matchesTarget(Class<?> targetClass) {
-            for (AbstractBooleanAssert<?> dependencyTargetAssert : dependencyMatchesTarget(targetClass)) {
-                dependencyTargetAssert.isTrue();
-            }
-            return this;
-        }
-
-        void doesntMatchTarget(Class<?> targetClass) {
-            for (AbstractBooleanAssert<?> dependencyTargetAssert : dependencyMatchesTarget(targetClass)) {
-                dependencyTargetAssert.isFalse();
-            }
-        }
-
-        private List<AbstractBooleanAssert<?>> dependencyMatchesTarget(Class<?> targetClass) {
-            return ImmutableList.of(
-                    assertThat(dependencyTarget(targetClass).apply(input))
-                            .as("Dependency target matches '%s.class'", targetClass.getSimpleName()),
-                    assertThat(dependencyTarget(targetClass.getName()).apply(input))
-                            .as("Dependency target matches '%s.class'", targetClass.getSimpleName()),
-                    assertThat(dependencyTarget(HasName.Predicates.name(targetClass.getName())).apply(input))
-                            .as("Dependency target matches '%s.class'", targetClass.getSimpleName()));
-        }
-    }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -457,13 +457,14 @@ public class JavaClassTest {
 
     @Test
     public void function_getPackage() {
-        assertThat(JavaClass.Functions.GET_PACKAGE_NAME.apply(importClassWithContext(List.class)))
-                .as("result of GET_PACKAGE_NAME(clazz)")
-                .isEqualTo(List.class.getPackage().getName());
-
-        assertThat(JavaClass.Functions.GET_PACKAGE.apply(importClassWithContext(List.class)))
+        JavaClass javaClass = importClassWithContext(List.class);
+        assertThat(JavaClass.Functions.GET_PACKAGE.apply(javaClass))
                 .as("result of GET_PACKAGE(clazz)")
-                .isEqualTo(List.class.getPackage().getName());
+                .isEqualTo(javaClass.getPackage());
+
+        assertThat(JavaClass.Functions.GET_PACKAGE_NAME.apply(javaClass))
+                .as("result of GET_PACKAGE_NAME(clazz)")
+                .isEqualTo(javaClass.getPackageName());
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
@@ -19,7 +19,7 @@ public class JavaClassesTest {
     private static final ImmutableMap<String, JavaClass> BY_TYPE_NAME = ImmutableMap.of(
             SomeClass.class.getName(), SOME_CLASS,
             SomeOtherClass.class.getName(), SOME_OTHER_CLASS);
-    public static final JavaClasses ALL_CLASSES = new JavaClasses(BY_TYPE_NAME, "classes");
+    public static final JavaClasses ALL_CLASSES = new JavaClasses(JavaPackage.from(BY_TYPE_NAME.values()), BY_TYPE_NAME);
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -1,0 +1,269 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Predicate;
+import com.tngtech.archunit.core.domain.JavaPackage.ClassVisitor;
+import com.tngtech.archunit.core.domain.JavaPackage.PackageVisitor;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_SIMPLE_NAME;
+import static com.tngtech.archunit.core.domain.JavaPackage.Functions.GET_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaPackage.Functions.GET_RELATIVE_NAME;
+import static com.tngtech.archunit.core.domain.JavaPackage.Functions.GET_SUB_PACKAGES;
+import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
+import static com.tngtech.archunit.testutil.Assertions.assertThatPackages;
+import static java.util.regex.Pattern.quote;
+
+public class JavaPackageTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void creates_default_package() {
+        JavaPackage defaultPackage = importDefaultPackage();
+
+        assertThat(defaultPackage.getName()).isEmpty();
+        assertThat(defaultPackage.getRelativeName()).isEmpty();
+        assertThat(defaultPackage.containsPackage("any")).isFalse();
+        assertThat(defaultPackage.containsClass(Object.class)).isFalse();
+        assertThat(defaultPackage.containsClassWithFullyQualifiedName("some.SomeClass")).isFalse();
+        assertThat(defaultPackage.containsClassWithSimpleName("SomeClass")).isFalse();
+    }
+
+    @Test
+    public void rejects_retrieving_non_existing_subpackages() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("does not contain");
+        thrown.expectMessage("some.pkg");
+
+        importDefaultPackage().getPackage("some.pkg");
+    }
+
+    @Test
+    public void rejects_retrieving_non_existing_classes_by_class_object() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("does not contain");
+        thrown.expectMessage(Object.class.getName());
+
+        importDefaultPackage().getClass(Object.class);
+    }
+
+    @Test
+    public void rejects_retrieving_non_existing_classes_by_fully_qualified_name() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("does not contain");
+        thrown.expectMessage(Object.class.getName());
+
+        importDefaultPackage().getClassWithFullyQualifiedName(Object.class.getName());
+    }
+
+    @Test
+    public void rejects_retrieving_non_existing_classes_by_simple_name() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("does not contain");
+        thrown.expectMessage(Object.class.getSimpleName());
+
+        importDefaultPackage().getClassWithSimpleName(Object.class.getSimpleName());
+    }
+
+    @Test
+    public void creates_simple_package() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+
+        assertThat(defaultPackage.containsPackage("java.lang"))
+                .as("default package contains 'java.lang'").isTrue();
+
+        JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
+
+        assertThat(javaPackage.getName()).isEqualTo("java.lang");
+        assertThat(javaPackage.getRelativeName()).isEqualTo("lang");
+        assertThatClasses(javaPackage.getClasses()).contain(Object.class, String.class);
+    }
+
+    @Test
+    public void retrieves_class_by_class_object() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+
+        assertThat(defaultPackage.getPackage("java").containsClass(Object.class))
+                .as("package 'java' contains java.lang.Object").isFalse();
+
+        JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
+
+        assertThat(javaPackage.containsClass(Object.class))
+                .as("java.lang.Object is reported contained by class object").isTrue();
+        assertThat(javaPackage.getClass(Object.class).isEquivalentTo(Object.class))
+                .as("java.lang.Object is returned by class object").isTrue();
+    }
+
+    @Test
+    public void retrieves_class_by_fully_qualified_name() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+
+        assertThat(defaultPackage.getPackage("java").containsClassWithFullyQualifiedName(Object.class.getName()))
+                .as("package 'java' contains java.lang.Object").isFalse();
+
+        JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
+
+        assertThat(javaPackage.containsClassWithFullyQualifiedName(Object.class.getName()))
+                .as("java.lang.Object is reported contained by fully qualified name").isTrue();
+        assertThat(javaPackage.getClassWithFullyQualifiedName(Object.class.getName()).isEquivalentTo(Object.class))
+                .as("java.lang.Object is returned by fully qualified name").isTrue();
+    }
+
+    @Test
+    public void retrieves_class_by_simple_class_name() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+
+        assertThat(defaultPackage.getPackage("java").containsClassWithSimpleName(Object.class.getSimpleName()))
+                .as("package 'java' contains java.lang.Object").isFalse();
+
+        JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
+
+        assertThat(javaPackage.containsClassWithSimpleName(Object.class.getSimpleName()))
+                .as("java.lang.Object is reported contained by simple name").isTrue();
+        assertThat(javaPackage.getClassWithSimpleName(Object.class.getSimpleName()).isEquivalentTo(Object.class))
+                .as("java.lang.Object is returned by simple name").isTrue();
+    }
+
+    @Test
+    public void creates_empty_middle_packages() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class);
+
+        assertThat(defaultPackage.containsPackage("java")).as("default package contains 'java'").isTrue();
+
+        JavaPackage java = defaultPackage.getPackage("java");
+        assertThat(java.containsPackage("lang")).isTrue();
+        assertThat(java.getPackage("lang").getName()).isEqualTo("java.lang");
+    }
+
+    @Test
+    public void creates_parent_packages() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class);
+        assertThat(defaultPackage.getParent()).as("parent of default package").isAbsent();
+
+        JavaPackage javaLang = defaultPackage.getPackage("java.lang");
+
+        JavaPackage java = javaLang.getParent().get();
+        assertThat(java.getName()).isEqualTo("java");
+        assertThat(java.containsPackage("lang")).as("package 'java' contains 'lang'").isTrue();
+    }
+
+    @Test
+    public void iterates_sub_packages() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, Collection.class, File.class, Security.class);
+
+        JavaPackage java = defaultPackage.getPackage("java");
+
+        assertThatPackages(java.getSubPackages()).containOnlyRelativeNames("lang", "util", "io", "security");
+        assertThatPackages(java.getSubPackages()).containOnlyNames("java.lang", "java.util", "java.io", "java.security");
+    }
+
+    @Test
+    public void iterates_all_classes() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class, Annotation.class, Field.class, Security.class);
+
+        JavaPackage javaLang = defaultPackage.getPackage("java.lang");
+
+        assertThatClasses(javaLang.getAllClasses()).contain(Object.class, String.class, Annotation.class, Field.class);
+    }
+
+    @Test
+    public void iterates_all_sub_packages() {
+        JavaPackage defaultPackage = importDefaultPackage(
+                Object.class, Annotation.class, Collection.class, BlockingQueue.class, Security.class, getClass());
+
+        JavaPackage java = defaultPackage.getPackage("java");
+
+        assertThatPackages(java.getAllSubPackages()).matchOnlyPackagesOf(
+                Object.class, Annotation.class, Collection.class, BlockingQueue.class, Security.class);
+    }
+
+    @Test
+    public void visits_classes() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class, File.class, Serializable.class, Security.class);
+
+        final List<JavaClass> visitedClasses = new ArrayList<>();
+        defaultPackage.accept(startsWith("S"), new ClassVisitor() {
+            @Override
+            public void visit(JavaClass javaClass) {
+                visitedClasses.add(javaClass);
+            }
+        });
+
+        assertThatClasses(visitedClasses).matchInAnyOrder(String.class, Serializable.class, Security.class);
+    }
+
+    @Test
+    public void visits_packages() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, Annotation.class, File.class, Security.class);
+
+        final List<JavaPackage> visitedPackages = new ArrayList<>();
+        defaultPackage.accept(nameContains(".lang"), new PackageVisitor() {
+            @Override
+            public void visit(JavaPackage javaPackage) {
+                visitedPackages.add(javaPackage);
+            }
+        });
+
+        assertThatPackages(visitedPackages).matchOnlyPackagesOf(Object.class, Annotation.class);
+    }
+
+    @Test
+    public void function_GET_RELATIVE_NAME() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class);
+
+        String name = GET_RELATIVE_NAME.apply(defaultPackage.getPackage("java.lang"));
+
+        assertThat(name).isEqualTo("lang");
+    }
+
+    @Test
+    public void function_GET_CLASSES() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class, Collection.class);
+
+        Iterable<JavaClass> classes = GET_CLASSES.apply(defaultPackage.getPackage("java.lang"));
+
+        assertThatClasses(classes).matchInAnyOrder(Object.class, String.class);
+    }
+
+    @Test
+    public void function_GET_SUB_PACKAGES() {
+        JavaPackage defaultPackage = importDefaultPackage(Object.class, Annotation.class, Field.class, Collection.class);
+
+        Iterable<JavaPackage> packages = GET_SUB_PACKAGES.apply(defaultPackage.getPackage("java.lang"));
+
+        assertThatPackages(packages).matchOnlyPackagesOf(Annotation.class, Field.class);
+    }
+
+    private Predicate<? super JavaPackage> nameContains(String infix) {
+        return HasName.Predicates.nameMatching(".*" + quote(infix) + ".*");
+    }
+
+    private DescribedPredicate<JavaClass> startsWith(final String prefix) {
+        return GET_SIMPLE_NAME.is(new DescribedPredicate<String>("starts with '%s'", prefix) {
+            @Override
+            public boolean apply(String input) {
+                return input.startsWith(prefix);
+            }
+        });
+    }
+
+    private JavaPackage importDefaultPackage(Class<?>... classes) {
+        return JavaPackage.from(importClassesWithContext(classes));
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -78,12 +78,12 @@ public class TestUtils {
     public static JavaClasses importClassesWithContext(Class<?>... classes) {
         JavaClasses importedHierarchy = importHierarchies(classes);
         final List<String> classNames = JavaClass.namesOf(classes);
-        return JavaClasses.of(importedHierarchy.that(new DescribedPredicate<JavaClass>(importedHierarchy.getDescription()) {
+        return importedHierarchy.that(new DescribedPredicate<JavaClass>(importedHierarchy.getDescription()) {
             @Override
             public boolean apply(JavaClass input) {
                 return classNames.contains(input.getName());
             }
-        }));
+        });
     }
 
     public static JavaMethodCallBuilder newMethodCallBuilder(JavaMethod origin, MethodCallTarget target, int lineNumber) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/first/First1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/first/First1.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.core.domain.packageexamples.first;
+
+import com.tngtech.archunit.core.domain.packageexamples.second.Second1;
+
+public class First1 {
+    Second1 second1;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/first/First2.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/first/First2.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.core.domain.packageexamples.first;
+
+import com.tngtech.archunit.core.domain.packageexamples.second.sub.SecondSub1;
+
+public class First2 {
+    SecondSub1 secondSub1;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/ClassDependingOnOtherSecondClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/ClassDependingOnOtherSecondClass.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.domain.packageexamples.second;
+
+public class ClassDependingOnOtherSecondClass {
+    Second1 second1;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second1.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.core.domain.packageexamples.second;
+
+import com.tngtech.archunit.core.domain.packageexamples.first.First2;
+
+public class Second1 {
+    First2 first2;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/sub/SecondSub1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/sub/SecondSub1.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.core.domain.packageexamples.second.sub;
+
+import com.tngtech.archunit.core.domain.packageexamples.first.First1;
+import com.tngtech.archunit.core.domain.packageexamples.third.sub.ThirdSub1;
+
+public class SecondSub1 extends ThirdSub1 {
+    SecondSub1(First1 first1) {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/third/sub/ThirdSub1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/third/sub/ThirdSub1.java
@@ -1,0 +1,6 @@
+package com.tngtech.archunit.core.domain.packageexamples.third.sub;
+
+import com.tngtech.archunit.core.domain.packageexamples.first.First1;
+
+public class ThirdSub1 extends First1 {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/unrelated/AnyClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/unrelated/AnyClass.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.domain.packageexamples.unrelated;
+
+public class AnyClass {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -55,6 +55,7 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaPackage;
 import com.tngtech.archunit.core.domain.Source;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.core.domain.properties.HasName;
@@ -323,6 +324,16 @@ public class ClassFileImporterTest {
         JavaClasses classes = new ClassFileImporter().importPackagesOf(File.class);
 
         assertThatClasses(classes).contain(File.class);
+    }
+
+    @Test
+    public void creates_JavaPackages_for_each_JavaClass() {
+        JavaClasses classes = new ClassFileImporter().importPackagesOf(getClass());
+
+        JavaPackage javaPackage = classes.get(SomeClass.class).getPackage();
+
+        assertThat(javaPackage.containsClass(SomeEnum.class)).as("Package contains " + SomeEnum.class).isTrue();
+        assertThatClasses(javaPackage.getParent().get().getClasses()).contain(getClass());
     }
 
     @Test
@@ -1873,7 +1884,7 @@ public class ClassFileImporterTest {
         classes = classFileImporter.importUrl(independentClasspathRule.getOnlyUrl());
         assertThat(classes).extracting("name")
                 .containsAll(independentClasspathRule.getNamesOfClasses());
-        assertThat(classes).extracting("package")
+        assertThat(classes).extracting("packageName")
                 .containsAll(independentClasspathRule.getPackagesOfClasses());
 
         classes = classFileImporter.importPackages(packageToImport);

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassList;
@@ -47,6 +48,8 @@ import com.tngtech.archunit.testutil.assertion.JavaFieldAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodsAssertion;
+import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
+import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaPackagesAssertion;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIterableAssert;
@@ -143,6 +146,14 @@ public class Assertions extends org.assertj.core.api.Assertions {
     @SuppressWarnings("unchecked") // covariant
     public static AccessesAssertion assertThatAccesses(Collection<? extends JavaAccess<?>> accesses) {
         return new AccessesAssertion((Collection<JavaAccess<?>>) accesses);
+    }
+
+    public static DependencyAssertion assertThatDependency(Dependency dependency) {
+        return new DependencyAssertion(dependency);
+    }
+
+    public static DependenciesAssertion assertThatDependencies(Iterable<Dependency> dependencies) {
+        return new DependenciesAssertion(dependencies);
     }
 
     public static ExpectedAccessCreation expectedAccess() {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -33,17 +33,21 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaPackage;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.lang.CollectsLines;
 import com.tngtech.archunit.lang.ConditionEvent;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
+import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaConstructorAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodsAssertion;
+import com.tngtech.archunit.testutil.assertion.JavaPackagesAssertion;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -61,6 +65,7 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.TestUtils.resolvedTargetFrom;
 import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
 import static com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion.propertiesOf;
+import static com.tngtech.archunit.testutil.assertion.JavaPackagesAssertion.sortByName;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     public static ConditionEventsAssert assertThat(ConditionEvents events) {
@@ -77,6 +82,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static JavaClassesAssertion assertThatClasses(Iterable<JavaClass> javaClasses) {
         return new JavaClassesAssertion(javaClasses);
+    }
+
+    public static JavaPackagesAssertion assertThatPackages(Iterable<JavaPackage> javaPackages) {
+        return new JavaPackagesAssertion(javaPackages);
     }
 
     public static JavaMethodsAssertion assertThatMethods(Iterable<JavaMethod> methods) {
@@ -213,12 +222,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
         private static JavaClass[] sort(Iterable<JavaClass> actual) {
             JavaClass[] result = Iterables.toArray(actual, JavaClass.class);
-            Arrays.sort(result, new Comparator<JavaClass>() {
-                @Override
-                public int compare(JavaClass o1, JavaClass o2) {
-                    return o1.getName().compareTo(o2.getName());
-                }
-            });
+            sortByName(result);
             return result;
         }
 
@@ -279,7 +283,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
                     .isEqualTo(clazz.getName());
             assertThat(actual.getSimpleName()).as("Simple name of " + actual)
                     .isEqualTo(ensureArrayName(clazz.getSimpleName()));
-            assertThat(actual.getPackage()).as("Package of " + actual)
+            assertThat(actual.getPackage().getName()).as("Package of " + actual)
                     .isEqualTo(clazz.getPackage() != null ? clazz.getPackage().getName() : "");
             assertThat(actual.getPackageName()).as("Package name of " + actual)
                     .isEqualTo(clazz.getPackage() != null ? clazz.getPackage().getName() : "");
@@ -344,8 +348,8 @@ public class Assertions extends org.assertj.core.api.Assertions {
         }
     }
 
-    public static class ThrowsDeclarationAssertion extends AbstractObjectAssert<ThrowsDeclarationAssertion, ThrowsDeclaration> {
-        private ThrowsDeclarationAssertion(ThrowsDeclaration throwsDeclaration) {
+    public static class ThrowsDeclarationAssertion extends AbstractObjectAssert<ThrowsDeclarationAssertion, ThrowsDeclaration<?>> {
+        private ThrowsDeclarationAssertion(ThrowsDeclaration<?> throwsDeclaration) {
             super(throwsDeclaration, ThrowsDeclarationAssertion.class);
         }
 
@@ -356,7 +360,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
     }
 
     public static class ThrowsClauseAssertion extends
-            AbstractIterableAssert<ThrowsClauseAssertion, ThrowsClause<?>, ThrowsDeclaration, ObjectAssert<ThrowsDeclaration>> {
+            AbstractIterableAssert<ThrowsClauseAssertion, ThrowsClause<?>, ThrowsDeclaration<?>, ObjectAssert<ThrowsDeclaration<?>>> {
         private ThrowsClauseAssertion(ThrowsClause<?> throwsClause) {
             super(throwsClause, ThrowsClauseAssertion.class);
         }
@@ -369,8 +373,8 @@ public class Assertions extends org.assertj.core.api.Assertions {
         }
 
         @Override
-        protected ObjectAssert<ThrowsDeclaration> toAssert(ThrowsDeclaration value, String description) {
-            return new ObjectAssertFactory<ThrowsDeclaration>().createAssert(value).as(description);
+        protected ObjectAssert<ThrowsDeclaration<?>> toAssert(ThrowsDeclaration<?> value, String description) {
+            return new ObjectAssertFactory<ThrowsDeclaration<?>>().createAssert(value).as(description);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
@@ -1,0 +1,53 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.Dependency;
+import org.assertj.core.api.AbstractIterableAssert;
+
+public class DependenciesAssertion extends AbstractIterableAssert<
+        DependenciesAssertion, Iterable<? extends Dependency>, Dependency, DependencyAssertion> {
+
+    public DependenciesAssertion(Iterable<Dependency> dependencies) {
+        super(dependencies, DependenciesAssertion.class);
+    }
+
+    @Override
+    protected DependencyAssertion toAssert(Dependency value, String description) {
+        return new DependencyAssertion(value).as(description);
+    }
+
+    public DependenciesAssertion contain(Class<?> expectedOrigin, Class<?> expectedTarget) {
+        if (!thisContains(expectedOrigin, expectedTarget)) {
+            throw new AssertionError(String.format("%s is not contained in %s",
+                    formatDependency(expectedOrigin, expectedTarget), actual));
+        }
+        return this;
+    }
+
+    private boolean thisContains(Class<?> expectedOrigin, Class<?> expectedTarget) {
+        for (Dependency dependency : actual) {
+            if (dependency.getOriginClass().isEquivalentTo(expectedOrigin) && dependency.getTargetClass().isEquivalentTo(expectedTarget)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public DependenciesAssertion doesNotContain(Class<?> expectedOrigin, Class<?> expectedTarget) {
+        if (thisContains(expectedOrigin, expectedTarget)) {
+            throw new AssertionError(String.format("%s is contained in %s",
+                    formatDependency(expectedOrigin, expectedTarget), actual));
+        }
+        return this;
+    }
+
+    public DependenciesAssertion containOnly(Class<?> expectedOrigin, Class<?> expectedTarget) {
+        for (Dependency dependency : actual) {
+            toAssert(dependency, dependency.getDescription()).matches(expectedOrigin, expectedTarget);
+        }
+        return this;
+    }
+
+    private Object formatDependency(Class<?> origin, Class<?> target) {
+        return String.format("Dependency [%s -> %s]", origin.getName(), target.getName());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependencyAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependencyAssertion.java
@@ -1,0 +1,92 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
+
+import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependency;
+import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
+import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyTarget;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyAssertion extends AbstractAssert<DependencyAssertion, Dependency> {
+    public DependencyAssertion(Dependency actual) {
+        super(actual, DependencyAssertion.class);
+    }
+
+    public DependencyAssertion matches(Class<?> originClass, Class<?> targetClass) {
+        for (AbstractBooleanAssert<?> dependencyAssert : dependencyMatches(originClass, targetClass)) {
+            dependencyAssert.isTrue();
+        }
+        return this;
+    }
+
+    public DependencyAssertion doesntMatch(Class<?> originClass, Class<?> targetClass) {
+        for (AbstractBooleanAssert<?> dependencyAssert : dependencyMatches(originClass, targetClass)) {
+            dependencyAssert.isFalse();
+        }
+        return this;
+    }
+
+    private List<AbstractBooleanAssert<?>> dependencyMatches(Class<?> originClass, Class<?> targetClass) {
+        return ImmutableList.of(
+                assertThat(dependency(originClass, targetClass).apply(actual))
+                        .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()),
+                assertThat(dependency(originClass.getName(), targetClass.getName()).apply(actual))
+                        .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()),
+                assertThat(dependency(
+                        HasName.Predicates.name(originClass.getName()),
+                        HasName.Predicates.name(targetClass.getName())).apply(actual))
+                        .as("Dependency matches '%s.class' -> '%s.class'", originClass.getSimpleName(), targetClass.getSimpleName()));
+    }
+
+    public DependencyAssertion matchesOrigin(Class<?> originClass) {
+        for (AbstractBooleanAssert<?> dependencyOriginAssert : dependencyMatchesOrigin(originClass)) {
+            dependencyOriginAssert.isTrue();
+        }
+        return this;
+    }
+
+    public void doesntMatchOrigin(Class<?> originClass) {
+        for (AbstractBooleanAssert<?> dependencyOriginAssert : dependencyMatchesOrigin(originClass)) {
+            dependencyOriginAssert.isFalse();
+        }
+    }
+
+    private List<AbstractBooleanAssert<?>> dependencyMatchesOrigin(Class<?> originClass) {
+        return ImmutableList.of(
+                assertThat(dependencyOrigin(originClass).apply(actual))
+                        .as("Dependency origin matches '%s.class'", originClass.getSimpleName()),
+                assertThat(dependencyOrigin(originClass.getName()).apply(actual))
+                        .as("Dependency origin matches '%s.class'", originClass.getSimpleName()),
+                assertThat(dependencyOrigin(HasName.Predicates.name(originClass.getName())).apply(actual))
+                        .as("Dependency origin matches '%s.class'", originClass.getSimpleName()));
+    }
+
+    public DependencyAssertion matchesTarget(Class<?> targetClass) {
+        for (AbstractBooleanAssert<?> dependencyTargetAssert : dependencyMatchesTarget(targetClass)) {
+            dependencyTargetAssert.isTrue();
+        }
+        return this;
+    }
+
+    public void doesntMatchTarget(Class<?> targetClass) {
+        for (AbstractBooleanAssert<?> dependencyTargetAssert : dependencyMatchesTarget(targetClass)) {
+            dependencyTargetAssert.isFalse();
+        }
+    }
+
+    private List<AbstractBooleanAssert<?>> dependencyMatchesTarget(Class<?> targetClass) {
+        return ImmutableList.of(
+                assertThat(dependencyTarget(targetClass).apply(actual))
+                        .as("Dependency target matches '%s.class'", targetClass.getSimpleName()),
+                assertThat(dependencyTarget(targetClass.getName()).apply(actual))
+                        .as("Dependency target matches '%s.class'", targetClass.getSimpleName()),
+                assertThat(dependencyTarget(HasName.Predicates.name(targetClass.getName())).apply(actual))
+                        .as("Dependency target matches '%s.class'", targetClass.getSimpleName()));
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaPackagesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaPackagesAssertion.java
@@ -1,0 +1,62 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.tngtech.archunit.core.domain.JavaPackage;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.base.Guava.toGuava;
+import static com.tngtech.archunit.core.domain.JavaPackage.Functions.GET_RELATIVE_NAME;
+import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaPackagesAssertion extends AbstractObjectAssert<JavaPackagesAssertion, JavaPackage[]> {
+    public JavaPackagesAssertion(Iterable<JavaPackage> javaPackages) {
+        super(sort(javaPackages), JavaPackagesAssertion.class);
+    }
+
+    private static JavaPackage[] sort(Iterable<JavaPackage> actual) {
+        JavaPackage[] result = Iterables.toArray(actual, JavaPackage.class);
+        sortByName(result);
+        return result;
+    }
+
+    public void matchOnlyPackagesOf(Class<?>... classes) {
+        HashSet<String> expectedNames = new HashSet<>();
+        for (Class<?> clazz : classes) {
+            expectedNames.add(clazz.getPackage().getName());
+        }
+        assertThat(getActualNames()).containsOnlyElementsOf(expectedNames);
+    }
+
+    public void containOnlyRelativeNames(String... relativeNames) {
+        assertThat(getActualRelativeNames()).containsOnly(relativeNames);
+    }
+
+    public void containOnlyNames(String... names) {
+        assertThat(getActualNames()).containsOnly(names);
+    }
+
+    private ImmutableSet<String> getActualNames() {
+        return FluentIterable.from(actual).transform(toGuava(GET_NAME)).toSet();
+    }
+
+    private ImmutableSet<String> getActualRelativeNames() {
+        return FluentIterable.from(actual).transform(toGuava(GET_RELATIVE_NAME)).toSet();
+    }
+
+    public static <T extends HasName> void sortByName(T[] result) {
+        Arrays.sort(result, new Comparator<HasName>() {
+            @Override
+            public int compare(HasName o1, HasName o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds more sophisticated `JavaPackage` objects to ArchUnit's core domain. `JavaClasses` now offer `getDefaultPackage()` and `getPackage(name)` and each `JavaClass` offers its own `getPackage()`.
The old deprecated method `String getPackage()` was thus replaced by `JavaPackage getPackage()`.

`JavaPackage` provides a way neater API allowing to query for neighbor classes or classes in sub-packages and quickly querying all dependencies of a package.

I've somewhat measured performance and heap (on ca 50000 classes from the JDK) and I found the impact to create the packages to be negligible, so I did not create some lazy solution (like a supplier) for this, but instead always eagerly create the packages.

Resolves: #82 