### PR TITLE
Make array type return package name of their component type

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/cycle/complexcycles/slice1/UnrelatedEnum.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/cycle/complexcycles/slice1/UnrelatedEnum.java
@@ -1,0 +1,14 @@
+package com.tngtech.archunit.example.cycle.complexcycles.slice1;
+
+// This was just added for the integration tests since it creates some synthetic byte code
+@SuppressWarnings("SwitchStatementWithTooFewBranches")
+public enum UnrelatedEnum {
+    INSTANCE;
+
+    static void doSomeSwitching(UnrelatedEnum unrelatedEnum) {
+        switch (unrelatedEnum) {
+            case INSTANCE:
+                throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -223,11 +223,11 @@ public interface JavaType {
             ObjectType(String fullName) {
                 super(fullName, ensureSimpleName(fullName), createPackage(fullName));
             }
+        }
 
-            private static String createPackage(String fullName) {
-                int packageEnd = fullName.lastIndexOf('.');
-                return packageEnd >= 0 ? fullName.substring(0, packageEnd) : "";
-            }
+        private static String createPackage(String fullName) {
+            int packageEnd = fullName.lastIndexOf('.');
+            return packageEnd >= 0 ? fullName.substring(0, packageEnd) : "";
         }
 
         private static class PrimitiveType extends AbstractType {
@@ -249,7 +249,12 @@ public interface JavaType {
 
         private static class ArrayType extends AbstractType {
             ArrayType(String fullName) {
-                super(fullName, createSimpleName(fullName), "");
+                super(fullName, createSimpleName(fullName), createPackageOfComponentType(fullName));
+            }
+
+            private static String createPackageOfComponentType(String fullName) {
+                String componentType = getCanonicalName(fullName).replace("[]", "");
+                return createPackage(componentType);
             }
 
             private static String createSimpleName(String fullName) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
@@ -225,10 +225,9 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
         }
 
         private Slices createSlices(JavaClasses classes) {
-            SliceBuilders sliceBuilders = new SliceBuilders();
+            SliceBuilders sliceBuilders = new SliceBuilders(sliceAssignment);
             for (JavaClass clazz : classes) {
-                List<String> identifierParts = sliceAssignment.getIdentifierOf(clazz).getParts();
-                sliceBuilders.add(identifierParts, clazz);
+                sliceBuilders.add(clazz);
             }
             return new Slices(sliceBuilders.build());
         }
@@ -295,18 +294,22 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
 
     private static class SliceBuilders {
         private final Map<List<String>, Slice.Builder> sliceBuilders = new HashMap<>();
+        private final SliceAssignment sliceAssignment;
 
-        void add(List<String> identifierParts, JavaClass clazz) {
-            if (!identifierParts.isEmpty()) {
-                put(identifierParts, clazz);
-            }
+        SliceBuilders(SliceAssignment sliceAssignment) {
+            this.sliceAssignment = sliceAssignment;
         }
 
-        private void put(List<String> matchingGroups, JavaClass clazz) {
-            if (!sliceBuilders.containsKey(matchingGroups)) {
-                sliceBuilders.put(matchingGroups, Slice.Builder.from(matchingGroups));
+        void add(JavaClass clazz) {
+            List<String> identifierParts = sliceAssignment.getIdentifierOf(clazz).getParts();
+            if (identifierParts.isEmpty()) {
+                return;
             }
-            sliceBuilders.get(matchingGroups).addClass(clazz);
+
+            if (!sliceBuilders.containsKey(identifierParts)) {
+                sliceBuilders.put(identifierParts, Slice.Builder.from(identifierParts, sliceAssignment));
+            }
+            sliceBuilders.get(identifierParts).addClass(clazz);
         }
 
         Set<Slice> build() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 import java.lang.annotation.Retention;
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -122,14 +121,6 @@ public class JavaClassTest {
         JavaClass anonymous = importClassWithContext(ClassWithInnerClass.Inner.class);
 
         assertThat(anonymous.getPackageName()).isEqualTo(getClass().getPackage().getName());
-    }
-
-    @Test
-    public void Array_class_has_default_package() {
-        JavaClass arrayType = importClassWithContext(Arrays.class)
-                .getMethod("toString", Object[].class).getRawParameterTypes().get(0);
-
-        assertThat(arrayType.getPackageName()).isEmpty();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassAccessingOneDimensionalArray.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassAccessingOneDimensionalArray.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.core.importer.testexamples.arrays;
+
+public class ClassAccessingOneDimensionalArray {
+    ClassUsedInArray[] array;
+
+    ClassUsedInArray access() {
+        return array[1];
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassAccessingTwoDimensionalArray.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassAccessingTwoDimensionalArray.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.core.importer.testexamples.arrays;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class ClassAccessingTwoDimensionalArray {
+    ClassUsedInArray[][] array;
+
+    ClassUsedInArray access() {
+        return array[1][1];
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassUsedInArray.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/arrays/ClassUsedInArray.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.arrays;
+
+public class ClassUsedInArray {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -47,6 +47,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.testutil.assertion.ArchConditionAssertion;
 import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
 import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
+import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaCodeUnitAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaConstructorAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldAssertion;
@@ -56,7 +57,6 @@ import com.tngtech.archunit.testutil.assertion.JavaMembersAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMethodsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaPackagesAssertion;
-import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -321,9 +321,9 @@ public class Assertions extends org.assertj.core.api.Assertions {
             assertThat(actual.getSimpleName()).as("Simple name of " + actual)
                     .isEqualTo(ensureArrayName(clazz.getSimpleName()));
             assertThat(actual.getPackage().getName()).as("Package of " + actual)
-                    .isEqualTo(clazz.getPackage() != null ? clazz.getPackage().getName() : "");
+                    .isEqualTo(getExpectedPackageName(clazz));
             assertThat(actual.getPackageName()).as("Package name of " + actual)
-                    .isEqualTo(clazz.getPackage() != null ? clazz.getPackage().getName() : "");
+                    .isEqualTo(getExpectedPackageName(clazz));
             assertThat(actual.getModifiers()).as("Modifiers of " + actual)
                     .isEqualTo(JavaModifier.getModifiersForClass(clazz.getModifiers()));
             assertThat(propertiesOf(actual.getAnnotations())).as("Annotations of " + actual)
@@ -627,7 +627,15 @@ public class Assertions extends org.assertj.core.api.Assertions {
         public void isEquivalentTo(Class<?> clazz) {
             assertThat(actual.getName()).as("name").isEqualTo(clazz.getName());
             assertThat(actual.getSimpleName()).as("simple name").isEqualTo(clazz.getSimpleName());
-            assertThat(actual.getPackageName()).as("package").isEqualTo(clazz.getPackage() != null ? clazz.getPackage().getName() : "");
+            String expectedPackageName = getExpectedPackageName(clazz);
+            assertThat(actual.getPackageName()).as("package").isEqualTo(expectedPackageName);
         }
+    }
+
+    private static String getExpectedPackageName(Class<?> clazz) {
+        if (!clazz.isArray()) {
+            return clazz.getPackage() != null ? clazz.getPackage().getName() : "";
+        }
+        return getExpectedPackageName(clazz.getComponentType());
     }
 }


### PR DESCRIPTION
This PR changes the behavior of the class import with respect to array class package names.
So far an imported array class like `com.foo.SomeClass[]` always had an empty package (similar to `getPackage() == null` of the Reflection API).
However this behavior is usually not useful, because normally an user would expect a class like 

```
package com.foo;
class SomeClass {
    com.bar.OtherClass[] array;
}
```

to cause a dependency to package `com.bar`.
From now on `access.getTargetOwner().getPackageName()` will report `com.bar` instead of empty in such cases.