### PR TITLE
Allow usage of TestSets in Gradle

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
@@ -76,7 +76,7 @@ public interface ImportOption {
      */
     final class DoNotIncludeTests implements ImportOption {
         private static final Pattern MAVEN_PATTERN = Pattern.compile(".*/target/test-classes/.*");
-        private static final Pattern GRADLE_PATTERN = Pattern.compile(".*/build/classes/([^/]+/)?test/.*");
+        private static final Pattern GRADLE_PATTERN = Pattern.compile(".*/build/classes/([^/]+/)?.*[tT]est/.*");
         private static final Pattern INTELLIJ_PATTERN = Pattern.compile(".*/out/test/classes/.*");
 
         private static final Set<Pattern> EXCLUDED_PATTERN = ImmutableSet.of(MAVEN_PATTERN, GRADLE_PATTERN, INTELLIJ_PATTERN);


### PR DESCRIPTION
When using TestSets in Gradle, tests are separated in different test folders, this change allows the use of `DoNotIncludeTests` to filter out those tests.