### PR TITLE
Run integration tests for all JDKs in Github action for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,57 +7,21 @@ on:
       - release-*
   pull_request:
 
+env:
+  build_java_version: 11
+
 jobs:
-  build-unix:
+  integration-test:
     strategy:
       matrix:
         os:
           - ubuntu-latest
           - macos-latest
-        java_version:
-          -  7
-          -  8
-          -  9
-          - 10
-          - 11
-          - 12
-          - 13
-          - 14
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Java for build
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Build
-        run: ./gradlew -PallTests build
-      - name: Prepare integration test
-        run: ./gradlew publishToMavenLocal
-      - name: Set up Java for integration test
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java_version }}
-      - name: Integration test
-        env:
-          JAVA_VERSION: ${{ matrix.java_version }}
-        run: |
-          echo ${JAVA_VERSION}
-          JAVA_HOME_MAVEN=${JAVA_HOME}
-          echo ${JAVA_HOME_MAVEN}
-          JAVA_HOME=${JAVA_HOME_11_X64}
-          echo ${JAVA_HOME}
-          ./gradlew runMavenTest -Pjava${JAVA_VERSION}Home=${JAVA_HOME_MAVEN}
-  build-windows:
-    strategy:
-      matrix:
-        os:
           - windows-latest
         java_version:
-          -  7
-          -  8
-          -  9
+          - 7
+          - 8
+          - 9
           - 10
           - 11
           - 12
@@ -67,25 +31,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Java for build
+      - name: Set up Build JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
-      - name: Build
-        run: .\gradlew.bat -PallTests build
-      - name: Prepare integration test
-        run: .\gradlew.bat publishToMavenLocal
-      - name: Set up Java for integration test
+          java-version: ${{ env.build_java_version }}
+      - name: Set up Test JDK
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java_version }}
+      - name: Provide installed JDKs
+        uses: actions/github-script@v1
+        id: provideJdkPaths
+        with:
+          script: |
+            for ( let envVarName in process.env ) {
+              if (/JAVA_HOME_\d.*64/.test(envVarName)) {
+                const version = envVarName.match(/JAVA_HOME_(\d+).*64/)[1];
+                if (version === "${{ matrix.test_java_version }}") {
+                  core.exportVariable('test_jdk_path', process.env[envVarName]);
+                } else if (version === "${{ env.build_java_version }}") {
+                  core.exportVariable('build_jdk_path', process.env[envVarName]);
+                }
+              }
+            }
       - name: Integration test
+        uses: eskatos/gradle-command-action@v1
         env:
-          JAVA_VERSION: ${{ matrix.java_version }}
-        run: |
-          $env:JAVA_VERSION
-          $env:JAVA_HOME_MAVEN = $env:JAVA_HOME
-          $env:JAVA_HOME_MAVEN
-          $env:JAVA_HOME = $env:JAVA_HOME_11_X64
-          $env:JAVA_HOME
-          .\gradlew.bat runMavenTest "-Pjava$($env:JAVA_VERSION)Home=$($env:JAVA_HOME_MAVEN)"
+          JAVA_HOME: ${{ env.build_jdk_path }}
+        with:
+          arguments: build -xtest -xspotbugsMain -xjavadoc publishToMavenLocal runMavenTest -Pjava${{ matrix.test_java_version }}Home="${{ env.test_jdk_path }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,26 +8,84 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-unix:
     strategy:
       matrix:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         java_version:
+          -  7
+          -  8
+          -  9
+          - 10
           - 11
-
+          - 12
+          - 13
+          - 14
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Java
+      - name: Set up Java for build
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build
+        run: ./gradlew -PallTests build
+      - name: Prepare integration test
+        run: ./gradlew publishToMavenLocal
+      - name: Set up Java for integration test
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java_version }}
-      - name: Build
-        uses: eskatos/gradle-command-action@v1
+      - name: Integration test
+        env:
+          JAVA_VERSION: ${{ matrix.java_version }}
+        run: |
+          echo ${JAVA_VERSION}
+          JAVA_HOME_MAVEN=${JAVA_HOME}
+          echo ${JAVA_HOME_MAVEN}
+          JAVA_HOME=${JAVA_HOME_11_X64}
+          echo ${JAVA_HOME}
+          ./gradlew runMavenTest -Pjava${JAVA_VERSION}Home=${JAVA_HOME_MAVEN}
+  build-windows:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+        java_version:
+          -  7
+          -  8
+          -  9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Java for build
+        uses: actions/setup-java@v1
         with:
-          arguments: build -PallTests
+          java-version: 11
+      - name: Build
+        run: .\gradlew.bat -PallTests build
+      - name: Prepare integration test
+        run: .\gradlew.bat publishToMavenLocal
+      - name: Set up Java for integration test
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java_version }}
+      - name: Integration test
+        env:
+          JAVA_VERSION: ${{ matrix.java_version }}
+        run: |
+          $env:JAVA_VERSION
+          $env:JAVA_HOME_MAVEN = $env:JAVA_HOME
+          $env:JAVA_HOME_MAVEN
+          $env:JAVA_HOME = $env:JAVA_HOME_11_X64
+          $env:JAVA_HOME
+          .\gradlew.bat runMavenTest "-Pjava$($env:JAVA_VERSION)Home=$($env:JAVA_HOME_MAVEN)"

--- a/build-steps/build-steps.gradle
+++ b/build-steps/build-steps.gradle
@@ -1,5 +1,6 @@
 def utilsPath = { "build-steps/${it}" }
 
+apply from: utilsPath('testing/testing.gradle')
 apply from: utilsPath('archiving/archiving.gradle')
 apply from: utilsPath('codequality/spotbugs.gradle')
 apply from: utilsPath('release/publish.gradle')

--- a/build-steps/maven-integration-test/maven-integration-test.gradle
+++ b/build-steps/maven-integration-test/maven-integration-test.gradle
@@ -190,23 +190,9 @@ def addMavenTest = { config ->
     }
 }
 
-def javaConfigs = [
-        [suffix: "java7", javaVersion: JavaVersion.VERSION_1_7, jdkProp: "java7Home"],
-        [suffix: "java8", javaVersion: JavaVersion.VERSION_1_8, jdkProp: "java8Home"],
-        [suffix: "java9", javaVersion: JavaVersion.VERSION_1_9, jdkProp: "java9Home"],
-        [suffix: "java10", javaVersion: JavaVersion.VERSION_1_10, jdkProp: "java10Home"],
-        [suffix: "java11", javaVersion: JavaVersion.VERSION_11, jdkProp: "java11Home"],
-        [suffix: "java12", javaVersion: JavaVersion.VERSION_12, jdkProp: "java12Home"],
-        [suffix: "java13", javaVersion: JavaVersion.VERSION_13, jdkProp: "java13Home"],
-        [suffix: "java14", javaVersion: JavaVersion.VERSION_14, jdkProp: "java14Home"]
-]
+def integrationTestJdks = testJdks() ?: [[suffix: 'java7', javaVersion: JavaVersion.VERSION_1_7]]
 
-javaConfigs = javaConfigs.findAll { project.hasProperty(it.jdkProp) }
-                         .collect { config -> config + [jdkPath: project[config.jdkProp]] }
-
-javaConfigs = javaConfigs ?: [[suffix: 'java7', javaVersion: JavaVersion.VERSION_1_7]]
-
-javaConfigs = javaConfigs.collect { config ->
+integrationTestJdks = integrationTestJdks.collect { config ->
     // JUnit 5 needs at least Java 8
     def testSupportTypes = config.javaVersion > JavaVersion.VERSION_1_7 ?
             ['plain', 'junit4', 'junit5'] :
@@ -216,17 +202,17 @@ javaConfigs = javaConfigs.collect { config ->
     }
 }.flatten()
 
-javaConfigs.findAll { it.suffix.endsWith('plain') }*.with {
+integrationTestJdks.findAll { it.suffix.endsWith('plain') }*.with {
     surefireExampleConfiguration = '<groups>com.tngtech.archunit.exampletest.Example</groups>'
     archunitTestArtifact = 'archunit'
 }
 
-javaConfigs.findAll { it.suffix.endsWith('junit4') }*.with {
+integrationTestJdks.findAll { it.suffix.endsWith('junit4') }*.with {
     surefireExampleConfiguration = '<groups>com.tngtech.archunit.exampletest.junit4.Example</groups>'
     archunitTestArtifact = 'archunit-junit4'
 }
 
-javaConfigs.findAll { it.suffix.endsWith('junit5') }*.with {
+integrationTestJdks.findAll { it.suffix.endsWith('junit5') }*.with {
     surefireExampleConfiguration = '<groups>example</groups>'
     archunitTestArtifact = 'archunit-junit5'
     additionalDependencies = """
@@ -238,11 +224,11 @@ javaConfigs.findAll { it.suffix.endsWith('junit5') }*.with {
         </dependency>"""
 }
 
-javaConfigs.each { config ->
+integrationTestJdks.each { config ->
     project.with(addMavenTest(config))
 }
 
-def suffixes = javaConfigs*.suffix.sort()
+def suffixes = integrationTestJdks*.suffix.sort()
 [suffixes, suffixes.tail()].transpose().each { twoConsecutiveSuffixes ->
     tasks["prepareMavenTest${twoConsecutiveSuffixes[1]}"].mustRunAfter(tasks["cleanUpMavenTest${twoConsecutiveSuffixes[0]}"])
 }

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -1,0 +1,19 @@
+def unquote = { string -> string.replaceAll(/^"(.*)"$/, '$1')}
+def testJdksDefinition = [
+        [suffix: "Jre7", javaVersion: JavaVersion.VERSION_1_7, jdkProp: "java7Home"],
+        [suffix: "Jre8", javaVersion: JavaVersion.VERSION_1_8, jdkProp: "java8Home"],
+        [suffix: "Jre9", javaVersion: JavaVersion.VERSION_1_9, jdkProp: "java9Home"],
+        [suffix: "Jre10", javaVersion: JavaVersion.VERSION_1_10, jdkProp: "java10Home"],
+        [suffix: "Jre11", javaVersion: JavaVersion.VERSION_11, jdkProp: "java11Home"],
+        [suffix: "Jre12", javaVersion: JavaVersion.VERSION_12, jdkProp: "java12Home"],
+        [suffix: "Jre13", javaVersion: JavaVersion.VERSION_13, jdkProp: "java13Home"],
+        [suffix: "Jre14", javaVersion: JavaVersion.VERSION_14, jdkProp: "java14Home"]
+]
+        .findAll { project.hasProperty(it.jdkProp) }
+        .collect { config -> config + [jdkPath: unquote(project[config.jdkProp])] }
+
+ext {
+    testJdks = {
+        testJdksDefinition.collect { [:] + it }
+    }
+}


### PR DESCRIPTION
Simply changing the JDK (and thus `JAVA_HOME`) using the `actions/setup-java@v1`does not work for Java 7as Gradle requires at least Java 8. Thus we now add a adedicated env var `JAVA_HOME_MAVEN` to override the JDK in the Maven integration tests. Unfortunately, due to the need of env vars and the different handling in Unix and Windows, we needed to duplicate the build logic in two different jobs.