### PR TITLE
Fix example output for configured JDK in Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Windows users should use `gradlew.bat` instead.
 ```
 $ cd /path/to/git/clone/of/ArchUnit
 $ ./gradlew showJdkVersion
-Configured JDK: 1.9
+Configured JDK: 14
 $ ./gradlew build
 ```
 


### PR DESCRIPTION
> ArchUnit requires at least JDK 11 to build.

So the example output should also show at least version.