### PR TITLE
add possibility to execute multi JDK multi OS tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,69 @@ env:
   build_java_version: 11
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.build_java_version }}
+      - name: Build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
+
+  test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        test_java_version:
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Build JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.build_java_version }}
+      - name: Set up Test JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.test_java_version }}
+      - name: Provide installed JDKs
+        uses: actions/github-script@v1
+        with:
+          script: |
+            for ( let envVarName in process.env ) {
+              if (/JAVA_HOME_\d.*64/.test(envVarName)) {
+                const version = envVarName.match(/JAVA_HOME_(\d+).*64/)[1];
+                if (version === "${{ matrix.test_java_version }}") {
+                  core.exportVariable('test_jdk_path', process.env[envVarName]);
+                } else if (version === "${{ env.build_java_version }}") {
+                  core.exportVariable('build_jdk_path', process.env[envVarName]);
+                }
+              }
+            }
+      - name: Test
+        uses: eskatos/gradle-command-action@v1
+        env:
+          JAVA_HOME: ${{ env.build_jdk_path }}
+        with:
+          arguments: testJre${{ matrix.test_java_version }} -PallTests -PmultiJdkTest -Pjava${{ matrix.test_java_version }}Home="${{ env.test_jdk_path }}"
+
   integration-test:
     strategy:
       matrix:

--- a/archunit-integration-test/build.gradle
+++ b/archunit-integration-test/build.gradle
@@ -26,3 +26,4 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+addMultiJdkTestsFor project, test

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -89,6 +89,10 @@ task jdk9Test(type: Test) {
 
 [jar, test]*.dependsOn compileJdk9mainJava
 
+[test, jdk9Test].each { testTask ->
+    addMultiJdkTestsFor project, testTask
+}
+
 spotbugsJdk9test.enabled = false
 
 idea {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
@@ -18,12 +18,14 @@ package com.tngtech.archunit.lang;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
 import com.google.common.reflect.TypeToken;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.Optional;
@@ -94,10 +96,9 @@ public final class ConditionEvents implements Iterable<ConditionEvent> {
      */
     @PublicAPI(usage = ACCESS)
     public FailureMessages getFailureMessages() {
-        SortedSet<String> result = new TreeSet<>();
-        for (ConditionEvent event : getViolating()) {
-            result.addAll(event.getDescriptionLines());
-        }
+        ImmutableList<String> result = FluentIterable.from(getViolating())
+                .transformAndConcat(TO_DESCRIPTION_LINES)
+                .toSortedList(Ordering.natural());
         return new FailureMessages(result, informationAboutNumberOfViolations);
     }
 
@@ -159,6 +160,13 @@ public final class ConditionEvents implements Iterable<ConditionEvent> {
                 "; Violating Events: " + getViolating() +
                 '}';
     }
+
+    private static final Function<ConditionEvent, Iterable<String>> TO_DESCRIPTION_LINES = new Function<ConditionEvent, Iterable<String>>() {
+        @Override
+        public Iterable<String> apply(ConditionEvent input) {
+            return input.getDescriptionLines();
+        }
+    };
 
     private enum Type {
         ALLOWED, VIOLATION;

--- a/archunit/src/main/java/com/tngtech/archunit/lang/FailureMessages.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/FailureMessages.java
@@ -15,7 +15,6 @@
  */
 package com.tngtech.archunit.lang;
 
-import java.util.Collection;
 import java.util.List;
 
 import com.google.common.base.Predicate;
@@ -31,8 +30,8 @@ public class FailureMessages extends ForwardingList<String> {
     private final List<String> failures;
     private final Optional<String> informationAboutNumberOfViolations;
 
-    FailureMessages(Collection<String> failures, Optional<String> informationAboutNumberOfViolations) {
-        this.failures = ImmutableList.copyOf(failures);
+    FailureMessages(ImmutableList<String> failures, Optional<String> informationAboutNumberOfViolations) {
+        this.failures = failures;
         this.informationAboutNumberOfViolations = informationAboutNumberOfViolations;
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
@@ -218,7 +218,7 @@ class SliceCycleArchCondition extends ArchCondition<Slice> {
         private String createDetails(Map<String, Edge<Slice, Dependency>> descriptionsToEdges) {
             List<String> details = new ArrayList<>();
             for (Map.Entry<String, Edge<Slice, Dependency>> edgeWithDescription : descriptionsToEdges.entrySet()) {
-                details.add(String.format("Dependencies of %s", edgeWithDescription.getKey()));
+                details.add("Dependencies of " + edgeWithDescription.getKey());
                 details.addAll(dependenciesDescription(edgeWithDescription.getValue()));
             }
             return Joiner.on(System.lineSeparator()).join(details);

--- a/archunit/src/test/java/com/tngtech/archunit/ArchConfigurationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/ArchConfigurationTest.java
@@ -231,7 +231,7 @@ public class ArchConfigurationTest {
 
         assertThat(configuration.md5InClassSourcesEnabled()).as("MD5 sum in class sources enabled").isTrue();
         assertThat(configuration.getProperty(customPropertyName)).as("custom property").isEqualTo("changed");
-        assertThat(configuration.getSubProperties(subPropertyKeyOf(customPropertyName))).containsExactly(
+        assertThat(configuration.getSubProperties(subPropertyKeyOf(customPropertyName))).containsOnly(
                 entry(subPropertyNameOf(customPropertyName), "changed"),
                 entry(subPropertyNameOf(otherPropertyName), "other"));
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
@@ -43,7 +42,11 @@ public class TestUtils {
 
     @SafeVarargs
     public static ThrowsClause<?> throwsClause(Class<? extends Throwable>... types) {
-        List<JavaClass> importedTypes = ImmutableList.copyOf(importClassesWithContext(types));
+        JavaClasses classes = importClassesWithContext(types);
+        List<JavaClass> importedTypes = new ArrayList<>();
+        for (Class<? extends Throwable> type : types) {
+            importedTypes.add(classes.get(type));
+        }
         JavaMethod irrelevantOwner = importClassWithContext(Object.class).getMethod("toString");
         return ThrowsClause.from(irrelevantOwner, importedTypes);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.TestUtils.throwsClause;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
@@ -77,6 +78,11 @@ public class HasThrowsClauseTest {
             @Override
             public ThrowsClause<?> getThrowsClause() {
                 return throwsClause(throwsDeclarations);
+            }
+
+            @Override
+            public String toString() {
+                return HasThrowsClause.class.getSimpleName() + "{ throws " + namesOf(throwsDeclarations) + "}";
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Iterables.getLast;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
@@ -99,7 +99,7 @@ public class ImportOptionsTest {
                 .isFalse();
         assertThat(doNotIncludeJars.includes(locationOf(Object.class)))
                 .as("includes Jrt location")
-                .isTrue();
+                .isEqualTo(!comesFromJarArchive(Object.class));
     }
 
     @DataProvider
@@ -122,6 +122,10 @@ public class ImportOptionsTest {
     }
 
     private static Location locationOf(Class<?> clazz) {
-        return getOnlyElement(Locations.ofClass(clazz));
+        return getLast(Locations.ofClass(clazz));
+    }
+
+    private static boolean comesFromJarArchive(Class<?> clazz) {
+        return LocationTest.urlOfClass(clazz).getProtocol().equals("jar");
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/TestClassFile.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/TestClassFile.java
@@ -1,0 +1,51 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.google.common.io.Files;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.tngtech.archunit.testutil.TestUtils.newTemporaryFolder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.tools.ToolProvider.getSystemJavaCompiler;
+
+public class TestClassFile {
+    private static final String PACKAGE_NAME = "com.dummy";
+    private static final String SOURCE_FOLDER = PACKAGE_NAME.replace(".", File.separator) + File.separator;
+    private static final String CLASS_NAME = "Dummy";
+    private final File classpathRoot = newTemporaryFolder();
+    private final File sourceFile = new File(classpathRoot, SOURCE_FOLDER + CLASS_NAME + ".java");
+
+    public TestClassFile() {
+    }
+
+    public TestClassFile create() {
+        try {
+            String sourceCode = String.format("package %s;public class %s {}", PACKAGE_NAME, CLASS_NAME);
+
+            checkState(sourceFile.getParentFile().exists() || sourceFile.getParentFile().mkdirs(),
+                    "Can't create directory %s", sourceFile.getParentFile().getAbsolutePath());
+            Files.write(sourceCode, sourceFile, UTF_8);
+
+            int result = getSystemJavaCompiler().run(null, null, null, sourceFile.getAbsolutePath());
+            checkState(result == 0, "Compiler exit code should be 0, but it was " + result);
+
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getPackageName() {
+        return PACKAGE_NAME;
+    }
+
+    public String getClassName() {
+        return PACKAGE_NAME + "." + CLASS_NAME;
+    }
+
+    public File getClasspathRoot() {
+        return classpathRoot;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
@@ -80,6 +80,7 @@ public class UrlSourceTest {
         String classPath = createClassPathProperty(valid.toString(),
                 "/invalid/path/because/of/" + CHARACTER_THAT_IS_HOPEFULLY_ILLEGAL_ON_EVERY_PLATFORM + "/");
         System.setProperty(JAVA_CLASS_PATH_PROP, classPath);
+        System.clearProperty(JAVA_BOOT_PATH_PROP);
 
         assertThat(UrlSource.From.classPathSystemProperties()).containsOnly(toUrl(valid));
     }
@@ -142,6 +143,7 @@ public class UrlSourceTest {
                 .create(jarTwoPath);
 
         System.setProperty(JAVA_CLASS_PATH_PROP, jarOne.getName());
+        System.clearProperty(JAVA_BOOT_PATH_PROP);
         UrlSource urls = UrlSource.From.classPathSystemProperties();
 
         assertThat(urls).containsOnly(toUrl(Paths.get(jarOne.getName())), toUrl(Paths.get(jarTwo.getName())));

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodCallChain.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodCallChain.java
@@ -18,7 +18,7 @@ class MethodCallChain {
     MethodCallChain(MethodChoiceStrategy methodChoiceStrategy, TypedValue typedValue) {
         this.methodChoiceStrategy = checkNotNull(methodChoiceStrategy);
         currentValue = checkNotNull(typedValue);
-        nextMethodCandidate = methodChoiceStrategy.choose(typedValue.getType());
+        nextMethodCandidate = methodChoiceStrategy.choose(typedValue.getType(), false);
     }
 
     TypedValue getCurrentValue() {
@@ -33,11 +33,11 @@ class MethodCallChain {
         return nextMethodCandidate.isPresent();
     }
 
-    void invokeNextMethodCandidate(Parameters parameters) {
+    void invokeNextMethodCandidate(Parameters parameters, boolean tryToTerminate) {
         PropagatedType nextType = currentValue.resolveType(nextMethodCandidate.get().getGenericReturnType());
         Object nextValue = invoke(nextMethodCandidate.get(), currentValue.getValue(), parameters.getValues());
         currentValue = validate(new TypedValue(nextType, nextValue));
-        nextMethodCandidate = methodChoiceStrategy.choose(currentValue.getType());
+        nextMethodCandidate = methodChoiceStrategy.choose(currentValue.getType(), tryToTerminate);
     }
 
     private TypedValue validate(TypedValue value) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodCallChainTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodCallChainTest.java
@@ -115,7 +115,7 @@ public class MethodCallChainTest {
     }
 
     private void invokeNext(MethodCallChain callChain) {
-        callChain.invokeNextMethodCandidate(new Parameters(Collections.<Parameter>emptyList()));
+        callChain.invokeNextMethodCandidate(new Parameters(Collections.<Parameter>emptyList()), false);
     }
 
     private static class CallChainTestCase<T> {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
@@ -48,11 +48,24 @@ public class MethodChoiceStrategy {
         };
     }
 
-    Optional<Method> choose(PropagatedType type) {
+    Optional<Method> choose(PropagatedType type, boolean tryToTerminate) {
         List<Method> methods = getPossibleMethodCandidates(type.getRawType());
-        return !methods.isEmpty()
-                ? Optional.of(methods.get(random.nextInt(methods.size())))
-                : Optional.<Method>absent();
+        if (methods.isEmpty()) {
+            return Optional.absent();
+        }
+
+        return tryToTerminate
+                ? findMethodWithReturnType(methods, ArchRule.class).or(Optional.of(methods.iterator().next()))
+                : Optional.of(methods.get(random.nextInt(methods.size())));
+    }
+
+    private Optional<Method> findMethodWithReturnType(List<Method> methods, Class<ArchRule> returnType) {
+        for (Method method : methods) {
+            if (returnType.isAssignableFrom(method.getReturnType())) {
+                return Optional.of(method);
+            }
+        }
+        return Optional.absent();
     }
 
     private List<Method> getPossibleMethodCandidates(Class<?> clazz) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/RandomSyntaxTestBase.java
@@ -217,10 +217,12 @@ public abstract class RandomSyntaxTestBase {
                 throw new IllegalStateException("Creating rule was not finished within " + maxSteps + " steps");
             }
 
-            methodCallChain.invokeNextMethodCandidate(parameters);
+            int stepsLeft = maxSteps - currentStepCount;
+            boolean lowNumberOfStepsLeft = stepsLeft <= LOW_NUMBER_OF_LEFT_STEPS;
+            methodCallChain.invokeNextMethodCandidate(parameters, lowNumberOfStepsLeft);
 
             boolean shouldContinue = methodCallChain.hasAnotherMethodCandidate()
-                    && shouldContinue(methodCallChain.getCurrentValue(), maxSteps - currentStepCount);
+                    && shouldContinue(methodCallChain.getCurrentValue(), lowNumberOfStepsLeft);
             Step nextStep = shouldContinue
                     ? new PartialStep(expectedDescription, methodCallChain)
                     : new LastStep(expectedDescription, methodCallChain);
@@ -229,11 +231,11 @@ public abstract class RandomSyntaxTestBase {
             return nextStep.continueSteps(currentStepCount + 1, maxSteps);
         }
 
-        private boolean shouldContinue(TypedValue nextValue, int stepsLeft) {
+        private boolean shouldContinue(TypedValue nextValue, boolean lowNumberOfStepsLeft) {
             if (!ArchRule.class.isAssignableFrom(nextValue.getRawType())) {
                 return true;
             }
-            return random.nextBoolean() && stepsLeft > LOW_NUMBER_OF_LEFT_STEPS;
+            return random.nextBoolean() && !lowNumberOfStepsLeft;
         }
 
         public String getDescription() {
@@ -471,7 +473,7 @@ public abstract class RandomSyntaxTestBase {
             }
         }
 
-        private abstract class CallCodeUnitParametersProvider extends SpecificParametersProvider {
+        private abstract static class CallCodeUnitParametersProvider extends SpecificParametersProvider {
             private final CanHandlePredicate predicate;
 
             CallCodeUnitParametersProvider(CanHandlePredicate predicate) {

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -54,7 +54,7 @@ ext {
         assert testTask.name == 'test' || testTask.name ==~ /jdk\d+Test/: "Task must either be named 'test' or match 'jdk{x}Test'"
         testTask.enabled = false
 
-        def taskMinimumJdkVersion = testTask.name.replaceAll(/jdk(\d+)Test/, '$1').with { it ==~ /\d+/ ? JavaVersion.toVersion(it) : JavaVersion.VERSION_1_7 }
+        def taskMinimumJdkVersion = testTask.name.replaceAll(/jdk(\d+)Test/, '$1').with { it ==~ /\d+/ ? JavaVersion.toVersion(it) : proj.targetCompatibility }
         def additionalJdksToTest = testJdks().findAll { it.javaVersion >= taskMinimumJdkVersion }
 
         def findJavaExecutable = { jdkPath ->

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -16,4 +16,79 @@ ext {
     testJdks = {
         testJdksDefinition.collect { [:] + it }
     }
+
+    addTestJarTo = { proj ->
+        proj.with {
+            configurations {
+                tests.extendsFrom testRuntime
+            }
+
+            task testJar(type: Jar) {
+                archiveClassifier = 'tests'
+                from sourceSets.test.output
+            }
+
+            artifacts {
+                tests testJar
+            }
+        }
+    }
+
+    configureSlowTestsFor = { proj ->
+        proj.afterEvaluate { projAfterEvaluate ->
+            projAfterEvaluate.tasks.withType(Test) {
+                if (!project.hasProperty('allTests')) {
+                    useJUnit {
+                        excludeCategories 'com.tngtech.archunit.Slow'
+                    }
+                }
+            }
+        }
+    }
+
+    addMultiJdkTestsFor = { Project proj, Test testTask ->
+        if (!project.hasProperty('multiJdkTest')) {
+            return
+        }
+
+        assert testTask.name == 'test' || testTask.name ==~ /jdk\d+Test/: "Task must either be named 'test' or match 'jdk{x}Test'"
+        testTask.enabled = false
+
+        def taskMinimumJdkVersion = testTask.name.replaceAll(/jdk(\d+)Test/, '$1').with { it ==~ /\d+/ ? JavaVersion.toVersion(it) : JavaVersion.VERSION_1_7 }
+        def additionalJdksToTest = testJdks().findAll { it.javaVersion >= taskMinimumJdkVersion }
+
+        def findJavaExecutable = { jdkPath ->
+            def javaExecutableUnix = new File("${jdkPath}", 'bin/java')
+            def javaExecutableWindows = new File("${javaExecutableUnix.absolutePath}.exe")
+            def result = javaExecutableUnix.exists() ? javaExecutableUnix : javaExecutableWindows
+            assert result.exists(): "Could not find path of Java executable for JDK path ${jdkPath}. Tried ${javaExecutableUnix} and ${javaExecutableWindows}."
+            result
+        }
+
+        additionalJdksToTest.each { jdk ->
+            def additionalTestTask = proj.tasks.create(name: "${testTask.name}${jdk.suffix}", type: Test) {
+                executable = findJavaExecutable(jdk.jdkPath)
+
+                testClassesDirs = testTask.testClassesDirs
+                classpath = testTask.classpath
+            }
+
+            testTask.dependsOn(additionalTestTask)
+        }
+    }
+}
+
+configure(subprojects.findAll { it.name != 'docs' }) {
+    afterEvaluate { project ->
+        project.tasks.withType(Test) {
+            maxHeapSize = "2G"
+
+            testLogging {
+                events "failed"
+                exceptionFormat "full"
+            }
+
+            ignoreFailures = project.hasProperty('ignoreTestFailures')
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,35 +89,6 @@ ext {
             project(':archunit-junit5')]
     createModuleDescription = { description, proj -> "${description} - Module '${proj.name}'" }
 
-    addTestJarTo = { proj ->
-        proj.with {
-            configurations {
-                tests.extendsFrom testRuntime
-            }
-
-            task testJar(type: Jar) {
-                archiveClassifier = 'tests'
-                from sourceSets.test.output
-            }
-
-            artifacts {
-                tests testJar
-            }
-        }
-    }
-
-    configureSlowTestsFor = { proj ->
-        proj.with {
-            test {
-                if (!project.hasProperty('allTests')) {
-                    useJUnit {
-                        excludeCategories 'com.tngtech.archunit.Slow'
-                    }
-                }
-            }
-        }
-    }
-
     currentScriptRootOf = { it.buildscript.sourceFile.parentFile }
 }
 
@@ -142,7 +113,7 @@ task clean {
     }
 }
 
-configure(subprojects.findAll {it.name != 'docs'})  {
+configure(subprojects.findAll { it.name != 'docs' }) {
     apply plugin: 'java-library'
 
     description createModuleDescription(rootProject.description, project)
@@ -152,17 +123,6 @@ configure(subprojects.findAll {it.name != 'docs'})  {
 
     javadoc {
         options.addBooleanOption('html5', true)
-    }
-
-    test {
-        maxHeapSize = "2G"
-
-        testLogging {
-            events "failed"
-            exceptionFormat "full"
-        }
-
-        ignoreFailures = project.hasProperty('ignoreTestFailures')
     }
 }
 


### PR DESCRIPTION
Adds the possibility to `addMultiJdkTestsFor` any test tasks, which will look for the same properties as the `mavenIntegrationTest`, i.e. `javaxHome` properties, and then use those to run the tests. If `-PmultiJdkTest` is set then the original test task will be replaced by adjusted `originalTestJre${x}` tasks for all Java versions that are available.
Furthermore extended GitHub actions to run these cross JDK tests as a matrix. Unfortunately this has proven to be way more difficult than expected, e.g. installing several JDKs and assigning the correct one to build and test. One problem is that for some reason the `setup-java` task does not provide the output described in the documentation (i.e. the path of the installed JDK). Furthermore the environment variables it sets are illegal for bash / Gradle, i.e. `System.env` will not detect these environment variables (or not all `process.env` variables are provided as environment variables to the task by GH Actions, unfortunately the docs at the moment are a little fuzzy there). So altogether you can specify `setup-java: with: java-version: 9`, but then there is no easy way to reference the path of the installed JDK, because it will be a variable like `JAVA_HOME_9.0.4_x64` and to hard reference this version number seems brittle. Thus I have included a simple script action as a workaround that will slurp all the `JAVA_HOME_.._x64` variables, parse the version number and then set robust env variables to be used to define the Gradle task (i.e. specify `JAVA_HOME` for the Gradle task, but also the `java${x}Home` for the multi-JDK test). Note that the GH Actions machines also have predefined JDKs that follow the naming pattern `JAVA_HOME_11_X64` without exact version numbers, so this is somewhat ambiguous, but in the end the exact `JAVA_HOME` doesn't matter, as long as the version is correct. Also note that the convention of `setup-java` for Java versions < 9 still follows the pattern `JAVA_HOME_7.x.y_x64` and not `1.7.x` like the legacy versioning would suggest. Thus the simple regex checking for the first number that the script action does seems good enough for now.

I also fixed all the tests that are meanwhile broken, because they have not been run with JRE < 9 for a long time. And hopefully finally fixed the flaky `Random...SyntaxTests`, because obviously the danger of failures is increased a lot if a matrix of 3 x 8 of tests has to pass for a PR.