### PR TITLE
Fix classpath scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,10 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   validation:

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -140,9 +140,9 @@ public abstract class Location {
     }
 
     void checkScheme(String scheme, NormalizedUri uri) {
-        checkArgument(scheme.equals(uri.getScheme()),
-                "URI %s of %s must have scheme %s, but has %s",
-                uri, getClass().getSimpleName(), scheme, uri.getScheme());
+        String actualScheme = uri.getScheme();
+        checkArgument(scheme.equals(actualScheme),
+                "URI %s of Location must have scheme %s, but has %s", uri, scheme, actualScheme);
     }
 
     /**

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -6,27 +6,38 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.Slow;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaPackage;
+import com.tngtech.archunit.testutil.SystemPropertiesRule;
 import com.tngtech.archunit.testutil.TransientCopyRule;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
 import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
 import static com.tngtech.archunit.core.importer.ClassFileImporterTest.jarFileOf;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+import static com.tngtech.archunit.core.importer.UrlSourceTest.JAVA_CLASS_PATH_PROP;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatClasses;
+import static java.util.jar.Attributes.Name.CLASS_PATH;
 
 @Category(Slow.class)
 public class ClassFileImporterSlowTest {
     @Rule
     public final TransientCopyRule copyRule = new TransientCopyRule();
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule
+    public final SystemPropertiesRule systemPropertiesRule = new SystemPropertiesRule();
 
     @Test
     public void imports_the_classpath() {
@@ -100,6 +111,31 @@ public class ClassFileImporterSlowTest {
         JavaClasses classes = new ClassFileImporter().importPackages(getClass().getPackage().getName());
 
         assertThat(classes.get(JavaClass.class)).isNotNull();
+    }
+
+    @Test
+    public void imports_classes_from_classpath_specified_in_manifest_file() {
+        String manifestClasspath = Joiner.on(" ").join(Splitter.on(File.pathSeparator).omitEmptyStrings().split(System.getProperty(JAVA_CLASS_PATH_PROP)));
+        String jarPath = new TestJarFile()
+                .withManifestAttribute(CLASS_PATH, manifestClasspath)
+                .create()
+                .getName();
+
+        System.clearProperty(JAVA_CLASS_PATH_PROP);
+        verifyCantLoadWithCurrentClasspath(getClass());
+        System.setProperty(JAVA_CLASS_PATH_PROP, jarPath);
+
+        JavaClasses javaClasses = new ClassFileImporter().importPackages(getClass().getPackage().getName());
+
+        assertThatClasses(javaClasses).contain(getClass());
+    }
+
+    private void verifyCantLoadWithCurrentClasspath(Class<?> clazz) {
+        try {
+            new ClassFileImporter().importClass(clazz);
+            Assert.fail(String.format("Should not have been able to load class %s with the current classpath", clazz.getName()));
+        } catch (RuntimeException ignored) {
+        }
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
@@ -6,18 +6,28 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarFile;
 
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.testutil.SystemPropertiesRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Sets.union;
+import static java.util.jar.Attributes.Name.CLASS_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UrlSourceTest {
-    private static final String JAVA_CLASS_PATH_PROP = "java.class.path";
+    static final String JAVA_CLASS_PATH_PROP = "java.class.path";
     private static final String JAVA_BOOT_PATH_PROP = "sun.boot.class.path";
 
     private static final char CHARACTER_THAT_IS_HOPEFULLY_ILLEGAL_ON_EVERY_PLATFORM = '\0';
@@ -46,11 +56,11 @@ public class UrlSourceTest {
         UrlSource urlSource = UrlSource.From.classPathSystemProperties();
 
         assertThat(urlSource).containsOnly(
-                firstFileEntry.toUri().toURL(),
+                toUrl(firstFileEntry),
                 new URL("jar:" + firstJarEntry.toUri() + "!/"),
-                secondFileEntry.toUri().toURL(),
+                toUrl(secondFileEntry),
                 new URL("jar:" + secondJarEntry.toUri() + "!/"),
-                bootstrapFileEntry.toUri().toURL(),
+                toUrl(bootstrapFileEntry),
                 new URL("jar:" + bootstrapJarEntry.toUri() + "!/")
         );
     }
@@ -64,14 +74,14 @@ public class UrlSourceTest {
     }
 
     @Test
-    public void ignores_invalid_paths_in_class_path_property() throws MalformedURLException {
+    public void ignores_invalid_paths_in_class_path_property() {
         Path valid = Paths.get("some", "valid", "path");
 
         String classPath = createClassPathProperty(valid.toString(),
                 "/invalid/path/because/of/" + CHARACTER_THAT_IS_HOPEFULLY_ILLEGAL_ON_EVERY_PLATFORM + "/");
         System.setProperty(JAVA_CLASS_PATH_PROP, classPath);
 
-        assertThat(UrlSource.From.classPathSystemProperties()).containsOnly(valid.toUri().toURL());
+        assertThat(UrlSource.From.classPathSystemProperties()).containsOnly(toUrl(valid));
     }
 
     @Test
@@ -94,10 +104,228 @@ public class UrlSourceTest {
         System.setProperty(JAVA_CLASS_PATH_PROP, classPath);
         UrlSource urls = UrlSource.From.classPathSystemProperties();
 
-        assertThat(urls).contains(destination.toUri().toURL());
+        assertThat(urls).contains(toUrl(destination));
+    }
+
+    @Test
+    public void recursively_resolves_classpath_attributes_in_manifests() throws Exception {
+        File folder = temporaryFolder.newFolder();
+        WrittenJarFile grandChildOne = writeJarWithManifestClasspathAttribute(folder, subPath("grandchild", "one"));
+        WrittenJarFile grandChildTwo = writeJarWithManifestClasspathAttribute(folder, subPath("grandchild", "two"));
+        WrittenJarFile grandChildThree = writeJarWithManifestClasspathAttribute(folder, subPath("grandchild", "three"));
+        WrittenJarFile childOne = writeJarWithManifestClasspathAttribute(folder, subPath("child", "one"), grandChildOne.getPathAsAbsoluteUrl(), ManifestClasspathEntry.relativeUrl(grandChildTwo.path));
+        WrittenJarFile childTwo = writeJarWithManifestClasspathAttribute(folder, subPath("child", "two"), ManifestClasspathEntry.absoluteUrl(grandChildThree.path));
+        WrittenJarFile parent = writeJarWithManifestClasspathAttribute(folder, "parent", ManifestClasspathEntry.relativePath(childOne.path), ManifestClasspathEntry.absoluteUrl(childTwo.path));
+
+        System.setProperty(JAVA_CLASS_PATH_PROP, parent.path.toString());
+        UrlSource urls = UrlSource.From.classPathSystemProperties();
+
+        assertThat(urls).containsAll(concat(
+                grandChildOne.getExpectedClasspathUrls(),
+                grandChildTwo.getExpectedClasspathUrls(),
+                grandChildThree.getExpectedClasspathUrls(),
+                childOne.getExpectedClasspathUrls(),
+                childTwo.getExpectedClasspathUrls(),
+                parent.getExpectedClasspathUrls()));
+    }
+
+    @Test
+    public void terminates_recursively_resolving_manifest_classpaths_if_manifests_have_circular_reference() throws Exception {
+        File folder = temporaryFolder.newFolder();
+        File jarOnePath = new File(folder, "one.jar");
+        File jarTwoPath = new File(folder, "two.jar");
+        JarFile jarOne = new TestJarFile()
+                .withManifestAttribute(CLASS_PATH, jarTwoPath.getAbsolutePath())
+                .create(jarOnePath);
+        JarFile jarTwo = new TestJarFile()
+                .withManifestAttribute(CLASS_PATH, jarOnePath.getAbsolutePath())
+                .create(jarTwoPath);
+
+        System.setProperty(JAVA_CLASS_PATH_PROP, jarOne.getName());
+        UrlSource urls = UrlSource.From.classPathSystemProperties();
+
+        assertThat(urls).containsOnly(toUrl(Paths.get(jarOne.getName())), toUrl(Paths.get(jarTwo.getName())));
+    }
+
+    private String subPath(String... parts) {
+        return Joiner.on(File.separator).join(parts);
+    }
+
+    private WrittenJarFile writeJarWithManifestClasspathAttribute(final File folder, String identifier, ManifestClasspathEntry... additionalClasspathManifestClasspathEntries) {
+        Set<ManifestClasspathEntry> classpathManifestEntries = union(createManifestClasspathEntries(identifier), ImmutableSet.copyOf(additionalClasspathManifestClasspathEntries));
+        JarFile jarFile = new TestJarFile()
+                .withManifestAttribute(CLASS_PATH, Joiner.on(" ").join(FluentIterable.from(classpathManifestEntries).transform(resolveTo(folder)).toSet()))
+                .create(new File(folder, identifier.replace(File.separator, "-") + ".jar"));
+        return new WrittenJarFile(Paths.get(jarFile.getName()), classpathManifestEntries);
+    }
+
+    private Function<ManifestClasspathEntry, String> resolveTo(final File folder) {
+        return new Function<ManifestClasspathEntry, String>() {
+            @Override
+            public String apply(ManifestClasspathEntry manifestClasspathEntry) {
+                return manifestClasspathEntry.create(folder);
+            }
+        };
+    }
+
+    private Set<ManifestClasspathEntry> createManifestClasspathEntries(String infix) {
+        Set<ManifestClasspathEntry> result = new HashSet<>();
+        for (int i = 0; i < 10; i++) {
+            result.add(ManifestClasspathEntry
+                    .absolutePath(Paths.get(File.separator + subPath("some", "path", "parent", infix + i, "")).toAbsolutePath()));
+        }
+        return result;
     }
 
     private String createClassPathProperty(String... paths) {
         return Joiner.on(File.pathSeparatorChar).join(paths);
+    }
+
+    private static class WrittenJarFile {
+        private final Path path;
+        private final Set<ManifestClasspathEntry> classpathManifestEntries;
+
+        private WrittenJarFile(Path path, Set<ManifestClasspathEntry> classpathManifestEntries) {
+            this.path = path;
+            this.classpathManifestEntries = classpathManifestEntries;
+        }
+
+        public ManifestClasspathEntry getPathAsAbsoluteUrl() {
+            return ManifestClasspathEntry.absoluteUrl(path);
+        }
+
+        public Iterable<URL> getExpectedClasspathUrls() {
+            return FluentIterable.from(classpathManifestEntries)
+                    .transform(new Function<ManifestClasspathEntry, URL>() {
+                        @Override
+                        public URL apply(ManifestClasspathEntry input) {
+                            return input.toExpectedClasspathUrl();
+                        }
+                    });
+        }
+    }
+
+    private abstract static class ManifestClasspathEntry {
+        final Path path;
+
+        protected ManifestClasspathEntry(Path path) {
+            this.path = path;
+        }
+
+        abstract String create(File folder);
+
+        static ManifestClasspathEntry absoluteUrl(Path path) {
+            return new AbsoluteUrl(path);
+        }
+
+        static ManifestClasspathEntry absolutePath(Path path) {
+            return new AbsolutePath(path);
+        }
+
+        static ManifestClasspathEntry relativeUrl(Path path) {
+            return new RelativeUrl(path);
+        }
+
+        static ManifestClasspathEntry relativePath(Path path) {
+            return new RelativePath(path);
+        }
+
+        public abstract URL toExpectedClasspathUrl();
+
+        private static class AbsoluteUrl extends ManifestClasspathEntry {
+            private AbsoluteUrl(Path path) {
+                super(path);
+                checkArgument(path.isAbsolute(), "Path is not absolute: %s", path);
+            }
+
+            @Override
+            String create(File folder) {
+                return ensureTrailingSeparatorForFolders(path.toUri().toString());
+            }
+
+            @Override
+            public URL toExpectedClasspathUrl() {
+                return toUrl(path);
+            }
+        }
+
+        private static class AbsolutePath extends ManifestClasspathEntry {
+            private AbsolutePath(Path path) {
+                super(path);
+                checkArgument(path.isAbsolute(), "Path is not absolute: %s", path);
+            }
+
+            @Override
+            String create(File folder) {
+                String pathString = path.toString();
+                return ensureTrailingSeparatorForFolders(pathString);
+            }
+
+            @Override
+            public URL toExpectedClasspathUrl() {
+                return toUrl(path);
+            }
+        }
+
+        private static class RelativeUrl extends ManifestClasspathEntry {
+            private URL expectedClasspathUrl;
+
+            private RelativeUrl(Path path) {
+                super(path);
+            }
+
+            @Override
+            String create(File folder) {
+                String relativePath = new RelativePath(path).create(folder);
+                this.expectedClasspathUrl = toUrl(folder.toPath().resolve(relativePath));
+                return "file:" + relativePath;
+            }
+
+            @Override
+            public URL toExpectedClasspathUrl() {
+                return expectedClasspathUrl;
+            }
+        }
+
+        private static class RelativePath extends ManifestClasspathEntry {
+            private URL expectedClasspathUrl;
+
+            private RelativePath(Path path) {
+                super(path);
+            }
+
+            @Override
+            String create(File folder) {
+                Path parent = folder.toPath();
+                Path relativePath = parent.relativize(path);
+                this.expectedClasspathUrl = toUrl(parent.resolve(relativePath));
+                return ensureTrailingSeparatorForFolders(relativePath.toString());
+            }
+
+            @Override
+            public URL toExpectedClasspathUrl() {
+                return expectedClasspathUrl;
+            }
+        }
+    }
+
+    private static String ensureTrailingSeparatorForFolders(String pathString) {
+        boolean isFolder = !pathString.matches(".*\\.\\w+$");
+        return isFolder
+                ? ensureTrailingSeparator(pathString)
+                : pathString;
+    }
+
+    private static String ensureTrailingSeparator(String pathString) {
+        return pathString.endsWith(File.separator) ? pathString : pathString + File.separator;
+    }
+
+    private static URL toUrl(Path path) {
+        try {
+            URL result = path.toUri().toURL();
+            return result.toString().endsWith(".jar") ? new URL("jar:" + result + "!/") : result;
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/ContextClassLoaderRule.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/ContextClassLoaderRule.java
@@ -1,0 +1,17 @@
+package com.tngtech.archunit.testutil;
+
+import org.junit.rules.ExternalResource;
+
+public class ContextClassLoaderRule extends ExternalResource {
+    private ClassLoader contextClassLoader;
+
+    @Override
+    public void before() {
+        contextClassLoader = Thread.currentThread().getContextClassLoader();
+    }
+
+    @Override
+    public void after() {
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+    }
+}


### PR DESCRIPTION
Unfortunately #347 broke the possibility to use a manifest `Class-Path` attribute to specify the classpath. Since this is a feature that many tools use to avoid "command line too long" problems (e.g. on Windows) when the classpath grows in size, I have added support for this to the new way of scanning the classpath.
I have also added back the old way to resolve files through the context classloader, since I could not measure a real performance impact and using both sources seems safer in case there is some other classpath quirk I have overlooked. The set will remove duplicates anyway, before starting to import the classes.