### PR TITLE
Normalize backslashes of Windows paths

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
@@ -21,8 +21,13 @@ class NormalizedResourceName {
     private final String resourceName;
 
     private NormalizedResourceName(String resourceName) {
-        resourceName = resourceName.replaceAll("^/*", "").replaceAll("/*$", "");
-        this.resourceName = resourceName;
+        this.resourceName = resourceName
+                // normalize Windows backslashes
+                .replace('\\', '/')
+                // remove leading slashes
+                .replaceAll("^/*", "")
+                // remove trailing slashes
+                .replaceAll("/*$", "");
     }
 
     static NormalizedResourceName from(String resourceName) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/NormalizedResourceNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/NormalizedResourceNameTest.java
@@ -18,6 +18,7 @@ public class NormalizedResourceNameTest {
                 $("com", "com", true),
                 $("com/foo", "com", true),
                 $("/com/", "/com", true),
+                $("\\com\\foo", "/com/foo", true),
                 $("com", "bar", false),
                 $("com", "co", false),
                 $("co/m", "co", true),


### PR DESCRIPTION
Now that we uniformly search all classpath resources by iterating the classpath URLs and matching them against the specified classes to import (where we used `ClassLoader.getResources(..)` in the past), we also need to normalize URIs by replacing Windows path separators `\` with Unix path separators `/`. Otherwise the mechanism does not work for file URI classpath resources like `file:/C:\foo\bar\..`.

Fixes #356