### PR TITLE
add full name restrictions/assertions to members API

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -91,6 +91,10 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         return owner;
     }
 
+    /**
+     * @return The full name of this {@link AccessTarget}, i.e. a string containing {@code ${declaringClass}.${name}} for a field and
+     *         {@code ${declaringClass}.${name}(${parameterTypes})} for a code unit
+     */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getFullName() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -109,6 +109,9 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations, HasModifi
         javaPackage = JavaPackage.simple(this);
     }
 
+    /**
+     * @return The {@link Source} of this {@link JavaClass}, i.e. where this class has been imported from
+     */
     @PublicAPI(usage = ACCESS)
     public Optional<Source> getSource() {
         return source;
@@ -126,12 +129,18 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations, HasModifi
         return "Class <" + getName() + ">";
     }
 
+    /**
+     * @return The fully qualified name of this {@link JavaClass}, compare {@link Class#getName()} of the Reflection API
+     */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getName() {
         return javaType.getName();
     }
 
+    /**
+     * @return The fully qualified name of this {@link JavaClass}, i.e. the result is the same as invoking {@link #getName()}
+     */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getFullName() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -62,6 +62,9 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
         fullName = formatMethod(getOwner().getName(), getName(), getRawParameterTypes());
     }
 
+    /**
+     * @return The full name of this {@link JavaCodeUnit}, i.e. a string containing {@code ${declaringClass}.${name}(${parameterTypes})}
+     */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getFullName() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -42,6 +42,9 @@ public class JavaField extends JavaMember implements HasType {
         fieldSupplier = Suppliers.memoize(new ReflectFieldSupplier());
     }
 
+    /**
+     * @return The full name of this {@link JavaField}, i.e. a string containing {@code ${declaringClass}.${name}}
+     */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getFullName() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -44,8 +44,8 @@ public interface HasName {
              * Matches full names against a regular expression.
              */
             @PublicAPI(usage = ACCESS)
-            public static DescribedPredicate<HasName.AndFullName> fullNameMatching(String regex) {
-                return new FullNameMatchingPredicate(regex);
+            public static <HAS_FULL_NAME extends HasName.AndFullName> DescribedPredicate<HAS_FULL_NAME> fullNameMatching(String regex) {
+                return new FullNameMatchingPredicate<>(regex);
             }
 
             private static class FullNameEqualsPredicate extends DescribedPredicate<HasName.AndFullName> {
@@ -62,7 +62,7 @@ public interface HasName {
                 }
             }
 
-            private static class FullNameMatchingPredicate extends DescribedPredicate<HasName.AndFullName> {
+            private static class FullNameMatchingPredicate<HAS_FULL_NAME extends HasName.AndFullName> extends DescribedPredicate<HAS_FULL_NAME> {
                 private final Pattern pattern;
 
                 FullNameMatchingPredicate(String regex) {
@@ -86,8 +86,8 @@ public interface HasName {
          * Matches names against a regular expression.
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameMatching(final String regex) {
-            return new NameMatchingPredicate(regex);
+        public static <HAS_NAME extends HasName> DescribedPredicate<HAS_NAME> nameMatching(final String regex) {
+            return new NameMatchingPredicate<>(regex);
         }
 
         @PublicAPI(usage = ACCESS)
@@ -95,7 +95,7 @@ public interface HasName {
             return new NameEqualsPredicate(name);
         }
 
-        private static class NameMatchingPredicate extends DescribedPredicate<HasName> {
+        private static class NameMatchingPredicate<HAS_NAME extends HasName> extends DescribedPredicate<HAS_NAME> {
             private final Pattern pattern;
 
             NameMatchingPredicate(String regex) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -28,6 +28,9 @@ public interface HasName {
     String getName();
 
     interface AndFullName extends HasName {
+        /**
+         * @return The full name of the given object. Varies by context, for details consult Javadoc of the concrete subclass.
+         */
         @PublicAPI(usage = ACCESS)
         String getFullName();
 
@@ -44,8 +47,8 @@ public interface HasName {
              * Matches full names against a regular expression.
              */
             @PublicAPI(usage = ACCESS)
-            public static <HAS_FULL_NAME extends HasName.AndFullName> DescribedPredicate<HAS_FULL_NAME> fullNameMatching(String regex) {
-                return new FullNameMatchingPredicate<>(regex);
+            public static DescribedPredicate<HasName.AndFullName> fullNameMatching(String regex) {
+                return new FullNameMatchingPredicate(regex);
             }
 
             private static class FullNameEqualsPredicate extends DescribedPredicate<HasName.AndFullName> {
@@ -62,7 +65,7 @@ public interface HasName {
                 }
             }
 
-            private static class FullNameMatchingPredicate<HAS_FULL_NAME extends HasName.AndFullName> extends DescribedPredicate<HAS_FULL_NAME> {
+            private static class FullNameMatchingPredicate extends DescribedPredicate<HasName.AndFullName> {
                 private final Pattern pattern;
 
                 FullNameMatchingPredicate(String regex) {
@@ -76,18 +79,23 @@ public interface HasName {
                 }
             }
         }
+
+        final class Functions {
+            private Functions() {
+            }
+
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<HasName.AndFullName, String> GET_FULL_NAME = new ChainableFunction<HasName.AndFullName, String>() {
+                @Override
+                public String apply(HasName.AndFullName input) {
+                    return input.getFullName();
+                }
+            };
+        }
     }
 
     final class Predicates {
         private Predicates() {
-        }
-
-        /**
-         * Matches names against a regular expression.
-         */
-        @PublicAPI(usage = ACCESS)
-        public static <HAS_NAME extends HasName> DescribedPredicate<HAS_NAME> nameMatching(final String regex) {
-            return new NameMatchingPredicate<>(regex);
         }
 
         @PublicAPI(usage = ACCESS)
@@ -95,18 +103,12 @@ public interface HasName {
             return new NameEqualsPredicate(name);
         }
 
-        private static class NameMatchingPredicate<HAS_NAME extends HasName> extends DescribedPredicate<HAS_NAME> {
-            private final Pattern pattern;
-
-            NameMatchingPredicate(String regex) {
-                super(String.format("name matching '%s'", regex));
-                this.pattern = Pattern.compile(regex);
-            }
-
-            @Override
-            public boolean apply(HasName input) {
-                return pattern.matcher(input.getName()).matches();
-            }
+        /**
+         * Matches names against a regular expression.
+         */
+        @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<HasName> nameMatching(final String regex) {
+            return new NameMatchingPredicate(regex);
         }
 
         private static class NameEqualsPredicate extends DescribedPredicate<HasName> {
@@ -120,6 +122,20 @@ public interface HasName {
             @Override
             public boolean apply(HasName input) {
                 return input.getName().equals(name);
+            }
+        }
+
+        private static class NameMatchingPredicate extends DescribedPredicate<HasName> {
+            private final Pattern pattern;
+
+            NameMatchingPredicate(String regex) {
+                super(String.format("name matching '%s'", regex));
+                this.pattern = Pattern.compile(regex);
+            }
+
+            @Override
+            public boolean apply(HasName input) {
+                return pattern.matcher(input.getName()).matches();
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -30,6 +30,52 @@ public interface HasName {
     interface AndFullName extends HasName {
         @PublicAPI(usage = ACCESS)
         String getFullName();
+
+        final class Predicates {
+            private Predicates() {
+            }
+
+            @PublicAPI(usage = ACCESS)
+            public static DescribedPredicate<HasName.AndFullName> fullName(String fullName) {
+                return new FullNameEqualsPredicate(fullName);
+            }
+
+            /**
+             * Matches full names against a regular expression.
+             */
+            @PublicAPI(usage = ACCESS)
+            public static DescribedPredicate<HasName.AndFullName> fullNameMatching(String regex) {
+                return new FullNameMatchingPredicate(regex);
+            }
+
+            private static class FullNameEqualsPredicate extends DescribedPredicate<HasName.AndFullName> {
+                private final String fullName;
+
+                FullNameEqualsPredicate(String fullName) {
+                    super(String.format("full name '%s'", fullName));
+                    this.fullName = fullName;
+                }
+
+                @Override
+                public boolean apply(HasName.AndFullName input) {
+                    return input.getFullName().equals(fullName);
+                }
+            }
+
+            private static class FullNameMatchingPredicate extends DescribedPredicate<HasName.AndFullName> {
+                private final Pattern pattern;
+
+                FullNameMatchingPredicate(String regex) {
+                    super(String.format("full name matching '%s'", regex));
+                    this.pattern = Pattern.compile(regex);
+                }
+
+                @Override
+                public boolean apply(HasName.AndFullName input) {
+                    return pattern.matcher(input.getFullName()).matches();
+                }
+            }
+        }
     }
 
     final class Predicates {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasSourceCodeLocation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasSourceCodeLocation.java
@@ -21,6 +21,9 @@ import com.tngtech.archunit.core.domain.SourceCodeLocation;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public interface HasSourceCodeLocation {
+    /**
+     * @return The {@link SourceCodeLocation} of this object, i.e. how to locate the respective object within the set of source files.
+     */
     @PublicAPI(usage = ACCESS)
     SourceCodeLocation getSourceCodeLocation();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -99,7 +99,9 @@ import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predica
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullName;
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.rawParameterTypes;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
@@ -452,12 +454,14 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_FULL_NAME> haveFullName(String fullName) {
+    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
+    ArchCondition<HAS_FULL_NAME> haveFullName(String fullName) {
         return new HaveConditionByPredicate<>(fullName(fullName));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_FULL_NAME> notHaveFullName(String fullName) {
+    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
+    ArchCondition<HAS_FULL_NAME> notHaveFullName(String fullName) {
         return not(new HaveConditionByPredicate<HAS_FULL_NAME>(fullName(fullName)));
     }
 
@@ -526,7 +530,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameMatching(final String regex) {
-        final DescribedPredicate<HAS_NAME> haveNameMatching = have(HasName.Predicates.<HAS_NAME>nameMatching(regex));
+        final DescribedPredicate<HAS_NAME> haveNameMatching = have(nameMatching(regex)).forSubType();
         return new MatchingCondition<>(haveNameMatching, regex);
     }
 
@@ -536,13 +540,15 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_FULL_NAME> haveFullNameMatching(String regex) {
-        final DescribedPredicate<HAS_FULL_NAME> haveFullNameMatching = have(HasName.AndFullName.Predicates.<HAS_FULL_NAME>fullNameMatching(regex));
-        return new MatchingCondition<HAS_FULL_NAME>(haveFullNameMatching, regex);
+    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
+    ArchCondition<HAS_FULL_NAME> haveFullNameMatching(String regex) {
+        final DescribedPredicate<HAS_FULL_NAME> haveFullNameMatching = have(fullNameMatching(regex)).forSubType();
+        return new MatchingCondition<>(haveFullNameMatching, regex);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_FULL_NAME> haveFullNameNotMatching(String regex) {
+    public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_FULL_NAME>
+    haveFullNameNotMatching(String regex) {
         return not(ArchConditions.<HAS_FULL_NAME>haveFullNameMatching(regex)).as("have full name not matching '%s'", regex);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
@@ -80,6 +80,25 @@ abstract class AbstractMembersShouldInternal<MEMBER extends JavaMember, SELF ext
     }
 
     @Override
+    public SELF haveFullName(String fullName) {
+        return addCondition(ArchConditions.haveFullName(fullName));
+    }
+
+    @Override
+    public SELF notHaveFullName(String fullName) {
+        return addCondition(ArchConditions.notHaveFullName(fullName));
+    }
+
+    @Override
+    public SELF haveFullNameMatching(String regex) {
+        return addCondition(ArchConditions.haveFullNameMatching(regex));
+    }
+
+    @Override
+    public SELF haveFullNameNotMatching(String regex) {
+        return addCondition(ArchConditions.haveFullNameNotMatching(regex));
+    }
+    @Override
     public SELF bePublic() {
         return addCondition(ArchConditions.bePublic());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersThatInternal.java
@@ -31,6 +31,8 @@ import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaMember.Predicates.declaredIn;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.metaAnnotatedWith;
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullName;
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
@@ -69,6 +71,26 @@ class MembersThatInternal<
     @Override
     public CONJUNCTION haveNameNotMatching(String regex) {
         return givenWith(SyntaxPredicates.haveNameNotMatching(regex));
+    }
+
+    @Override
+    public CONJUNCTION haveFullName(String fullName) {
+        return givenWith(have(fullName(fullName)));
+    }
+
+    @Override
+    public CONJUNCTION doNotHaveFullName(String fullName) {
+        return givenWith(doNot(have(fullName(fullName))));
+    }
+
+    @Override
+    public CONJUNCTION haveFullNameMatching(String regex) {
+        return givenWith(have(fullNameMatching(regex)));
+    }
+
+    @Override
+    public CONJUNCTION haveFullNameNotMatching(String regex) {
+        return givenWith(have(not(fullNameMatching(regex)).as("full name not matching '%s'", regex)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
@@ -68,6 +68,42 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
     CONJUNCTION haveNameNotMatching(String regex);
 
     /**
+     * Asserts that members have a certain full name.
+     *
+     * @param fullName The member's full name
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullName(String fullName);
+
+    /**
+     * Asserts that members do not have a certain full name.
+     *
+     * @param fullName The member's full name
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION notHaveFullName(String fullName);
+
+    /**
+     * Asserts that members have a full name matching a given regular expression.
+     *
+     * @param regex A regular expression
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullNameMatching(String regex);
+
+    /**
+     * Asserts that members have a full name not matching a given regular expression.
+     *
+     * @param regex A regular expression
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullNameNotMatching(String regex);
+
+    /**
      * Asserts that members are public.
      *
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
@@ -21,7 +21,9 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
@@ -68,7 +70,7 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
     CONJUNCTION haveNameNotMatching(String regex);
 
     /**
-     * Asserts that members have a certain full name.
+     * Asserts that members have a certain full name (compare {@link JavaField#getFullName()} and {@link JavaCodeUnit#getFullName()}).
      *
      * @param fullName The member's full name
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -77,7 +79,7 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
     CONJUNCTION haveFullName(String fullName);
 
     /**
-     * Asserts that members do not have a certain full name.
+     * Asserts that members do not have a certain full name (compare {@link JavaField#getFullName()} and {@link JavaCodeUnit#getFullName()}).
      *
      * @param fullName The member's full name
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -86,7 +88,8 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
     CONJUNCTION notHaveFullName(String fullName);
 
     /**
-     * Asserts that members have a full name matching a given regular expression.
+     * Asserts that members have a full name matching a given regular expression (compare {@link JavaField#getFullName()}
+     * and {@link JavaCodeUnit#getFullName()}).
      *
      * @param regex A regular expression
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -95,7 +98,8 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
     CONJUNCTION haveFullNameMatching(String regex);
 
     /**
-     * Asserts that members have a full name not matching a given regular expression.
+     * Asserts that members have a full name not matching a given regular expression (compare {@link JavaField#getFullName()}
+     * and {@link JavaCodeUnit#getFullName()}).
      *
      * @param regex A regular expression
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
@@ -68,6 +68,42 @@ public interface MembersThat<CONJUNCTION extends GivenMembersConjunction<?>> {
     CONJUNCTION haveNameNotMatching(String regex);
 
     /**
+     * Matches members by their full name.
+     *
+     * @param fullName The member's full name
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullName(String fullName);
+
+    /**
+     * Matches members that do not have a certain full name.
+     *
+     * @param fullName The member's full name
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION doNotHaveFullName(String fullName);
+
+    /**
+     * Matches members with a full name matching a given regular expression.
+     *
+     * @param regex A regular expression
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullNameMatching(String regex);
+
+    /**
+     * Matches members with a full name not matching a given regular expression.
+     *
+     * @param regex A regular expression
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullNameNotMatching(String regex);
+
+    /**
      * Matches public members.
      *
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -3,8 +3,10 @@ package com.tngtech.archunit.core.domain.properties;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.Test;
 
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Functions.GET_FULL_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullName;
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
+import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
@@ -51,6 +53,13 @@ public class HasNameTest {
                 .accepts(newHasNameAndFullName("method", "some.Foo.method()"))
                 .rejects(newHasNameAndFullName("method", "some.Foo.method"))
                 .hasDescription("full name matching '.*method\\(.*\\)'");
+    }
+
+    @Test
+    public void functions() {
+        HasName.AndFullName test = newHasNameAndFullName("simple", "full");
+        assertThat(GET_NAME.apply(test)).isEqualTo("simple");
+        assertThat(GET_FULL_NAME.apply(test)).isEqualTo("full");
     }
 
     private AbstractBooleanAssert assertNameMatches(String input, String regex) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -3,28 +3,30 @@ package com.tngtech.archunit.core.domain.properties;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.junit.Test;
 
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullName;
+import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class HasNameTest {
     @Test
-    public void match_against_regex() {
-        assertMatches("Some.foobar", ".*foo.*").isTrue();
-        assertMatches("Some.fobar", ".*foo.*").isFalse();
-        assertMatches("Some.foobar", ".*fob?o*.*").isTrue();
-        assertMatches("com.tngtech.SomeClass", ".*W.*").isFalse();
-        assertMatches("com.tngtech.SomeClass", "com.*").isTrue();
-        assertMatches("com.tngtech.SomeClass", "co\\..*").isFalse();
-        assertMatches("com.tngtech.SomeClass", ".*Class").isTrue();
-        assertMatches("com.tngtech.SomeClass", ".*Clas").isFalse();
-        assertMatches("com.tngtech.SomeClass", ".*\\.S.*s").isTrue();
+    public void nameMatching_predicate() {
+        assertNameMatches("Some.foobar", ".*foo.*").isTrue();
+        assertNameMatches("Some.fobar", ".*foo.*").isFalse();
+        assertNameMatches("Some.foobar", ".*fob?o*.*").isTrue();
+        assertNameMatches("com.tngtech.SomeClass", ".*W.*").isFalse();
+        assertNameMatches("com.tngtech.SomeClass", "com.*").isTrue();
+        assertNameMatches("com.tngtech.SomeClass", "co\\..*").isFalse();
+        assertNameMatches("com.tngtech.SomeClass", ".*Class").isTrue();
+        assertNameMatches("com.tngtech.SomeClass", ".*Clas").isFalse();
+        assertNameMatches("com.tngtech.SomeClass", ".*\\.S.*s").isTrue();
 
         assertThat(nameMatching(".*foo")).hasDescription("name matching '.*foo'");
     }
 
     @Test
-    public void match_against_name() {
+    public void name_predicate() {
         assertThat(name("some.Foo"))
                 .accepts(newHasName("some.Foo"))
                 .rejects(newHasName("some.Fo"))
@@ -32,16 +34,44 @@ public class HasNameTest {
         assertThat(name("Foo")).rejects(newHasName("some.Foo"));
     }
 
-    private AbstractBooleanAssert assertMatches(String input, String regex) {
+    @Test
+    public void fullName_predicate() {
+        assertThat(fullName("some.Foo.field1"))
+                .accepts(newHasNameAndFullName("field1", "some.Foo.field1"))
+                .rejects(newHasNameAndFullName("field", "some.Foo.field"))
+                .rejects(newHasNameAndFullName("field12", "some.Foo.field12"))
+                .rejects(newHasNameAndFullName("some.Foo.field1", "some.Foo.field1.property"))
+                .hasDescription("full name 'some.Foo.field1'");
+    }
+
+    @Test
+    public void fullNameMatching_predicate() {
+        assertThat(fullNameMatching(".*method\\(.*\\)"))
+                .accepts(newHasNameAndFullName("method", "some.Foo.method(int)"))
+                .accepts(newHasNameAndFullName("method", "some.Foo.method()"))
+                .rejects(newHasNameAndFullName("method", "some.Foo.method"))
+                .hasDescription("full name matching '.*method\\(.*\\)'");
+    }
+
+    private AbstractBooleanAssert assertNameMatches(String input, String regex) {
         return assertThat(nameMatching(regex).apply(newHasName(input)))
                 .as(input + " =~ " + regex);
     }
 
     private HasName newHasName(final String name) {
-        return new HasName() {
+        return newHasNameAndFullName(name, "full " + name);
+    }
+
+    private HasName.AndFullName newHasNameAndFullName(final String name, final String fullName) {
+        return new HasName.AndFullName() {
             @Override
             public String getName() {
                 return name;
+            }
+
+            @Override
+            public String getFullName() {
+                return fullName;
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/FieldsShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/FieldsShouldTest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.java.junit.dataprovider.DataProvider;

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
@@ -5,7 +5,6 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -195,7 +194,7 @@ public class GivenMembersTest {
                 $(described(constructors().that().haveFullName(classNameDot + CONSTRUCTOR_ONE_ARG)), ImmutableSet.of(CONSTRUCTOR_ONE_ARG)),
                 $(described(fields().that().haveFullName(classNameDot + FIELD_A)), ImmutableSet.of(FIELD_A)),
                 $(described(members().that().doNotHaveFullName(classNameDot + FIELD_A)), union(allFieldsExcept(FIELD_A), ALL_CODE_UNIT_DESCRIPTIONS)),
-                $(described(codeUnits().that().doNotHaveFullName(classNameDot + FIELD_A)), ALL_CODE_UNIT_DESCRIPTIONS),
+                $(described(codeUnits().that().doNotHaveFullName(classNameDot + METHOD_A)), allCodeUnitsExcept(METHOD_A)),
                 $(described(methods().that().doNotHaveFullName(classNameDot + METHOD_A)), allMethodsExcept(METHOD_A)),
                 $(described(constructors().that().doNotHaveFullName(classNameDot + CONSTRUCTOR_ONE_ARG)), allConstructorsExcept(CONSTRUCTOR_ONE_ARG)),
                 $(described(fields().that().doNotHaveFullName(classNameDot + FIELD_A)), allFieldsExcept(FIELD_A)),
@@ -203,14 +202,16 @@ public class GivenMembersTest {
                 $(described(members().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(FIELD_A, METHOD_A)),
                 $(described(codeUnits().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(METHOD_A)),
                 $(described(methods().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(METHOD_A)),
-                $(described(constructors().that().haveFullNameMatching(".*init.*")), ALL_CONSTRUCTOR_DESCRIPTIONS),
+                $(described(constructors().that().haveFullNameMatching(quote(classNameDot) + ".*init.*String\\)")),
+                        ImmutableSet.of(CONSTRUCTOR_ONE_ARG)),
                 $(described(fields().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(FIELD_A)),
                 $(described(members().that().haveFullNameNotMatching(quote(classNameDot) + "f.*A.*")), union(
                         allFieldsExcept(FIELD_A),
                         ALL_CODE_UNIT_DESCRIPTIONS)),
                 $(described(codeUnits().that().haveFullNameNotMatching(quote(classNameDot) + "f.*A.*")), ALL_CODE_UNIT_DESCRIPTIONS),
                 $(described(methods().that().haveFullNameNotMatching(quote(classNameDot) + ".*A.*")), allMethodsExcept(METHOD_A)),
-                $(described(constructors().that().haveFullNameNotMatching(".*init.*")), emptySet()),
+                $(described(constructors().that().haveFullNameNotMatching(quote(classNameDot) + ".*init.*String\\)")),
+                        allConstructorsExcept(CONSTRUCTOR_ONE_ARG)),
                 $(described(fields().that().haveFullNameNotMatching(quote(classNameDot) + ".*A.*")), allFieldsExcept(FIELD_A)),
 
                 $(described(members().that().arePublic()), ImmutableSet.of(

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +53,7 @@ import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static java.util.regex.Pattern.quote;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(DataProviderRunner.class)
@@ -147,6 +149,7 @@ public class GivenMembersTest {
 
     @DataProvider
     public static Object[][] restricted_property_rule_starts() {
+        String classNameDot = ClassWithVariousMembers.class.getName() + ".";
         ImmutableList.Builder<Object[]> data = ImmutableList.<Object[]>builder().add(
                 $(described(members().that().haveName(FIELD_A)), ImmutableSet.of(FIELD_A)),
                 $(described(codeUnits().that().haveName(FIELD_A)), ImmutableSet.of()),
@@ -185,6 +188,30 @@ public class GivenMembersTest {
                 $(described(methods().that().haveNameNotMatching("m.*A")), allMethodsExcept(METHOD_A)),
                 $(described(codeUnits().that().haveNameNotMatching(".*init.*")), ALL_METHOD_DESCRIPTIONS),
                 $(described(constructors().that().haveNameNotMatching(".*init.*")), emptySet()),
+
+                $(described(members().that().haveFullName(classNameDot + FIELD_A)), ImmutableSet.of(FIELD_A)),
+                $(described(codeUnits().that().haveFullName(classNameDot + METHOD_A)), ImmutableSet.of(METHOD_A)),
+                $(described(methods().that().haveFullName(classNameDot + METHOD_A)), ImmutableSet.of(METHOD_A)),
+                $(described(constructors().that().haveFullName(classNameDot + CONSTRUCTOR_ONE_ARG)), ImmutableSet.of(CONSTRUCTOR_ONE_ARG)),
+                $(described(fields().that().haveFullName(classNameDot + FIELD_A)), ImmutableSet.of(FIELD_A)),
+                $(described(members().that().doNotHaveFullName(classNameDot + FIELD_A)), union(allFieldsExcept(FIELD_A), ALL_CODE_UNIT_DESCRIPTIONS)),
+                $(described(codeUnits().that().doNotHaveFullName(classNameDot + FIELD_A)), ALL_CODE_UNIT_DESCRIPTIONS),
+                $(described(methods().that().doNotHaveFullName(classNameDot + METHOD_A)), allMethodsExcept(METHOD_A)),
+                $(described(constructors().that().doNotHaveFullName(classNameDot + CONSTRUCTOR_ONE_ARG)), allConstructorsExcept(CONSTRUCTOR_ONE_ARG)),
+                $(described(fields().that().doNotHaveFullName(classNameDot + FIELD_A)), allFieldsExcept(FIELD_A)),
+
+                $(described(members().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(FIELD_A, METHOD_A)),
+                $(described(codeUnits().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(METHOD_A)),
+                $(described(methods().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(METHOD_A)),
+                $(described(constructors().that().haveFullNameMatching(".*init.*")), ALL_CONSTRUCTOR_DESCRIPTIONS),
+                $(described(fields().that().haveFullNameMatching(quote(classNameDot) + ".*A.*")), ImmutableSet.of(FIELD_A)),
+                $(described(members().that().haveFullNameNotMatching(quote(classNameDot) + "f.*A.*")), union(
+                        allFieldsExcept(FIELD_A),
+                        ALL_CODE_UNIT_DESCRIPTIONS)),
+                $(described(codeUnits().that().haveFullNameNotMatching(quote(classNameDot) + "f.*A.*")), ALL_CODE_UNIT_DESCRIPTIONS),
+                $(described(methods().that().haveFullNameNotMatching(quote(classNameDot) + ".*A.*")), allMethodsExcept(METHOD_A)),
+                $(described(constructors().that().haveFullNameNotMatching(".*init.*")), emptySet()),
+                $(described(fields().that().haveFullNameNotMatching(quote(classNameDot) + ".*A.*")), allFieldsExcept(FIELD_A)),
 
                 $(described(members().that().arePublic()), ImmutableSet.of(
                         FIELD_PUBLIC, METHOD_PUBLIC, CONSTRUCTOR_PUBLIC)),

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -46,6 +46,7 @@ import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.ALL_OTH
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.ALL_OTHER_MEMBER_DESCRIPTIONS;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.ALL_OTHER_METHOD_DESCRIPTIONS;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.CONSTRUCTOR_ANNOTATED_WITH_A;
+import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.CONSTRUCTOR_ONE_ARG;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.CONSTRUCTOR_PACKAGE_PRIVATE;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.CONSTRUCTOR_PRIVATE;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.CONSTRUCTOR_PROTECTED;
@@ -149,14 +150,15 @@ public class MembersShouldTest {
                 $(codeUnits().should().haveFullNameMatching(quote(classNameDot) + ".*A" + quote("()")), allCodeUnitsExcept(METHOD_A)),
                 $(methods().should().haveFullNameMatching(quote(classNameDot) + ".*A" + quote("()")), allMethodsExcept(METHOD_A)),
                 $(codeUnits().should().haveFullNameMatching(quote(classNameDot) + "..*init.*"), ALL_METHOD_DESCRIPTIONS),
-                $(constructors().should().haveFullNameMatching(quote(classNameDot) + ".*init.*"), emptySet()),
+                $(constructors().should().haveFullNameMatching(quote(classNameDot) + ".*init.*String\\)"),
+                        allConstructorsExcept(CONSTRUCTOR_ONE_ARG)),
                 $(members().should().haveFullNameNotMatching(quote(classNameDot) + ".*A\\(?\\)?"), ImmutableSet.of(FIELD_A, METHOD_A)),
                 $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*A"), emptySet()),
                 $(fields().should().haveFullNameNotMatching(quote(classNameDot) + ".*A"), ImmutableSet.of(FIELD_A)),
                 $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*A" + quote("()")), ImmutableSet.of(METHOD_A)),
                 $(methods().should().haveFullNameNotMatching(quote(classNameDot) + ".*A" + quote("()")), ImmutableSet.of(METHOD_A)),
                 $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
-                $(constructors().should().haveFullNameNotMatching(quote(classNameDot) + ".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
+                $(constructors().should().haveFullNameNotMatching(quote(classNameDot) + ".*init.*String\\)"), ImmutableSet.of(CONSTRUCTOR_ONE_ARG)),
 
                 $(members().should().bePublic(), allMembersExcept(
                         FIELD_PUBLIC, METHOD_PUBLIC, CONSTRUCTOR_PUBLIC)),

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -100,6 +100,7 @@ public class MembersShouldTest {
 
     @DataProvider
     public static Object[][] restricted_property_rule_ends() {
+        String classNameDot = ClassWithVariousMembers.class.getName() + ".";
         ImmutableList.Builder<Object[]> data = ImmutableList.<Object[]>builder().add(
                 $(members().should().haveName(FIELD_A), allMembersExcept(FIELD_A)),
                 $(codeUnits().should().haveName(FIELD_A), ALL_CODE_UNIT_DESCRIPTIONS),
@@ -130,6 +131,32 @@ public class MembersShouldTest {
                 $(methods().should().haveNameNotMatching("m.*A"), ImmutableSet.of(METHOD_A)),
                 $(codeUnits().should().haveNameNotMatching(".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
                 $(constructors().should().haveNameNotMatching(".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
+
+                $(members().should().haveFullName(classNameDot + FIELD_A), allMembersExcept(FIELD_A)),
+                $(fields().should().haveFullName(classNameDot + FIELD_A), allFieldsExcept(FIELD_A)),
+                $(codeUnits().should().haveFullName(classNameDot + FIELD_A), ALL_CODE_UNIT_DESCRIPTIONS),
+                $(methods().should().haveFullName(classNameDot + METHOD_A), allMethodsExcept(METHOD_A)),
+                $(codeUnits().should().haveFullName(classNameDot + METHOD_A), allCodeUnitsExcept(METHOD_A)),
+                $(members().should().notHaveFullName(classNameDot + FIELD_A), ImmutableSet.of(FIELD_A)),
+                $(fields().should().notHaveFullName(classNameDot + FIELD_A), ImmutableSet.of(FIELD_A)),
+                $(codeUnits().should().notHaveFullName(classNameDot + FIELD_A), emptySet()),
+                $(methods().should().notHaveFullName(classNameDot + METHOD_A), ImmutableSet.of(METHOD_A)),
+                $(codeUnits().should().notHaveFullName(classNameDot + METHOD_A), ImmutableSet.of(METHOD_A)),
+
+                $(members().should().haveFullNameMatching(quote(classNameDot) + ".*A\\(?\\)?"), allMembersExcept(FIELD_A, METHOD_A)),
+                $(codeUnits().should().haveFullNameMatching(quote(classNameDot) + ".*A"), ALL_CODE_UNIT_DESCRIPTIONS),
+                $(fields().should().haveFullNameMatching(quote(classNameDot) + ".*A"), allFieldsExcept(FIELD_A)),
+                $(codeUnits().should().haveFullNameMatching(quote(classNameDot) + ".*A" + quote("()")), allCodeUnitsExcept(METHOD_A)),
+                $(methods().should().haveFullNameMatching(quote(classNameDot) + ".*A" + quote("()")), allMethodsExcept(METHOD_A)),
+                $(codeUnits().should().haveFullNameMatching(quote(classNameDot) + "..*init.*"), ALL_METHOD_DESCRIPTIONS),
+                $(constructors().should().haveFullNameMatching(quote(classNameDot) + ".*init.*"), emptySet()),
+                $(members().should().haveFullNameNotMatching(quote(classNameDot) + ".*A\\(?\\)?"), ImmutableSet.of(FIELD_A, METHOD_A)),
+                $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*A"), emptySet()),
+                $(fields().should().haveFullNameNotMatching(quote(classNameDot) + ".*A"), ImmutableSet.of(FIELD_A)),
+                $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*A" + quote("()")), ImmutableSet.of(METHOD_A)),
+                $(methods().should().haveFullNameNotMatching(quote(classNameDot) + ".*A" + quote("()")), ImmutableSet.of(METHOD_A)),
+                $(codeUnits().should().haveFullNameNotMatching(quote(classNameDot) + ".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
+                $(constructors().should().haveFullNameNotMatching(quote(classNameDot) + ".*init.*"), ALL_CONSTRUCTOR_DESCRIPTIONS),
 
                 $(members().should().bePublic(), allMembersExcept(
                         FIELD_PUBLIC, METHOD_PUBLIC, CONSTRUCTOR_PUBLIC)),


### PR DESCRIPTION
* `members().that().`｛`have`, `doNotHave`｝`FullName`
* `members().that().haveFullName`［`Not`］`Matching`
* `members().should().`｛`have`, `notHave`｝`FullName`
* `members().should().haveFullName`［`Not`］`Matching`