### PR TITLE
reduce log levels of class import details

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -139,7 +139,7 @@ class ClassFileProcessor {
         @Override
         public void handleFieldInstruction(int opcode, String owner, String name, String desc) {
             AccessType accessType = AccessType.forOpCode(opcode);
-            LOG.debug("Found {} access to field {}.{}:{} in line {}", accessType, owner, name, desc, lineNumber);
+            LOG.trace("Found {} access to field {}.{}:{} in line {}", accessType, owner, name, desc, lineNumber);
             TargetInfo target = new RawAccessRecord.FieldTargetInfo(owner, name, desc);
             importRecord.registerFieldAccess(filled(new RawAccessRecord.ForField.Builder(), target)
                     .withAccessType(accessType)
@@ -148,7 +148,7 @@ class ClassFileProcessor {
 
         @Override
         public void handleMethodInstruction(String owner, String name, String desc) {
-            LOG.debug("Found call of method {}.{}:{} in line {}", owner, name, desc, lineNumber);
+            LOG.trace("Found call of method {}.{}:{} in line {}", owner, name, desc, lineNumber);
             if (CONSTRUCTOR_NAME.equals(name)) {
                 TargetInfo target = new ConstructorTargetInfo(owner, name, desc);
                 importRecord.registerConstructorCall(filled(new RawAccessRecord.Builder(), target).build());

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -108,11 +108,11 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         ImmutableSet<String> interfaceNames = createInterfaceNames(interfaces);
-        LOG.debug("Found interfaces {} on class '{}'", interfaceNames, name);
+        LOG.trace("Found interfaces {} on class '{}'", interfaceNames, name);
         boolean opCodeForInterfaceIsPresent = (access & Opcodes.ACC_INTERFACE) != 0;
         boolean opCodeForEnumIsPresent = (access & Opcodes.ACC_ENUM) != 0;
         Optional<String> superClassName = getSuperClassName(superName, opCodeForInterfaceIsPresent);
-        LOG.debug("Found superclass {} on class '{}'", superClassName.orNull(), name);
+        LOG.trace("Found superclass {} on class '{}'", superClassName.orNull(), name);
 
         javaClassBuilder = new DomainBuilders.JavaClassBuilder()
                 .withSourceUri(sourceURI)
@@ -216,7 +216,7 @@ class JavaClassProcessor extends ClassVisitor {
             return super.visitMethod(access, name, desc, signature, exceptions);
         }
 
-        LOG.debug("Analyzing method {}.{}:{}", className, name, desc);
+        LOG.trace("Analyzing method {}.{}:{}", className, name, desc);
         accessHandler.setContext(new CodeUnit(name, namesOf(Type.getArgumentTypes(desc)), className));
 
         DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder = addCodeUnitBuilder(name);
@@ -282,7 +282,7 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         declarationHandler.onDeclaredAnnotations(annotations);
-        LOG.debug("Done analyzing {}", className);
+        LOG.trace("Done analyzing {}", className);
     }
 
     private static List<String> namesOf(Type[] types) {


### PR DESCRIPTION
Since some users had trouble configuring their logging and consequently hanging Maven builds when using Windows CMD as their console, the log levels for the most detailed information during class file import is now reduced to TRACE. In the end it also seems reasonable to log details about field accesses and method calls on a different level than which classes are imported. And since meanwhile the logging of which classes are imported is DEBUG level and not INFO level anymore like originally, this is a reasonable adjustment.