### PR TITLE
Fix grammar in Javadoc

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -455,7 +455,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
     }
 
     /**
-     * Represents an {@link CodeUnitCallTarget CodeUnitCallTarget} where the target is a method. For further elaboration about the necessity to distinguish
+     * Represents a {@link CodeUnitCallTarget} where the target is a method. For further elaboration about the necessity to distinguish
      * {@link MethodCallTarget MethodCallTarget} from {@link JavaMethod}, refer to the documentation at {@link AccessTarget} and in particular the
      * documentation at {@link #resolve()}.
      */

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -49,7 +49,7 @@ import static java.util.Collections.emptySet;
 
 /**
  * Handles various forms of location from where classes can be imported in a consistent way. Any location
- * will be treated like an {@link URI}, thus there will not be any platform dependent file separator problems.<br><br>
+ * will be treated like a {@link URI}, thus there will not be any platform dependent file separator problems.<br><br>
  * Examples for locations could be
  * <ul>
  *     <li><code>file:///home/someuser/workspace/myproject/target/classes/myproject/Foo.class</code></li>


### PR DESCRIPTION
Replace article "an" by "a" in cases where it is not appropriate.

Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>