### PR TITLE
Prevent excessive logging when supplying system properties

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -135,8 +135,8 @@ public class DomainObjectCreationContext {
         return new JavaEnumConstant(builder);
     }
 
-    public static Source createSource(URI uri, Optional<String> sourceFileName) {
-        return new Source(uri, sourceFileName);
+    public static Source createSource(URI uri, Optional<String> sourceFileName, boolean md5InClassSourcesEnabled) {
+        return new Source(uri, sourceFileName, md5InClassSourcesEnabled);
     }
 
     public static <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> createThrowsClause(CODE_UNIT codeUnit, List<JavaClass> types) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
@@ -48,10 +48,10 @@ public class Source {
     private final Optional<String> fileName;
     private final Md5sum md5sum;
 
-    Source(URI uri, Optional<String> fileName) {
+    Source(URI uri, Optional<String> fileName, boolean md5InClassSourcesEnabled) {
         this.uri = checkNotNull(uri);
         this.fileName = checkNotNull(fileName);
-        md5sum = Md5sum.of(uri);
+        md5sum = md5InClassSourcesEnabled ? Md5sum.of(uri) : Md5sum.DISABLED;
     }
 
     @PublicAPI(usage = ACCESS)
@@ -167,21 +167,13 @@ public class Source {
             }
         }
 
-        static Md5sum of(byte[] input) {
+        private static Md5sum of(URI uri) {
             if (MD5_DIGEST == null) {
                 return NOT_SUPPORTED;
             }
 
-            return ArchConfiguration.get().md5InClassSourcesEnabled() ? new Md5sum(input, MD5_DIGEST) : DISABLED;
-        }
-
-        private static Md5sum of(URI uri) {
-            if (!ArchConfiguration.get().md5InClassSourcesEnabled()) {
-                return DISABLED;
-            }
-
             Optional<byte[]> bytesFromUri = read(uri);
-            return bytesFromUri.isPresent() ? Md5sum.of(bytesFromUri.get()) : UNDETERMINED;
+            return bytesFromUri.isPresent() ? new Md5sum(bytesFromUri.get(), MD5_DIGEST) : UNDETERMINED;
         }
 
         private static Optional<byte[]> read(URI uri) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -15,7 +15,6 @@
  */
 package com.tngtech.archunit.core.importer;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -318,7 +317,7 @@ public final class DomainBuilders {
 
     @Internal
     public static final class JavaClassBuilder {
-        private Optional<URI> sourceURI = Optional.absent();
+        private Optional<SourceDescriptor> sourceDescriptor = Optional.absent();
         private Optional<String> sourceFileName = Optional.absent();
         private JavaType javaType;
         private boolean isInterface;
@@ -330,8 +329,8 @@ public final class DomainBuilders {
         JavaClassBuilder() {
         }
 
-        JavaClassBuilder withSourceUri(URI sourceUri) {
-            this.sourceURI = Optional.of(sourceUri);
+        JavaClassBuilder withSourceDescriptor(SourceDescriptor sourceDescriptor) {
+            this.sourceDescriptor = Optional.of(sourceDescriptor);
             return this;
         }
 
@@ -380,7 +379,9 @@ public final class DomainBuilders {
         }
 
         public Optional<Source> getSource() {
-            return sourceURI.isPresent() ? Optional.of(createSource(sourceURI.get(), sourceFileName)) : Optional.<Source>absent();
+            return sourceDescriptor.isPresent()
+                    ? Optional.of(createSource(sourceDescriptor.get().getUri(), sourceFileName, sourceDescriptor.get().isMd5InClassSourcesEnabled()))
+                    : Optional.<Source>absent();
         }
 
         public JavaType getJavaType() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -16,7 +16,6 @@
 package com.tngtech.archunit.core.importer;
 
 import java.lang.reflect.Array;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -69,18 +68,18 @@ class JavaClassProcessor extends ClassVisitor {
 
     private DomainBuilders.JavaClassBuilder javaClassBuilder;
     private final Set<DomainBuilders.JavaAnnotationBuilder> annotations = new HashSet<>();
-    private final URI sourceURI;
+    private final SourceDescriptor sourceDescriptor;
     private final DeclarationHandler declarationHandler;
     private final AccessHandler accessHandler;
     private String className;
 
-    JavaClassProcessor(URI sourceURI, DeclarationHandler declarationHandler) {
-        this(sourceURI, declarationHandler, NO_OP);
+    JavaClassProcessor(SourceDescriptor sourceDescriptor, DeclarationHandler declarationHandler) {
+        this(sourceDescriptor, declarationHandler, NO_OP);
     }
 
-    JavaClassProcessor(URI sourceURI, DeclarationHandler declarationHandler, AccessHandler accessHandler) {
+    JavaClassProcessor(SourceDescriptor sourceDescriptor, DeclarationHandler declarationHandler, AccessHandler accessHandler) {
         super(ASM_API_VERSION);
-        this.sourceURI = sourceURI;
+        this.sourceDescriptor = sourceDescriptor;
         this.declarationHandler = declarationHandler;
         this.accessHandler = accessHandler;
     }
@@ -112,7 +111,7 @@ class JavaClassProcessor extends ClassVisitor {
         LOG.trace("Found superclass {} on class '{}'", superClassName.orNull(), name);
 
         javaClassBuilder = new DomainBuilders.JavaClassBuilder()
-                .withSourceUri(sourceURI)
+                .withSourceDescriptor(sourceDescriptor)
                 .withType(javaType)
                 .withInterface(opCodeForInterfaceIsPresent)
                 .withEnum(opCodeForEnumIsPresent)

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/SourceDescriptor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/SourceDescriptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2020 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import java.net.URI;
+
+class SourceDescriptor {
+    private final URI sourceUri;
+    private final boolean md5InClassSourcesEnabled;
+
+    SourceDescriptor(URI sourceUri, boolean md5InClassSourcesEnabled) {
+        this.sourceUri = sourceUri;
+        this.md5InClassSourcesEnabled = md5InClassSourcesEnabled;
+    }
+
+    URI getUri() {
+        return sourceUri;
+    }
+
+    boolean isMd5InClassSourcesEnabled() {
+        return md5InClassSourcesEnabled;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/ArchConfigurationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/ArchConfigurationTest.java
@@ -1,17 +1,17 @@
 package com.tngtech.archunit;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.lang.reflect.Constructor;
-import java.util.Arrays;
-import java.util.Properties;
-
 import com.tngtech.archunit.testutil.SystemPropertiesRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -234,6 +234,12 @@ public class ArchConfigurationTest {
         assertThat(configuration.getSubProperties(subPropertyKeyOf(customPropertyName))).containsOnly(
                 entry(subPropertyNameOf(customPropertyName), "changed"),
                 entry(subPropertyNameOf(otherPropertyName), "other"));
+
+        System.clearProperty("archunit." + ArchConfiguration.ENABLE_MD5_IN_CLASS_SOURCES);
+        System.clearProperty("archunit." + customPropertyName);
+
+        assertThat(configuration.md5InClassSourcesEnabled()).as("MD5 sum in class sources enabled").isFalse();
+        assertThat(configuration.getProperty(customPropertyName)).as("custom property").isEqualTo("original");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -1,5 +1,7 @@
 package com.tngtech.archunit.core.domain;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -9,7 +11,9 @@ import java.util.Set;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
@@ -26,6 +30,7 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.importer.ImportTestUtils.newFieldAccess;
 import static com.tngtech.archunit.core.importer.ImportTestUtils.newMethodCall;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.getHierarchy;
+import static org.assertj.core.util.Files.newTemporaryFile;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +81,13 @@ public class TestUtils {
     }
 
     public static Md5sum md5sumOf(byte[] bytes) {
-        return Md5sum.of(bytes);
+        File file = newTemporaryFile();
+        try {
+            Files.write(bytes, file);
+            return new Source(file.toURI(), Optional.<String>absent(), true).getMd5sum();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static JavaClass importClassWithContext(Class<?> owner) {


### PR DESCRIPTION
Prevent excessive logging when supplying system properties by only logging if the system properties have changed.

I didn't add test case for the change since the `ArchConfigurationTest#allows_to_override_any_property_via_system_property` already covers the scenario.

Resolves #375 