### PR TITLE
Reuse supplied import options in ClassFileImporter.importClasspath()

### DIFF
--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -15,10 +15,6 @@ sourceSets {
     }
 }
 
-spotbugs {
-    sourceSets += [project.sourceSets.api]
-}
-
 dependencies {
     compileOnly sourceSets.api.output
     testCompile sourceSets.api.output

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -89,6 +89,8 @@ task jdk9Test(type: Test) {
 
 [jar, test]*.dependsOn compileJdk9mainJava
 
+spotbugsJdk9test.enabled = false
+
 idea {
     module {
         sourceDirs += jdk9MainDirs.collect { file(it) }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -248,7 +248,7 @@ public final class ClassFileImporter {
      */
     @PublicAPI(usage = ACCESS)
     public JavaClasses importClasspath() {
-        return importClasspath(new ImportOptions().with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES));
+        return importClasspath(importOptions.with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES));
     }
 
     /**

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -34,11 +34,16 @@ public class ClassFileImporterSlowTest {
 
         assertThatClasses(classes).contain(ClassFileImporter.class, getClass());
         assertThatClasses(classes).doNotContain(Rule.class); // Default does not import jars
+        assertThatClasses(classes).doNotContain(File.class); // Default does not import JDK classes
 
-        JavaClasses javaBaseClasses = importJavaBase();
+        classes = new ClassFileImporter().importClasspath(new ImportOptions().with(new ImportOption() {
+            @Override
+            public boolean includes(Location location) {
+                return !location.asURI().getScheme().equals("jrt") || location.contains("java.base");
+            }
+        }));
 
-        assertThatClasses(javaBaseClasses).contain(String.class, Annotation.class);
-        assertThatClasses(javaBaseClasses).doNotContain(ClassFileImporter.class, getClass(), Rule.class);
+        assertThatClasses(classes).contain(ClassFileImporter.class, getClass(), Rule.class, File.class);
     }
 
     @Test
@@ -119,8 +124,7 @@ public class ClassFileImporterSlowTest {
         return new ClassFileImporter().importClasspath(new ImportOptions().with(new ImportOption() {
             @Override
             public boolean includes(Location location) {
-                return location.asURI().getScheme().equals("jrt") &&
-                        location.contains("java.base"); // Only import the base jdk classes
+                return location.asURI().getScheme().equals("jrt") && location.contains("java.base");
             }
         }));
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -19,6 +19,7 @@ import org.junit.experimental.categories.Category;
 
 import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
 import static com.tngtech.archunit.core.importer.ClassFileImporterTest.jarFileOf;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
 
@@ -38,6 +39,14 @@ public class ClassFileImporterSlowTest {
 
         assertThatClasses(javaBaseClasses).contain(String.class, Annotation.class);
         assertThatClasses(javaBaseClasses).doNotContain(ClassFileImporter.class, getClass(), Rule.class);
+    }
+
+    @Test
+    public void respects_ImportOptions_when_using_the_default_importClasspath_method() {
+        JavaClasses classes = new ClassFileImporter().withImportOption(DO_NOT_INCLUDE_TESTS).importClasspath();
+
+        assertThatClasses(classes).contain(ClassFileImporter.class);
+        assertThatClasses(classes).doNotContain(getClass(), Rule.class, String.class);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -34,9 +34,10 @@ public class ClassFileImporterSlowTest {
         assertThatClasses(classes).contain(ClassFileImporter.class, getClass());
         assertThatClasses(classes).doNotContain(Rule.class); // Default does not import jars
 
-        classes = importJavaBase();
+        JavaClasses javaBaseClasses = importJavaBase();
 
-        assertThatClasses(classes).contain(ClassFileImporter.class, getClass(), Rule.class);
+        assertThatClasses(javaBaseClasses).contain(String.class, Annotation.class);
+        assertThatClasses(javaBaseClasses).doNotContain(ClassFileImporter.class, getClass(), Rule.class);
     }
 
     @Test
@@ -109,7 +110,7 @@ public class ClassFileImporterSlowTest {
         return new ClassFileImporter().importClasspath(new ImportOptions().with(new ImportOption() {
             @Override
             public boolean includes(Location location) {
-                return !location.asURI().getScheme().equals("jrt") ||
+                return location.asURI().getScheme().equals("jrt") &&
                         location.contains("java.base"); // Only import the base jdk classes
             }
         }));

--- a/build-steps/codequality/spotbugs.gradle
+++ b/build-steps/codequality/spotbugs.gradle
@@ -4,9 +4,8 @@ productionProjects*.with {
     apply plugin: 'com.github.spotbugs'
 
     spotbugs {
-        toolVersion = '3.1.8'
+        toolVersion = '4.0.1'
 
-        sourceSets = [sourceSets.main]
         excludeFilter = new File(scriptRoot, 'spotbugs-excludes.xml')
     }
 
@@ -16,4 +15,6 @@ productionProjects*.with {
             html.enabled true
         }
     }
+
+    spotbugsTest.enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.gradle.build-scan' version '3.1.1'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'com.github.spotbugs' version '3.0.0'
+    id 'com.github.spotbugs' version '4.0.5'
 }
 
 def appAndSourceUrl = 'https://github.com/TNG/ArchUnit'


### PR DESCRIPTION
Until now any `ImportOption` supplied via `classFileImporter.withImportOptions(importOptions)` was disregarded, if `importClasspath()` was used (that method just used new `ImportOptions` with some default).
Now any previously added `ImportOptions` will be merged with the defaults resulting in a more consistent and less surprising development experience.

Fixes #296