### PR TITLE
Migrate build to "maven-publish" plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 script:
-- ./gradlew --no-daemon -PallTests -PscanBuild clean build install runMavenTest
+- ./gradlew --no-daemon -PallTests -PscanBuild clean build publishToMavenLocal runMavenTest
 
 jdk:
   - openjdk11

--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -84,8 +84,15 @@ ext.configureJUnitArchive = { configureDependencies ->
         delegate.with addCleanThirdPartyTask
         compileJava.dependsOn project(':archunit-junit').finishArchive
 
-        install.repositories.mavenInstaller.pom.whenConfigured configureDependencies
-        uploadArchives.repositories.mavenDeployer.pom.whenConfigured configureDependencies
+        publishing{
+            publications{
+                mavenJava{
+                    pom.withXml {
+                        configureDependencies(asNode().dependencies.first()) // there is only one "dependencies" element
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/archunit-junit/junit4/build.gradle
+++ b/archunit-junit/junit4/build.gradle
@@ -43,10 +43,9 @@ shadowJar {
     }
 }
 
-def configureDependencies = { pom ->
-    pom.dependencies.removeAll {
-        it.scope != 'compile' || !(it.artifactId in ['archunit', 'archunit-junit5-api', 'archunit-junit5-engine-api', 'junit'])
+def configureDependencies = { deps ->
+    deps.children().removeIf { dep ->
+        dep.scope.text() != 'compile' || !(dep.artifactId.text() in ['archunit', 'archunit-junit5-api', 'archunit-junit5-engine-api', 'junit'])
     }
-    pom.dependencies.find { it.artifactId == 'archunit' }.classifier = null
 }
 this.with project(':archunit-junit').configureJUnitArchive(configureDependencies)

--- a/archunit-junit/junit5/aggregator/build.gradle
+++ b/archunit-junit/junit5/aggregator/build.gradle
@@ -1,13 +1,15 @@
+apply plugin: 'java-library'
+
 ext.moduleName = 'com.tngtech.archunit.junit5'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-	compile(project(":archunit-junit5-api"))
-	runtime(project(":archunit-junit5-engine"))
+    api(project(":archunit-junit5-api"))
+    implementation(project(":archunit-junit5-engine"))
 }
 
 shadowJar {
-	exclude '**'
+    exclude '**'
 }

--- a/archunit-junit/junit5/api/build.gradle
+++ b/archunit-junit/junit5/api/build.gradle
@@ -25,10 +25,9 @@ shadowJar {
     }
 }
 
-def configureDependencies = { pom ->
-    pom.dependencies.removeAll {
-        it.scope != 'compile' || !(it.artifactId in ['archunit'])
+def configureDependencies = { deps ->
+    deps.children().removeIf { dep ->
+        dep.scope.text() != 'compile' || !(dep.artifactId.text() in ['archunit'])
     }
-    pom.dependencies.find { it.artifactId == 'archunit' }.classifier = null
 }
 this.with project(':archunit-junit').configureJUnitArchive(configureDependencies)

--- a/archunit-junit/junit5/engine-api/build.gradle
+++ b/archunit-junit/junit5/engine-api/build.gradle
@@ -36,8 +36,10 @@ shadowJar {
     }
 }
 
-def configureDependencies = { pom ->
-    // dependencies to archunit only cover annotations; we can skip those without breaking consumers to keep the dependency slim
-    pom.dependencies.removeAll { it.artifactId != 'junit-platform-engine' }
+// dependencies to archunit only cover annotations; we can skip those without breaking consumers to keep the dependency slim
+def configureDependencies = { deps ->
+    deps.children().removeIf{ dep ->
+        dep.artifactId.text() != 'junit-platform-engine'
+    }
 }
 this.with project(':archunit-junit').configureJUnitArchive(configureDependencies)

--- a/archunit-junit/junit5/engine/build.gradle
+++ b/archunit-junit/junit5/engine/build.gradle
@@ -49,10 +49,9 @@ shadowJar {
     }
 }
 
-def configureDependencies = { pom ->
-    pom.dependencies.removeAll {
-        it.scope != 'compile' || !(it.artifactId in ['archunit', 'archunit-junit5-api', 'archunit-junit5-engine-api'])
+def configureDependencies = { deps ->
+    deps.children().removeIf { dep ->
+        dep.scope.text() != 'compile' || !(dep.artifactId.text() in ['archunit', 'archunit-junit5-api', 'archunit-junit5-engine-api'])
     }
-    pom.dependencies.find { it.artifactId == 'archunit' }.classifier = null
 }
 this.with project(':archunit-junit').configureJUnitArchive(configureDependencies)

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -30,13 +30,18 @@ shadowJar {
 }
 
 /* Besides SLF4J we'll shadow everything we need into the JAR to avoid conflicts with other libraries*/
-def configureDependenciesAfterShadow = { pom ->
-    pom.dependencies.removeAll {
-        it.artifactId != 'slf4j-api' || it.scope != 'compile'
+publishing{
+    publications{
+        mavenJava{
+            pom.withXml {
+                def deps = asNode().dependencies.first() // there is only one "dependencies" element
+                deps.children().removeIf { dep ->
+                    dep.artifactId.text() != 'slf4j-api' || dep.scope.text() != 'compile'
+                }
+            }
+        }
     }
 }
-install.repositories.mavenInstaller.pom.whenConfigured configureDependenciesAfterShadow
-uploadArchives.repositories.mavenDeployer.pom.whenConfigured configureDependenciesAfterShadow
 
 addTestJarTo this
 configureSlowTestsFor this

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     }
 }
 
-ext.repackagesAsm = true // Will cause the ASM License to be packaged -> license.gradle
 shadowJar {
     exclude 'META-INF/**'
 

--- a/build-steps/archiving/archiving.gradle
+++ b/build-steps/archiving/archiving.gradle
@@ -5,8 +5,6 @@ buildscript {
 }
 
 subprojects {
-    ext.repackagesAsm = false
-
     afterEvaluate {
         tasks.withType(Jar) {
             manifest {

--- a/build-steps/license/license.gradle
+++ b/build-steps/license/license.gradle
@@ -87,23 +87,25 @@ task updateLicenses {
 }
 
 releaseProjects*.with {
-    def installer = install.repositories.mavenInstaller
-    def deployer = uploadArchives.repositories.mavenDeployer
-
-    [installer, deployer]*.pom*.whenConfigured {
-        project {
-            licenses {
-                license {
-                    name app.license.name
-                    url app.license.url
-                    distribution 'repo'
-                }
-                if (repackagesAsm) {
-                    def asmLicense = rootProject.file(asmLicenseFile).readLines() as Queue
-                    license {
-                        name asmLicense.poll().replaceAll(/^.*?: /, '')
-                        url asmLicense.poll().replaceAll(/^.*?: /, '')
-                        distribution 'repo'
+    ext.repackagesAsm = project.name == "archunit"
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                pom {
+                    licenses {
+                        license {
+                            name = app.license.name
+                            url = app.license.url
+                            distribution = 'repo'
+                        }
+                        if (repackagesAsm) {
+                            def asmLicense = rootProject.file(asmLicenseFile).readLines() as Queue
+                            license {
+                                name = asmLicense.poll().replaceAll(/^.*?: /, '')
+                                url = asmLicense.poll().replaceAll(/^.*?: /, '')
+                                distribution = 'repo'
+                            }
+                        }
                     }
                 }
             }

--- a/build-steps/maven-integration-test/maven-integration-test.gradle
+++ b/build-steps/maven-integration-test/maven-integration-test.gradle
@@ -175,7 +175,7 @@ def addMavenTest = { config ->
 
         def executeRulesTask = tasks[executeRules]
         releaseProjects*.with {
-            [install, uploadArchives].each { executeRulesTask.mustRunAfter it }
+            [publish, publishToMavenLocal].each { executeRulesTask.mustRunAfter it }
         }
     }
 }

--- a/build-steps/release/expected/archunit-junit4.pom
+++ b/build-steps/release/expected/archunit-junit4.pom
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>

--- a/build-steps/release/expected/archunit-junit5-api.pom
+++ b/build-steps/release/expected/archunit-junit5-api.pom
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>

--- a/build-steps/release/expected/archunit-junit5-engine-api.pom
+++ b/build-steps/release/expected/archunit-junit5-engine-api.pom
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>

--- a/build-steps/release/expected/archunit-junit5-engine.pom
+++ b/build-steps/release/expected/archunit-junit5-engine.pom
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>

--- a/build-steps/release/expected/archunit-junit5.pom
+++ b/build-steps/release/expected/archunit-junit5.pom
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tngtech.archunit</groupId>
   <artifactId>archunit-junit5</artifactId>

--- a/build-steps/release/expected/archunit-junit5.pom
+++ b/build-steps/release/expected/archunit-junit5.pom
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tngtech.archunit</groupId>

--- a/build-steps/release/expected/archunit.pom
+++ b/build-steps/release/expected/archunit.pom
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
@@ -55,3 +55,4 @@
         </dependency>
     </dependencies>
 </project>
+

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -1,90 +1,18 @@
+ext.isReleaseVersion = !project.version.endsWith("-SNAPSHOT")
+
+if (!hasProperty("sonatypeUsername")) {
+    ext.sonatypeUsername = ""
+}
+if (!hasProperty("sonatypePassword")) {
+    ext.sonatypePassword = ""
+}
+
 releaseProjects*.with {
-    apply plugin: 'maven'
-    apply plugin: 'signing'
+    apply plugin: "maven-publish"
+    apply plugin: "signing"
 
-    install.dependsOn(build)
-    uploadArchives.dependsOn(build)
-
-    signing {
-        // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
-        required {
-            gradle.taskGraph.hasTask('uploadArchives') && project.hasProperty('sonatypeUsername')
-        }
-        sign configurations.archives
-    }
-    signArchives.dependsOn finishArchive
-
-    uploadArchives {
-        doFirst {
-            assert project.property('org.gradle.parallel') == 'false':
-                    'uploading archives with parallel execution seems to lead to broken uploads in Sonatype Nexus'
-        }
-
-        repositories {
-            mavenDeployer {
-                beforeDeployment { deployment ->
-                    signing.signPom(deployment)
-                }
-
-                // respective username and password can be configured in ~/.gradle/gradle.properties
-                if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
-                    repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
-                        authentication(userName: sonatypeUsername, password: sonatypePassword)
-                    }
-                    snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/') {
-                        authentication(userName: sonatypeUsername, password: sonatypePassword)
-                    }
-                }
-                if (project.hasProperty('tngNexusUsername') && project.hasProperty('tngNexusPassword')) {
-                    repository(url: 'https://nexus.int.tngtech.com/repository/maven-releases/') {
-                        authentication(userName: tngNexusUsername, password: tngNexusPassword)
-                    }
-                    snapshotRepository(url: 'https://nexus.int.tngtech.com/repository/maven-snapshots/') {
-                        authentication(userName: tngNexusUsername, password: tngNexusPassword)
-                    }
-                }
-            }
-        }
-    }
-
-    def installer = install.repositories.mavenInstaller
-    def deployer = uploadArchives.repositories.mavenDeployer
-
-    [installer, deployer]*.pom*.whenConfigured {
-        project {
-            name app.name
-            description description
-            url app.urls.entry
-
-            organization {
-                name company.name
-                url company.url
-            }
-
-            scm {
-                url app.urls.source
-                connection "scm:${app.gitRepo}"
-                developerConnection "scm:${app.gitRepo}"
-            }
-
-            developers {
-                developer {
-                    id 'codecholeric'
-                    name 'Peter Gafert'
-                    email 'peter.gafert@tngtech.com'
-                }
-                developer {
-                    id 'rweisleder'
-                    name 'Roland Weisleder'
-                    email 'roland.weisleder@googlemail.com'
-                }
-                developer {
-                    id 'hankem'
-                    name 'Manfred Hanke'
-                    email 'manfred.hanke@tngtech.com'
-                }
-            }
-        }
+    tasks.withType(GenerateModuleMetadata) {
+        enabled = isReleaseVersion // signing of these artifacts causes failure for snapshot versions
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
@@ -106,7 +34,79 @@ releaseProjects*.with {
         }
     }
 
-    artifacts {
-        archives sourcesJar, javadocJar
+    publish.dependsOn(build)
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = project.archivesBaseName
+                from components.java
+                artifact tasks.sourcesJar
+                artifact tasks.javadocJar
+                pom {
+                    name = app.name
+                    packaging = "jar"
+                    description = project.description
+                    url = app.urls.entry
+
+                    developers {
+                        developer {
+                            id = 'codecholeric'
+                            name = 'Peter Gafert'
+                            email = 'peter.gafert@tngtech.com'
+                        }
+                        developer {
+                            id = 'rweisleder'
+                            name = 'Roland Weisleder'
+                            email = 'roland.weisleder@googlemail.com'
+                        }
+                        developer {
+                            id = 'hankem'
+                            name = 'Manfred Hanke'
+                            email = 'manfred.hanke@tngtech.com'
+                        }
+                    }
+
+                    organization {
+                        name = company.name
+                        url = company.url
+                    }
+
+                    scm {
+                        url = app.urls.source
+                        connection = "scm:${app.gitRepo}"
+                        developerConnection = "scm:${app.gitRepo}"
+                    }
+                }
+            }
+        }
+
+        repositories {
+            // respective username and password can be configured in ~/.gradle/gradle.properties
+            if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
+                maven {
+                    def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                    def snapshotRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                    url = isReleaseVersion ? releasesRepoUrl : snapshotRepoUrl
+
+                    credentials {
+                        username = sonatypeUsername
+                        password = sonatypePassword
+                    }
+
+                    metadataSources {
+                        gradleMetadata()
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
+        required {
+            isReleaseVersion && gradle.taskGraph.hasTask('publish') && project.hasProperty('sonatypeUsername')
+        }
+        sign publishing.publications.mavenJava
     }
 }

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -35,6 +35,10 @@ releaseProjects*.with {
     }
 
     publish.dependsOn(build)
+    publish.doFirst {
+        assert !gradle.startParameter.isParallelProjectExecutionEnabled():
+                'uploading archives with parallel execution seems to lead to broken uploads in Sonatype Nexus'
+    }
 
     publishing {
         publications {


### PR DESCRIPTION
Finally got it running @codecholeric. But haven't had a look at the new "shadow" plugin and it's possibilities in order to get rid of dependencies removal in published poms, yet.

See commit message for still open points and tell me what you think about these as well as with I should get fixed.

You can check the results of a `publish` run at https://oss.sonatype.org/content/repositories/snapshots/com/tngtech/archunit/, version `0.13.0-SNAPSHOT` or run `publishToMavenLocal` yourself. I also created a release (which is again dropped) and run `checkUAr -PtngRepoId=1202` besides some pom formattings - at least as far as I could see manually ;-) - quite successfully IMO.
Note: Only thing was that I needed to run `./gradlew --no-parallel publish` multiple times to have all artifacts in the OSS Sonatype repo but could not find out why this is the case ...

Unfortunately, the upgrade to Gradle version 5 (first commit) is required unless you want to add `enableFeaturePreview('STABLE_PUBLISHING')` to your settings.
