### PR TITLE
Enhance FreezingArchRule

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static com.tngtech.archunit.library.freeze.ViolationStoreFactory.FREEZE_STORE_PROPERTY;
+import static com.tngtech.archunit.library.freeze.ViolationStoreFactory.FREEZE_STORE_PROPERTY_NAME;
 
 /**
  * A decorator around an existing {@link ArchRule} that "freezes" the state of all violations on the first call instead of failing the test.
@@ -102,7 +102,7 @@ public final class FreezingArchRule implements ArchRule {
     @Override
     @PublicAPI(usage = ACCESS)
     public EvaluationResult evaluate(JavaClasses classes) {
-        store.initialize(ArchConfiguration.get().getSubProperties(FREEZE_STORE_PROPERTY));
+        store.initialize(ArchConfiguration.get().getSubProperties(FREEZE_STORE_PROPERTY_NAME));
 
         EvaluationResult result = delegate.evaluate(classes);
         if (!store.contains(delegate)) {
@@ -129,7 +129,9 @@ public final class FreezingArchRule implements ArchRule {
     private void removeObsoleteViolationsFromStore(CategorizedViolations categorizedViolations) {
         List<String> solvedViolations = categorizedViolations.getStoredSolvedViolations();
         log.debug("Removing {} obsolete violations from store: {}", solvedViolations.size(), solvedViolations);
-        store.save(delegate, categorizedViolations.getStoredUnsolvedViolations());
+        if (!solvedViolations.isEmpty()) {
+            store.save(delegate, categorizedViolations.getStoredUnsolvedViolations());
+        }
     }
 
     private EvaluationResult filterOutKnownViolations(EvaluationResult result, final Set<String> knownActualViolations) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/StoreUpdateFailedException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/StoreUpdateFailedException.java
@@ -16,6 +16,10 @@
 package com.tngtech.archunit.library.freeze;
 
 class StoreUpdateFailedException extends RuntimeException {
+    StoreUpdateFailedException(String message) {
+        super(message);
+    }
+
     StoreUpdateFailedException(Throwable cause) {
         super(cause);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
@@ -1,8 +1,6 @@
 package com.tngtech.archunit.core.importer.resolvers;
 
-import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Properties;
 
 import com.google.common.base.Preconditions;
 import com.tngtech.archunit.ArchConfiguration;
@@ -64,7 +62,7 @@ public class ClassResolverFactoryTest {
 
     @Test
     public void wrong_resolver_class_name() {
-        setConfiguredResolverClass("not.There");
+        ArchConfiguration.get().setProperty("classResolver", "not.There");
 
         thrown.expect(ClassResolverConfigurationException.class);
         thrown.expectMessage("Error loading resolver class not.There");
@@ -126,17 +124,6 @@ public class ClassResolverFactoryTest {
                 description.appendText(String.format("cause with cause with message containing '%s'", message));
             }
         };
-    }
-
-    private void setConfiguredResolverClass(String className) {
-        try {
-            Field field = ArchConfiguration.class.getDeclaredField("properties");
-            field.setAccessible(true);
-            Properties props = (Properties) field.get(ArchConfiguration.get());
-            props.setProperty("classResolver", className);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     static class TestResolver implements ClassResolver {

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
@@ -37,7 +37,9 @@ public class TextFileBasedViolationStoreTest {
     public void setUp() throws Exception {
         configuredFolder = new File(temporaryFolder.newFolder(), "notyetthere");
 
-        store.initialize(propertiesOf("default.path", configuredFolder.getAbsolutePath()));
+        store.initialize(propertiesOf(
+                "default.path", configuredFolder.getAbsolutePath(),
+                "default.allowStoreCreation", String.valueOf(true)));
     }
 
     @Test

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -318,6 +318,32 @@ You can configure the location of the violation store within `archunit.propertie
 freeze.store.default.path=/some/path/in/a/vcs/repo
 ----
 
+Furthermore, it is possible to configure
+
+[source,options="nowrap"]
+.archunit.properties
+----
+# must be set to true to allow the creation of a new violation store
+# default is false
+freeze.store.default.allowStoreCreation=true
+
+# can be set to false to forbid updates of the violations stored for frozen rules
+# default is true
+freeze.store.default.allowStoreUpdate=false
+----
+
+This can help in CI environments to prevent misconfiguration:
+For example, a CI build should probably never create a new the violation store, but operate on
+an existing one.
+
+As mentioned in <<Overriding configuration>>, these properties can be passed as system properties as needed.
+For example to allow the creation of the violation store in a specific environment, it is possible to pass the system property via
+
+[source,options="nowrap"]
+----
+-Darchunit.freeze.store.default.allowStoreCreation=true
+----
+
 ==== Extension
 
 `FreezingArchRule` provides two extension points to adjust the behavior to custom needs.

--- a/docs/userguide/010_Advanced_Configuration.adoc
+++ b/docs/userguide/010_Advanced_Configuration.adoc
@@ -1,8 +1,28 @@
 == Advanced Configuration
 
 Some behavior of ArchUnit can be centrally configured by adding a file `archunit.properties`
-to the root of the classpath (e.g. under `src/test/resources`). This section will outline
-those configuration options.
+to the root of the classpath (e.g. under `src/test/resources`).
+This section will outline some global configuration options.
+
+=== Overriding configuration
+
+ArchUnit will use exactly the `archunit.properties` file returned by the context
+`ClassLoader` from the classpath root, via the standard Java resource loading mechanism.
+
+It is possible to override any property from `archunit.properties`, by passing a system property
+to the respective JVM process executing ArchUnit:
+
+[source,options="nowrap"]
+----
+-Darchunit.propertyName=propertyValue
+----
+
+E.g. to override the property `resolveMissingDependenciesFromClassPath` described in the next section, it would be possible to pass:
+
+[source,options="nowrap"]
+----
+-Darchunit.resolveMissingDependenciesFromClassPath=false
+----
 
 === Configuring the Resolution Behavior
 

--- a/docs/userguide/html/000_Index.html
+++ b/docs/userguide/html/000_Index.html
@@ -523,8 +523,9 @@ h4 {
 </li>
 <li><a href="#_advanced_configuration">10. Advanced Configuration</a>
 <ul class="sectlevel2">
-<li><a href="#_configuring_the_resolution_behavior">10.1. Configuring the Resolution Behavior</a></li>
-<li><a href="#_md5_sums_of_classes">10.2. MD5 Sums of Classes</a></li>
+<li><a href="#_overriding_configuration">10.1. Overriding configuration</a></li>
+<li><a href="#_configuring_the_resolution_behavior">10.2. Configuring the Resolution Behavior</a></li>
+<li><a href="#_md5_sums_of_classes">10.3. MD5 Sums of Classes</a></li>
 </ul>
 </li>
 </ul>
@@ -2056,6 +2057,35 @@ You can configure the location of the violation store within <code>archunit.prop
 <pre class="highlightjs highlight nowrap"><code>freeze.store.default.path=/some/path/in/a/vcs/repo</code></pre>
 </div>
 </div>
+<div class="paragraph">
+<p>Furthermore, it is possible to configure</p>
+</div>
+<div class="listingblock">
+<div class="title">archunit.properties</div>
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code># must be set to true to allow the creation of a new violation store
+# default is false
+freeze.store.default.allowStoreCreation=true
+
+# can be set to false to forbid updates of the violations stored for frozen rules
+# default is true
+freeze.store.default.allowStoreUpdate=false</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This can help in CI environments to prevent misconfiguration:
+For example, a CI build should probably never create a new the violation store, but operate on
+an existing one.</p>
+</div>
+<div class="paragraph">
+<p>As mentioned in <a href="#_overriding_configuration">Overriding configuration</a>, these properties can be passed as system properties as needed.
+For example to allow the creation of the violation store in a specific environment, it is possible to pass the system property via</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code>-Darchunit.freeze.store.default.allowStoreCreation=true</code></pre>
+</div>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_extension"><a class="anchor" href="#_extension"></a>8.5.3. Extension</h4>
@@ -2361,11 +2391,35 @@ in different projects or modules.</p>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Some behavior of ArchUnit can be centrally configured by adding a file <code>archunit.properties</code>
-to the root of the classpath (e.g. under <code>src/test/resources</code>). This section will outline
-those configuration options.</p>
+to the root of the classpath (e.g. under <code>src/test/resources</code>).
+This section will outline some global configuration options.</p>
 </div>
 <div class="sect2">
-<h3 id="_configuring_the_resolution_behavior"><a class="anchor" href="#_configuring_the_resolution_behavior"></a>10.1. Configuring the Resolution Behavior</h3>
+<h3 id="_overriding_configuration"><a class="anchor" href="#_overriding_configuration"></a>10.1. Overriding configuration</h3>
+<div class="paragraph">
+<p>ArchUnit will use exactly the <code>archunit.properties</code> file returned by the context
+<code>ClassLoader</code> from the classpath root, via the standard Java resource loading mechanism.</p>
+</div>
+<div class="paragraph">
+<p>It is possible to override any property from <code>archunit.properties</code>, by passing a system property
+to the respective JVM process executing ArchUnit:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code>-Darchunit.propertyName=propertyValue</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>E.g. to override the property <code>resolveMissingDependenciesFromClassPath</code> described in the next section, it would be possible to pass:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code>-Darchunit.resolveMissingDependenciesFromClassPath=false</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_configuring_the_resolution_behavior"><a class="anchor" href="#_configuring_the_resolution_behavior"></a>10.2. Configuring the Resolution Behavior</h3>
 <div class="paragraph">
 <p>As mentioned in <a href="#_dealing_with_missing_classes">Dealing with Missing Classes</a>, it might be preferable to configure a different
 import behavior if dealing with missing classes wastes too much performance.
@@ -2429,7 +2483,7 @@ argument, and supply the concrete arguments as</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_md5_sums_of_classes"><a class="anchor" href="#_md5_sums_of_classes"></a>10.2. MD5 Sums of Classes</h3>
+<h3 id="_md5_sums_of_classes"><a class="anchor" href="#_md5_sums_of_classes"></a>10.3. MD5 Sums of Classes</h3>
 <div class="paragraph">
 <p>Sometimes it can be valuable to record the MD5 sums of classes being imported to track
 unexpected behavior. Since this has a performance impact, it is disabled by default,


### PR DESCRIPTION
As mentioned in #211, `FreezingArchRule` needs some more configuration options to prevent misuse. Furthermore there are different scenarios how `FreezingArchRule` is used. In some scenarios, developers are required to update the violation store and check the current state into the repository. In some scenarios the CI job is more sophisticated and clones, updates and pushes a violation store automatically. In any case, within a CI environment it will normally not be necessary to ever create a new violation store, but on the contrary, this will easily be a sign of misconfiguration (the violation store being mounted / checked out to a different folder than configured for `FreezingArchRule`).

This PR will make it configurable, if `FreezingArchRule` may create a new default store, or if updates to the store are allowed in the specific environment.
Note that the default for allowing to create a violation store is now `false`, i.e. without further configuration running a `FreezingArchRule` without any existing violation store will cause an exception and explicitly demand to configure `allowStoreCreation=true`.

To make it easier to configure these capabilities per environment (e.g. one job or a developer might be allowed to update the violation store, another job may not), ArchUnit configuration may now be overwritten by system properties. This will in particular make it easier to configure the violation store folder based on the specific environment.

Resolves: #211