### PR TITLE
WIP introducing new method to receive a `CodeUnitParameterList` from a JavaCodeUnit

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/CodeUnitParameter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/CodeUnitParameter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import com.google.common.collect.ImmutableList;
+
+public class CodeUnitParameter {
+
+    private JavaClass type;
+    private ImmutableList<JavaAnnotation> annotations;
+
+    public CodeUnitParameter(JavaClass type, ImmutableList<JavaAnnotation> annotations) {
+        this.type = type;
+        this.annotations = annotations;
+    }
+
+    public JavaClass getType() {
+        return type;
+    }
+
+    public void setType(JavaClass type) {
+        this.type = type;
+    }
+
+    public ImmutableList<JavaAnnotation> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(ImmutableList<JavaAnnotation> annotations) {
+        this.annotations = annotations;
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/CodeUnitParameterList.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/CodeUnitParameterList.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.base.ForwardingList;
+
+public class CodeUnitParameterList extends ForwardingList<CodeUnitParameter> {
+
+    private final ImmutableList<CodeUnitParameter> elements;
+
+    public CodeUnitParameterList(ImmutableList<CodeUnitParameter> elements) {
+        this.elements = ImmutableList.copyOf(elements);
+    }
+
+    // Temporary Constructor for WIP
+    public CodeUnitParameterList(JavaClassList parameters) {
+        List<CodeUnitParameter> codeUnitParameters = new ArrayList<>();
+
+        for (JavaClass javaClass : parameters.delegate()) {
+            codeUnitParameters.add(new CodeUnitParameter(javaClass, ImmutableList.<JavaAnnotation>of()));
+        }
+
+        elements = ImmutableList.copyOf(codeUnitParameters);
+
+    }
+
+    @Override
+    protected List<CodeUnitParameter> delegate() {
+        return elements;
+    }
+
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -48,7 +48,7 @@ import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
  */
 public abstract class JavaCodeUnit extends JavaMember implements HasParameterTypes, HasReturnType, HasThrowsClause<JavaCodeUnit> {
     private final JavaClass returnType;
-    private final JavaClassList parameters;
+    private final CodeUnitParameterList codeUnitParameters;
     private final String fullName;
 
     private Set<JavaFieldAccess> fieldAccesses = Collections.emptySet();
@@ -58,7 +58,7 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
         this.returnType = builder.getReturnType();
-        this.parameters = builder.getParameters();
+        this.codeUnitParameters = builder.getCodeUnitParameters();
         fullName = formatMethod(getOwner().getName(), getName(), getRawParameterTypes());
     }
 
@@ -81,10 +81,23 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
         return getRawParameterTypes();
     }
 
+    /**
+     * @deprecated Use {@link #getCodeUnitParameters()} instead
+     */
+    @Deprecated
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaClassList getRawParameterTypes() {
-        return parameters;
+        List<JavaClass> javaClasses = new ArrayList<JavaClass>();
+        for(CodeUnitParameter codeUnitParameter: getCodeUnitParameters()){
+            javaClasses.add(codeUnitParameter.getType());
+        }
+
+        return new JavaClassList(javaClasses);
+    }
+
+    public CodeUnitParameterList getCodeUnitParameters(){
+        return codeUnitParameters;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -34,6 +34,7 @@ import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.CodeUnitParameterList;
 import com.tngtech.archunit.core.domain.DomainObjectCreationContext;
 import com.tngtech.archunit.core.domain.Formatters;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
@@ -244,8 +245,16 @@ public final class DomainBuilders {
             return get(returnType.getName());
         }
 
+        @Deprecated
+        /**
+         * @deprecated Use {@link #getCodeUnitParameters()} instead
+         */
         public JavaClassList getParameters() {
             return createJavaClassList(asJavaClasses(parameters));
+        }
+
+        public CodeUnitParameterList getCodeUnitParameters() {
+            return new CodeUnitParameterList(getParameters());
         }
 
         public <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> getThrowsClause(CODE_UNIT codeUnit) {
@@ -259,6 +268,8 @@ public final class DomainBuilders {
             }
             return result.build();
         }
+
+
     }
 
     @Internal


### PR DESCRIPTION
This PR is still WIP.
I just wanted to check if the general Idea used here to solve Issue #113 is okay.

As explanation:
The Idea is that one of the Builders in DomainBuilders.java will be extended to return a `CodeUnitParameterList` (The name is based on the new `CodeUnitParameter` suggested in the issue). This List is then used to initialize the `JavaCodeUnit`.
From there on the the flow is the same as it is right now - The `JavaCodeUnit` gets a new method `getCodeUnitParameters` and so on.

The deprecated method `JavaCodeUnit::getRawParameterTypes` will create its return value based on the new `getCodeUnitParameters` Method. This way the backwards compatibility should be 
assured.



Any thoughts about it @codecholeric ?