### PR TITLE
Set log level debug for debug output

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -98,7 +98,7 @@ class JavaClassProcessor extends ClassVisitor {
 
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-        LOG.info("Analysing class '{}'", name);
+        LOG.debug("Analyzing class '{}'", name);
         JavaType javaType = JavaTypeImporter.createFromAsmObjectTypeName(name);
         if (alreadyImported(javaType)) {
             return;
@@ -202,7 +202,7 @@ class JavaClassProcessor extends ClassVisitor {
             return super.visitMethod(access, name, desc, signature, exceptions);
         }
 
-        LOG.debug("Analysing method {}.{}:{}", className, name, desc);
+        LOG.debug("Analyzing method {}.{}:{}", className, name, desc);
         accessHandler.setContext(new CodeUnit(name, namesOf(Type.getArgumentTypes(desc)), className));
 
         DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder = addCodeUnitBuilder(name);


### PR DESCRIPTION
The info level logging of classes causes huge amounts of unwanted log output in Maven. Change it to the same debug log level as being used for all the other logging in this class. See https://github.com/societe-generale/arch-unit-maven-plugin/issues/10
Also change the text to American English, since that is used in other parts of the code base.