### PR TITLE
fix broken JRT URL handling for JDK >= 13

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedUri.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedUri.java
@@ -16,16 +16,25 @@
 package com.tngtech.archunit.core.importer;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Objects;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 
 class NormalizedUri {
     private final URI uri;
+    private final String firstSegment;
+    private final String tailSegments;
 
     private NormalizedUri(URI uri) {
-        String uriString = uri.toString();
+        String uriString = uri.normalize().toString();
         uriString = uriString.replaceAll("://*", ":/"); // this is how getClass().getResource(..) returns URLs
         uriString = !uriString.endsWith("/") && !uriString.endsWith(".class") ? uriString + "/" : uriString; // we always want folders to end in '/'
         this.uri = URI.create(uriString);
+        List<String> path = Splitter.on("/").omitEmptyStrings().splitToList(this.uri.toString().replaceAll("^.*:", ""));
+        firstSegment = path.get(0);
+        tailSegments = path.size() < 2 ? "" : Joiner.on("/").join(path.subList(1, path.size()));
     }
 
     URI toURI() {
@@ -34,6 +43,14 @@ class NormalizedUri {
 
     String getScheme() {
         return uri.getScheme();
+    }
+
+    public String getFirstSegment() {
+        return firstSegment;
+    }
+
+    public String getTailSegments() {
+        return tailSegments;
     }
 
     @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/NormalizedUriTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/NormalizedUriTest.java
@@ -1,0 +1,45 @@
+package com.tngtech.archunit.core.importer;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NormalizedUriTest {
+    @Test
+    public void normalizes_URI() {
+        NormalizedUri uri = NormalizedUri.from(URI.create("prot:/some/.././uri/."));
+
+        assertThat(uri.toURI()).isEqualTo(URI.create("prot:/uri/"));
+    }
+
+    @Test
+    public void normalizes_URI_from_string() {
+        NormalizedUri uri = NormalizedUri.from("prot:/some/../uri/.");
+
+        assertThat(uri.toURI()).isEqualTo(URI.create("prot:/uri/"));
+    }
+
+    @Test
+    public void parses_first_segment() {
+        NormalizedUri uri = NormalizedUri.from("jrt:/java.base/java/io/File.class");
+
+        assertThat(uri.getFirstSegment()).isEqualTo("java.base");
+
+        uri = NormalizedUri.from("jrt:/java.base");
+
+        assertThat(uri.getFirstSegment()).isEqualTo("java.base");
+    }
+
+    @Test
+    public void parses_tail_segments() {
+        NormalizedUri uri = NormalizedUri.from("jrt:/java.base/java/io/File.class");
+
+        assertThat(uri.getTailSegments()).isEqualTo("java/io/File.class");
+
+        uri = NormalizedUri.from("jrt:/java.base");
+
+        assertThat(uri.getTailSegments()).isEmpty();
+    }
+}

--- a/build-steps/maven-integration-test/maven-integration-test.gradle
+++ b/build-steps/maven-integration-test/maven-integration-test.gradle
@@ -185,7 +185,10 @@ def javaConfigs = [
         [suffix: "java8", javaVersion: JavaVersion.VERSION_1_8, jdkProp: "java8Home"],
         [suffix: "java9", javaVersion: JavaVersion.VERSION_1_9, jdkProp: "java9Home"],
         [suffix: "java10", javaVersion: JavaVersion.VERSION_1_10, jdkProp: "java10Home"],
-        [suffix: "java11", javaVersion: JavaVersion.VERSION_11, jdkProp: "java11Home"]
+        [suffix: "java11", javaVersion: JavaVersion.VERSION_11, jdkProp: "java11Home"],
+        [suffix: "java12", javaVersion: JavaVersion.VERSION_HIGHER, jdkProp: "java12Home"],
+        [suffix: "java13", javaVersion: JavaVersion.VERSION_HIGHER, jdkProp: "java13Home"],
+        [suffix: "java14", javaVersion: JavaVersion.VERSION_HIGHER, jdkProp: "java14Home"]
 ]
 
 javaConfigs = javaConfigs.findAll { project.hasProperty(it.jdkProp) }


### PR DESCRIPTION
With JDK 13 some wrongly implemented behavior of JRT path handling was fixed. I.e. by JEP-220 (https://openjdk.java.net/jeps/220) while URIs possess the shape of `jrt:/module.name/some/clazz/Name.class` the respective (virtual) file system path for JRTs supposedly has the shape of `/modules/module.name/some/clazz/Name.class`. Unfortunately ArchUnit was relying on the wrongly implemented version of `JrtFileSystemProvider` which would return a path for JRTs of `/module.name/some/clazz/Name.class`. Thus with JDK >= 13 the URI handling for JRTs was broken.
This will now be fixed by relying on pure JRT URI handling without relying on conversion to `java.nio.file.Path`. We simply split the path of a JRT URI on `/` and treat the first segment as module name, the rest of the segments as the resource/class name (e.g. `module.name` and `some/clazz/Name.class`). Note that we unfortunately cannot use `URI.getPath()` within `NormalizedUri` to retrieve the path without the schema, since `URI.getPath()` will return `null` for JAR URIs (i.e. `jar:file:/...`).

Resolves: #303