### PR TITLE
fix inconsistent behavior with respect to primitive array types

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
@@ -13,8 +13,6 @@ import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With;
-import com.tngtech.archunit.core.importer.ClassFileImporter;
-import com.tngtech.archunit.core.importer.DomainBuilders;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -59,9 +57,7 @@ public class ArchUnitArchitectureTest {
             .whereLayer("Base").mayOnlyBeAccessedByLayers("Root", "Core", "Lang", "Library", "JUnit");
 
     @ArchTest
-    public static final ArchRule domain_does_not_access_importer =
-            noClasses().that().resideInAPackage("..core.domain..")
-                    .should().accessClassesThat(belong_to_the_import_context());
+    public static final ArchRules importer_rules = ArchRules.in(ImporterRules.class);
 
     @ArchTest
     public static final ArchRule types_are_only_resolved_via_reflection_in_allowed_places =
@@ -70,18 +66,7 @@ public class ArchUnitArchitectureTest {
                     .as("no classes should illegally resolve classes via reflection");
 
     @ArchTest
-    public static final ArchRules public_API_rules =
-            ArchRules.in(PublicAPIRules.class);
-
-    private static DescribedPredicate<JavaClass> belong_to_the_import_context() {
-        return new DescribedPredicate<JavaClass>("belong to the import context") {
-            @Override
-            public boolean apply(JavaClass input) {
-                return input.getPackageName().startsWith(ClassFileImporter.class.getPackage().getName())
-                        && !input.getName().contains(DomainBuilders.class.getSimpleName());
-            }
-        };
-    }
+    public static final ArchRules public_API_rules = ArchRules.in(PublicAPIRules.class);
 
     private static DescribedPredicate<JavaCall<?>> typeIsIllegallyResolvedViaReflection() {
         DescribedPredicate<JavaCall<?>> explicitlyAllowedUsage =

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/ImporterRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/ImporterRules.java
@@ -1,0 +1,43 @@
+package com.tngtech.archunit;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.DomainBuilders;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.ArchUnitArchitectureTest.THIRDPARTY_PACKAGE_IDENTIFIER;
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.belongToAnyOf;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+public class ImporterRules {
+
+    @ArchTest
+    public static final ArchRule domain_does_not_access_importer =
+            noClasses().that().resideInAPackage("..core.domain..")
+                    .should().accessClassesThat(belong_to_the_import_context());
+
+    @ArchTest
+    public static final ArchRule ASM_type_is_only_accessed_within_JavaType_or_JavaTypeImporter =
+            noClasses()
+                    .that().resideOutsideOfPackage(THIRDPARTY_PACKAGE_IDENTIFIER)
+                    .and(not(belongToAnyOf(JavaType.class)))
+                    .and().doNotHaveFullyQualifiedName("com.tngtech.archunit.core.importer.JavaTypeImporter")
+                    .should().dependOnClassesThat().haveNameMatching(".*\\.asm\\..*Type")
+                    .as("org.objectweb.asm.Type should only be accessed within JavaType(Importer)")
+                    .because("org.objectweb.asm.Type handles array types inconsistently (uses the canonical name instead of the class name), "
+                            + "so the correct behavior is implemented only within JavaType");
+
+    private static DescribedPredicate<JavaClass> belong_to_the_import_context() {
+        return new DescribedPredicate<JavaClass>("belong to the import context") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.getPackageName().startsWith(ClassFileImporter.class.getPackage().getName())
+                        && !input.getName().contains(DomainBuilders.class.getSimpleName());
+            }
+        };
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
@@ -48,10 +48,6 @@ class ImportedClasses {
         return directlyImported;
     }
 
-    void add(JavaClass clazz) {
-        additionalClasses.put(clazz.getName(), clazz);
-    }
-
     JavaClass getOrResolve(String typeName) {
         ensurePresent(typeName);
         return directlyImported.containsKey(typeName) ?

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaTypeImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaTypeImporter.java
@@ -15,6 +15,9 @@
  */
 package com.tngtech.archunit.core.importer;
 
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.core.domain.JavaType;
 import org.objectweb.asm.Type;
 
@@ -29,5 +32,25 @@ class JavaTypeImporter {
 
     static JavaType importAsmType(Type type) {
         return JavaType.From.name(type.getClassName());
+    }
+
+    static Object importAsmTypeIfPossible(Object value) {
+        return value instanceof Type ? importAsmType((Type) value) : value;
+    }
+
+    static JavaType importAsmType(String typeDescriptor) {
+        return importAsmType(Type.getType(typeDescriptor));
+    }
+
+    static List<JavaType> importAsmMethodArgumentTypes(String methodDescriptor) {
+        ImmutableList.Builder<JavaType> result = ImmutableList.builder();
+        for (Type type : Type.getArgumentTypes(methodDescriptor)) {
+            result.add(importAsmType(type));
+        }
+        return result.build();
+    }
+
+    static JavaType importAsmMethodReturnType(String methodDescriptor) {
+        return importAsmType(Type.getReturnType(methodDescriptor));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
@@ -183,7 +183,7 @@ public interface ClassResolver {
             }
         }
 
-        private abstract class ClassResolverProvider {
+        private abstract static class ClassResolverProvider {
             private final Function<Exception, ClassResolverConfigurationException> onFailure;
 
             ClassResolverProvider(Function<Exception, ClassResolverConfigurationException> onFailure) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -326,8 +326,13 @@ public class Assertions extends org.assertj.core.api.Assertions {
                     .isEqualTo(getExpectedPackageName(clazz));
             assertThat(actual.getModifiers()).as("Modifiers of " + actual)
                     .isEqualTo(JavaModifier.getModifiersForClass(clazz.getModifiers()));
+            assertThat(actual.isArray()).as(actual + " is array").isEqualTo(clazz.isArray());
             assertThat(propertiesOf(actual.getAnnotations())).as("Annotations of " + actual)
                     .isEqualTo(propertiesOf(clazz.getAnnotations()));
+
+            if (clazz.isArray()) {
+                new JavaClassAssertion(actual.getComponentType()).matches(clazz.getComponentType());
+            }
         }
 
         private String ensureArrayName(String name) {


### PR DESCRIPTION
When we tried to resolve the component type of primitive array types (or other types missing from the import), we used `org.objectweb.asm.Type.getType(descriptor)` in some places, which unfortunately uses the canonical name as type name, instead of the class name. Then when the imported classes were checked for the type, e.g. only the type `[B` was present, but not the canonical name `byte[]` and consequently a new type `byte[]` was created that behaved inconsistently and could not return its component type.
The correct handling of this case was actually already handled within `JavaType`, thus I have encapsulated all type parsing into this class and its facade `JavaTypeImporter` and written an architecture test to ensure that in the future only `JavaType` and `JavaTypeImporter` will be used to parse types from type names.

On the way I noticed that `AnnotationTypeConversion` was actually misleading, it looked like a generic class to handle many different cases when in fact for each caller only one specific case was relevant. Thus I have inlined most of the cases where they are actually relevant (e.g. some places only cared to handle a type `Class[]` but did not care about `org.objectweb.asm.Type`, while the concrete conversion only cared about that case and not e.g. `Class`, etc.). Usually only one specific case was relevant and most of the time there was only one caller. The only thing left is the generic `convert(Object value)` method, since it is called from different places and encapsulates that we need to convert `org.objectweb.asm.Type` transparently, since we do not want to deal with this type anymore outside of `JavaType(Importer)`.