### PR TITLE
Fix parameter types lacking contravariance

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -112,43 +112,43 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
         return new GreaterThanOrEqualToPredicate<>(value);
     }
 
-    public static <T> DescribedPredicate<T> describe(String description, Predicate<T> predicate) {
-        return new DescribePredicate<>(description, predicate);
+    public static <T> DescribedPredicate<T> describe(String description, Predicate<? super T> predicate) {
+        return new DescribePredicate<>(description, predicate).forSubType();
     }
 
     /**
      * @deprecated Decided to consistently never use contractions -&gt; use {@link #doesNot(DescribedPredicate)}
      */
     @Deprecated
-    public static <T> DescribedPredicate<T> doesnt(final DescribedPredicate<T> predicate) {
-        return not(predicate).as("doesn't %s", predicate.getDescription());
+    public static <T> DescribedPredicate<T> doesnt(final DescribedPredicate<? super T> predicate) {
+        return not(predicate).as("doesn't %s", predicate.getDescription()).forSubType();
     }
 
     /**
      * @deprecated Decided to consistently never use contractions -&gt; use {@link #doNot(DescribedPredicate)}
      */
     @Deprecated
-    public static <T> DescribedPredicate<T> dont(final DescribedPredicate<T> predicate) {
-        return not(predicate).as("don't %s", predicate.getDescription());
+    public static <T> DescribedPredicate<T> dont(final DescribedPredicate<? super T> predicate) {
+        return not(predicate).as("don't %s", predicate.getDescription()).forSubType();
     }
 
-    public static <T> DescribedPredicate<T> doesNot(final DescribedPredicate<T> predicate) {
-        return not(predicate).as("does not %s", predicate.getDescription());
+    public static <T> DescribedPredicate<T> doesNot(final DescribedPredicate<? super T> predicate) {
+        return not(predicate).as("does not %s", predicate.getDescription()).forSubType();
     }
 
-    public static <T> DescribedPredicate<T> doNot(final DescribedPredicate<T> predicate) {
-        return not(predicate).as("do not %s", predicate.getDescription());
+    public static <T> DescribedPredicate<T> doNot(final DescribedPredicate<? super T> predicate) {
+        return not(predicate).as("do not %s", predicate.getDescription()).forSubType();
     }
 
-    public static <T> DescribedPredicate<T> not(final DescribedPredicate<T> predicate) {
+    public static <T> DescribedPredicate<T> not(final DescribedPredicate<? super T> predicate) {
         return new NotPredicate<>(predicate);
     }
 
-    public static <T> DescribedPredicate<Iterable<T>> anyElementThat(final DescribedPredicate<T> predicate) {
+    public static <T> DescribedPredicate<Iterable<T>> anyElementThat(final DescribedPredicate<? super T> predicate) {
         return new AnyElementPredicate<>(predicate);
     }
 
-    public static <T> DescribedPredicate<Iterable<T>> allElements(final DescribedPredicate<T> predicate) {
+    public static <T> DescribedPredicate<Iterable<T>> allElements(final DescribedPredicate<? super T> predicate) {
         return new AllElementsPredicate<>(predicate);
     }
 
@@ -217,9 +217,9 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     private static class NotPredicate<T> extends DescribedPredicate<T> {
         private final DescribedPredicate<T> predicate;
 
-        NotPredicate(DescribedPredicate<T> predicate) {
+        NotPredicate(DescribedPredicate<? super T> predicate) {
             super("not " + predicate.getDescription());
-            this.predicate = checkNotNull(predicate);
+            this.predicate = checkNotNull(predicate).forSubType();
         }
 
         @Override
@@ -315,9 +315,9 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     private static class AnyElementPredicate<T> extends DescribedPredicate<Iterable<T>> {
         private final DescribedPredicate<T> predicate;
 
-        AnyElementPredicate(DescribedPredicate<T> predicate) {
+        AnyElementPredicate(DescribedPredicate<? super T> predicate) {
             super("any element that " + predicate.getDescription());
-            this.predicate = predicate;
+            this.predicate = predicate.forSubType();
         }
 
         @Override
@@ -334,9 +334,9 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     private static class AllElementsPredicate<T> extends DescribedPredicate<Iterable<T>> {
         private final DescribedPredicate<T> predicate;
 
-        AllElementsPredicate(DescribedPredicate<T> predicate) {
+        AllElementsPredicate(DescribedPredicate<? super T> predicate) {
             super("all elements " + predicate.getDescription());
-            this.predicate = predicate;
+            this.predicate = predicate.forSubType();
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -92,12 +92,12 @@ public interface HasParameterTypes {
          */
         @Deprecated
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> parameterTypes(final DescribedPredicate<JavaClassList> predicate) {
+        public static DescribedPredicate<HasParameterTypes> parameterTypes(final DescribedPredicate<? super JavaClassList> predicate) {
             return adjustDeprecatedDescription(new RawParameterTypesPredicate(predicate));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final DescribedPredicate<List<JavaClass>> predicate) {
+        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final DescribedPredicate<? super List<JavaClass>> predicate) {
             return new RawParameterTypesPredicate(predicate);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
@@ -54,7 +54,7 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
     }
 
     @PublicAPI(usage = ACCESS)
-    public AllDependenciesCondition ignoreDependency(DescribedPredicate<Dependency> ignorePredicate) {
+    public AllDependenciesCondition ignoreDependency(DescribedPredicate<? super Dependency> ignorePredicate) {
         return new AllDependenciesCondition(getDescription(),
                 conditionPredicate,
                 javaClassToRelevantDependencies,

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
@@ -54,7 +54,7 @@ public final class AnyDependencyCondition extends AnyAttributeMatchesCondition<D
     }
 
     @PublicAPI(usage = ACCESS)
-    public AnyDependencyCondition ignoreDependency(DescribedPredicate<Dependency> ignorePredicate) {
+    public AnyDependencyCondition ignoreDependency(DescribedPredicate<? super Dependency> ignorePredicate) {
         return new AnyDependencyCondition(getDescription(),
                 conditionPredicate,
                 javaClassToRelevantDependencies,

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -840,7 +840,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> containNumberOfElements(final DescribedPredicate<Integer> predicate) {
+    public static ArchCondition<JavaClass> containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
         return new NumberOfElementsCondition(predicate);
     }
 
@@ -897,7 +897,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaCodeUnit> haveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate) {
+    public static ArchCondition<JavaCodeUnit> haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
         return new HaveConditionByPredicate<>(rawParameterTypes(predicate));
     }
 
@@ -912,7 +912,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaCodeUnit> haveRawReturnType(DescribedPredicate<JavaClass> predicate) {
+    public static ArchCondition<JavaCodeUnit> haveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
         return new HaveConditionByPredicate<>(rawReturnType(predicate));
     }
 
@@ -1024,9 +1024,9 @@ public final class ArchConditions {
         private final DescribedPredicate<Integer> predicate;
         private SortedSet<String> allClassNames;
 
-        NumberOfElementsCondition(DescribedPredicate<Integer> predicate) {
+        NumberOfElementsCondition(DescribedPredicate<? super Integer> predicate) {
             super("contain number of elements " + predicate.getDescription());
-            this.predicate = predicate;
+            this.predicate = predicate.forSubType();
             allClassNames = new TreeSet<>();
         }
 
@@ -1190,7 +1190,7 @@ public final class ArchConditions {
     private static class IsConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
         private final DescribedPredicate<T> predicate;
 
-        private IsConditionByPredicate(DescribedPredicate<? super T> predicate) {
+        IsConditionByPredicate(DescribedPredicate<? super T> predicate) {
             super(ArchPredicates.be(predicate).getDescription());
             this.predicate = predicate.forSubType();
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
@@ -32,8 +32,8 @@ public class ArchPredicates {
      * @return The original predicate with adjusted description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> is(DescribedPredicate<T> predicate) {
-        return predicate.as("is " + predicate.getDescription());
+    public static <T> DescribedPredicate<T> is(DescribedPredicate<? super T> predicate) {
+        return predicate.as("is " + predicate.getDescription()).forSubType();
     }
 
     /**
@@ -44,8 +44,8 @@ public class ArchPredicates {
      * @return The original predicate with adjusted description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> are(DescribedPredicate<T> predicate) {
-        return predicate.as("are " + predicate.getDescription());
+    public static <T> DescribedPredicate<T> are(DescribedPredicate<? super T> predicate) {
+        return predicate.as("are " + predicate.getDescription()).forSubType();
     }
 
     /**
@@ -56,8 +56,8 @@ public class ArchPredicates {
      * @return The original predicate with adjusted description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> has(DescribedPredicate<T> predicate) {
-        return predicate.as("has " + predicate.getDescription());
+    public static <T> DescribedPredicate<T> has(DescribedPredicate<? super T> predicate) {
+        return predicate.as("has " + predicate.getDescription()).forSubType();
     }
 
     /**
@@ -68,8 +68,8 @@ public class ArchPredicates {
      * @return The original predicate with adjusted description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> have(DescribedPredicate<T> predicate) {
-        return predicate.as("have " + predicate.getDescription());
+    public static <T> DescribedPredicate<T> have(DescribedPredicate<? super T> predicate) {
+        return predicate.as("have " + predicate.getDescription()).forSubType();
     }
 
     /**
@@ -80,7 +80,7 @@ public class ArchPredicates {
      * @return The original predicate with adjusted description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> be(DescribedPredicate<T> predicate) {
-        return predicate.as("be " + predicate.getDescription());
+    public static <T> DescribedPredicate<T> be(DescribedPredicate<? super T> predicate) {
+        return predicate.as("be " + predicate.getDescription()).forSubType();
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractCodeUnitsShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractCodeUnitsShouldInternal.java
@@ -79,12 +79,12 @@ abstract class AbstractCodeUnitsShouldInternal<CODE_UNIT extends JavaCodeUnit, S
     }
 
     @Override
-    public SELF haveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate) {
+    public SELF haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
         return addCondition(ArchConditions.haveRawParameterTypes(predicate));
     }
 
     @Override
-    public SELF notHaveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate) {
+    public SELF notHaveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
         return addCondition(not(ArchConditions.haveRawParameterTypes(predicate)));
     }
 
@@ -109,12 +109,12 @@ abstract class AbstractCodeUnitsShouldInternal<CODE_UNIT extends JavaCodeUnit, S
     }
 
     @Override
-    public SELF haveRawReturnType(DescribedPredicate<JavaClass> predicate) {
+    public SELF haveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(ArchConditions.haveRawReturnType(predicate));
     }
 
     @Override
-    public SELF notHaveRawReturnType(DescribedPredicate<JavaClass> predicate) {
+    public SELF notHaveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(not(ArchConditions.haveRawReturnType(predicate)));
     }
 
@@ -139,12 +139,12 @@ abstract class AbstractCodeUnitsShouldInternal<CODE_UNIT extends JavaCodeUnit, S
     }
 
     @Override
-    public SELF declareThrowableOfType(DescribedPredicate<JavaClass> predicate) {
+    public SELF declareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(ArchConditions.declareThrowableOfType(predicate));
     }
 
     @Override
-    public SELF notDeclareThrowableOfType(DescribedPredicate<JavaClass> predicate) {
+    public SELF notDeclareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(not(ArchConditions.declareThrowableOfType(predicate)));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -585,7 +585,7 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
-    public ClassesShouldConjunction containNumberOfElements(DescribedPredicate<Integer> predicate) {
+    public ClassesShouldConjunction containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
         return addCondition(ArchConditions.containNumberOfElements(predicate));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/CodeUnitsThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/CodeUnitsThatInternal.java
@@ -61,12 +61,12 @@ class CodeUnitsThatInternal<
     }
 
     @Override
-    public CONJUNCTION haveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate) {
+    public CONJUNCTION haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
         return withPredicate(have(rawParameterTypes(predicate)));
     }
 
     @Override
-    public CONJUNCTION doNotHaveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate) {
+    public CONJUNCTION doNotHaveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
         return withPredicate(doNot(have(rawParameterTypes(predicate))));
     }
 
@@ -91,12 +91,12 @@ class CodeUnitsThatInternal<
     }
 
     @Override
-    public CONJUNCTION haveRawReturnType(DescribedPredicate<JavaClass> predicate) {
+    public CONJUNCTION haveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
         return withPredicate(have(rawReturnType(predicate)));
     }
 
     @Override
-    public CONJUNCTION doNotHaveRawReturnType(DescribedPredicate<JavaClass> predicate) {
+    public CONJUNCTION doNotHaveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
         return withPredicate(doNot(have(rawReturnType(predicate))));
     }
 
@@ -129,16 +129,16 @@ class CodeUnitsThatInternal<
     }
 
     @Override
-    public CONJUNCTION declareThrowableOfType(DescribedPredicate<JavaClass> predicate) {
+    public CONJUNCTION declareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         return withPredicate(declareThrowableOfTypePredicate(predicate));
     }
 
-    private DescribedPredicate<HasThrowsClause<?>> declareThrowableOfTypePredicate(DescribedPredicate<JavaClass> predicate) {
+    private DescribedPredicate<HasThrowsClause<?>> declareThrowableOfTypePredicate(DescribedPredicate<? super JavaClass> predicate) {
         return throwsClauseContainingType(predicate).as("declare throwable of type " + predicate.getDescription());
     }
 
     @Override
-    public CONJUNCTION doNotDeclareThrowableOfType(DescribedPredicate<JavaClass> predicate) {
+    public CONJUNCTION doNotDeclareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         return withPredicate(doNot(declareThrowableOfTypePredicate(predicate)));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -1030,5 +1030,5 @@ public interface ClassesShould {
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
     @PublicAPI(usage = ACCESS)
-    ClassesShouldConjunction containNumberOfElements(DescribedPredicate<Integer> predicate);
+    ClassesShouldConjunction containNumberOfElements(DescribedPredicate<? super Integer> predicate);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
@@ -130,7 +130,7 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION haveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate);
+    CONJUNCTION haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate);
 
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} do not have raw parameter types matching the given predicate.
@@ -151,7 +151,7 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION notHaveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate);
+    CONJUNCTION notHaveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate);
 
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} have the specified raw return type.
@@ -256,7 +256,7 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION haveRawReturnType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION haveRawReturnType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} do not have raw return types matching the given predicate.
@@ -277,7 +277,7 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION notHaveRawReturnType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION notHaveRawReturnType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} declare a {@link Throwable} of the specified type in their throws clause.
@@ -382,7 +382,7 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION declareThrowableOfType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION declareThrowableOfType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} do not declare a {@link Throwable} which matches the given predicate.
@@ -403,5 +403,5 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION notDeclareThrowableOfType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION notDeclareThrowableOfType(DescribedPredicate<? super JavaClass> predicate);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
@@ -120,7 +120,7 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION haveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate);
+    CONJUNCTION haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate);
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that do not have raw parameter types matching the given predicate.
@@ -139,7 +139,7 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION doNotHaveRawParameterTypes(DescribedPredicate<List<JavaClass>> predicate);
+    CONJUNCTION doNotHaveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate);
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that have the specified raw return types.
@@ -234,7 +234,7 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION haveRawReturnType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION haveRawReturnType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that do not have raw return types matching the given predicate.
@@ -253,7 +253,7 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION doNotHaveRawReturnType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION doNotHaveRawReturnType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that declare a {@link Throwable} of the specified type in their throws clause.
@@ -348,7 +348,7 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION declareThrowableOfType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION declareThrowableOfType(DescribedPredicate<? super JavaClass> predicate);
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that do not declare a {@link Throwable} which matches the given predicate.
@@ -367,5 +367,5 @@ public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>>
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION doNotDeclareThrowableOfType(DescribedPredicate<JavaClass> predicate);
+    CONJUNCTION doNotDeclareThrowableOfType(DescribedPredicate<? super JavaClass> predicate);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -315,9 +315,9 @@ public final class Architectures {
             }
 
             @PublicAPI(usage = ACCESS)
-            public LayeredArchitecture definedBy(DescribedPredicate<JavaClass> predicate) {
+            public LayeredArchitecture definedBy(DescribedPredicate<? super JavaClass> predicate) {
                 checkNotNull(predicate, "Supplied predicate must not be null");
-                this.containsPredicate = predicate;
+                this.containsPredicate = predicate.forSubType();
                 return LayeredArchitecture.this.addLayerDefinition(this);
             }
 

--- a/build-steps/maven-integration-test/maven-integration-test.gradle
+++ b/build-steps/maven-integration-test/maven-integration-test.gradle
@@ -174,7 +174,7 @@ def addMavenTest = { config ->
         tasks.create(name: runMavenTest, dependsOn: [prepareMavenTest, executeRules, verifyRules, cleanUpMavenTest])
 
         def executeRulesTask = tasks[executeRules]
-        releaseProjects.with {
+        releaseProjects*.with {
             [install, uploadArchives].each { executeRulesTask.mustRunAfter it }
         }
     }

--- a/build-steps/maven-integration-test/maven-integration-test.gradle
+++ b/build-steps/maven-integration-test/maven-integration-test.gradle
@@ -213,7 +213,6 @@ javaConfigs.findAll { it.suffix.endsWith('junit4') }*.with {
     archunitTestArtifact = 'archunit-junit4'
 }
 
-def archUnitVersion = version
 javaConfigs.findAll { it.suffix.endsWith('junit5') }*.with {
     surefireExampleConfiguration = '<groups>example</groups>'
     archunitTestArtifact = 'archunit-junit5'


### PR DESCRIPTION
For some public API methods of the fluent API (or static factory methods offering `DescribedPredicate`/`ArchCondition`) that took a `DescribedParameter` as a parameter type, the type parameter of `DescribedPredicate` was not specified in a contravariant way.

E.g. 

```
methods().should().haveRawReturnType(DescribedPredicate<JavaClass> predicate)
```

This prevented compatible predicates for super types (like `HasName.Predicates.name(..)`) to be passed to these methods, even though the would be fully compatible.

This PR fixes those methods and adds a new rule to `PublicAPIRules` to prevent this easy to make mistake for the future.

Resolves: #262