### PR TITLE
Add note about JUnit's `@Disabled` to documentation

### DIFF
--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -156,6 +156,9 @@ public class ArchitectureTest {
 }
 ----
 
+Note for users of JUnit 5: the annotation `@Disabled` has no effect here.
+Instead, `@ArchIgnore` should be used.
+
 ==== Grouping Rules
 
 Often a project might end up with different categories of rules, for example "service rules"


### PR DESCRIPTION
From now on, users should be able to find `@ArchIgnore` if they search for one of "skip", "disable" or "ignore".

Resolves #380