### PR TITLE
Release 0.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ framework.
 ###### Gradle
 
 ```
-testImplementation 'com.tngtech.archunit:archunit:0.14.0'
+testImplementation 'com.tngtech.archunit:archunit:0.14.1'
 ```
 
 ###### Maven
@@ -26,7 +26,7 @@ testImplementation 'com.tngtech.archunit:archunit:0.14.0'
 <dependency>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit</artifactId>
-    <version>0.14.0</version>
+    <version>0.14.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/build-steps/release/expected/archunit-junit4.pom
+++ b/build-steps/release/expected/archunit-junit4.pom
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <!-- This module was also published with a richer model, Gradle metadata,  -->
-    <!-- which should be used instead. Do not delete the following line which  -->
-    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-    <!-- that they should prefer consuming it instead. -->
-    <!-- do_not_remove: published-with-gradle-metadata -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit-junit4</artifactId>

--- a/build-steps/release/expected/archunit-junit5-api.pom
+++ b/build-steps/release/expected/archunit-junit5-api.pom
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <!-- This module was also published with a richer model, Gradle metadata,  -->
-    <!-- which should be used instead. Do not delete the following line which  -->
-    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-    <!-- that they should prefer consuming it instead. -->
-    <!-- do_not_remove: published-with-gradle-metadata -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit-junit5-api</artifactId>

--- a/build-steps/release/expected/archunit-junit5-engine-api.pom
+++ b/build-steps/release/expected/archunit-junit5-engine-api.pom
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <!-- This module was also published with a richer model, Gradle metadata,  -->
-    <!-- which should be used instead. Do not delete the following line which  -->
-    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-    <!-- that they should prefer consuming it instead. -->
-    <!-- do_not_remove: published-with-gradle-metadata -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit-junit5-engine-api</artifactId>

--- a/build-steps/release/expected/archunit-junit5-engine.pom
+++ b/build-steps/release/expected/archunit-junit5-engine.pom
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <!-- This module was also published with a richer model, Gradle metadata,  -->
-    <!-- which should be used instead. Do not delete the following line which  -->
-    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-    <!-- that they should prefer consuming it instead. -->
-    <!-- do_not_remove: published-with-gradle-metadata -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit-junit5-engine</artifactId>

--- a/build-steps/release/expected/archunit-junit5.pom
+++ b/build-steps/release/expected/archunit-junit5.pom
@@ -2,11 +2,6 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <!-- This module was also published with a richer model, Gradle metadata,  -->
-  <!-- which should be used instead. Do not delete the following line which  -->
-  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-  <!-- that they should prefer consuming it instead. -->
-  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tngtech.archunit</groupId>
   <artifactId>archunit-junit5</artifactId>

--- a/build-steps/release/expected/archunit.pom
+++ b/build-steps/release/expected/archunit.pom
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <!-- This module was also published with a richer model, Gradle metadata,  -->
-    <!-- which should be used instead. Do not delete the following line which  -->
-    <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-    <!-- that they should prefer consuming it instead. -->
-    <!-- do_not_remove: published-with-gradle-metadata -->
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit</artifactId>

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -12,7 +12,7 @@ releaseProjects*.with {
     apply plugin: "signing"
 
     tasks.withType(GenerateModuleMetadata) {
-        enabled = isReleaseVersion // signing of these artifacts causes failure for snapshot versions
+        enabled = false // the meta-data does not match the way the Maven artifacts are composed and thus is broken
     }
 
     java {

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -10,6 +10,7 @@ if (!hasProperty("sonatypePassword")) {
 releaseProjects*.with {
     apply plugin: "maven-publish"
     apply plugin: "signing"
+    apply plugin: "de.marcphilipp.nexus-publish"
 
     tasks.withType(GenerateModuleMetadata) {
         enabled = false // the meta-data does not match the way the Maven artifacts are composed and thus is broken
@@ -82,22 +83,11 @@ releaseProjects*.with {
             }
         }
 
-        repositories {
-            // respective username and password can be configured in ~/.gradle/gradle.properties
-            if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
-                maven {
-                    def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                    def snapshotRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-                    url = isReleaseVersion ? releasesRepoUrl : snapshotRepoUrl
-
-                    credentials {
-                        username = sonatypeUsername
-                        password = sonatypePassword
-                    }
-
-                    metadataSources {
-                        gradleMetadata()
-                    }
+        // respective username and password can be configured in ~/.gradle/gradle.properties
+        if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
+            nexusPublishing {
+                repositories {
+                    sonatype()
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ ext {
 
 allprojects {
     group = 'com.tngtech.archunit'
-    version = '0.14.0'
+    version = '0.14.1'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
     id 'com.github.spotbugs' version '4.0.5' apply false
+    id "de.marcphilipp.nexus-publish" version "0.4.0" apply false
 }
 
 def appAndSourceUrl = 'https://github.com/TNG/ArchUnit'

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -8,7 +8,7 @@ main:
   - title: "User Guide"
     url: /userguide/html/000_Index.html
   - title: "API"
-    url: https://javadoc.io/doc/com.tngtech.archunit/archunit/0.14.0
+    url: https://javadoc.io/doc/com.tngtech.archunit/archunit/0.14.1
   - title: "About"
     url: /about
 

--- a/docs/_pages/getting-started.md
+++ b/docs/_pages/getting-started.md
@@ -15,7 +15,7 @@ ArchUnit can be obtained from Maven Central.
 <dependency>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit</artifactId>
-    <version>0.14.0</version>
+    <version>0.14.1</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -23,7 +23,7 @@ ArchUnit can be obtained from Maven Central.
 #### Gradle
 ```groovy
 dependencies {
-    testImplementation 'com.tngtech.archunit:archunit:0.14.0'
+    testImplementation 'com.tngtech.archunit:archunit:0.14.1'
 }
 ```
 

--- a/docs/_posts/2020-05-24-release-v0.14.1.markdown
+++ b/docs/_posts/2020-05-24-release-v0.14.1.markdown
@@ -1,0 +1,8 @@
+---
+layout: splash
+title:  "New release of ArchUnit (v0.14.1)"
+date:   2020-05-24 2:00:00
+categories: news release
+---
+
+A new release of ArchUnit (v0.14.1) is out. For details see [the release on GitHub](https://github.com/TNG/ArchUnit/releases/tag/v0.14.1 "ArchUnit v0.14.1 on GitHub").

--- a/docs/userguide/html/000_Index.html
+++ b/docs/userguide/html/000_Index.html
@@ -449,7 +449,7 @@ h4 {
 <div id="header">
 <h1>ArchUnit User Guide</h1>
 <div class="details">
-<span id="revnumber">version 0.14.0</span>
+<span id="revnumber">version 0.14.1</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -614,7 +614,7 @@ Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code data-lang="xml" class="language-xml hljs">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit-junit4&lt;/artifactId&gt;
-    &lt;version&gt;0.14.0&lt;/version&gt;
+    &lt;version&gt;0.14.1&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -623,7 +623,7 @@ Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-    testImplementation 'com.tngtech.archunit:archunit-junit4:0.14.0'
+    testImplementation 'com.tngtech.archunit:archunit-junit4:0.14.1'
 }</code></pre>
 </div>
 </div>
@@ -644,7 +644,7 @@ from Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code data-lang="xml" class="language-xml hljs">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit-junit5&lt;/artifactId&gt;
-    &lt;version&gt;0.14.0&lt;/version&gt;
+    &lt;version&gt;0.14.1&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -653,7 +653,7 @@ from Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-    testImplementation 'com.tngtech.archunit:archunit-junit5:0.14.0'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:0.14.1'
 }</code></pre>
 </div>
 </div>
@@ -670,7 +670,7 @@ context, include the core ArchUnit dependency from Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code data-lang="xml" class="language-xml hljs">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit&lt;/artifactId&gt;
-    &lt;version&gt;0.14.0&lt;/version&gt;
+    &lt;version&gt;0.14.1&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -679,7 +679,7 @@ context, include the core ArchUnit dependency from Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-   testImplementation 'com.tngtech.archunit:archunit:0.14.0'
+   testImplementation 'com.tngtech.archunit:archunit:0.14.1'
 }</code></pre>
 </div>
 </div>


### PR DESCRIPTION
Unfortunately with `0.14.0` some broken Gradle meta data was published to Maven Central :frowning_face: Should not play a role for projects using Maven or another build tool, but for Gradle builds it will now complain that the artifact `archunit-junit` does not exist.
I do not see any benefit from using the Gradle meta data in our case, since the Maven artifacts and their POMs are the single source of truth and those are built correctly. Thus I have disabled publishing the meta data.

Also I have noticed that the Gradle Publish plugin behaves really erratically (I could not publish at all anymore, when I tried to publish `0.14.1`), i.e. there were always split repositories on Sonatype Nexus. I found https://github.com/gradle/gradle/issues/5711 and from there https://github.com/marcphilipp/nexus-publish-plugin which seems to nicely solve the problem.