### PR TITLE
Extend syntax to query different kinds of classes

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
@@ -29,6 +29,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
@@ -188,15 +189,6 @@ public class PublicAPIRules {
         };
     }
 
-    private static DescribedPredicate<JavaClass> anonymousClass() {
-        return new DescribedPredicate<JavaClass>("anonymous class") {
-            @Override
-            public boolean apply(JavaClass input) {
-                return input.isAnonymousClass();
-            }
-        };
-    }
-
     private static DescribedPredicate<JavaMember> declaredInClassIn(String packageIdentifier) {
         return declaredIn(resideInAPackage(packageIdentifier).as("class in '%s'", packageIdentifier));
     }
@@ -286,7 +278,7 @@ public class PublicAPIRules {
     private static DescribedPredicate<JavaMember> relevantArchUnitMembers() {
         return not(inheritedFromObjectOrEnum())
                 .and(not(declaredIn(assignableTo(Annotation.class))))
-                .and(not(declaredIn(anonymousClass())))
+                .and(not(declaredIn(ANONYMOUS_CLASSES)))
                 .and(not(declaredIn(internal())))
                 .and(not(declaredInClassIn(THIRDPARTY_PACKAGE_IDENTIFIER)))
                 .as("relevant members");

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
@@ -192,7 +192,7 @@ public class PublicAPIRules {
         return new DescribedPredicate<JavaClass>("anonymous class") {
             @Override
             public boolean apply(JavaClass input) {
-                return input.isAnonymous();
+                return input.isAnonymousClass();
             }
         };
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -241,7 +241,35 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
     }
 
     /**
-     * A top level class is a class that is not a nested class.
+     * A <b>top level class</b> is a class that is not a nested class, i.e. not declared within the body
+     * of another class.<br><br>
+     *
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class NestedNonStatic {}
+     *     static class NestedStatic {}
+     *
+     *     void method() {
+     *         class NestedLocal {}
+     *
+     *         new NestedAnonymous() {}
+     *     }
+     * }
+     * </code></pre>
+     * Of all these class declarations only {@code TopLevel} is a top level class, since all
+     * other classes are declared within the body of {@code TopLevel} and are thereby nested classes.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isNestedClass()
+     * @see #isMemberClass()
+     * @see #isInnerClass()
+     * @see #isLocalClass()
+     * @see #isAnonymousClass()
+     * @return {@code true} if this class is a top level class, i.e. not nested inside of
+     *         any other class, {@code false} otherwise
      */
     @PublicAPI(usage = ACCESS)
     public boolean isTopLevelClass() {
@@ -249,11 +277,37 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
     }
 
     /**
-     * A nested class is any class whose declaration occurs
-     * within the body of another class or interface.
+     * A <b>nested class</b> is any class whose declaration occurs
+     * within the body of another class or interface.<br><br>
      *
-     * @return Returns true if this class is declared within another class.
-     *         Returns false for top-level classes.
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class NestedNonStatic {}
+     *     static class NestedStatic {}
+     *
+     *     void method() {
+     *         class NestedLocal {}
+     *
+     *         new NestedAnonymous() {}
+     *     }
+     * }
+     * </code></pre>
+     * All classes {@code NestedNonStatic}, {@code NestedStatic}, {@code NestedLocal} and the class
+     * the compiler creates for the anonymous class derived from {@code "new NestedAnonymous() {}"}
+     * (which will have some generated name like {@code TopLevel$1})
+     * are considered nested classes. {@code TopLevel} on the other side is no nested class.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isTopLevelClass()
+     * @see #isMemberClass()
+     * @see #isInnerClass()
+     * @see #isLocalClass()
+     * @see #isAnonymousClass()
+     * @return {@code true} if this class is nested, i.e. declared within another class,
+     *         {@code false} otherwise (i.e. for top-level classes)
      */
     @PublicAPI(usage = ACCESS)
     public boolean isNestedClass() {
@@ -261,8 +315,39 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
     }
 
     /**
-     * A member class is a class whose declaration is directly enclosed
-     * in the body of another class or interface declaration.
+     * A <b>member class</b> is a class whose declaration is <u>directly</u> enclosed
+     * in the body of another class or interface declaration.<br><br>
+     *
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class MemberClassNonStatic {}
+     *     static class MemberClassStatic {}
+     *
+     *     void method() {
+     *         class NoMemberLocal {}
+     *
+     *         new NoMemberAnonymous() {}
+     *     }
+     * }
+     * </code></pre>
+     * Both {@code MemberClassNonStatic} and {@code MemberClassStatic} are member classes,
+     * since they are directly declared within the body of {@code TopLevel}.
+     * On the other hand {@code NoMemberLocal} and the class
+     * the compiler creates for the anonymous class derived from {@code "new NoMemberAnonymous() {}"}
+     * (which will have some generated name like {@code TopLevel$1}), as well as {@code TopLevel}
+     * itself, are not considered member classes.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isTopLevelClass()
+     * @see #isNestedClass()
+     * @see #isInnerClass()
+     * @see #isLocalClass()
+     * @see #isAnonymousClass()
+     * @return {@code true} if this class is a member class, i.e. directly declared within
+     *         the body of another class, {@code false} otherwise
      */
     @PublicAPI(usage = ACCESS)
     public boolean isMemberClass() {
@@ -270,27 +355,125 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
     }
 
     /**
-     * An inner class is a nested class that is not explicitly or implicitly declared static.
+     * An <b>inner class</b> is a nested class that is not explicitly or implicitly declared static.<br><br>
      *
-     * @return Returns true if this class is a non-static nested class.
-     *         Returns false otherwise.
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class InnerMemberClass {}
+     *     static class NoInnerClassSinceDeclaredStatic {}
+     *     interface NoInnerClassSinceInterface {}
+     *
+     *     void method() {
+     *         class InnerLocalClass {}
+     *
+     *         new InnerAnonymousClass() {}
+     *     }
+     * }
+     * </code></pre>
+     * The classes {@code InnerMemberClass}, {@code InnerLocalClass} and the class
+     * the compiler creates for the anonymous class derived from {@code "new InnerAnonymousClass() {}"}
+     * (which will have some generated name like {@code TopLevel$1})
+     * are inner classes since they are nested but not static.
+     * On the other hand {@code NoInnerClassSinceDeclaredStatic}, {@code NoInnerClassSinceInterface} and {@code TopLevel}
+     * are no inner classes, because the former two explicitly or implicitly have the
+     * {@code static} modifier while the latter one is a top level class.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isTopLevelClass()
+     * @see #isNestedClass()
+     * @see #isMemberClass()
+     * @see #isLocalClass()
+     * @see #isAnonymousClass()
+     * @return {@code true} if this class is an inner class (i.e. nested but non-static)
+     *         {@code false} otherwise
      */
     @PublicAPI(usage = ACCESS)
     public boolean isInnerClass() {
         return isNestedClass() && !getModifiers().contains(JavaModifier.STATIC);
     }
 
-    @PublicAPI(usage = ACCESS)
-    public boolean isAnonymousClass() {
-        return isAnonymousClass;
-    }
-
     /**
-     * A local class is a nested class that is not a member of any class and that has a name.
+     * A <b>local class</b> is a nested class that is not a member of any class and that has a name.<br><br>
+     *
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class InnerClass {}
+     *     static class NestedStaticClass {}
+     *
+     *     void method() {
+     *         class LocalClass {}
+     *
+     *         new AnonymousClass() {}
+     *     }
+     * }
+     * </code></pre>
+     * Only The class {@code LocalClass} is a local class, since it is a nested class that is not a member
+     * class, but it has the name "LocalClass".<br>
+     * All the other classes {@code TopLevel}, {@code InnerClass}, {@code NestedStaticClass} and
+     * the class the compiler creates for the anonymous class derived from {@code "new AnonymousClass() {}"}
+     * (which will have some generated name like {@code TopLevel$1}) are considered non-local, since they
+     * either are top level, directly declared within the body of {@code TopLevel} or are anonymous
+     * and thus have no name.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isTopLevelClass()
+     * @see #isNestedClass()
+     * @see #isMemberClass()
+     * @see #isInnerClass()
+     * @see #isAnonymousClass()
+     * @return {@code true} if this class is local class,
+     *         {@code false} otherwise
      */
     @PublicAPI(usage = ACCESS)
     public boolean isLocalClass() {
         return isNestedClass() && !isMemberClass() && !getSimpleName().isEmpty();
+    }
+
+    /**
+     * An <b>anonymous class</b> is an inner class that is automatically derived from a class
+     * creation expression with a declared class body, e.g. {@code new Example(){ <some-body> }}.<br>
+     * The compiler will automatically create a class backing this instance, typically with an
+     * autogenerated name like {@code SomeClass$1}, where {@code SomeClass} is the class holding
+     * the class creation expression.<br><br>
+     *
+     * Example:
+     * <pre><code>
+     * public class TopLevel {
+     *     class InnerClass {}
+     *     static class NestedStaticClass {}
+     *
+     *     void method() {
+     *         class LocalClass {}
+     *
+     *         new AnonymousClass() {}
+     *     }
+     * }
+     * </code></pre>
+     * Only the class the compiler creates for the anonymous class derived from {@code "new AnonymousClass() {}"}
+     * (which will have some generated name like {@code TopLevel$1}) is considered an anonymous class.<br>
+     * All the other classes {@code TopLevel}, {@code InnerClass}, {@code NestedStaticClass} and
+     * {@code LocalClass} are considered non-anonymous.
+     * <br><br>
+     * Compare e.g. <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html">
+     *     Java Language Specification</a>
+     *
+     * @see #isTopLevelClass()
+     * @see #isNestedClass()
+     * @see #isMemberClass()
+     * @see #isInnerClass()
+     * @see #isLocalClass()
+     * @return {@code true} if this class is an anonymous class,
+     *         {@code false} otherwise
+     */
+    @PublicAPI(usage = ACCESS)
+    public boolean isAnonymousClass() {
+        return isAnonymousClass;
     }
 
     @Override
@@ -1189,18 +1372,18 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
         };
 
         @PublicAPI(usage = ACCESS)
-        public static final DescribedPredicate<JavaClass> ANONYMOUS_CLASSES = new DescribedPredicate<JavaClass>("anonymous classes") {
-            @Override
-            public boolean apply(JavaClass input) {
-                return input.isAnonymousClass();
-            }
-        };
-
-        @PublicAPI(usage = ACCESS)
         public static final DescribedPredicate<JavaClass> LOCAL_CLASSES = new DescribedPredicate<JavaClass>("local classes") {
             @Override
             public boolean apply(JavaClass input) {
                 return input.isLocalClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> ANONYMOUS_CLASSES = new DescribedPredicate<JavaClass>("anonymous classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isAnonymousClass();
             }
         };
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1157,6 +1157,54 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
         };
 
         @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> TOP_LEVEL_CLASSES = new DescribedPredicate<JavaClass>("top level classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isTopLevelClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> NESTED_CLASSES = new DescribedPredicate<JavaClass>("nested classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isNestedClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> MEMBER_CLASSES = new DescribedPredicate<JavaClass>("member classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isMemberClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> INNER_CLASSES = new DescribedPredicate<JavaClass>("inner classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isInnerClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> ANONYMOUS_CLASSES = new DescribedPredicate<JavaClass>("anonymous classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isAnonymousClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> LOCAL_CLASSES = new DescribedPredicate<JavaClass>("local classes") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isLocalClass();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> type(final Class<?> type) {
             return equalTo(type.getName()).<JavaClass>onResultOf(GET_NAME).as("type " + type.getName());
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -314,6 +314,8 @@ public final class DomainBuilders {
         private JavaType javaType;
         private boolean isInterface;
         private boolean isEnum;
+        private boolean isAnonymousClass;
+        private boolean isMemberClass;
         private Set<JavaModifier> modifiers = new HashSet<>();
 
         JavaClassBuilder() {
@@ -336,6 +338,16 @@ public final class DomainBuilders {
 
         JavaClassBuilder withInterface(boolean isInterface) {
             this.isInterface = isInterface;
+            return this;
+        }
+
+        JavaClassBuilder withAnonymousClass(boolean isAnonymousClass) {
+            this.isAnonymousClass = isAnonymousClass;
+            return this;
+        }
+
+        JavaClassBuilder withMemberClass(boolean isMemberClass) {
+            this.isMemberClass = isMemberClass;
             return this;
         }
 
@@ -372,6 +384,14 @@ public final class DomainBuilders {
 
         public boolean isEnum() {
             return isEnum;
+        }
+
+        public boolean isAnonymousClass() {
+            return isAnonymousClass;
+        }
+
+        public boolean isMemberClass() {
+            return isMemberClass;
         }
 
         public Set<JavaModifier> getModifiers() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -154,6 +154,12 @@ class JavaClassProcessor extends ClassVisitor {
 
         javaClassBuilder.withSimpleName(nullToEmpty(innerName));
 
+        // Javadoc for innerName: "May be null for anonymous inner classes."
+        javaClassBuilder.withAnonymousClass(innerName == null);
+
+        // Javadoc for outerName: "May be null for not member classes."
+        javaClassBuilder.withMemberClass(outerName != null);
+
         if (isNamedNestedClass(outerName)) {
             javaClassBuilder.withModifiers(JavaModifier.getModifiersForClass(access));
             declarationHandler.registerEnclosingClass(innerTypeName, createTypeName(outerName));

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -155,12 +155,14 @@ class JavaClassProcessor extends ClassVisitor {
         javaClassBuilder.withSimpleName(nullToEmpty(innerName));
 
         // Javadoc for innerName: "May be null for anonymous inner classes."
-        javaClassBuilder.withAnonymousClass(innerName == null);
+        boolean isAnonymousClass = innerName == null;
+        javaClassBuilder.withAnonymousClass(isAnonymousClass);
 
         // Javadoc for outerName: "May be null for not member classes."
-        javaClassBuilder.withMemberClass(outerName != null);
+        boolean isMemberClass = outerName != null;
+        javaClassBuilder.withMemberClass(isMemberClass);
 
-        if (isNamedNestedClass(outerName)) {
+        if (isMemberClass) {
             javaClassBuilder.withModifiers(JavaModifier.getModifiersForClass(access));
             declarationHandler.registerEnclosingClass(innerTypeName, createTypeName(outerName));
         }
@@ -174,10 +176,6 @@ class JavaClassProcessor extends ClassVisitor {
     // are found in the access flags of visitInnerClass(..)
     private boolean visitingCurrentClass(String innerTypeName) {
         return innerTypeName.equals(className);
-    }
-
-    private boolean isNamedNestedClass(String outerName) {
-        return outerName != null;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -840,6 +840,66 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beTopLevelClasses() {
+        return ClassKindCondition.BE_TOP_LEVEL_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeTopLevelClasses() {
+        return not(ClassKindCondition.BE_TOP_LEVEL_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beNestedClasses() {
+        return ClassKindCondition.BE_NESTED_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeNestedClasses() {
+        return not(ClassKindCondition.BE_NESTED_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beMemberClasses() {
+        return ClassKindCondition.BE_MEMBER_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeMemberClasses() {
+        return not(ClassKindCondition.BE_MEMBER_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beInnerClasses() {
+        return ClassKindCondition.BE_INNER_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeInnerClasses() {
+        return not(ClassKindCondition.BE_INNER_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beAnonymousClasses() {
+        return ClassKindCondition.BE_ANONYMOUS_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeAnonymousClasses() {
+        return not(ClassKindCondition.BE_ANONYMOUS_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> beLocalClasses() {
+        return ClassKindCondition.BE_LOCAL_CLASSES;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notBeLocalClasses() {
+        return not(ClassKindCondition.BE_LOCAL_CLASSES);
+    }
+
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
         return new NumberOfElementsCondition(predicate);
     }
@@ -1017,6 +1077,34 @@ public final class ArchConditions {
             String message = createMessage(javaClass,
                     (isEnum ? "is an" : "is not an") + " enum");
             events.add(new SimpleConditionEvent(javaClass, isEnum, message));
+        }
+    }
+
+    private static class ClassKindCondition extends ArchCondition<JavaClass> {
+
+        private static final ClassKindCondition BE_TOP_LEVEL_CLASSES =
+                new ClassKindCondition("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
+        private static final ClassKindCondition BE_NESTED_CLASSES = new ClassKindCondition("a nested class", JavaClass.Predicates.NESTED_CLASSES);
+        private static final ClassKindCondition BE_MEMBER_CLASSES = new ClassKindCondition("a member class", JavaClass.Predicates.MEMBER_CLASSES);
+        private static final ClassKindCondition BE_INNER_CLASSES = new ClassKindCondition("an inner class", JavaClass.Predicates.INNER_CLASSES);
+        private static final ClassKindCondition BE_ANONYMOUS_CLASSES =
+                new ClassKindCondition("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
+        private static final ClassKindCondition BE_LOCAL_CLASSES = new ClassKindCondition("a local class", JavaClass.Predicates.LOCAL_CLASSES);
+
+        private final String kind;
+        private final DescribedPredicate<JavaClass> predicate;
+
+        private ClassKindCondition(String kind, DescribedPredicate<JavaClass> predicate) {
+            super("be " + predicate.getDescription());
+            this.kind = kind;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void check(JavaClass javaClass, ConditionEvents events) {
+            boolean isSatisfied = predicate.apply(javaClass);
+            String message = createMessage(javaClass, (isSatisfied ? "is" : "is not") + " " + kind);
+            events.add(new SimpleConditionEvent(javaClass, isSatisfied, message));
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -841,62 +841,62 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beTopLevelClasses() {
-        return ClassKindCondition.BE_TOP_LEVEL_CLASSES;
+        return BE_TOP_LEVEL_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeTopLevelClasses() {
-        return not(ClassKindCondition.BE_TOP_LEVEL_CLASSES);
+        return not(BE_TOP_LEVEL_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beNestedClasses() {
-        return ClassKindCondition.BE_NESTED_CLASSES;
+        return BE_NESTED_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeNestedClasses() {
-        return not(ClassKindCondition.BE_NESTED_CLASSES);
+        return not(BE_NESTED_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beMemberClasses() {
-        return ClassKindCondition.BE_MEMBER_CLASSES;
+        return BE_MEMBER_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeMemberClasses() {
-        return not(ClassKindCondition.BE_MEMBER_CLASSES);
+        return not(BE_MEMBER_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beInnerClasses() {
-        return ClassKindCondition.BE_INNER_CLASSES;
+        return BE_INNER_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeInnerClasses() {
-        return not(ClassKindCondition.BE_INNER_CLASSES);
+        return not(BE_INNER_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAnonymousClasses() {
-        return ClassKindCondition.BE_ANONYMOUS_CLASSES;
+        return BE_ANONYMOUS_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAnonymousClasses() {
-        return not(ClassKindCondition.BE_ANONYMOUS_CLASSES);
+        return not(BE_ANONYMOUS_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beLocalClasses() {
-        return ClassKindCondition.BE_LOCAL_CLASSES;
+        return BE_LOCAL_CLASSES;
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeLocalClasses() {
-        return not(ClassKindCondition.BE_LOCAL_CLASSES);
+        return not(BE_LOCAL_CLASSES);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -997,6 +997,19 @@ public final class ArchConditions {
         return object.getDescription() + " " + message + " in " + object.getSourceCodeLocation();
     }
 
+    private static final IsConditionByPredicate<JavaClass> BE_TOP_LEVEL_CLASSES =
+            new IsConditionByPredicate<>("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
+    private static final IsConditionByPredicate<JavaClass> BE_NESTED_CLASSES =
+            new IsConditionByPredicate<>("a nested class", JavaClass.Predicates.NESTED_CLASSES);
+    private static final IsConditionByPredicate<JavaClass> BE_MEMBER_CLASSES =
+            new IsConditionByPredicate<>("a member class", JavaClass.Predicates.MEMBER_CLASSES);
+    private static final IsConditionByPredicate<JavaClass> BE_INNER_CLASSES =
+            new IsConditionByPredicate<>("an inner class", JavaClass.Predicates.INNER_CLASSES);
+    private static final IsConditionByPredicate<JavaClass> BE_ANONYMOUS_CLASSES =
+            new IsConditionByPredicate<>("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
+    private static final IsConditionByPredicate<JavaClass> BE_LOCAL_CLASSES =
+            new IsConditionByPredicate<>("a local class", JavaClass.Predicates.LOCAL_CLASSES);
+
     private static class HaveOnlyModifiersCondition<T extends HasModifiers & HasDescription & HasSourceCodeLocation>
             extends AllAttributesMatchCondition<T> {
 
@@ -1077,34 +1090,6 @@ public final class ArchConditions {
             String message = createMessage(javaClass,
                     (isEnum ? "is an" : "is not an") + " enum");
             events.add(new SimpleConditionEvent(javaClass, isEnum, message));
-        }
-    }
-
-    private static class ClassKindCondition extends ArchCondition<JavaClass> {
-
-        private static final ClassKindCondition BE_TOP_LEVEL_CLASSES =
-                new ClassKindCondition("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
-        private static final ClassKindCondition BE_NESTED_CLASSES = new ClassKindCondition("a nested class", JavaClass.Predicates.NESTED_CLASSES);
-        private static final ClassKindCondition BE_MEMBER_CLASSES = new ClassKindCondition("a member class", JavaClass.Predicates.MEMBER_CLASSES);
-        private static final ClassKindCondition BE_INNER_CLASSES = new ClassKindCondition("an inner class", JavaClass.Predicates.INNER_CLASSES);
-        private static final ClassKindCondition BE_ANONYMOUS_CLASSES =
-                new ClassKindCondition("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
-        private static final ClassKindCondition BE_LOCAL_CLASSES = new ClassKindCondition("a local class", JavaClass.Predicates.LOCAL_CLASSES);
-
-        private final String kind;
-        private final DescribedPredicate<JavaClass> predicate;
-
-        private ClassKindCondition(String kind, DescribedPredicate<JavaClass> predicate) {
-            super("be " + predicate.getDescription());
-            this.kind = kind;
-            this.predicate = predicate;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean isSatisfied = predicate.apply(javaClass);
-            String message = createMessage(javaClass, (isSatisfied ? "is" : "is not") + " " + kind);
-            events.add(new SimpleConditionEvent(javaClass, isSatisfied, message));
         }
     }
 
@@ -1276,10 +1261,16 @@ public final class ArchConditions {
     }
 
     private static class IsConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
+        private final String eventDescription;
         private final DescribedPredicate<T> predicate;
 
         IsConditionByPredicate(DescribedPredicate<? super T> predicate) {
+            this(predicate.getDescription(), predicate);
+        }
+
+        IsConditionByPredicate(String eventDescription, DescribedPredicate<? super T> predicate) {
             super(ArchPredicates.be(predicate).getDescription());
+            this.eventDescription = eventDescription;
             this.predicate = predicate.forSubType();
         }
 
@@ -1287,7 +1278,7 @@ public final class ArchConditions {
         public void check(T member, ConditionEvents events) {
             boolean satisfied = predicate.apply(member);
             String message = createMessage(member,
-                    (satisfied ? "is " : "is not ") + predicate.getDescription());
+                    (satisfied ? "is " : "is not ") + eventDescription);
             events.add(new SimpleConditionEvent(member, satisfied, message));
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -585,6 +585,66 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesShouldConjunction beTopLevelClasses() {
+        return addCondition(ArchConditions.beTopLevelClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeTopLevelClasses() {
+        return addCondition(ArchConditions.notBeTopLevelClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction beNestedClasses() {
+        return addCondition(ArchConditions.beNestedClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeNestedClasses() {
+        return addCondition(ArchConditions.notBeNestedClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction beMemberClasses() {
+        return addCondition(ArchConditions.beMemberClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeMemberClasses() {
+        return addCondition(ArchConditions.notBeMemberClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction beInnerClasses() {
+        return addCondition(ArchConditions.beInnerClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeInnerClasses() {
+        return addCondition(ArchConditions.notBeInnerClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction beAnonymousClasses() {
+        return addCondition(ArchConditions.beAnonymousClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeAnonymousClasses() {
+        return addCondition(ArchConditions.notBeAnonymousClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction beLocalClasses() {
+        return addCondition(ArchConditions.beLocalClasses());
+    }
+
+    @Override
+    public ClassesShouldConjunction notBeLocalClasses() {
+        return addCondition(ArchConditions.notBeLocalClasses());
+    }
+
+    @Override
     public ClassesShouldConjunction containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
         return addCondition(ArchConditions.containNumberOfElements(predicate));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -28,8 +28,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INNER_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.LOCAL_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.MEMBER_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.NESTED_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.TOP_LEVEL_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
@@ -290,6 +296,66 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
     @Override
     public CONJUNCTION areNotEnums() {
         return givenWith(are(not(ENUMS)));
+    }
+
+    @Override
+    public CONJUNCTION areTopLevelClasses() {
+        return givenWith(are(TOP_LEVEL_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotTopLevelClasses() {
+        return givenWith(are(not(TOP_LEVEL_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areNestedClasses() {
+        return givenWith(are(NESTED_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotNestedClasses() {
+        return givenWith(are(not(NESTED_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areMemberClasses() {
+        return givenWith(are(MEMBER_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotMemberClasses() {
+        return givenWith(are(not(MEMBER_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areInnerClasses() {
+        return givenWith(are(INNER_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotInnerClasses() {
+        return givenWith(are(not(INNER_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areAnonymousClasses() {
+        return givenWith(are(ANONYMOUS_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotAnonymousClasses() {
+        return givenWith(are(not(ANONYMOUS_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areLocalClasses() {
+        return givenWith(are(LOCAL_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotLocalClasses() {
+        return givenWith(are(not(LOCAL_CLASSES)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -29,8 +29,14 @@ import com.tngtech.archunit.lang.syntax.elements.GivenMembersConjunction;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.dont;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INNER_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.LOCAL_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.MEMBER_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.NESTED_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.TOP_LEVEL_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
@@ -378,6 +384,66 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
     @Override
     public CONJUNCTION areNotEnums() {
         return givenWith(are(not(ENUMS)));
+    }
+
+    @Override
+    public CONJUNCTION areTopLevelClasses() {
+        return givenWith(are(TOP_LEVEL_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotTopLevelClasses() {
+        return givenWith(are(not(TOP_LEVEL_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areNestedClasses() {
+        return givenWith(are(NESTED_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotNestedClasses() {
+        return givenWith(are(not(NESTED_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areMemberClasses() {
+        return givenWith(are(MEMBER_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotMemberClasses() {
+        return givenWith(are(not(MEMBER_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areInnerClasses() {
+        return givenWith(are(INNER_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotInnerClasses() {
+        return givenWith(are(not(INNER_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areAnonymousClasses() {
+        return givenWith(are(ANONYMOUS_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotAnonymousClasses() {
+        return givenWith(are(not(ANONYMOUS_CLASSES)));
+    }
+
+    @Override
+    public CONJUNCTION areLocalClasses() {
+        return givenWith(are(LOCAL_CLASSES));
+    }
+
+    @Override
+    public CONJUNCTION areNotLocalClasses() {
+        return givenWith(are(not(LOCAL_CLASSES)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -988,6 +988,42 @@ public interface ClassesShould {
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeEnums();
 
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beTopLevelClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeTopLevelClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beNestedClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeNestedClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beMemberClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeMemberClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beInnerClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeInnerClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beAnonymousClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeAnonymousClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction beLocalClasses();
+
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction notBeLocalClasses();
+
     /**
      * Asserts that the rule matches exactly the given class.
      *

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -642,6 +642,42 @@ public interface ClassesThat<CONJUNCTION> {
     @PublicAPI(usage = ACCESS)
     CONJUNCTION areNotEnums();
 
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areTopLevelClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotTopLevelClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNestedClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotNestedClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areMemberClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotMemberClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areInnerClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotInnerClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areAnonymousClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotAnonymousClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areLocalClasses();
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotLocalClasses();
+
     /**
      * Matches every class in the supplied list and any of their named/anonymous inner classes,
      * no matter how deeply nested. E.g. consider

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -271,8 +271,12 @@ public class ClassFileImporterTest {
         assertThat(javaClass.isInterface()).as("is interface").isFalse();
         assertThat(javaClass.isEnum()).as("is enum").isFalse();
         assertThat(javaClass.getEnclosingClass()).as("enclosing class").isAbsent();
+        assertThat(javaClass.isTopLevelClass()).as("is top level class").isTrue();
+        assertThat(javaClass.isNestedClass()).as("is nested class").isFalse();
+        assertThat(javaClass.isMemberClass()).as("is member class").isFalse();
         assertThat(javaClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(javaClass.isAnonymous()).as("is anonymous class").isFalse();
+        assertThat(javaClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(javaClass.isLocalClass()).as("is local class").isFalse();
 
         assertThat(classes.get(ClassToImportTwo.class).getModifiers()).containsOnly(JavaModifier.PUBLIC, JavaModifier.FINAL);
     }
@@ -304,9 +308,12 @@ public class ClassFileImporterTest {
         JavaClass staticNestedClass = classes.get(ClassWithInnerClass.Nested.class);
 
         assertThat(staticNestedClass).matches(ClassWithInnerClass.Nested.class);
+        assertThat(staticNestedClass.isTopLevelClass()).as("is top level class").isFalse();
         assertThat(staticNestedClass.isNestedClass()).as("is nested class").isTrue();
+        assertThat(staticNestedClass.isMemberClass()).as("is member class").isTrue();
         assertThat(staticNestedClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(staticNestedClass.isAnonymous()).as("is anonymous class").isFalse();
+        assertThat(staticNestedClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(staticNestedClass.isLocalClass()).as("is local class").isFalse();
     }
 
     @Test
@@ -315,9 +322,12 @@ public class ClassFileImporterTest {
         JavaClass innerClass = classes.get(ClassWithInnerClass.Inner.class);
 
         assertThat(innerClass).matches(ClassWithInnerClass.Inner.class);
+        assertThat(innerClass.isTopLevelClass()).as("is top level class").isFalse();
         assertThat(innerClass.isNestedClass()).as("is nested class").isTrue();
+        assertThat(innerClass.isMemberClass()).as("is member class").isTrue();
         assertThat(innerClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(innerClass.isAnonymous()).as("is anonymous class").isFalse();
+        assertThat(innerClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(innerClass.isLocalClass()).as("is local class").isFalse();
     }
 
     @Test
@@ -326,9 +336,12 @@ public class ClassFileImporterTest {
         JavaClass anonymousClass = classes.get(ClassWithInnerClass.class.getName() + "$1");
 
         assertThat(anonymousClass).matches(Class.forName(anonymousClass.getName()));
+        assertThat(anonymousClass.isTopLevelClass()).as("is top level class").isFalse();
         assertThat(anonymousClass.isNestedClass()).as("is nested class").isTrue();
+        assertThat(anonymousClass.isMemberClass()).as("is member class").isFalse();
         assertThat(anonymousClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(anonymousClass.isAnonymous()).as("class is anonymous").isTrue();
+        assertThat(anonymousClass.isAnonymousClass()).as("is anonymous class").isTrue();
+        assertThat(anonymousClass.isLocalClass()).as("is local class").isFalse();
     }
 
     @Test
@@ -337,9 +350,12 @@ public class ClassFileImporterTest {
         JavaClass localClass = classes.get(ClassWithInnerClass.class.getName() + "$1LocalCaller");
 
         assertThat(localClass).matches(Class.forName(localClass.getName()));
+        assertThat(localClass.isTopLevelClass()).as("is top level class").isFalse();
         assertThat(localClass.isNestedClass()).as("is nested class").isTrue();
+        assertThat(localClass.isMemberClass()).as("is member class").isFalse();
         assertThat(localClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(localClass.isAnonymous()).as("class is anonymous").isFalse();
+        assertThat(localClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(localClass.isLocalClass()).as("is local class").isTrue();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -275,8 +275,8 @@ public class ClassFileImporterTest {
         assertThat(javaClass.isNestedClass()).as("is nested class").isFalse();
         assertThat(javaClass.isMemberClass()).as("is member class").isFalse();
         assertThat(javaClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(javaClass.isAnonymousClass()).as("is anonymous class").isFalse();
         assertThat(javaClass.isLocalClass()).as("is local class").isFalse();
+        assertThat(javaClass.isAnonymousClass()).as("is anonymous class").isFalse();
 
         assertThat(classes.get(ClassToImportTwo.class).getModifiers()).containsOnly(JavaModifier.PUBLIC, JavaModifier.FINAL);
     }
@@ -302,18 +302,24 @@ public class ClassFileImporterTest {
                 .containsOnly(EnumToImport.FIRST.name(), EnumToImport.SECOND.name());
     }
 
-    @Test
-    public void imports_simple_static_nested_class() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
-        JavaClass staticNestedClass = classes.get(ClassWithInnerClass.Nested.class);
+    @DataProvider
+    public static Object[][] nested_static_classes() {
+        return testForEach(ClassWithInnerClass.NestedStatic.class, ClassWithInnerClass.ImplicitlyNestedStatic.class);
+    }
 
-        assertThat(staticNestedClass).matches(ClassWithInnerClass.Nested.class);
+    @Test
+    @UseDataProvider("nested_static_classes")
+    public void imports_simple_static_nested_class(Class<?> nestedStaticClass) throws Exception {
+        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+        JavaClass staticNestedClass = classes.get(nestedStaticClass);
+
+        assertThat(staticNestedClass).matches(nestedStaticClass);
         assertThat(staticNestedClass.isTopLevelClass()).as("is top level class").isFalse();
         assertThat(staticNestedClass.isNestedClass()).as("is nested class").isTrue();
         assertThat(staticNestedClass.isMemberClass()).as("is member class").isTrue();
         assertThat(staticNestedClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(staticNestedClass.isAnonymousClass()).as("is anonymous class").isFalse();
         assertThat(staticNestedClass.isLocalClass()).as("is local class").isFalse();
+        assertThat(staticNestedClass.isAnonymousClass()).as("is anonymous class").isFalse();
     }
 
     @Test
@@ -326,8 +332,8 @@ public class ClassFileImporterTest {
         assertThat(innerClass.isNestedClass()).as("is nested class").isTrue();
         assertThat(innerClass.isMemberClass()).as("is member class").isTrue();
         assertThat(innerClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(innerClass.isAnonymousClass()).as("is anonymous class").isFalse();
         assertThat(innerClass.isLocalClass()).as("is local class").isFalse();
+        assertThat(innerClass.isAnonymousClass()).as("is anonymous class").isFalse();
     }
 
     @Test
@@ -340,8 +346,8 @@ public class ClassFileImporterTest {
         assertThat(anonymousClass.isNestedClass()).as("is nested class").isTrue();
         assertThat(anonymousClass.isMemberClass()).as("is member class").isFalse();
         assertThat(anonymousClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(anonymousClass.isAnonymousClass()).as("is anonymous class").isTrue();
         assertThat(anonymousClass.isLocalClass()).as("is local class").isFalse();
+        assertThat(anonymousClass.isAnonymousClass()).as("is anonymous class").isTrue();
     }
 
     @Test
@@ -354,8 +360,8 @@ public class ClassFileImporterTest {
         assertThat(localClass.isNestedClass()).as("is nested class").isTrue();
         assertThat(localClass.isMemberClass()).as("is member class").isFalse();
         assertThat(localClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(localClass.isAnonymousClass()).as("is anonymous class").isFalse();
         assertThat(localClass.isLocalClass()).as("is local class").isTrue();
+        assertThat(localClass.isAnonymousClass()).as("is anonymous class").isFalse();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/innerclassimport/ClassWithInnerClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/innerclassimport/ClassWithInnerClass.java
@@ -36,13 +36,16 @@ public class ClassWithInnerClass {
         }
     }
 
-    public static class Nested implements CanBeCalled {
+    public static class NestedStatic implements CanBeCalled {
         private CalledClass calledClass;
 
         @Override
         public void call() {
             calledClass.doIt();
         }
+    }
+
+    public interface ImplicitlyNestedStatic {
     }
 
     public interface CanBeCalled {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1358,6 +1358,270 @@ public class ClassesShouldTest {
     }
 
     @DataProvider
+    public static Object[][] beTopLevelClasses_rules() {
+        Class<?> topLevelClass = List.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().beTopLevelClasses(), topLevelClass, staticNestedClass),
+                $(classes().should(ArchConditions.beTopLevelClasses()), topLevelClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beTopLevelClasses_rules")
+    public void beTopLevelClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be top level classes")
+                .containsPattern(String.format("Class <%s> is not a top level class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* top level class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeTopLevelClasses_rules() {
+        Class<?> topLevelClass = List.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().notBeTopLevelClasses(), staticNestedClass, topLevelClass),
+                $(classes().should(ArchConditions.notBeTopLevelClasses()), staticNestedClass, topLevelClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeTopLevelClasses_rules")
+    public void notBeTopLevelClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be top level classes")
+                .containsPattern(String.format("Class <%s> is a top level class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* top level class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] beNestedClasses_rules() {
+        Class<?> topLevelClass = List.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().beNestedClasses(), staticNestedClass, topLevelClass),
+                $(classes().should(ArchConditions.beNestedClasses()), staticNestedClass, topLevelClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beNestedClasses_rules")
+    public void beNestedClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be nested classes")
+                .containsPattern(String.format("Class <%s> is not a nested class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* nested class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeNestedClasses_rules() {
+        Class<?> topLevelClass = List.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().notBeNestedClasses(), topLevelClass, staticNestedClass),
+                $(classes().should(ArchConditions.notBeNestedClasses()), topLevelClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeNestedClasses_rules")
+    public void notBeNestedClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be nested classes")
+                .containsPattern(String.format("Class <%s> is a nested class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* nested class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] beMemberClasses_rules() {
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+        Class<?> anonymousClass = NestedClassWithSomeMoreClasses.getAnonymousClass();
+
+        return $$(
+                $(classes().should().beMemberClasses(), staticNestedClass, anonymousClass),
+                $(classes().should(ArchConditions.beMemberClasses()), staticNestedClass, anonymousClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beMemberClasses_rules")
+    public void beMemberClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be member classes")
+                .containsPattern(String.format("Class <%s> is not a member class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* member class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeMemberClasses_rules() {
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+        Class<?> anonymousClass = NestedClassWithSomeMoreClasses.getAnonymousClass();
+
+        return $$(
+                $(classes().should().notBeMemberClasses(), anonymousClass, staticNestedClass),
+                $(classes().should(ArchConditions.notBeMemberClasses()), anonymousClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeMemberClasses_rules")
+    public void notBeMemberClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be member classes")
+                .containsPattern(String.format("Class <%s> is a member class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* member class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] beInnerClasses_rules() {
+        Class<?> nonStaticNestedClass = NestedClassWithSomeMoreClasses.NonStaticNestedClass.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().beInnerClasses(), nonStaticNestedClass, staticNestedClass),
+                $(classes().should(ArchConditions.beInnerClasses()), nonStaticNestedClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beInnerClasses_rules")
+    public void beInnerClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be inner classes")
+                .containsPattern(String.format("Class <%s> is not an inner class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* inner class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeInnerClasses_rules() {
+        Class<?> nonStaticNestedClass = NestedClassWithSomeMoreClasses.NonStaticNestedClass.class;
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().notBeInnerClasses(), staticNestedClass, nonStaticNestedClass),
+                $(classes().should(ArchConditions.notBeInnerClasses()), staticNestedClass, nonStaticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeInnerClasses_rules")
+    public void notBeInnerClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be inner classes")
+                .containsPattern(String.format("Class <%s> is an inner class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* inner class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] beAnonymousClasses_rules() {
+        Class<?> anonymousClass = NestedClassWithSomeMoreClasses.getAnonymousClass();
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().beAnonymousClasses(), anonymousClass, staticNestedClass),
+                $(classes().should(ArchConditions.beAnonymousClasses()), anonymousClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beAnonymousClasses_rules")
+    public void beAnonymousClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be anonymous classes")
+                .containsPattern(String.format("Class <%s> is not an anonymous class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* anonymous class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeAnonymousClasses_rules() {
+        Class<?> anonymousClass = NestedClassWithSomeMoreClasses.getAnonymousClass();
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().notBeAnonymousClasses(), staticNestedClass, anonymousClass),
+                $(classes().should(ArchConditions.notBeAnonymousClasses()), staticNestedClass, anonymousClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeAnonymousClasses_rules")
+    public void notBeAnonymousClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be anonymous classes")
+                .containsPattern(String.format("Class <%s> is an anonymous class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* anonymous class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] beLocalClasses_rules() {
+        Class<?> localClass = NestedClassWithSomeMoreClasses.getLocalClass();
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().beLocalClasses(), localClass, staticNestedClass),
+                $(classes().should(ArchConditions.beLocalClasses()), localClass, staticNestedClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("beLocalClasses_rules")
+    public void beLocalClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be local classes")
+                .containsPattern(String.format("Class <%s> is not a local class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* local class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] notBeLocalClasses_rules() {
+        Class<?> localClass = NestedClassWithSomeMoreClasses.getLocalClass();
+        Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
+
+        return $$(
+                $(classes().should().notBeLocalClasses(), staticNestedClass, localClass),
+                $(classes().should(ArchConditions.notBeLocalClasses()), staticNestedClass, localClass)
+        );
+    }
+
+    @Test
+    @UseDataProvider("notBeLocalClasses_rules")
+    public void notBeLocalClasses(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be local classes")
+                .containsPattern(String.format("Class <%s> is a local class", quote(violated.getName())))
+                .doesNotMatch(String.format(".*%s.* local class.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
     public static Object[][] containNumberOfElements_rules() {
         return $$(
                 $(equalTo(999)),
@@ -1681,4 +1945,26 @@ public class ClassesShouldTest {
     @RuntimeRetentionAnnotation
     private static class SomeAnnotatedClass {
     }
+
+    private static class NestedClassWithSomeMoreClasses {
+
+        static class StaticNestedClass {
+        }
+
+        @SuppressWarnings("InnerClassMayBeStatic")
+        class NonStaticNestedClass {
+        }
+
+        static Class<?> getAnonymousClass() {
+            return new Serializable() {
+            }.getClass();
+        }
+
+        static Class<?> getLocalClass() {
+            class LocalClass {
+            }
+            return LocalClass.class;
+        }
+    }
+
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1491,12 +1491,12 @@ public class ClassesShouldTest {
 
     @DataProvider
     public static Object[][] beInnerClasses_rules() {
-        Class<?> nonStaticNestedClass = NestedClassWithSomeMoreClasses.NonStaticNestedClass.class;
+        Class<?> innerMemberClass = NestedClassWithSomeMoreClasses.InnerMemberClass.class;
         Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
 
         return $$(
-                $(classes().should().beInnerClasses(), nonStaticNestedClass, staticNestedClass),
-                $(classes().should(ArchConditions.beInnerClasses()), nonStaticNestedClass, staticNestedClass)
+                $(classes().should().beInnerClasses(), innerMemberClass, staticNestedClass),
+                $(classes().should(ArchConditions.beInnerClasses()), innerMemberClass, staticNestedClass)
         );
     }
 
@@ -1513,7 +1513,7 @@ public class ClassesShouldTest {
 
     @DataProvider
     public static Object[][] notBeInnerClasses_rules() {
-        Class<?> nonStaticNestedClass = NestedClassWithSomeMoreClasses.NonStaticNestedClass.class;
+        Class<?> nonStaticNestedClass = NestedClassWithSomeMoreClasses.InnerMemberClass.class;
         Class<?> staticNestedClass = NestedClassWithSomeMoreClasses.StaticNestedClass.class;
 
         return $$(
@@ -1952,7 +1952,7 @@ public class ClassesShouldTest {
         }
 
         @SuppressWarnings("InnerClassMayBeStatic")
-        class NonStaticNestedClass {
+        class InnerMemberClass {
         }
 
         static Class<?> getAnonymousClass() {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -658,7 +658,7 @@ public class GivenClassesThatTest {
     public void areTopLevelClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areTopLevelClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes).matchInAnyOrder(List.class, Map.class);
@@ -668,12 +668,12 @@ public class GivenClassesThatTest {
     public void areNotTopLevelClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotTopLevelClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes)
                 .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -681,12 +681,12 @@ public class GivenClassesThatTest {
     public void areNestedClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areNestedClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes)
                 .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -694,7 +694,7 @@ public class GivenClassesThatTest {
     public void areNotNestedClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotNestedClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes).matchInAnyOrder(List.class, Map.class);
@@ -704,19 +704,19 @@ public class GivenClassesThatTest {
     public void areMemberClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areMemberClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes)
                 .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class);
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class);
     }
 
     @Test
     public void areNotMemberClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotMemberClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes).matchInAnyOrder(List.class, Map.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
@@ -727,11 +727,11 @@ public class GivenClassesThatTest {
     public void areInnerClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areInnerClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes)
-                .matchInAnyOrder(NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                .matchInAnyOrder(NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -739,7 +739,7 @@ public class GivenClassesThatTest {
     public void areNotInnerClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areNotInnerClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
-                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                         NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatClasses(classes).matchInAnyOrder(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
@@ -911,7 +911,7 @@ public class GivenClassesThatTest {
         }
 
         @SuppressWarnings("InnerClassMayBeStatic")
-        class NonStaticNestedClass {
+        class InnerMemberClass {
         }
 
         static Class<?> getAnonymousClass() {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -11,6 +11,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.tngtech.archunit.base.DescribedPredicate;
@@ -654,6 +655,130 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void areTopLevelClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areTopLevelClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Map.class);
+    }
+
+    @Test
+    public void areNotTopLevelClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotTopLevelClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes)
+                .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNestedClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNestedClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes)
+                .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotNestedClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotNestedClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Map.class);
+    }
+
+    @Test
+    public void areMemberClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areMemberClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes)
+                .matchInAnyOrder(Map.Entry.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class);
+    }
+
+    @Test
+    public void areNotMemberClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotMemberClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Map.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areInnerClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areInnerClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes)
+                .matchInAnyOrder(NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotInnerClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotInnerClasses())
+                .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                        NestedClassWithSomeMoreClasses.StaticNestedClass.class, NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,
+                NestedClassWithSomeMoreClasses.StaticNestedClass.class);
+    }
+
+    @Test
+    public void areAnonymousClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areAnonymousClasses())
+                .on(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(NestedClassWithSomeMoreClasses.getAnonymousClass());
+    }
+
+    @Test
+    public void areNotAnonymousClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotAnonymousClasses())
+                .on(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areLocalClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areLocalClasses())
+                .on(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotLocalClasses_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotLocalClasses())
+                .on(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatClasses(classes).matchInAnyOrder(Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.getAnonymousClass());
+    }
+
+    @Test
     public void belongToAnyOf() {
         List<JavaClass> classes = filterResultOf(classes().that().belongToAnyOf(ClassWithInnerClasses.class, String.class))
                 .on(ClassWithInnerClasses.class, ClassWithInnerClasses.InnerClass.class, ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class,
@@ -777,6 +902,27 @@ public class GivenClassesThatTest {
         private static class InnerClass {
             private static class EvenMoreInnerClass {
             }
+        }
+    }
+
+    private static class NestedClassWithSomeMoreClasses {
+
+        static class StaticNestedClass {
+        }
+
+        @SuppressWarnings("InnerClassMayBeStatic")
+        class NonStaticNestedClass {
+        }
+
+        static Class<?> getAnonymousClass() {
+            return new Serializable() {
+            }.getClass();
+        }
+
+        static Class<?> getLocalClass() {
+            class LocalClass {
+            }
+            return LocalClass.class;
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -652,6 +652,135 @@ public class GivenMembersDeclaredInClassesThatTest {
     }
 
     @Test
+    public void areTopLevelClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areTopLevelClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(String.class);
+    }
+
+    @Test
+    public void areNotTopLevelClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotTopLevelClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNestedClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNestedClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotNestedClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotNestedClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(String.class);
+    }
+
+    @Test
+    public void areMemberClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areMemberClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class);
+    }
+
+    @Test
+    public void areNotMemberClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotMemberClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(String.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areInnerClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areInnerClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+                NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotInnerClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotInnerClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
+                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class);
+    }
+
+    @Test
+    public void areAnonymousClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areAnonymousClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.getAnonymousClass());
+    }
+
+    @Test
+    public void areNotAnonymousClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotAnonymousClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areLocalClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areLocalClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.getLocalClass());
+    }
+
+    @Test
+    public void areNotLocalClasses_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotLocalClasses())
+                .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.getLocalClass());
+
+        assertThatMembers(members)
+                .matchInAnyOrderMembersOf(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.getAnonymousClass());
+    }
+
+    @Test
     public void belongToAnyOf() {
         List<JavaMember> members =
                 filterResultOf(members().that().areDeclaredInClassesThat().belongToAnyOf(ClassWithInnerClasses.class, String.class))
@@ -763,6 +892,34 @@ public class GivenMembersDeclaredInClassesThatTest {
             private static class EvenMoreInnerClass {
                 String member;
             }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class NestedClassWithSomeMoreClasses {
+
+        String member;
+
+        static class StaticNestedClass {
+            String member;
+        }
+
+        @SuppressWarnings("InnerClassMayBeStatic")
+        class NonStaticNestedClass {
+            String member;
+        }
+
+        static Class<?> getAnonymousClass() {
+            return new Serializable() {
+                String member;
+            }.getClass();
+        }
+
+        static Class<?> getLocalClass() {
+            class LocalClass {
+                String member;
+            }
+            return LocalClass.class;
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -655,7 +655,7 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areTopLevelClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areTopLevelClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members).matchInAnyOrderMembersOf(String.class);
@@ -665,12 +665,12 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areNotTopLevelClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotTopLevelClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members)
                 .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -678,12 +678,12 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areNestedClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNestedClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members)
                 .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -691,7 +691,7 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areNotNestedClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotNestedClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members).matchInAnyOrderMembersOf(String.class);
@@ -701,19 +701,19 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areMemberClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areMemberClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members)
                 .matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class);
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class);
     }
 
     @Test
     public void areNotMemberClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotMemberClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members).matchInAnyOrderMembersOf(String.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
@@ -724,10 +724,10 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areInnerClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areInnerClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
-        assertThatMembers(members).matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.NonStaticNestedClass.class,
+        assertThatMembers(members).matchInAnyOrderMembersOf(NestedClassWithSomeMoreClasses.InnerMemberClass.class,
                 NestedClassWithSomeMoreClasses.getAnonymousClass(), NestedClassWithSomeMoreClasses.getLocalClass());
     }
 
@@ -735,7 +735,7 @@ public class GivenMembersDeclaredInClassesThatTest {
     public void areNotInnerClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotInnerClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,
-                        NestedClassWithSomeMoreClasses.NonStaticNestedClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
+                        NestedClassWithSomeMoreClasses.InnerMemberClass.class, NestedClassWithSomeMoreClasses.getAnonymousClass(),
                         NestedClassWithSomeMoreClasses.getLocalClass());
 
         assertThatMembers(members)
@@ -905,7 +905,7 @@ public class GivenMembersDeclaredInClassesThatTest {
         }
 
         @SuppressWarnings("InnerClassMayBeStatic")
-        class NonStaticNestedClass {
+        class InnerMemberClass {
             String member;
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -774,6 +774,126 @@ public class ShouldClassesThatTest {
 
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areTopLevelClasses())
+                .on(ClassAccessingTopLevelClass.class, ClassAccessingStaticNestedClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotTopLevelClasses())
+                .on(ClassAccessingTopLevelClass.class, ClassAccessingStaticNestedClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNestedClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNestedClasses())
+                .on(ClassAccessingStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotNestedClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotNestedClasses())
+                .on(ClassAccessingStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areMemberClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areMemberClasses())
+                .on(ClassAccessingStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotMemberClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotMemberClasses())
+                .on(ClassAccessingStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areInnerClasses())
+                .on(ClassAccessingNonStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingNonStaticNestedClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotInnerClasses())
+                .on(ClassAccessingNonStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areAnonymousClasses())
+                .on(ClassAccessingAnonymousClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingAnonymousClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotAnonymousClasses())
+                .on(ClassAccessingAnonymousClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areLocalClasses())
+                .on(ClassAccessingLocalClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingLocalClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotLocalClasses())
+                .on(ClassAccessingLocalClass.class, ClassAccessingTopLevelClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
     public void belongToAnyOf(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.belongToAnyOf(ClassWithInnerClasses.class, String.class))
@@ -1679,6 +1799,59 @@ public class ShouldClassesThatTest {
         @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
         void access() {
             StandardCopyOption.ATOMIC_MOVE.name();
+        }
+    }
+
+    private static class ClassAccessingTopLevelClass {
+        @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
+        void access() {
+            String.valueOf(123);
+        }
+    }
+
+    private static class ClassAccessingStaticNestedClass {
+        @SuppressWarnings("unused")
+        void access() {
+            StaticNestedClass.access();
+        }
+    }
+
+    private static class StaticNestedClass {
+        static void access() {
+        }
+    }
+
+    private static class ClassAccessingNonStaticNestedClass {
+        @SuppressWarnings("unused")
+        void access() {
+            new NonStaticNestedClass().access();
+        }
+
+        @SuppressWarnings("InnerClassMayBeStatic")
+        private class NonStaticNestedClass {
+            void access() {
+            }
+        }
+    }
+
+    private static class ClassAccessingAnonymousClass {
+        @SuppressWarnings("unused")
+        void access() {
+            new Serializable() {
+                void access() {
+                }
+            }.access();
+        }
+    }
+
+    private static class ClassAccessingLocalClass {
+        @SuppressWarnings("unused")
+        void access() {
+            class LocalClass {
+                void access() {
+                }
+            }
+            new LocalClass().access();
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -837,9 +837,9 @@ public class ShouldClassesThatTest {
     public void areInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areInnerClasses())
-                .on(ClassAccessingNonStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+                .on(ClassAccessingInnerMemberClass.class, ClassAccessingTopLevelClass.class);
 
-        assertThatClasses(classes).matchInAnyOrder(ClassAccessingNonStaticNestedClass.class);
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingInnerMemberClass.class);
     }
 
     @Test
@@ -847,7 +847,7 @@ public class ShouldClassesThatTest {
     public void areNotInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areNotInnerClasses())
-                .on(ClassAccessingNonStaticNestedClass.class, ClassAccessingTopLevelClass.class);
+                .on(ClassAccessingInnerMemberClass.class, ClassAccessingTopLevelClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingTopLevelClass.class);
     }
@@ -1821,14 +1821,14 @@ public class ShouldClassesThatTest {
         }
     }
 
-    private static class ClassAccessingNonStaticNestedClass {
+    private static class ClassAccessingInnerMemberClass {
         @SuppressWarnings("unused")
         void access() {
-            new NonStaticNestedClass().access();
+            new InnerMemberClass().access();
         }
 
         @SuppressWarnings("InnerClassMayBeStatic")
-        private class NonStaticNestedClass {
+        private class InnerMemberClass {
             void access() {
             }
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -893,6 +893,138 @@ public class ShouldOnlyByClassesThatTest {
 
     @Test
     @UseDataProvider("should_only_be_by_rule_starts")
+    public void areTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areTopLevelClasses())
+                .on(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class,
+                        ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotTopLevelClasses())
+                .on(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class,
+                        ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNestedClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNestedClasses())
+                .on(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotNestedClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotNestedClasses())
+                .on(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areMemberClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areMemberClasses())
+                .on(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotMemberClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotMemberClasses())
+                .on(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingStaticNestedClass.class, StaticNestedClassBeingAccessed.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areInnerClasses())
+                .on(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotInnerClasses())
+                .on(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class,
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnonymousClasses())
+                .on(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass(),
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAnonymousClasses())
+                .on(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass(),
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass());
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areLocalClasses())
+                .on(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass(),
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotLocalClasses())
+                .on(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass(),
+                        ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
+
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass());
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
     public void belongToAnyOf(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterViolationCausesInFailureReport(
                 classesShouldOnlyBeBy.belongToAnyOf(ClassWithInnerClasses.class))
@@ -1178,6 +1310,53 @@ public class ShouldOnlyByClassesThatTest {
 
         static void access() {
             new ClassBeingAccessedByEnum();
+        }
+    }
+
+    private static class ClassAccessingStaticNestedClass {
+        @SuppressWarnings("unused")
+        void access() {
+            new StaticNestedClassBeingAccessed();
+        }
+    }
+
+    private static class StaticNestedClassBeingAccessed {
+    }
+
+    private class ClassAccessingNonStaticNestedClass {
+        @SuppressWarnings("unused")
+        void access() {
+            new NonStaticNestedClassBeingAccessed();
+        }
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    private class NonStaticNestedClassBeingAccessed {
+    }
+
+    private static class ClassAccessingAnonymousClass {
+        @SuppressWarnings("unused")
+        void access() {
+            anonymousClassBeingAccessed.run();
+        }
+    }
+
+    private static Runnable anonymousClassBeingAccessed = new Runnable() {
+        @Override
+        public void run() {
+            new ClassAccessingAnonymousClass();
+        }
+    };
+
+    private static class ClassAccessingLocalClass {
+        static Class<?> getLocalClass() {
+            class LocalClass {
+                @SuppressWarnings("unused")
+                void access() {
+                    new ClassAccessingLocalClass();
+                }
+            }
+            return LocalClass.class;
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -962,7 +962,7 @@ public class ShouldOnlyByClassesThatTest {
     public void areInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areInnerClasses())
-                .on(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class,
+                .on(ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class,
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
@@ -973,10 +973,10 @@ public class ShouldOnlyByClassesThatTest {
     public void areNotInnerClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areNotInnerClasses())
-                .on(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class,
+                .on(ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class,
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
-        assertThatClasses(classes).matchInAnyOrder(ClassAccessingNonStaticNestedClass.class, NonStaticNestedClassBeingAccessed.class);
+        assertThatClasses(classes).matchInAnyOrder(ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class);
     }
 
     @Test
@@ -1006,7 +1006,7 @@ public class ShouldOnlyByClassesThatTest {
     public void areLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areLocalClasses())
-                .on(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass(),
+                .on(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatClasses(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
@@ -1017,10 +1017,10 @@ public class ShouldOnlyByClassesThatTest {
     public void areNotLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areNotLocalClasses())
-                .on(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass(),
+                .on(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
-        assertThatClasses(classes).matchInAnyOrder(ClassAccessingLocalClass.class, ClassAccessingLocalClass.getLocalClass());
+        assertThatClasses(classes).matchInAnyOrder(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass());
     }
 
     @Test
@@ -1323,15 +1323,15 @@ public class ShouldOnlyByClassesThatTest {
     private static class StaticNestedClassBeingAccessed {
     }
 
-    private class ClassAccessingNonStaticNestedClass {
+    private class ClassAccessingInnerMemberClass {
         @SuppressWarnings("unused")
         void access() {
-            new NonStaticNestedClassBeingAccessed();
+            new InnerMemberClassBeingAccessed();
         }
     }
 
     @SuppressWarnings("InnerClassMayBeStatic")
-    private class NonStaticNestedClassBeingAccessed {
+    private class InnerMemberClassBeingAccessed {
     }
 
     private static class ClassAccessingAnonymousClass {
@@ -1348,12 +1348,12 @@ public class ShouldOnlyByClassesThatTest {
         }
     };
 
-    private static class ClassAccessingLocalClass {
+    private static class ClassBeingAccessedByLocalClass {
         static Class<?> getLocalClass() {
             class LocalClass {
                 @SuppressWarnings("unused")
                 void access() {
-                    new ClassAccessingLocalClass();
+                    new ClassBeingAccessedByLocalClass();
                 }
             }
             return LocalClass.class;


### PR DESCRIPTION
This PR adds the following methods to JavaClass
* isTopLevelClass
* isMemberClass
* isAnonymousClass (as replacement for isAnonymous)
* isLocalClass

This PR also adds classes().that(). and classes().should().
* [are|be]TopLevelClasses
* [are|be]NestedClasses
* [are|be]MemberClasses
* [are|be]InnerClasses
* [are|be]AnonymousClasses
* [are|be]LocalClasses

and their corresponding negations.

The naming is based on the [Java Language Specification, chapter 8](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html).

Resolves #207 