### PR TITLE
Add JavaClass.tryGetConstructor(..) methods

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -673,11 +673,18 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
         return allFields.get();
     }
 
+    /**
+     * @return The field with the given name.
+     * @throws IllegalArgumentException If this class does not have such a field.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaField getField(String name) {
         return tryGetField(name).getOrThrow(new IllegalArgumentException("No field with name '" + name + " in class " + getName()));
     }
 
+    /**
+     * @return The field with the given name, if this class has such a field, otherwise {@link Optional#absent()}.
+     */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaField> tryGetField(String name) {
         for (JavaField field : fields) {
@@ -748,31 +755,53 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
         return Optional.absent();
     }
 
+    /**
+     * @return The method with the given name and with zero parameters.
+     * @throws IllegalArgumentException If this class does not have such a method.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaMethod getMethod(String name) {
         return findMatchingCodeUnit(methods, name, Collections.<String>emptyList());
     }
 
+    /**
+     * @return The method with the given name and the given parameter types.
+     * @throws IllegalArgumentException If this class does not have such a method.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaMethod getMethod(String name, Class<?>... parameters) {
         return findMatchingCodeUnit(methods, name, namesOf(parameters));
     }
 
+    /**
+     * Same as {@link #getMethod(String, Class[])}, but with parameter signature specified as fully qualified class names.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaMethod getMethod(String name, String... parameters) {
         return findMatchingCodeUnit(methods, name, ImmutableList.copyOf(parameters));
     }
 
+    /**
+     * @return The method with the given name and with zero parameters,
+     * if this class has such a method, otherwise {@link Optional#absent()}.
+     */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaMethod> tryGetMethod(String name) {
         return tryFindMatchingCodeUnit(methods, name, Collections.<String>emptyList());
     }
 
+    /**
+     * @return The method with the given name and the given parameter types,
+     * if this class has such a method, otherwise {@link Optional#absent()}.
+     */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaMethod> tryGetMethod(String name, Class<?>... parameters) {
         return tryFindMatchingCodeUnit(methods, name, namesOf(parameters));
     }
 
+    /**
+     * Same as {@link #tryGetMethod(String, Class[])}, but with parameter signature specified as fully qualified class names.
+     */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaMethod> tryGetMethod(String name, String... parameters) {
         return tryFindMatchingCodeUnit(methods, name, ImmutableList.copyOf(parameters));
@@ -789,19 +818,56 @@ public class JavaClass implements HasName.AndFullName, HasAnnotations<JavaClass>
         return allMethods.get();
     }
 
+    /**
+     * @return The constructor with zero parameters.
+     * @throws IllegalArgumentException If this class does not have such a constructor.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaConstructor getConstructor() {
         return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, Collections.<String>emptyList());
     }
 
+    /**
+     * @return The constructor with the given parameter types.
+     * @throws IllegalArgumentException If this class does not have a constructor with the given parameter types.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaConstructor getConstructor(Class<?>... parameters) {
         return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, namesOf(parameters));
     }
 
+    /**
+     * Same as {@link #getConstructor(Class[])}, but with parameter signature specified as full class names.
+     */
     @PublicAPI(usage = ACCESS)
     public JavaConstructor getConstructor(String... parameters) {
         return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, ImmutableList.copyOf(parameters));
+    }
+
+    /**
+     * @return The constructor with zero parameters,
+     * if this class has such a constructor, otherwise {@link Optional#absent()}.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaConstructor> tryGetConstructor() {
+        return tryFindMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, Collections.<String>emptyList());
+    }
+
+    /**
+     * @return The constructor with the given parameter types,
+     * if this class has such a constructor, otherwise {@link Optional#absent()}.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaConstructor> tryGetConstructor(Class<?>... parameters) {
+        return tryFindMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, namesOf(parameters));
+    }
+
+    /**
+     * Same as {@link #tryGetConstructor(Class[])}, but with parameter signature specified as fully qualified class names.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Optional<JavaConstructor> tryGetConstructor(String... parameters) {
+        return tryFindMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, ImmutableList.copyOf(parameters));
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -161,6 +161,19 @@ public class JavaClassTest {
     }
 
     @Test
+    public void reports_non_existing_members_as_absent() {
+        JavaClass javaClass = importClassWithContext(ParentWithFieldAndMethod.class);
+
+        assertThat(javaClass.tryGetField("notthere")).isAbsent();
+        assertThat(javaClass.tryGetMethod("notthere")).isAbsent();
+        assertThat(javaClass.tryGetMethod("notthere", Object.class)).isAbsent();
+        assertThat(javaClass.tryGetMethod("notthere", Object.class.getName())).isAbsent();
+        assertThat(javaClass.tryGetConstructor()).isAbsent();
+        assertThat(javaClass.tryGetConstructor(String.class)).isAbsent();
+        assertThat(javaClass.tryGetConstructor(String.class.getName())).isAbsent();
+    }
+
+    @Test
     public void anonymous_class_has_package_of_declaring_class() {
         Serializable input = new Serializable() {
         };

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -979,17 +979,24 @@ public class ClassFileImporterTest {
         JavaClass clazz = classesIn("testexamples/constructorimport").get(ClassWithSimpleConstructors.class);
 
         assertThat(clazz.getConstructors()).as("Constructors").hasSize(3);
-        assertThat(clazz.getConstructor()).isEquivalentTo(ClassWithSimpleConstructors.class.getDeclaredConstructor());
+
+        Constructor<ClassWithSimpleConstructors> expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor();
+        assertThat(clazz.getConstructor()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor().get()).isEquivalentTo(expectedConstructor);
 
         Class<?>[] parameterTypes = {Object.class};
-        Constructor<ClassWithSimpleConstructors> expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
+        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
         assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
         assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
 
         parameterTypes = new Class[]{int.class, int.class};
         expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
         assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
         assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
     }
 
     @Test


### PR DESCRIPTION
Before this commit, JavaClass had the methods
* `getField(..)` and `tryGetField(..)`
* `getMethod(..)` and `tryGetMethod(..)`
* `getConstructor(..)`

This PR adds the equivalent `tryGetConstructor(..)` methods.

Resolves #386