### PR TITLE
adding log statements around archUnit property file 

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
@@ -29,6 +29,8 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -46,6 +48,8 @@ public final class ArchConfiguration {
     @Internal
     public static final String ENABLE_MD5_IN_CLASS_SOURCES = "enableMd5InClassSources";
     private static final String EXTENSION_PREFIX = "extension";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ArchConfiguration.class);
 
     private static final Map<String, String> PROPERTY_DEFAULTS = ImmutableMap.of(
             RESOLVE_MISSING_DEPENDENCIES_FROM_CLASS_PATH, Boolean.TRUE.toString(),
@@ -80,7 +84,10 @@ public final class ArchConfiguration {
         properties.clear();
         try (InputStream inputStream = getClass().getResourceAsStream(propertiesResourceName)) {
             if (inputStream != null) {
+                LOG.info("reading ArchUnit properties from " + propertiesResourceName);
                 properties.load(inputStream);
+            } else {
+                LOG.debug("no ArchUnit properties file found, therefore going with default behavior");
             }
         } catch (IOException ignore) {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
@@ -90,6 +90,7 @@ public final class ArchConfiguration {
                 LOG.debug("no ArchUnit properties file found, therefore going with default behavior");
             }
         } catch (IOException ignore) {
+            LOG.warn("problem while accessing/reading ArchUnit properties file " + propertiesResourceName,ignore);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -82,15 +83,18 @@ public final class ArchConfiguration {
 
     private void readProperties(String propertiesResourceName) {
         properties.clear();
-        try (InputStream inputStream = getClass().getResourceAsStream(propertiesResourceName)) {
-            if (inputStream != null) {
-                LOG.info("reading ArchUnit properties from " + propertiesResourceName);
-                properties.load(inputStream);
-            } else {
-                LOG.debug("no ArchUnit properties file found, therefore going with default behavior");
-            }
-        } catch (IOException ignore) {
-            LOG.warn("problem while accessing/reading ArchUnit properties file " + propertiesResourceName,ignore);
+
+        URL archUnitPropertiesUrl = getClass().getResource(propertiesResourceName);
+        if (archUnitPropertiesUrl == null) {
+            LOG.debug("No configuration found in classpath at {} => Using default configuration", propertiesResourceName);
+            return;
+        }
+
+        try (InputStream inputStream = archUnitPropertiesUrl.openStream()) {
+            LOG.info("Reading ArchUnit properties from {}", archUnitPropertiesUrl);
+            properties.load(inputStream);
+        } catch (IOException e) {
+            LOG.warn("Error reading ArchUnit properties from " + archUnitPropertiesUrl, e);
         }
     }
 


### PR DESCRIPTION
adding log statements to indicate whether archUnit property file is found or not : when adding a property file but nothing happens, it's useful to easily see in the logs if the file is picked up or not. 

Having a simple log statement can also be very helpful to somebody new to a project using archUnit, but not getting the expected behavior : it will indicate clearly that a property file has been picked up