### PR TITLE
make tests compatible with Java 12 (#198)

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -280,7 +280,7 @@ public class ClassFileImporterTest {
         assertThat(javaClass.getModifiers()).as("modifiers").containsOnly(JavaModifier.PUBLIC, JavaModifier.FINAL);
         assertThat(javaClass.getSuperClass().get()).as("super class").matches(Enum.class);
         assertThat(javaClass.getInterfaces()).as("interfaces").isEmpty();
-        assertThatClasses(javaClass.getAllInterfaces()).matchInAnyOrder(Serializable.class, Comparable.class);
+        assertThatClasses(javaClass.getAllInterfaces()).matchInAnyOrder(Enum.class.getInterfaces());
         assertThat(javaClass.isInterface()).as("is interface").isFalse();
         assertThat(javaClass.isEnum()).as("is enum").isTrue();
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -3,7 +3,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import java.io.Serializable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.reflect.Constructor;
+import java.lang.ref.Reference;
 import java.text.AttributedString;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -173,17 +173,18 @@ public class GivenMembersDeclaredInClassesThatTest {
 
     @Test
     public void resideInAnyPackage() {
-        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().resideInAnyPackage("..tngtech..", "java.lang.reflect"))
-                .on(getClass(), String.class, Constructor.class);
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat()
+                .resideInAnyPackage("..tngtech..", "java.lang.ref")
+        ).on(getClass(), String.class, Reference.class);
 
-        assertThatMembers(members).matchInAnyOrderMembersOf(getClass(), Constructor.class);
+        assertThatMembers(members).matchInAnyOrderMembersOf(getClass(), Reference.class);
     }
 
     @Test
     public void resideOutsideOfPackages() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat()
-                .resideOutsideOfPackages("..tngtech..", "java.lang.reflect")
-        ).on(getClass(), String.class, Constructor.class);
+                .resideOutsideOfPackages("..tngtech..", "java.lang.ref")
+        ).on(getClass(), String.class, Reference.class);
 
         assertThatMembers(members).matchInAnyOrderMembersOf(String.class);
     }


### PR DESCRIPTION
Resolves #198:

With Java 12,
* `java.lang.Enum` also implements [`java.lang.constant.Constable`](https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/constant/Constable.html), not only `Comparable` & `Serializable`
* `java.lang.reflect.Constructor.class.getDeclaredFields()` returns an empty array ([JDK-8210522](https://bugs.openjdk.java.net/browse/JDK-8210522)),
  making `Constructor.class` a sub-optimal test object (ArchUnit's import seems to work just fine,
  but the test fails to construct reference values to be compared with the actual results.)

Signed-off-by: Manfred Hanke \<Manfred.Hanke@tngtech.com\>