### PR TITLE
make default ViolationLinerMatcher ignore numbers after a "$" (#248)

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
@@ -59,7 +59,8 @@ import static com.tngtech.archunit.library.freeze.ViolationStoreFactory.FREEZE_S
  * </li>
  * <li>
  *   a {@link ViolationLineMatcher} to decide which violations are "known", i.e. have already been present in the previous evaluation.<br>
- *   The default {@link ViolationLineMatcher} compares violations ignoring the line number of their source code location.<br>
+ *   The default {@link ViolationLineMatcher} compares violations ignoring the line number of their source code location
+ *   and auto-generated numbers of anonymous classes or lambda expressions.<br>
  *   A custom implementation can be configured in two ways.
  *   Again either programmatically via {@link #associateViolationLinesVia(ViolationLineMatcher)}, or within
  *   {@value com.tngtech.archunit.ArchConfiguration#ARCHUNIT_PROPERTIES_RESOURCE_NAME}, e.g.

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactory.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactory.java
@@ -15,9 +15,6 @@
  */
 package com.tngtech.archunit.library.freeze;
 
-import java.util.Iterator;
-
-import com.google.common.base.Splitter;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.MayResolveTypesViaReflection;
 
@@ -26,7 +23,7 @@ import static java.lang.Character.isDigit;
 
 class ViolationLineMatcherFactory {
     private static final String FREEZE_LINE_MATCHER_PROPERTY = "freeze.lineMatcher";
-    private static final FuzzyLineNumberMatcher DEFAULT_MATCHER = new FuzzyLineNumberMatcher();
+    private static final ViolationLineMatcher DEFAULT_MATCHER = new FuzzyViolationLineMatcher();
 
     static ViolationLineMatcher create() {
         return ArchConfiguration.get().containsProperty(FREEZE_LINE_MATCHER_PROPERTY)
@@ -45,32 +42,79 @@ class ViolationLineMatcherFactory {
         }
     }
 
-    private static class FuzzyLineNumberMatcher implements ViolationLineMatcher {
+    /**
+     * ignores numbers that are potentially line numbers (digits following a ':' and preceding a ')')
+     * or compiler-generated numbers of anonymous classes or lambda expressions (digits following a '$').
+     */
+    private static class FuzzyViolationLineMatcher implements ViolationLineMatcher {
         @Override
-        public boolean matches(String lineFromFirstViolation, String lineFromSecondViolation) {
-            return ignorePotentialLineNumbers(lineFromFirstViolation).equals(ignorePotentialLineNumbers(lineFromSecondViolation));
+        public boolean matches(String str1, String str2) {
+            // Compare relevant substrings, in a more performant way than a regex solution like this:
+            //
+            // normalize = str -> str.replaceAll(":\\d+\\)", ":0)").replaceAll("\\$\\d+", "\\$0");
+            // return normalize.apply(str1).equals(normalize.apply(str2));
+
+            RelevantPartIterator relevantPart1 = new RelevantPartIterator(str1);
+            RelevantPartIterator relevantPart2 = new RelevantPartIterator(str2);
+            while (relevantPart1.hasNext() && relevantPart2.hasNext()) {
+                relevantPart1.findEnd();
+                relevantPart2.findEnd();
+                if (!relevantPart1.relevantSubstringMatches(relevantPart2)) {
+                    return false;
+                }
+                relevantPart1.skipIgnoredPart();
+                relevantPart2.skipIgnoredPart();
+            }
+            return !relevantPart1.hasNext() && !relevantPart2.hasNext();
         }
 
-        // Would be nicer to use a regex here, but unfortunately that would have a massive performance impact.
-        // So we do some low level character processing instead.
-        private String ignorePotentialLineNumbers(String violation) {
-            Iterator<String> parts = Splitter.on(":").split(violation).iterator();
-            StringBuilder removedLineNumbers = new StringBuilder(parts.next());
-            while (parts.hasNext()) {
-                removedLineNumbers.append(removeNumberIfPresent(parts.next()));
-            }
-            return removedLineNumbers.toString();
-        }
+        static class RelevantPartIterator {
+            private final String str;
+            private final int length;
+            // (start, end) is the (first, last) index of current relevant part, moved through string during iteration:
+            private int start = 0;
+            private int end;
 
-        private String removeNumberIfPresent(String part) {
-            int i = 0;
-            while (part.length() > i && isDigit(part.charAt(i))) {
-                i++;
+            RelevantPartIterator(String str) {
+                this.str = str;
+                this.length = str.length();
             }
-            boolean foundClosingBracketFollowingDigits = i > 0 && part.length() > i && part.charAt(i) == ')';
-            return foundClosingBracketFollowingDigits
-                    ? part.substring(i)
-                    : part;
+
+            boolean hasNext() {
+                return start < length;
+            }
+
+            void findEnd() {
+                end = Math.min(nextIndexOfCharacterOrEndOfString(':'), nextIndexOfCharacterOrEndOfString('$'));
+            }
+
+            private int nextIndexOfCharacterOrEndOfString(char ch) {
+                int i = str.indexOf(ch, start);
+                return i < 0 ? length - 1 : i;
+            }
+
+            boolean relevantSubstringMatches(RelevantPartIterator other) {
+                return this.end - this.start == other.end - other.start
+                        && this.getRelevantSubstring().equals(other.getRelevantSubstring());
+            }
+
+            private String getRelevantSubstring() {
+                return str.substring(start, end + 1);
+            }
+
+            void skipIgnoredPart() {
+                int i = start = end + 1;
+                while (i < length && isDigit(str.charAt(i))) {
+                    i++;
+                }
+                if (str.charAt(end) == ':') {
+                    boolean foundNumber = i > start;
+                    boolean foundClosingParenthesisAfterNumber = foundNumber && i < length && str.charAt(i) == ')';
+                    start = foundClosingParenthesisAfterNumber ? i + 1 : start;
+                } else {  // str.charAt(end) == '$'
+                    start = i;
+                }
+            }
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
@@ -319,20 +319,23 @@ public class FreezingArchRuleTest {
     }
 
     @Test
-    public void default_ViolationLineMatcher_ignores_line_numbers() {
+    public void default_ViolationLineMatcher_ignores_line_numbers_and_auto_generated_numbers() {
         TestViolationStore violationStore = new TestViolationStore();
 
         createFrozen(violationStore, rule("some description")
                 .withViolations(
                         "first violation one in (SomeClass.java:12) and first violation two in (SomeClass.java:13)",
                         "second violation in (SomeClass.java:77)",
-                        "third violation in (OtherClass.java:123)"));
+                        "third violation in (OtherClass.java:123)",
+                        "Method <MyClass.lambda$myFunction$2()> has a violation in (MyClass.java:123)"
+                ));
 
         String onlyLineNumberChanged = "first violation one in (SomeClass.java:98) and first violation two in (SomeClass.java:99)";
         String locationClassDoesNotMatch = "second violation in (OtherClass.java:77)";
-        String descriptionDoesNotMatch = "unknown violation in (SomeClass.java:77";
+        String descriptionDoesNotMatch = "unknown violation in (SomeClass.java:77)";
+        String lambdaWithDifferentNumber = "Method <MyClass.lambda$myFunction$10()> has a violation in (MyClass.java:123)";
         FreezingArchRule updatedViolations = freeze(rule("some description")
-                .withViolations(onlyLineNumberChanged, locationClassDoesNotMatch, descriptionDoesNotMatch))
+                .withViolations(onlyLineNumberChanged, locationClassDoesNotMatch, descriptionDoesNotMatch, lambdaWithDifferentNumber))
                 .persistIn(violationStore);
 
         assertThat(updatedViolations)

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactoryTest.java
@@ -1,0 +1,57 @@
+package com.tngtech.archunit.library.freeze;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class ViolationLineMatcherFactoryTest {
+    @Test
+    @DataProvider(splitBy = "\\|", value = {
+            "" +
+                    "|" +
+                    "|" + true,
+            "" +
+                    "abc|" +
+                    "abc|" + true,
+            "" +
+                    "abc|" +
+                    "abcd|" + false,
+            "" +
+                    "(A.java:1)|" +
+                    "(A.java:2)|" + true,
+            "" +
+                    "A.java:1|" +
+                    "A.java:2|" + false,
+            "" +
+                    "(A.java:1)|" +
+                    "(A.java:2|" + false,
+            "" +
+                    "A$1 B$2 C$4 (X.java:111)|" +
+                    "A$2 B$3 C$5 (X.java:222)|" + true,
+            "" +
+                    "A$a|" +
+                    "A$b|" + false,
+            "" +
+                    "A:1|" +
+                    "A$2|" + false,
+            "" +
+                    "Method <MyClass.lambda$myFunction$2()> has a violation in (MyClass.java:123)|" +
+                    "Method <MyClass.lambda$myFunction$123()> has a violation in (MyClass.java:0)|" + true,
+            "" +
+                    "Method <C.lambda$myFunction$2()> is bad in (C.java:123)|" +
+                    "Method <C.lambda$myFunction$2()> is bad in (C.java:123), too|" + false,
+            "" +
+                    "A:1) B$2 C|" +  // limitation of the current implementation:
+                    "A: B$ C|" + true,  // false positive
+    })
+    public void default_matcher(String str1, String str2, boolean expected) {
+        ViolationLineMatcher defaultMatcher = ViolationLineMatcherFactory.create();
+        assertThat(defaultMatcher.matches(str1, str2))
+                .as(String.format("'%s' matches '%s'", str1, str2))
+                .isEqualTo(expected);
+    }
+}

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -391,7 +391,8 @@ propTwo=valueTwo
 ===== Violation Line Matcher
 
 The `ViolationLineMatcher` compares lines from occurred violations with lines from the store.
-The default implementation ignores line numbers and counts lines as equivalent when all other details match.
+The default implementation ignores line numbers and numbers of anonymous classes or lambda expressions,
+and counts lines as equivalent when all other details match.
 A custom `ViolationLineMatcher` can again either be defined programmatically:
 
 [source,java,options="nowrap"]


### PR DESCRIPTION
Resolves #248.

I haven't checked the performance with a larger number of violations yet.

I was thinking of why we're using `Character.isDigit` instead of `'0' <= ch && ch <= '9'`, and wonder whether `SourceCodeLocation.formatLocation` shouldn't actually use 
```
String.format(Locale.ENGLISH, LOCATION_TEMPLATE, sourceFileName, lineNumber)
```
to avoid a dependency on `Locale.getDefault`.

It wouldn't matter for the current default `FuzzyLineNumberMatcher`, but a custom `ViolationLineMatcher` could benefit from violations not having localized numbers such as `(MyClass.java:١٢٣)` or `(MyClass.java:১২৩)`.