### PR TITLE
add rule to prevent dependencies on upper packages

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/DependencyRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/DependencyRulesTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.exampletest.junit4;
+
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.library.DependencyRules.NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES;
+
+@Category(Example.class)
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packagesOf = ClassViolatingCodingRules.class)
+public class DependencyRulesTest {
+
+    @ArchTest
+    static final ArchRule no_accesses_to_upper_package = NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES;
+}

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/DependencyRulesTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/DependencyRulesTest.java
@@ -1,0 +1,17 @@
+package com.tngtech.archunit.exampletest.junit5;
+
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTag;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.library.DependencyRules.NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES;
+
+@ArchTag("example")
+@AnalyzeClasses(packagesOf = ClassViolatingCodingRules.class)
+public class DependencyRulesTest {
+
+    @ArchTest
+    static final ArchRule no_accesses_to_upper_package = NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES;
+}

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/AbstractController.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/AbstractController.java
@@ -6,5 +6,6 @@ import com.tngtech.archunit.example.layers.web.InheritedControllerImpl;
  * For demo purpose only, see {@link InheritedControllerImpl}
  */
 public abstract class AbstractController {
-
+    public abstract static class AbstractInnerControl {
+    }
 }

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/web/InheritedControllerImpl.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/web/InheritedControllerImpl.java
@@ -3,4 +3,6 @@ package com.tngtech.archunit.example.layers.web;
 import com.tngtech.archunit.example.layers.AbstractController;
 
 public class InheritedControllerImpl extends AbstractController {
+    public static class ChildControl extends AbstractInnerControl {
+    }
 }

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/DependencyRulesTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/DependencyRulesTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.exampletest;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.tngtech.archunit.library.DependencyRules.NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES;
+
+@Category(Example.class)
+public class DependencyRulesTest {
+
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
+
+    @Test
+    public void no_accesses_to_upper_package() {
+        NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES.check(classes);
+    }
+}

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedAccess.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedAccess.java
@@ -31,7 +31,7 @@ public abstract class ExpectedAccess implements ExpectedRelation {
 
     private String getExpectedMessage() {
         String expectedDescription = origin.getExpectedDescription() + " " + target.getExpectedDescription();
-        String expectedLocation = String.format("(%s.java:%d)", origin.getDeclaringClass().getSimpleName(), lineNumber);
+        String expectedLocation = String.format("(%s.java:%d)", origin.getLocationClass().getSimpleName(), lineNumber);
         return expectedDescription + " in " + expectedLocation;
     }
 

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -64,7 +64,7 @@ public class ExpectedDependency implements ExpectedRelation {
     }
 
     private static String getDependencyPattern(String originName, String dependencyTypePattern, String targetName, int lineNumber) {
-        return String.format(".*%s.*%s.*%s.*\\.java:%d.*", quote(originName), dependencyTypePattern, quote(targetName), lineNumber);
+        return String.format(".*%s[^$]*%s[^$]*%s.*\\.java:%d.*", quote(originName), dependencyTypePattern, quote(targetName), lineNumber);
     }
 
     public static class InheritanceCreator {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedMember.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedMember.java
@@ -32,10 +32,6 @@ abstract class ExpectedMember {
         }
     }
 
-    String lineMessage(int number) {
-        return String.format("(%s.java:%d)", clazz.getSimpleName(), number);
-    }
-
     List<String> getParams() {
         return params;
     }
@@ -46,6 +42,14 @@ abstract class ExpectedMember {
 
     Class<?> getDeclaringClass() {
         return clazz;
+    }
+
+    Class<?> getLocationClass() {
+        Class<?> result = clazz;
+        while (result.getEnclosingClass() != null) {
+            result = result.getEnclosingClass();
+        }
+        return result;
     }
 
     abstract String getExpectedDescription();

--- a/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2020 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.library;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@PublicAPI(usage = ACCESS)
+public final class DependencyRules {
+    private DependencyRules() {
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static final ArchRule NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES =
+            noClasses().should(dependOnUpperPackages())
+                    .because("that might prevent packages on that level from being split into separate artifacts in a clean way");
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> dependOnUpperPackages() {
+        return new DependOnUpperPackagesCondition();
+    }
+
+    private static class DependOnUpperPackagesCondition extends ArchCondition<JavaClass> {
+        DependOnUpperPackagesCondition() {
+            super("depend on upper packages");
+        }
+
+        @Override
+        public void check(final JavaClass clazz, final ConditionEvents events) {
+            for (Dependency dependency : clazz.getDirectDependenciesFromSelf()) {
+                boolean dependencyOnUpperPackage = isDependencyOnUpperPackage(dependency.getOriginClass(), dependency.getTargetClass());
+                events.add(new SimpleConditionEvent(dependency, dependencyOnUpperPackage, dependency.getDescription()));
+            }
+        }
+
+        private boolean isDependencyOnUpperPackage(JavaClass origin, JavaClass target) {
+            String originPackageName = origin.getPackageName();
+            String targetSubPackagePrefix = target.getPackageName() + ".";
+            return originPackageName.startsWith(targetSubPackagePrefix);
+        }
+    }
+}


### PR DESCRIPTION
To keep packages splittable into separate artifacts in a clean way it can make sense to forbid dependencies on any parent package, as that prevents the possibility to cleanly separate packages on the same sub-package level.