### PR TITLE
Add `ensureAllClassesAreContainedInLayers()` to Architectures

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -119,6 +119,7 @@ public final class Architectures {
         private final PredicateAggregator<Dependency> irrelevantDependenciesPredicate;
         private final Optional<String> overriddenDescription;
         private final boolean optionalLayers;
+        private final AllClassesAreContainedInArchitectureCheck allClassesAreContainedInArchitectureCheck;
 
         private LayeredArchitecture(DependencySettings dependencySettings) {
             this(new LayerDefinitions(),
@@ -126,7 +127,8 @@ public final class Architectures {
                     dependencySettings,
                     new PredicateAggregator<Dependency>().thatORs(),
                     Optional.empty(),
-                    false);
+                    false,
+                    new AllClassesAreContainedInArchitectureCheck.Disabled());
         }
 
         private LayeredArchitecture(LayerDefinitions layerDefinitions,
@@ -134,13 +136,15 @@ public final class Architectures {
                 DependencySettings dependencySettings,
                 PredicateAggregator<Dependency> irrelevantDependenciesPredicate,
                 Optional<String> overriddenDescription,
-                boolean optionalLayers) {
+                boolean optionalLayers,
+                AllClassesAreContainedInArchitectureCheck allClassesAreContainedInArchitectureCheck) {
             this.layerDefinitions = layerDefinitions;
             this.dependencySpecifications = dependencySpecifications;
             this.dependencySettings = dependencySettings;
             this.irrelevantDependenciesPredicate = irrelevantDependenciesPredicate;
             this.overriddenDescription = overriddenDescription;
             this.optionalLayers = optionalLayers;
+            this.allClassesAreContainedInArchitectureCheck = allClassesAreContainedInArchitectureCheck;
         }
 
         /**
@@ -158,7 +162,8 @@ public final class Architectures {
                     dependencySettings,
                     irrelevantDependenciesPredicate,
                     overriddenDescription,
-                    optionalLayers
+                    optionalLayers,
+                    allClassesAreContainedInArchitectureCheck
             );
         }
 
@@ -223,6 +228,8 @@ public final class Architectures {
         public EvaluationResult evaluate(JavaClasses classes) {
             EvaluationResult result = new EvaluationResult(this, Priority.MEDIUM);
             checkEmptyLayers(classes, result);
+            allClassesAreContainedInArchitectureCheck.evaluate(classes, layerDefinitions).ifPresent(result::add);
+
             for (LayerDependencySpecification specification : dependencySpecifications) {
                 result.add(evaluateDependenciesShouldBeSatisfied(classes, specification));
             }
@@ -237,6 +244,54 @@ public final class Architectures {
                     }
                 }
             }
+        }
+
+        /**
+         * Ensure that all classes under test are contained within a defined layer of the architecture.
+         *
+         * @see #ensureAllClassesAreContainedInArchitectureIgnoring(String...)
+         * @see #ensureAllClassesAreContainedInArchitectureIgnoring(DescribedPredicate)
+         */
+        @PublicAPI(usage = ACCESS)
+        public LayeredArchitecture ensureAllClassesAreContainedInArchitecture() {
+            return ensureAllClassesAreContainedInArchitectureIgnoring(alwaysFalse());
+        }
+
+        /**
+         * Like {@link #ensureAllClassesAreContainedInArchitecture()} but will ignore classes in packages matching
+         * the specified {@link PackageMatcher packageIdentifiers}.
+         *
+         * @param packageIdentifiers {@link PackageMatcher packageIdentifiers} specifying which classes may live outside the architecture
+         *
+         * @see #ensureAllClassesAreContainedInArchitecture()
+         * @see #ensureAllClassesAreContainedInArchitectureIgnoring(DescribedPredicate)
+         */
+        @PublicAPI(usage = ACCESS)
+        public LayeredArchitecture ensureAllClassesAreContainedInArchitectureIgnoring(String... packageIdentifiers) {
+            return ensureAllClassesAreContainedInArchitectureIgnoring(
+                    resideInAnyPackage(packageIdentifiers).as(joinSingleQuoted(packageIdentifiers)));
+        }
+
+        /**
+         * Like {@link #ensureAllClassesAreContainedInArchitecture()} but will ignore classes in packages matching
+         * the specified {@link DescribedPredicate predicate}.
+         *
+         * @param predicate {@link DescribedPredicate predicate} specifying which classes may live outside the architecture
+         *
+         * @see #ensureAllClassesAreContainedInArchitecture()
+         * @see #ensureAllClassesAreContainedInArchitectureIgnoring(String...)
+         */
+        @PublicAPI(usage = ACCESS)
+        public LayeredArchitecture ensureAllClassesAreContainedInArchitectureIgnoring(DescribedPredicate<? super JavaClass> predicate) {
+            return new LayeredArchitecture(
+                    layerDefinitions,
+                    dependencySpecifications,
+                    dependencySettings,
+                    irrelevantDependenciesPredicate,
+                    overriddenDescription,
+                    optionalLayers,
+                    new AllClassesAreContainedInArchitectureCheck.Enabled(predicate)
+            );
         }
 
         private EvaluationResult evaluateLayersShouldNotBeEmpty(JavaClasses classes, LayerDefinition layerDefinition) {
@@ -310,7 +365,8 @@ public final class Architectures {
                     dependencySettings,
                     irrelevantDependenciesPredicate,
                     Optional.of(newDescription),
-                    optionalLayers
+                    optionalLayers,
+                    allClassesAreContainedInArchitectureCheck
             );
         }
 
@@ -347,7 +403,8 @@ public final class Architectures {
                     dependencySettings,
                     irrelevantDependenciesPredicate.add(dependency(origin, target)),
                     overriddenDescription,
-                    optionalLayers
+                    optionalLayers,
+                    allClassesAreContainedInArchitectureCheck
             );
         }
 
@@ -366,6 +423,41 @@ public final class Architectures {
         private void checkLayerNamesExist(String... layerNames) {
             for (String layerName : layerNames) {
                 checkArgument(layerDefinitions.containLayer(layerName), "There is no layer named '%s'", layerName);
+            }
+        }
+
+        private abstract static class AllClassesAreContainedInArchitectureCheck {
+            abstract Optional<EvaluationResult> evaluate(final JavaClasses classes, final LayerDefinitions layerDefinitions);
+
+            static class Enabled extends AllClassesAreContainedInArchitectureCheck {
+                private final DescribedPredicate<? super JavaClass> ignorePredicate;
+
+                private Enabled(DescribedPredicate<? super JavaClass> ignorePredicate) {
+                    this.ignorePredicate = ignorePredicate;
+                }
+
+                Optional<EvaluationResult> evaluate(final JavaClasses classes, final LayerDefinitions layerDefinitions) {
+                    return Optional.of(classes().should(beContainedInLayers(layerDefinitions)).evaluate(classes));
+                }
+
+                private ArchCondition<JavaClass> beContainedInLayers(LayerDefinitions layerDefinitions) {
+                    DescribedPredicate<JavaClass> classContainedInLayers = layerDefinitions.containsPredicateForAll();
+                    return new ArchCondition<JavaClass>("be contained in architecture") {
+                        @Override
+                        public void check(JavaClass javaClass, ConditionEvents events) {
+                            if (!ignorePredicate.test(javaClass) && !classContainedInLayers.test(javaClass)) {
+                                events.add(violated(this, String.format("Class <%s> is not contained in architecture", javaClass.getName())));
+                            }
+                        }
+                    };
+                }
+            }
+
+            static class Disabled extends AllClassesAreContainedInArchitectureCheck {
+                @Override
+                Optional<EvaluationResult> evaluate(JavaClasses classes, LayerDefinitions layerDefinitions) {
+                    return Optional.empty();
+                }
             }
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/first/First.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/first/First.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.coveringallclasses.first;
+
+public class First {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/second/Second.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/second/Second.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.coveringallclasses.second;
+
+public class Second {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/third/Third.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/coveringallclasses/third/Third.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.coveringallclasses.third;
+
+public class Third {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
@@ -47,6 +47,15 @@ public class ArchRuleCheckAssertion {
     }
 
     @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public ArchRuleCheckAssertion hasOnlyOneViolation(String violationMessage) {
+        assertThat(evaluationResult.getFailureReport().getDetails()).as("Failure report details")
+                .hasSize(1)
+                .first().isEqualTo(violationMessage);
+        assertThat(error.get().getMessage()).contains(violationMessage);
+        return this;
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public ArchRuleCheckAssertion hasOnlyOneViolationMatching(String regex) {
         assertThat(getOnlyElement(evaluationResult.getFailureReport().getDetails())).matches(regex);
         assertThat(error.get().getMessage()).containsPattern(regex);


### PR DESCRIPTION
This will add possibilities to ensure that all classes under test are contained within the respective `LayeredArchitecture`/`OnionArchitecture`. It will help users to make sure they don't overlook any classes when defining their architectures. Furthermore, it will help with maintainability of the architectures when new classes are added to the code base later on. In detail the following methods have been added to `LayeredArchitecture` and `OnionArchitecture`:

* `ensureAllClassesAreContainedInArchitecture()`
* `ensureAllClassesAreContainedInArchitectureIgnoring(packageIdentifiers)`
* `ensureAllClassesAreContainedInArchitectureIgnoring(predicate)`

Resolves #222