### PR TITLE
Add classes().that().areAnyClass(...) to syntax

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -281,6 +281,11 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
     }
 
     @Override
+    public CONJUNCTION areAnyClass(Class... classes) {
+        return givenWith(are(JavaClass.Predicates.areAnyClass(classes)));
+    }
+
+    @Override
     public CONJUNCTION arePublic() {
         return givenWith(SyntaxPredicates.arePublic());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -369,6 +369,11 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
         return givenWith(are(not(INTERFACES)));
     }
 
+    @Override
+    public CONJUNCTION areAnyClass(final Class... classes) {
+        return givenWith(are(JavaClass.Predicates.areAnyClass(classes)));
+    }
+
     private CONJUNCTION givenWith(DescribedPredicate<? super JavaClass> predicate) {
         return predicateAggregator.apply(predicate);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -626,4 +626,13 @@ public interface ClassesThat<CONJUNCTION> {
     @PublicAPI(usage = ACCESS)
     CONJUNCTION areNotInterfaces();
 
+    /**
+     * Matches every class in the supplied list and their anonymous inner classes.
+     *
+     * @param classes list of {@link Class} objects.
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areAnyClass(Class... classes);
+
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -47,6 +47,13 @@ public class GivenClassesThatTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     @Test
+    public void areAnyClass() {
+        List<JavaClass> classes = filterResultOf(classes().that().areAnyClass(List.class, String.class))
+                .on(List.class, String.class, Iterable.class, StringBuilder.class);
+        assertThatClasses(classes).matchInAnyOrder(String.class, List.class);
+    }
+
+    @Test
     public void haveFullyQualifiedName() {
         List<JavaClass> classes = filterResultOf(classes().that().haveFullyQualifiedName(List.class.getName()))
                 .on(List.class, String.class, Iterable.class);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -44,6 +44,14 @@ public class GivenMembersDeclaredInClassesThatTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     @Test
+    public void areAnyClass() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areAnyClass(String.class, List.class))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(String.class, List.class);
+    }
+
+    @Test
     public void haveFullyQualifiedName() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().haveFullyQualifiedName(List.class.getName()))
                 .on(List.class, String.class, Iterable.class);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -59,6 +59,17 @@ public class ShouldClassesThatTest {
                 classes().should().onlyDependOnClassesThat());
     }
 
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnyClass(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areAnyClass(Iterable.class, String.class))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
+    }
+
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveFullyQualifiedName(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -56,6 +56,20 @@ public class ShouldOnlyByClassesThatTest {
 
     @Test
     @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnyClass(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnyClass(Foo.class))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatClasses(classes).matchInAnyOrder(
+                ClassAccessedByBar.class, Bar.class,
+                ClassAccessedByBaz.class, Baz.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
     public void haveFullyQualifiedName(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.haveFullyQualifiedName(Foo.class.getName()))


### PR DESCRIPTION
Extended the API to allow assertions to made against one or multiple types using class objects. 
E.g. The declaration
```
theClass(Foo.class).should().onlyHaveDependentClassesThat().areAnyClass(Bar.class, Baz.class).check(importedClasses);
```
should pass if only `Bar` and `Baz` and any of their anonymous inner classes depend on `Foo`.