### PR TITLE
Fix onlyxxx that behaving inconsistently for unresolvable targets

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -282,9 +282,6 @@ class ExamplesIntegrationTest {
                 .by(callFromMethod(SomeController.class, "doSthController")
                         .toMethod(ServiceViolatingDaoRules.class, "doSthService")
                         .inLine(11))
-                .by(callFromMethod(SomeEnum.class, "values")
-                        .toMethod(SomeEnum[].class, "clone")
-                        .inLine(3))
 
                 .ofRule(String.format("classes that reside in a package '..controller..' should "
                                 + "only call constructors that are declared in a package '..controller..' or are annotated with @%s",
@@ -308,9 +305,6 @@ class ExamplesIntegrationTest {
                 .by(callFromConstructor(UseCaseTwoController.class)
                         .toConstructor(AbstractController.class)
                         .inLine(6))
-                .by(callFromMethod(SomeEnum.class, "values")
-                        .toMethod(SomeEnum[].class, "clone")
-                        .inLine(3))
 
                 .ofRule(String.format("classes that reside in a package '..controller..' should "
                                 + "only access fields that are declared in a package '..controller..' or are annotated with @%s",
@@ -334,9 +328,6 @@ class ExamplesIntegrationTest {
                 .by(callFromConstructor(UseCaseTwoController.class)
                         .toConstructor(AbstractController.class)
                         .inLine(6))
-                .by(callFromMethod(SomeEnum.class, "values")
-                        .toMethod(SomeEnum[].class, "clone")
-                        .inLine(3))
 
                 .toDynamicTests();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -15,6 +15,7 @@
  */
 package com.tngtech.archunit.base;
 
+import com.google.common.collect.Iterables;
 import com.tngtech.archunit.PublicAPI;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -126,6 +127,10 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
 
     public static <T> DescribedPredicate<T> not(final DescribedPredicate<? super T> predicate) {
         return new NotPredicate<>(predicate);
+    }
+
+    public static DescribedPredicate<Iterable<?>> empty() {
+        return new EmptyPredicate();
     }
 
     public static <T> DescribedPredicate<Iterable<T>> anyElementThat(final DescribedPredicate<? super T> predicate) {
@@ -293,6 +298,17 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
         @Override
         public boolean apply(T input) {
             return delegate.apply(input);
+        }
+    }
+
+    private static class EmptyPredicate extends DescribedPredicate<Iterable<?>> {
+        EmptyPredicate() {
+            super("empty");
+        }
+
+        @Override
+        public boolean apply(Iterable<?> input) {
+            return Iterables.isEmpty(input);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -65,6 +65,7 @@ import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassSet
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
+import static com.tngtech.archunit.base.DescribedPredicate.empty;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_ORIGIN_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_TARGET_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
@@ -169,7 +170,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyAccessFieldsThat(final DescribedPredicate<? super JavaField> predicate) {
         ChainableFunction<JavaFieldAccess, FieldAccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaFieldAccess> accessPredicate = getTarget.then(FieldAccessTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaField>forSubType()));
+                .is(anyElementThat(predicate.<JavaField>forSubType()).or(empty()));
         return new ClassOnlyAccessesCondition<>(accessPredicate, GET_FIELD_ACCESSES_FROM_SELF)
                 .as("only access fields that " + predicate.getDescription());
     }
@@ -202,7 +203,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallMethodsThat(final DescribedPredicate<? super JavaMethod> predicate) {
         ChainableFunction<JavaMethodCall, MethodCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaMethodCall> callPredicate = getTarget.then(MethodCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaMethod>forSubType()));
+                .is(anyElementThat(predicate.<JavaMethod>forSubType()).or(empty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_METHOD_CALLS_FROM_SELF)
                 .as("only call methods that " + predicate.getDescription());
     }
@@ -235,7 +236,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallConstructorsThat(final DescribedPredicate<? super JavaConstructor> predicate) {
         ChainableFunction<JavaConstructorCall, ConstructorCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaConstructorCall> callPredicate = getTarget.then(ConstructorCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaConstructor>forSubType()));
+                .is(anyElementThat(predicate.<JavaConstructor>forSubType()).or(empty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CONSTRUCTOR_CALLS_FROM_SELF)
                 .as("only call constructors that " + predicate.getDescription());
     }
@@ -250,7 +251,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallCodeUnitsThat(final DescribedPredicate<? super JavaCodeUnit> predicate) {
         ChainableFunction<JavaCall<?>, CodeUnitCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaCodeUnit>forSubType()));
+                .is(anyElementThat(predicate.<JavaCodeUnit>forSubType()).or(empty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CALLS_FROM_SELF)
                 .as("only call code units that " + predicate.getDescription());
     }
@@ -259,7 +260,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyAccessMembersThat(final DescribedPredicate<? super JavaMember> predicate) {
         ChainableFunction<JavaAccess<?>, AccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(AccessTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaMember>forSubType()));
+                .is(anyElementThat(predicate.<JavaMember>forSubType()).or(empty()));
         return new ClassOnlyAccessesCondition<>(accessPredicate, GET_ACCESSES_FROM_SELF)
                 .as("only access members that " + predicate.getDescription());
     }

--- a/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
@@ -1,5 +1,7 @@
 package com.tngtech.archunit.base;
 
+import java.util.Collections;
+
 import com.google.common.collect.ImmutableList;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -14,6 +16,7 @@ import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
 import static com.tngtech.archunit.base.DescribedPredicate.describe;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.doesNot;
+import static com.tngtech.archunit.base.DescribedPredicate.empty;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.base.DescribedPredicate.greaterThan;
 import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
@@ -179,6 +182,16 @@ public class DescribedPredicateTest {
         assertThat(equalTo(5).onResultOf(constant(4))).rejects(new Object());
         assertThat(equalTo(5).onResultOf(constant(5))).accepts(new Object());
         assertThat(equalTo(5).onResultOf(constant(6))).rejects(new Object());
+    }
+
+    @Test
+    public void empty_works() {
+        assertThat(empty())
+                .hasDescription("empty")
+                .accepts(Collections.emptyList())
+                .accepts(Collections.emptySet())
+                .rejects(ImmutableList.of(1))
+                .rejects(Collections.singleton(""));
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/SourceCodeLocationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/SourceCodeLocationTest.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -13,14 +12,9 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class SourceCodeLocationTest {
 
+    // We need this to create a JavaClass without source, i.e. a stub because the class is missing and cannot be resolved
     @Rule
-    public final ArchConfigurationRule configuration = new ArchConfigurationRule();
-
-    @Before
-    public void setUp() {
-        // We need this to create a JavaClass without source, i.e. a stub because the class is missing and cannot be resolved
-        configuration.resolveAdditionalDependenciesFromClassPath(false);
-    }
+    public final ArchConfigurationRule configuration = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
 
     @Test
     public void format_location() {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.ArchConfiguration;
 import org.junit.rules.ExternalResource;
 
 public class ArchConfigurationRule extends ExternalResource {
-    private boolean resolveMissingDependenciesFromClassPath;
+    private boolean resolveMissingDependenciesFromClassPath = ArchConfiguration.get().resolveMissingDependenciesFromClassPath();
 
     public ArchConfigurationRule resolveAdditionalDependenciesFromClassPath(boolean enabled) {
         resolveMissingDependenciesFromClassPath = enabled;

--- a/archunit/src/test/resources/archunit.properties
+++ b/archunit/src/test/resources/archunit.properties
@@ -1,2 +1,1 @@
-resolveMissingDependenciesFromClassPath=true
 enableMd5InClassSources=true


### PR DESCRIPTION
So far the set of `should().only{Access/Call}...That...(..)` syntax methods have behaved a little strange when the target of the call was not imported from a class file. This happens for example for unresolvable types like array types.
The basic problem is, that from the byte code point of view only certain properties about an `AccessTarget` (like `SomeClass.method()`) can be derived. For further details (e.g. is the method called annotated with a certain annotation) it is necessary to try and resolve the respective method that is targeted from the imported target `JavaClass`. This resolution can unfortunately fail, if the target class has not been imported by ArchUnit (or is unresolvable like an array or primitive type).
So far these `only...` methods wanted that at least one of the resolved targets would satisfy the given predicate (e.g. `annotatedWith(..)`). If the target is unresolvable this assertion would always fail, reporting things like `[some.Array;.clone() is not annotated with ...`. But since it would always fail, it could at the same time complain about `[some.Array;.clone() is not annotated with ...` and  `[some.Array;.clone() is annotated with ...` which is certainly super confusing (and plain wrong in the second case where `not(annotatedWith(..))` would be used; compare the example).
This PR resolves this issue by counting unresolvable targets as always satisfying these predicates. This might lead to wrongly successful tests if classes are missing from the import, but in the end it is indeterminable for ArchUnit anyway, what classes are wanted / desired for the test and which classes are not wanted. It is also a fair point of view to say that unimported classes should not be considered when asserting `should().only...`.

Resolves: #340