### PR TITLE
Overload JavaClass.getConstructor() and JavaClass.getMethod()

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -502,13 +502,33 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations, HasModifi
     }
 
     @PublicAPI(usage = ACCESS)
+    public JavaMethod getMethod(String name) {
+        return findMatchingCodeUnit(methods, name, Collections.<String>emptyList());
+    }
+
+    @PublicAPI(usage = ACCESS)
     public JavaMethod getMethod(String name, Class<?>... parameters) {
         return findMatchingCodeUnit(methods, name, namesOf(parameters));
     }
 
     @PublicAPI(usage = ACCESS)
+    public JavaMethod getMethod(String name, String... parameters) {
+        return findMatchingCodeUnit(methods, name, ImmutableList.copyOf(parameters));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaMethod> tryGetMethod(String name) {
+        return tryFindMatchingCodeUnit(methods, name, Collections.<String>emptyList());
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Optional<JavaMethod> tryGetMethod(String name, Class<?>... parameters) {
         return tryFindMatchingCodeUnit(methods, name, namesOf(parameters));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaMethod> tryGetMethod(String name, String... parameters) {
+        return tryFindMatchingCodeUnit(methods, name, ImmutableList.copyOf(parameters));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -523,8 +543,18 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations, HasModifi
     }
 
     @PublicAPI(usage = ACCESS)
+    public JavaConstructor getConstructor() {
+        return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, Collections.<String>emptyList());
+    }
+
+    @PublicAPI(usage = ACCESS)
     public JavaConstructor getConstructor(Class<?>... parameters) {
         return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, namesOf(parameters));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public JavaConstructor getConstructor(String... parameters) {
+        return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, ImmutableList.copyOf(parameters));
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -178,6 +178,7 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.logging.log4j.Level;
 import org.assertj.core.api.Condition;
+import org.assertj.core.util.Objects;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -663,18 +664,14 @@ public class ClassFileImporterTest {
         JavaClass clazz = classesIn("testexamples/complexmethodimport").get(ClassWithComplexMethod.class);
 
         assertThat(clazz.getMethods()).as("Methods of %s", ClassWithComplexMethod.class.getSimpleName()).hasSize(1);
-        assertThat(clazz.getMethod("complex", String.class, long.class, long.class, Serializable.class, Serializable.class))
-                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
-                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
-        assertThat(clazz.tryGetMethod("complex", String.class, long.class, long.class, Serializable.class, Serializable.class).get())
-                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
-                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
-        assertThat(clazz.getMethod("complex", "java.lang.String", "long", "long", "java.io.Serializable", "java.io.Serializable"))
-                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
-                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
-        assertThat(clazz.tryGetMethod("complex", "java.lang.String", "long", "long", "java.io.Serializable", "java.io.Serializable").get())
-                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
-                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
+
+        Class<?>[] parameterTypes = {String.class, long.class, long.class, Serializable.class, Serializable.class};
+        Method expectedMethod = ClassWithComplexMethod.class.getDeclaredMethod("complex", parameterTypes);
+
+        assertThat(clazz.getMethod("complex", parameterTypes)).isEquivalentTo(expectedMethod);
+        assertThat(clazz.tryGetMethod("complex", parameterTypes).get()).isEquivalentTo(expectedMethod);
+        assertThat(clazz.getMethod("complex", Objects.namesOf(parameterTypes))).isEquivalentTo(expectedMethod);
+        assertThat(clazz.tryGetMethod("complex", Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedMethod);
     }
 
     @Test
@@ -898,14 +895,16 @@ public class ClassFileImporterTest {
 
         assertThat(clazz.getConstructors()).as("Constructors").hasSize(3);
         assertThat(clazz.getConstructor()).isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor());
-        assertThat(clazz.getConstructor(Object.class))
-                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(Object.class));
-        assertThat(clazz.getConstructor("java.lang.Object"))
-                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(Object.class));
-        assertThat(clazz.getConstructor(int.class, int.class))
-                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(int.class, int.class));
-        assertThat(clazz.getConstructor("int", "int"))
-                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(int.class, int.class));
+
+        Class<?>[] parameterTypes = {Object.class};
+        Constructor<ClassWithSimpleConstructors> expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
+        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
+
+        parameterTypes = new Class[]{int.class, int.class};
+        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
+        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -666,6 +666,15 @@ public class ClassFileImporterTest {
         assertThat(clazz.getMethod("complex", String.class, long.class, long.class, Serializable.class, Serializable.class))
                 .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
                         "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
+        assertThat(clazz.tryGetMethod("complex", String.class, long.class, long.class, Serializable.class, Serializable.class).get())
+                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
+                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
+        assertThat(clazz.getMethod("complex", "java.lang.String", "long", "long", "java.io.Serializable", "java.io.Serializable"))
+                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
+                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
+        assertThat(clazz.tryGetMethod("complex", "java.lang.String", "long", "long", "java.io.Serializable", "java.io.Serializable").get())
+                .isEquivalentTo(ClassWithComplexMethod.class.getDeclaredMethod(
+                        "complex", String.class, long.class, long.class, Serializable.class, Serializable.class));
     }
 
     @Test
@@ -891,7 +900,11 @@ public class ClassFileImporterTest {
         assertThat(clazz.getConstructor()).isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor());
         assertThat(clazz.getConstructor(Object.class))
                 .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(Object.class));
+        assertThat(clazz.getConstructor("java.lang.Object"))
+                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(Object.class));
         assertThat(clazz.getConstructor(int.class, int.class))
+                .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(int.class, int.class));
+        assertThat(clazz.getConstructor("int", "int"))
                 .isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor(int.class, int.class));
     }
 


### PR DESCRIPTION
This commit adds the methods
* JavaClass.getConstructor(String... parameters)
* JavaClass.getMethod(String name, String... parameters)
* JavaClass.tryGetMethod(String name, String... parameters)

to retrieve constructors/methods even if a parameter type is not present on the classpath.

The methods
* JavaClass.getConstructor()
* JavaClass.getMethod(String name)
* JavaClass.tryGetMethod(String name)

to retrieve constructors/methods without parameters where added to avoid ambiguous method calls.

Resolves #236