### PR TITLE
Allow empty layers in LayeredArchitecture & OnionArchitecture when configured

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -126,7 +126,9 @@ public final class Architectures {
 
         /**
          * By default, layers defined with {@link #layer(String)} must not be empty, i.e. contain at least one class.
-         * <code>withOptionalLayers(true)</code> can be used to make all layers optional.
+         * <br>
+         * <code>withOptionalLayers(true)</code> can be used to make all layers optional.<br>
+         * <code>withOptionalLayers(false)</code> still allows to define individual optional layers with {@link #optionalLayer(String)}.
          * @see #optionalLayer(String)
          */
         @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -175,7 +175,7 @@ public final class Architectures {
                 return overriddenDescription.get();
             }
 
-            List<String> lines = newArrayList("Layered architecture consisting of");
+            List<String> lines = newArrayList("Layered architecture consisting of" + (optionalLayers ? " (optional)" : ""));
             for (LayerDefinition definition : layerDefinitions) {
                 lines.add(definition.toString());
             }
@@ -538,7 +538,7 @@ public final class Architectures {
                 return overriddenDescription.get();
             }
 
-            List<String> lines = newArrayList("Onion architecture consisting of");
+            List<String> lines = newArrayList("Onion architecture consisting of" + (optionalLayers ? " (optional)" : ""));
             if (domainModelPackageIdentifiers.length > 0) {
                 lines.add(String.format("domain models ('%s')", Joiner.on("', '").join(domainModelPackageIdentifiers)));
             }

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -391,12 +391,12 @@ public final class Architectures {
         private static final String APPLICATION_SERVICE_LAYER = "application service";
         private static final String ADAPTER_LAYER = "adapter";
 
+        private final Optional<String> overriddenDescription;
         private String[] domainModelPackageIdentifiers = new String[0];
         private String[] domainServicePackageIdentifiers = new String[0];
         private String[] applicationPackageIdentifiers = new String[0];
         private Map<String, String[]> adapterPackageIdentifiers = new LinkedHashMap<>();
-
-        private final Optional<String> overriddenDescription;
+        private boolean allowEmptyLayers = false;
 
         private OnionArchitecture() {
             overriddenDescription = Optional.absent();
@@ -438,6 +438,12 @@ public final class Architectures {
             return this;
         }
 
+        @PublicAPI(usage = ACCESS)
+        public OnionArchitecture allowEmptyLayers(boolean allowEmptyLayers) {
+            this.allowEmptyLayers = allowEmptyLayers;
+            return this;
+        }
+
         private LayeredArchitecture layeredArchitectureDelegate() {
             LayeredArchitecture layeredArchitectureDelegate = layeredArchitecture()
                     .layer(DOMAIN_MODEL_LAYER).definedBy(domainModelPackageIdentifiers)
@@ -446,7 +452,8 @@ public final class Architectures {
                     .layer(ADAPTER_LAYER).definedBy(concatenateAll(adapterPackageIdentifiers.values()))
                     .whereLayer(DOMAIN_MODEL_LAYER).mayOnlyBeAccessedByLayers(DOMAIN_SERVICE_LAYER, APPLICATION_SERVICE_LAYER, ADAPTER_LAYER)
                     .whereLayer(DOMAIN_SERVICE_LAYER).mayOnlyBeAccessedByLayers(APPLICATION_SERVICE_LAYER, ADAPTER_LAYER)
-                    .whereLayer(APPLICATION_SERVICE_LAYER).mayOnlyBeAccessedByLayers(ADAPTER_LAYER);
+                    .whereLayer(APPLICATION_SERVICE_LAYER).mayOnlyBeAccessedByLayers(ADAPTER_LAYER)
+                    .allowEmptyLayers(allowEmptyLayers);
 
             for (Map.Entry<String, String[]> adapter : adapterPackageIdentifiers.entrySet()) {
                 String adapterLayer = getAdapterLayer(adapter.getKey());

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -69,7 +69,7 @@ public final class Architectures {
     /**
      * Can be used to assert a typical layered architecture, e.g. with an UI layer, a business logic layer and
      * a persistence layer, where specific access rules should be adhered to, like UI may not access persistence
-     * and each layer may only access lower layers, i.e. UI --&gt; business logic --&gt; persistence.
+     * and each layer may only access lower layers, i.e. UI &rarr; business logic &rarr; persistence.
      * <br><br>
      * A layered architecture can for example be defined like this:
      * <pre><code>layeredArchitecture()
@@ -86,7 +86,7 @@ public final class Architectures {
      * layer 'Persistence' MAY NOT access layer 'Business Logic' AND MAY NOT access layer 'UI' (black list).<br>
      * {@link LayeredArchitecture LayeredArchitecture} only supports the white list way, because it prevents detours "outside of
      * the architecture", e.g.<br>
-     * 'Persistence' --&gt; 'my.application.somehelper' --&gt; 'Business Logic'<br>
+     * 'Persistence' &rarr; 'my.application.somehelper' &rarr; 'Business Logic'<br>
      * The white list way enforces that every class that wants to interact with classes inside of
      * the layered architecture must be part of the layered architecture itself and thus adhere to the same rules.
      *
@@ -124,6 +124,11 @@ public final class Architectures {
             this.allowEmptyLayers = allowEmptyLayers;
         }
 
+        /**
+         * By default, layers defined with {@link #layer(String)} must not be empty, i.e. contain at least one class.
+         * <code>allowEmptyLayers(true)</code> can be used to skip this consistency check for all layers.
+         * @see #optionalLayer(String)
+         */
         @PublicAPI(usage = ACCESS)
         public LayeredArchitecture allowEmptyLayers(boolean allowEmptyLayers) {
             this.allowEmptyLayers = allowEmptyLayers;
@@ -140,11 +145,23 @@ public final class Architectures {
             return this;
         }
 
+        /**
+         * Starts the definition of a new layer within the current {@link #layeredArchitecture() LayeredArchitecture}.
+         * <br>
+         * Unless {@link #allowEmptyLayers(boolean) allowEmptyLayers(true)} is used, this layer must not be empty.
+         * @see #allowEmptyLayers(boolean)
+         * @see #optionalLayer(String)
+         */
         @PublicAPI(usage = ACCESS)
         public LayerDefinition layer(String name) {
             return new LayerDefinition(name, false);
         }
 
+        /**
+         * Starts the definition of a new layer within the current {@link #layeredArchitecture() LayeredArchitecture}.
+         * <br>
+         * The only difference to a layer defined with {@link #layer(String)} is that an optional layer may be empty.
+         */
         @PublicAPI(usage = ACCESS)
         public LayerDefinition optionalLayer(String name) {
             return new LayerDefinition(name, true);

--- a/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
@@ -144,7 +144,7 @@ public class ArchitecturesTest {
             architecture.allowEmptyLayers(allowEmptyLayers);
         }
 
-        JavaClasses classes = new ClassFileImporter().importPackages(getClass().getPackage().getName() + ".testclasses");
+        JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
 
         EvaluationResult result = architecture.evaluate(classes);
         boolean expectViolation = allowEmptyLayers != Boolean.TRUE;
@@ -160,7 +160,7 @@ public class ArchitecturesTest {
     @Test
     @UseDataProvider("layeredArchitectureDefinitions")
     public void layered_architecture_gathers_all_layer_violations(LayeredArchitecture architecture) {
-        JavaClasses classes = new ClassFileImporter().importPackages(getClass().getPackage().getName() + ".testclasses");
+        JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
 
         EvaluationResult result = architecture.evaluate(classes);
 
@@ -293,7 +293,7 @@ public class ArchitecturesTest {
                 .adapter("cli", absolute("onionarchitecture.adapter.cli"))
                 .adapter("persistence", absolute("onionarchitecture.adapter.persistence"))
                 .adapter("rest", absolute("onionarchitecture.adapter.rest"));
-        JavaClasses classes = new ClassFileImporter().importPackages(getClass().getPackage().getName() + ".testclasses.onionarchitecture");
+        JavaClasses classes = new ClassFileImporter().importPackages(absolute("onionarchitecture"));
 
         EvaluationResult result = architecture.evaluate(classes);
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
@@ -58,7 +58,7 @@ public class ArchitecturesTest {
                 layeredArchitecture()
                         .layer("One").definedBy("..library.testclasses.some.pkg..")
                         .layer("Two").definedBy("..library.testclasses.first.any.pkg..", "..library.testclasses.second.any.pkg..")
-                        .layer("Three").definedBy("..library.testclasses..three..")
+                        .optionalLayer("Three").definedBy("..library.testclasses..three..")
                         .whereLayer("One").mayNotBeAccessedByAnyLayer()
                         .whereLayer("Two").mayOnlyBeAccessedByLayers("One")
                         .whereLayer("Three").mayOnlyBeAccessedByLayers("One", "Two"),
@@ -69,7 +69,7 @@ public class ArchitecturesTest {
                         .layer("Two").definedBy(
                         resideInAnyPackage("..library.testclasses.first.any.pkg..", "..library.testclasses.second.any.pkg..")
                                 .as("'..library.testclasses.first.any.pkg..', '..library.testclasses.second.any.pkg..'"))
-                        .layer("Three").definedBy(
+                        .optionalLayer("Three").definedBy(
                         resideInAnyPackage("..library.testclasses..three..")
                                 .as("'..library.testclasses..three..'"))
                         .whereLayer("One").mayNotBeAccessedByAnyLayer()
@@ -84,7 +84,7 @@ public class ArchitecturesTest {
                 "Layered architecture consisting of" + lineSeparator() +
                         "layer 'One' ('..library.testclasses.some.pkg..')" + lineSeparator() +
                         "layer 'Two' ('..library.testclasses.first.any.pkg..', '..library.testclasses.second.any.pkg..')" + lineSeparator() +
-                        "layer 'Three' ('..library.testclasses..three..')" + lineSeparator() +
+                        "optional layer 'Three' ('..library.testclasses..three..')" + lineSeparator() +
                         "where layer 'One' may not be accessed by any layer" + lineSeparator() +
                         "where layer 'Two' may only be accessed by layers ['One']" + lineSeparator() +
                         "where layer 'Three' may only be accessed by layers ['One', 'Two']");
@@ -175,6 +175,18 @@ public class ArchitecturesTest {
         assertThat(result.hasViolation()).as("result of evaluating empty layers has violation").isTrue();
         assertPatternMatches(result.getFailureReport().getDetails(),
                 ImmutableSet.of(expectedEmptyLayer("Some"), expectedEmptyLayer("Other")));
+    }
+
+    @Test
+    public void layered_architecture_allows_empty_optionalLayer() {
+        LayeredArchitecture architecture = layeredArchitecture()
+                .optionalLayer("can be absent").definedBy(absolute("should.not.be.found.."));
+
+        JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
+
+        EvaluationResult result = architecture.evaluate(classes);
+        assertThat(result.hasViolation()).as("result of evaluating empty optionalLayer has violation").isFalse();
+        assertThat(result.getFailureReport().isEmpty()).as("failure report").isTrue();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
@@ -146,6 +146,7 @@ public class ArchitecturesTest {
     @Test
     public void layered_architecture_allows_empty_layers_if_all_layers_are_optional() {
         LayeredArchitecture architecture = aLayeredArchitectureWithEmptyLayers().withOptionalLayers(true);
+        assertThat(architecture.getDescription()).startsWith("Layered architecture consisting of (optional)");
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
 
@@ -357,6 +358,7 @@ public class ArchitecturesTest {
     @Test
     public void onion_architecture_allows_empty_layers_if_all_layers_are_optional() {
         OnionArchitecture architecture = anOnionArchitectureWithEmptyLayers().withOptionalLayers(true);
+        assertThat(architecture.getDescription()).startsWith("Onion architecture consisting of (optional)");
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute("onionarchitecture"));
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/ArchitecturesTest.java
@@ -144,8 +144,8 @@ public class ArchitecturesTest {
     }
 
     @Test
-    public void layered_architecture_allows_empty_layers_if_configured_to_allow() {
-        LayeredArchitecture architecture = aLayeredArchitectureWithEmptyLayers().allowEmptyLayers(true);
+    public void layered_architecture_allows_empty_layers_if_all_layers_are_optional() {
+        LayeredArchitecture architecture = aLayeredArchitectureWithEmptyLayers().withOptionalLayers(true);
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
 
@@ -155,8 +155,8 @@ public class ArchitecturesTest {
     }
 
     @Test
-    public void layered_architecture_rejects_empty_layers_if_explicitly_configured_to_not_allow() {
-        LayeredArchitecture architecture = aLayeredArchitectureWithEmptyLayers().allowEmptyLayers(false);
+    public void layered_architecture_rejects_empty_layers_if_layers_are_explicity_not_optional_by_default() {
+        LayeredArchitecture architecture = aLayeredArchitectureWithEmptyLayers().withOptionalLayers(false);
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute(""));
 
@@ -178,7 +178,7 @@ public class ArchitecturesTest {
     }
 
     @Test
-    public void layered_architecture_allows_empty_optionalLayer() {
+    public void layered_architecture_allows_individual_empty_optionalLayer() {
         LayeredArchitecture architecture = layeredArchitecture()
                 .optionalLayer("can be absent").definedBy(absolute("should.not.be.found.."));
 
@@ -355,8 +355,8 @@ public class ArchitecturesTest {
     }
 
     @Test
-    public void onion_architecture_allows_empty_layers_if_configured_to_allow() {
-        OnionArchitecture architecture = anOnionArchitectureWithEmptyLayers().allowEmptyLayers(true);
+    public void onion_architecture_allows_empty_layers_if_all_layers_are_optional() {
+        OnionArchitecture architecture = anOnionArchitectureWithEmptyLayers().withOptionalLayers(true);
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute("onionarchitecture"));
 
@@ -366,8 +366,8 @@ public class ArchitecturesTest {
     }
 
     @Test
-    public void onion_architecture_rejects_empty_layers_if_explicitly_configured_to_not_allow() {
-        OnionArchitecture architecture = anOnionArchitectureWithEmptyLayers().allowEmptyLayers(false);
+    public void onion_architecture_rejects_empty_layers_if_layers_are_explicitly_not_optional_by_default() {
+        OnionArchitecture architecture = anOnionArchitectureWithEmptyLayers().withOptionalLayers(false);
 
         JavaClasses classes = new ClassFileImporter().importPackages(absolute("onionarchitecture"));
 


### PR DESCRIPTION
Resolves #267 & #271:

After #177 had prevented empty layers by default, this can now be overridden to re-allow empty layers in `LayeredArchitecture` & `OnionArchitecture`.