### PR TITLE
Resolve transitive annotations

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -126,8 +126,8 @@ public class DomainObjectCreationContext {
         return new AccessTarget.ConstructorCallTarget(builder);
     }
 
-    public static JavaMethod createJavaMethod(JavaMethodBuilder builder) {
-        return new JavaMethod(builder);
+    public static JavaMethod createJavaMethod(JavaMethodBuilder builder, Function<JavaMethod, Optional<Object>> createAnnotationDefaultValue) {
+        return new JavaMethod(builder, createAnnotationDefaultValue);
     }
 
     public static JavaMethodCall createJavaMethodCall(JavaMethodCallBuilder builder) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -69,4 +69,6 @@ public interface ImportContext {
     Set<InstanceofCheck> getInstanceofChecksOfType(JavaClass javaClass);
 
     JavaClass resolveClass(String fullyQualifiedClassName);
+
+    Optional<JavaClass> getMethodReturnType(String declaringClassName, String methodName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -40,6 +40,8 @@ public interface ImportContext {
 
     Map<String, JavaAnnotation<JavaClass>> createAnnotations(JavaClass owner);
 
+    Map<String, JavaAnnotation<JavaMember>> createAnnotations(JavaMember owner);
+
     Optional<JavaClass> createEnclosingClass(JavaClass owner);
 
     Set<JavaFieldAccess> getFieldAccessesFor(JavaCodeUnit codeUnit);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1223,7 +1223,10 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     }
 
     void completeAnnotations(final ImportContext context) {
-        this.annotations = context.createAnnotations(this);
+        annotations = context.createAnnotations(this);
+        for (JavaMember member : members) {
+            member.completeAnnotations(context);
+        }
     }
 
     CompletionProcess completeFrom(ImportContext context) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -23,6 +23,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ArchUnitException.InconsistentClassPathException;
+import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.MayResolveTypesViaReflection;
 import com.tngtech.archunit.core.ResolvesTypesViaReflection;
@@ -36,13 +37,13 @@ public class JavaMethod extends JavaCodeUnit {
     private final Supplier<Method> methodSupplier;
     private final ThrowsClause<JavaMethod> throwsClause;
     private Supplier<Set<JavaMethodCall>> callsToSelf = Suppliers.ofInstance(Collections.<JavaMethodCall>emptySet());
-    private final Supplier<Optional<Object>> annotationDefaultValue;
+    private final Optional<Object> annotationDefaultValue;
 
-    JavaMethod(DomainBuilders.JavaMethodBuilder builder) {
+    JavaMethod(DomainBuilders.JavaMethodBuilder builder, Function<JavaMethod, Optional<Object>> createAnnotationDefaultValue) {
         super(builder);
         throwsClause = builder.getThrowsClause(this);
         methodSupplier = Suppliers.memoize(new ReflectMethodSupplier());
-        annotationDefaultValue = builder.getAnnotationDefaultValue();
+        annotationDefaultValue = createAnnotationDefaultValue.apply(this);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class JavaMethod extends JavaCodeUnit {
      */
     @PublicAPI(usage = ACCESS)
     public Optional<Object> getDefaultValue() {
-        return annotationDefaultValue.get();
+        return annotationDefaultValue;
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
@@ -19,6 +19,8 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
@@ -157,7 +159,24 @@ public interface CanBeAnnotated {
                 DescribedPredicate<? super JavaAnnotation<?>> predicate) {
 
             for (JavaAnnotation<?> annotation : annotations) {
-                if (annotation.getRawType().isAnnotatedWith(predicate) || annotation.getRawType().isMetaAnnotatedWith(predicate)) {
+                if (isMetaAnnotatedWith(annotation, predicate, new HashSet<String>())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static boolean isMetaAnnotatedWith(
+                JavaAnnotation<?> annotation,
+                DescribedPredicate<? super JavaAnnotation<?>> predicate,
+                Set<String> visitedAnnotations) {
+
+            if (!visitedAnnotations.add(annotation.getRawType().getName())) {
+                return false;
+            }
+
+            for (JavaAnnotation<?> metaAnnotation : annotation.getRawType().getAnnotations()) {
+                if (predicate.apply(metaAnnotation) || isMetaAnnotatedWith(metaAnnotation, predicate, visitedAnnotations)) {
                     return true;
                 }
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -140,6 +140,14 @@ class ClassFileImportRecord {
         return Optional.fromNullable(staticInitializerBuildersByOwner.get(ownerName));
     }
 
+    Set<String> getAnnotationTypeNamesFor(JavaClass owner) {
+        ImmutableSet.Builder<String> result = ImmutableSet.builder();
+        for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : annotationsByOwner.get(owner.getName())) {
+            result.add(annotationBuilder.getFullyQualifiedClassName());
+        }
+        return result.build();
+    }
+
     Set<DomainBuilders.JavaAnnotationBuilder> getAnnotationsFor(JavaClass owner) {
         return annotationsByOwner.get(owner.getName());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -113,8 +113,18 @@ class ClassFileProcessor {
         }
 
         @Override
-        public void onDeclaredAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders) {
-            importRecord.addAnnotations(ownerName, annotationBuilders);
+        public void onDeclaredClassAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders) {
+            importRecord.addClassAnnotations(ownerName, annotationBuilders);
+        }
+
+        @Override
+        public void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations) {
+            importRecord.addMemberAnnotations(ownerName, memberName, descriptor, annotations);
+        }
+
+        @Override
+        public void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, DomainBuilders.JavaAnnotationBuilder.ValueBuilder valueBuilder) {
+            importRecord.addAnnotationDefaultValue(ownerName, methodName, methodDescriptor, valueBuilder);
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -55,7 +55,6 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.TypeParametersBuilder;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 
-import static com.google.common.collect.Iterables.concat;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeClassHierarchy;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeEnclosingClass;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createJavaClasses;
@@ -156,7 +155,7 @@ class ClassGraphCreator implements ImportContext {
     private void completeAnnotations() {
         for (JavaClass javaClass : classes.getAllWithOuterClassesSortedBeforeInnerClasses()) {
             DomainObjectCreationContext.completeAnnotations(javaClass, this);
-            for (JavaMember member : concat(javaClass.getFields(), javaClass.getMethods(), javaClass.getConstructors())) {
+            for (JavaMember member : javaClass.getMembers()) {
                 memberDependenciesByTarget.registerAnnotations(member.getAnnotations());
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -162,14 +162,21 @@ class ClassGraphCreator implements ImportContext {
     }
 
     private void resolveAnnotationHierarchy(JavaClass javaClass) {
-        for (String annotationName : importRecord.getAnnotationTypeNamesFor(javaClass)) {
-            boolean hadBeenPreviouslyResolved = classes.isPresent(annotationName);
-            JavaClass annotationType = classes.getOrResolve(annotationName);
+        for (String annotationTypeName : getAnnotationTypeNamesToResolveFor(javaClass)) {
+            boolean hadBeenPreviouslyResolved = classes.isPresent(annotationTypeName);
+            JavaClass annotationType = classes.getOrResolve(annotationTypeName);
 
             if (!hadBeenPreviouslyResolved) {
                 resolveAnnotationHierarchy(annotationType);
             }
         }
+    }
+
+    private Set<String> getAnnotationTypeNamesToResolveFor(JavaClass javaClass) {
+        return ImmutableSet.<String>builder()
+                .addAll(importRecord.getAnnotationTypeNamesFor(javaClass))
+                .addAll(importRecord.getMemberAnnotationTypeNamesFor(javaClass))
+                .build();
     }
 
     private <T extends AccessRecord<?>, B extends RawAccessRecord> void tryProcess(

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -436,6 +436,10 @@ public final class DomainBuilders {
             return type;
         }
 
+        String getFullyQualifiedClassName() {
+            return type.getFullyQualifiedClassName();
+        }
+
         JavaAnnotationBuilder addProperty(String key, ValueBuilder valueBuilder) {
             values.put(key, valueBuilder);
             return this;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -481,16 +481,7 @@ public final class DomainBuilders {
                     result.put(entry.getKey(), value.get());
                 }
             }
-            addDefaultValues(result, importedClasses);
             return result.build();
-        }
-
-        private void addDefaultValues(ImmutableMap.Builder<String, Object> result, ClassesByTypeName importedClasses) {
-            for (JavaMethod method : importedClasses.get(type.getFullyQualifiedClassName()).getMethods()) {
-                if (!values.containsKey(method.getName()) && method.getDefaultValue().isPresent()) {
-                    result.put(method.getName(), method.getDefaultValue().get());
-                }
-            }
         }
 
         public <T extends HasDescription> JavaAnnotation<T> build(T owner, ClassesByTypeName importedClasses) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
@@ -61,6 +61,10 @@ class ImportedClasses {
         return javaClass;
     }
 
+    boolean isPresent(String typeName) {
+        return allClasses.containsKey(typeName);
+    }
+
     void ensurePresent(String typeName) {
         getOrResolve(typeName);
     }
@@ -90,5 +94,4 @@ class ImportedClasses {
             builder.withModifiers(PRIMITIVE_AND_ARRAY_TYPE_MODIFIERS);
         }
     }
-
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -531,7 +531,7 @@ class JavaClassProcessor extends ClassVisitor {
             return new AnnotationArrayProcessor(new AnnotationArrayContext() {
                 @Override
                 public String getDeclaringAnnotationTypeName() {
-                    return annotationBuilder.getTypeDescriptor().getFullyQualifiedClassName();
+                    return annotationBuilder.getFullyQualifiedClassName();
                 }
 
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -210,7 +210,7 @@ class JavaClassProcessor extends ClassVisitor {
                 .withModifiers(JavaModifier.getModifiersForField(access))
                 .withDescriptor(desc);
         declarationHandler.onDeclaredField(fieldBuilder);
-        return new FieldProcessor(fieldBuilder);
+        return new FieldProcessor(fieldBuilder, declarationHandler);
     }
 
     @Override
@@ -232,7 +232,7 @@ class JavaClassProcessor extends ClassVisitor {
                 .withDescriptor(desc)
                 .withThrowsClause(typesFrom(exceptions));
 
-        return new MethodProcessor(className, accessHandler, codeUnitBuilder);
+        return new MethodProcessor(className, accessHandler, codeUnitBuilder, declarationHandler);
     }
 
     private List<JavaClassDescriptor> typesFrom(String[] throwsDeclarations) {
@@ -276,7 +276,7 @@ class JavaClassProcessor extends ClassVisitor {
             return;
         }
 
-        declarationHandler.onDeclaredAnnotations(annotations);
+        declarationHandler.onDeclaredClassAnnotations(annotations);
         LOG.trace("Done analyzing {}", className);
     }
 
@@ -292,14 +292,16 @@ class JavaClassProcessor extends ClassVisitor {
         private final String declaringClassName;
         private final AccessHandler accessHandler;
         private final DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder;
+        private final DeclarationHandler declarationHandler;
         private final Set<DomainBuilders.JavaAnnotationBuilder> annotations = new HashSet<>();
         private int actualLineNumber;
 
-        MethodProcessor(String declaringClassName, AccessHandler accessHandler, DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder) {
+        MethodProcessor(String declaringClassName, AccessHandler accessHandler, DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder, DeclarationHandler declarationHandler) {
             super(ASM_API_VERSION);
             this.declaringClassName = declaringClassName;
             this.accessHandler = accessHandler;
             this.codeUnitBuilder = codeUnitBuilder;
+            this.declarationHandler = declarationHandler;
         }
 
         @Override
@@ -340,21 +342,23 @@ class JavaClassProcessor extends ClassVisitor {
 
         @Override
         public AnnotationVisitor visitAnnotationDefault() {
-            return new AnnotationDefaultProcessor(declaringClassName, codeUnitBuilder);
+            return new AnnotationDefaultProcessor(declaringClassName, codeUnitBuilder, declarationHandler);
         }
 
         @Override
         public void visitEnd() {
-            codeUnitBuilder.withAnnotations(annotations);
+            declarationHandler.onDeclaredMemberAnnotations(codeUnitBuilder.getName(), codeUnitBuilder.getDescriptor(), annotations);
         }
 
         private static class AnnotationDefaultProcessor extends AnnotationVisitor {
             private final String annotationTypeName;
+            private final DeclarationHandler declarationHandler;
             private final DomainBuilders.JavaMethodBuilder methodBuilder;
 
-            AnnotationDefaultProcessor(String annotationTypeName, DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder) {
+            AnnotationDefaultProcessor(String annotationTypeName, DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder, DeclarationHandler declarationHandler) {
                 super(ClassFileProcessor.ASM_API_VERSION);
                 this.annotationTypeName = annotationTypeName;
+                this.declarationHandler = declarationHandler;
                 checkArgument(codeUnitBuilder instanceof DomainBuilders.JavaMethodBuilder,
                         "tried to import annotation defaults for code unit '%s' that is not a method " +
                                 "(as any annotation.property() is assumed to be), " +
@@ -365,34 +369,35 @@ class JavaClassProcessor extends ClassVisitor {
 
             @Override
             public void visit(String name, Object value) {
-                methodBuilder.withAnnotationDefaultValue(AnnotationTypeConversion.convert(value));
+                declarationHandler.onDeclaredAnnotationDefaultValue(methodBuilder.getName(), methodBuilder.getDescriptor(), AnnotationTypeConversion.convert(value));
             }
 
             @Override
             public void visitEnum(String name, String desc, String value) {
-                methodBuilder.withAnnotationDefaultValue(javaEnumBuilder(desc, value));
+                declarationHandler.onDeclaredAnnotationDefaultValue(methodBuilder.getName(), methodBuilder.getDescriptor(), javaEnumBuilder(desc, value));
             }
 
             @Override
             public AnnotationVisitor visitAnnotation(String name, String desc) {
-                return new AnnotationProcessor(new SetAsAnnotationDefault(annotationTypeName, methodBuilder), annotationBuilderFor(desc));
+                return new AnnotationProcessor(new SetAsAnnotationDefault(annotationTypeName, methodBuilder, declarationHandler), annotationBuilderFor(desc));
             }
 
             @Override
             public AnnotationVisitor visitArray(String name) {
-                return new AnnotationArrayProcessor(new SetAsAnnotationDefault(annotationTypeName, methodBuilder));
+                return new AnnotationArrayProcessor(new SetAsAnnotationDefault(annotationTypeName, methodBuilder, declarationHandler));
             }
-
         }
     }
 
     private static class SetAsAnnotationDefault implements TakesAnnotationBuilder, AnnotationArrayContext {
         private final String annotationTypeName;
         private final DomainBuilders.JavaMethodBuilder methodBuilder;
+        private final DeclarationHandler declarationHandler;
 
-        private SetAsAnnotationDefault(String annotationTypeName, DomainBuilders.JavaMethodBuilder methodBuilder) {
+        private SetAsAnnotationDefault(String annotationTypeName, DomainBuilders.JavaMethodBuilder methodBuilder, DeclarationHandler declarationHandler) {
             this.annotationTypeName = annotationTypeName;
             this.methodBuilder = methodBuilder;
+            this.declarationHandler = declarationHandler;
         }
 
         @Override
@@ -412,7 +417,7 @@ class JavaClassProcessor extends ClassVisitor {
 
         @Override
         public void setArrayResult(ValueBuilder valueBuilder) {
-            methodBuilder.withAnnotationDefaultValue(valueBuilder);
+            declarationHandler.onDeclaredAnnotationDefaultValue(methodBuilder.getName(), methodBuilder.getDescriptor(), valueBuilder);
         }
     }
 
@@ -431,7 +436,11 @@ class JavaClassProcessor extends ClassVisitor {
 
         void onDeclaredStaticInitializer(DomainBuilders.JavaStaticInitializerBuilder staticInitializerBuilder);
 
-        void onDeclaredAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders);
+        void onDeclaredClassAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders);
+
+        void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations);
+
+        void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, ValueBuilder valueBuilder);
 
         void registerEnclosingClass(String ownerName, String enclosingClassName);
     }
@@ -467,12 +476,14 @@ class JavaClassProcessor extends ClassVisitor {
 
     private static class FieldProcessor extends FieldVisitor {
         private final DomainBuilders.JavaFieldBuilder fieldBuilder;
+        private final DeclarationHandler declarationHandler;
         private final Set<DomainBuilders.JavaAnnotationBuilder> annotations = new HashSet<>();
 
-        private FieldProcessor(DomainBuilders.JavaFieldBuilder fieldBuilder) {
+        private FieldProcessor(DomainBuilders.JavaFieldBuilder fieldBuilder, DeclarationHandler declarationHandler) {
             super(ASM_API_VERSION);
 
             this.fieldBuilder = fieldBuilder;
+            this.declarationHandler = declarationHandler;
         }
 
         @Override
@@ -482,7 +493,7 @@ class JavaClassProcessor extends ClassVisitor {
 
         @Override
         public void visitEnd() {
-            fieldBuilder.withAnnotations(annotations);
+            declarationHandler.onDeclaredMemberAnnotations(fieldBuilder.getName(), fieldBuilder.getDescriptor(), annotations);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AnnotationProxyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AnnotationProxyTest.java
@@ -14,15 +14,12 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
 import com.tngtech.archunit.core.InitialConfiguration;
-import com.tngtech.archunit.core.importer.ImportTestUtils;
-import com.tngtech.archunit.core.importer.JavaAnnotationTestBuilder;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.assertj.core.api.Condition;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static com.tngtech.archunit.core.domain.TestUtils.javaAnnotationFrom;
-import static com.tngtech.archunit.core.domain.TestUtils.simpleImportedClasses;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnnotationProxyTest {
@@ -31,14 +28,14 @@ public class AnnotationProxyTest {
 
     @Test
     public void annotation_type_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.annotationType()).isEqualTo(TestAnnotation.class);
     }
 
     @Test
     public void primitive_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.primitive())
                 .as(annotation.annotationType().getSimpleName() + ".primitive()")
@@ -47,7 +44,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void primitive_default_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.primitiveWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".primitiveWithDefault()")
@@ -56,7 +53,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void primitives_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.primitives())
                 .as(annotation.annotationType().getSimpleName() + ".primitives()")
@@ -65,7 +62,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void primitives_defaults_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.primitivesWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".primitivesWithDefault()")
@@ -74,7 +71,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void string_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.string())
                 .as(annotation.annotationType().getSimpleName() + ".string()")
@@ -83,7 +80,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void string_default_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.stringWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".stringWithDefault()")
@@ -92,7 +89,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void strings_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.strings())
                 .as(annotation.annotationType().getSimpleName() + ".strings()")
@@ -101,7 +98,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void strings_default_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.stringsWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".stringsWithDefault()")
@@ -110,7 +107,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void type_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.type())
                 .as(annotation.annotationType().getSimpleName() + ".type()")
@@ -119,7 +116,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void type_default_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.typeWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".typeWithDefault()")
@@ -128,7 +125,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void types_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.types())
                 .as(annotation.annotationType().getSimpleName() + ".types()")
@@ -137,7 +134,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void types_default_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.typesWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".typesWithDefault()")
@@ -146,7 +143,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void enumConstant_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.enumConstant())
                 .as(annotation.annotationType().getSimpleName() + ".enumConstant()")
@@ -155,7 +152,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void enumConstant_default_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.enumConstantWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".enumConstantWithDefault()")
@@ -164,7 +161,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void enumConstants_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.enumConstants())
                 .as(annotation.annotationType().getSimpleName() + ".enumConstants()")
@@ -173,7 +170,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void enumConstants_default_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.enumConstantsWithDefault())
                 .as(annotation.annotationType().getSimpleName() + ".enumConstantsWithDefault()")
@@ -182,7 +179,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void subAnnotation_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.subAnnotation().value())
                 .as(annotation.annotationType().getSimpleName() + ".subAnnotation().value()")
@@ -191,7 +188,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void subAnnotation_default_is_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation.subAnnotationWithDefault().value())
                 .as(annotation.annotationType().getSimpleName() + ".subAnnotationWithDefault().value()")
@@ -200,7 +197,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void subAnnotations_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(valuesOf(annotation.subAnnotations()))
                 .as(annotation.annotationType().getSimpleName() + ".subAnnotations()*.value()")
@@ -209,7 +206,7 @@ public class AnnotationProxyTest {
 
     @Test
     public void subAnnotations_default_are_returned() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(valuesOf(annotation.subAnnotationsWithDefault()))
                 .as(annotation.annotationType().getSimpleName() + ".subAnnotationsWithDefault()*.value()")
@@ -219,7 +216,7 @@ public class AnnotationProxyTest {
     @Test
     // NOTE: For now we'll just implement reference equality and hashcode of the proxy object
     public void equals_hashcode_and_toString() {
-        TestAnnotation annotation = getProxyFor(TestAnnotation.class);
+        TestAnnotation annotation = importAnnotation(ClassWithTestAnnotation.class, TestAnnotation.class);
 
         assertThat(annotation).isEqualTo(annotation);
         assertThat(annotation.hashCode()).isEqualTo(annotation.hashCode());
@@ -228,7 +225,8 @@ public class AnnotationProxyTest {
 
     @Test
     public void wrong_annotation_type_is_rejected() {
-        JavaAnnotation<?> mismatch = javaAnnotationFrom(TestAnnotation.class.getAnnotation(Retention.class), getClass());
+        JavaAnnotation<?> mismatch = new ClassFileImporter().importClasses(TestAnnotation.class, Retention.class)
+                .get(TestAnnotation.class).getAnnotationOfType(Retention.class.getName());
 
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage(Retention.class.getSimpleName());
@@ -239,15 +237,8 @@ public class AnnotationProxyTest {
 
     @Test
     public void array_is_converted_to_the_correct_type() {
-        ImportTestUtils.ImportedTestClasses importedClasses = simpleImportedClasses();
-        JavaAnnotation<?> annotation = new JavaAnnotationTestBuilder()
-                .withType(JavaClassDescriptor.From.name(TestAnnotation.class.getName()))
-                .addProperty("types", new Object[0])
-                .addProperty("enumConstants", new Object[0])
-                .addProperty("subAnnotations", new Object[0])
-                .build(importedClasses.get(getClass().getName()), importedClasses);
+        TestAnnotation reflected = importAnnotation(ClassWithTestAnnotationWithEmptyArrays.class, TestAnnotation.class);
 
-        TestAnnotation reflected = annotation.as(TestAnnotation.class);
         assertThat(reflected.types()).isEmpty();
         assertThat(reflected.enumConstants()).isEmpty();
         assertThat(reflected.subAnnotations()).isEmpty();
@@ -285,7 +276,7 @@ public class AnnotationProxyTest {
                                 subAnnotationFormatter(formatter, "defaultOne"),
                                 subAnnotationFormatter(formatter, "defaultTwo")}))
                 .build();
-        ensureInSync(Irrelevant.class.getAnnotation(type), result);
+        ensureInSync(ClassWithTestAnnotation.class.getAnnotation(type), result);
         return result;
     }
 
@@ -373,7 +364,21 @@ public class AnnotationProxyTest {
             enumConstants = {TestEnum.SECOND, TestEnum.THIRD},
             subAnnotation = @SubAnnotation("custom"),
             subAnnotations = {@SubAnnotation("customOne"), @SubAnnotation("customTwo")})
-    private static class Irrelevant {
+    private static class ClassWithTestAnnotation {
+    }
+
+    @TestAnnotation(
+            primitive = 0,
+            primitives = {},
+            string = "",
+            strings = {},
+            type = TestAnnotation.class,
+            types = {},
+            enumConstant = TestEnum.SECOND,
+            enumConstants = {},
+            subAnnotation = @SubAnnotation(""),
+            subAnnotations = {})
+    private static class ClassWithTestAnnotationWithEmptyArrays {
     }
 
     private void ensureInSync(TestAnnotation annotation, Map<String, String> result) {
@@ -422,8 +427,7 @@ public class AnnotationProxyTest {
         };
     }
 
-    private <A extends Annotation> A getProxyFor(Class<A> annotationType) {
-        JavaAnnotation<?> toProxy = javaAnnotationFrom(Irrelevant.class.getAnnotation(annotationType), Irrelevant.class);
-        return AnnotationProxy.of(annotationType, toProxy);
+    private <A extends Annotation> A importAnnotation(Class<?> ownerType, Class<A> annotationType) {
+        return new ClassFileImporter().importClasses(ownerType, annotationType).get(ownerType).getAnnotationOfType(annotationType);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -297,6 +297,17 @@ public class JavaClassTest {
     }
 
     @Test
+    public void isMetaAnnotatedWith_correctly_resolves_cyclic_annotations() {
+        JavaClass javaClass = importClasses(ClassWithCyclicMetaAnnotation.class,
+                AnnotationWithCyclicAnnotation.class, MetaAnnotationWithCyclicAnnotation.class,
+                Retention.class).get(ClassWithCyclicMetaAnnotation.class);
+
+        assertThat(javaClass.isMetaAnnotatedWith(Deprecated.class)).isFalse();
+        assertThat(javaClass.isMetaAnnotatedWith(Retention.class)).isTrue();
+        assertThat(javaClass.isMetaAnnotatedWith(MetaAnnotationWithCyclicAnnotation.class)).isTrue();
+    }
+
+    @Test
     public void allAccesses_contains_accesses_from_superclass() {
         JavaClass javaClass = importClasses(ClassWithTwoFieldsAndTwoMethods.class, SuperClassWithFieldAndMethod.class, Parent.class)
                 .get(ClassWithTwoFieldsAndTwoMethods.class);
@@ -1481,6 +1492,20 @@ public class JavaClassTest {
 
     enum SomeEnumAsAnnotationArrayParameter {
         ANNOTATION_ARRAY_PARAMETER
+    }
+
+    @AnnotationWithCyclicAnnotation
+    @Retention(RUNTIME)
+    @interface MetaAnnotationWithCyclicAnnotation {
+    }
+
+    @AnnotationWithCyclicAnnotation
+    @MetaAnnotationWithCyclicAnnotation
+    @interface AnnotationWithCyclicAnnotation {
+    }
+
+    @AnnotationWithCyclicAnnotation
+    private static class ClassWithCyclicMetaAnnotation {
     }
 
     @SuppressWarnings("ALL")

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -127,6 +127,7 @@ public class JavaClassTest {
 
     @Test
     public void finds_component_type_chain_of_otherwise_unreferenced_component_type() {
+        @SuppressWarnings("unused")
         class OnlyReferencingMultiDimArray {
             OnlyReferencingMultiDimArray[][][] field;
         }
@@ -517,8 +518,11 @@ public class JavaClassTest {
                 List.class, Serializable.class, SomeSuperClass.class,
                 WithType.class, WithNestedAnnotations.class, OnClass.class, OnMethod.class,
                 OnConstructor.class, OnField.class, MetaAnnotated.class, WithEnum.class, WithPrimitive.class,
+                WithOtherEnum.class, WithOtherType.class,
                 SomeEnumAsAnnotationParameter.class, SomeEnumAsAnnotationArrayParameter.class,
-                SomeEnumAsNestedAnnotationParameter.class, SomeEnumAsDefaultParameter.class);
+                SomeEnumAsNestedAnnotationParameter.class, SomeEnumAsDefaultParameter.class,
+                SomeOtherEnumAsAnnotationParameter.class, SomeOtherEnumAsDefaultParameter.class,
+                SomeOtherEnumAsAnnotationArrayParameter.class, SomeTypeAsDefaultParameter.class);
     }
 
     @Test
@@ -1071,7 +1075,7 @@ public class JavaClassTest {
 
         private class Step2 {
             private final Class<?> origin;
-            private String originDescription;
+            private final String originDescription;
 
             Step2(Class<?> origin) {
                 this.origin = origin;
@@ -1197,7 +1201,7 @@ public class JavaClassTest {
         }
 
         private class Evaluation<SELF> {
-            private List<AbstractBooleanAssert<?>> assignableAssertion = new ArrayList<>();
+            private final List<AbstractBooleanAssert<?>> assignableAssertion = new ArrayList<>();
 
             private final Set<Class<?>> additionalTypes = new HashSet<>();
 
@@ -1293,6 +1297,7 @@ public class JavaClassTest {
     }
 
     static class ClassWithInnerClass {
+        @SuppressWarnings("InnerClassMayBeStatic")
         class Inner {
         }
     }
@@ -1379,6 +1384,7 @@ public class JavaClassTest {
             };
         }
 
+        @SuppressWarnings("InnerClassMayBeStatic")
         private class NamedInnerClass {
             private class NestedNamedInnerClass {
             }
@@ -1395,13 +1401,15 @@ public class JavaClassTest {
             nested = {
                     @WithType(type = B.class)
             },
+            typeWithDefaults = @WithOtherType,
             withEnum = @WithEnum(
                     someEnum = SomeEnumAsNestedAnnotationParameter.NESTED_ANNOTATION_PARAMETER,
                     enumArray = {SomeEnumAsAnnotationArrayParameter.ANNOTATION_ARRAY_PARAMETER}
             )
     )
     @MetaAnnotated
-    public static class ClassWithAnnotationDependencies extends SomeSuperClass {
+    @SuppressWarnings("unused")
+    private static class ClassWithAnnotationDependencies extends SomeSuperClass {
         @OnField(SomeEnumAsAnnotationParameter.ANNOTATION_PARAMETER)
         Object field;
 
@@ -1418,48 +1426,62 @@ public class JavaClassTest {
         }
     }
 
-    @interface OnClass {
+    private @interface OnClass {
     }
 
-    @interface OnField {
+    private @interface OnField {
         SomeEnumAsAnnotationParameter value();
     }
 
-    @interface OnConstructor {
+    private @interface OnConstructor {
     }
 
-    @interface OnMethod {
+    private @interface OnMethod {
     }
 
     @WithType(type = B.class)
-    @interface OnMethodParam {
+    private @interface OnMethodParam {
     }
 
     @Retention(RUNTIME)
-    @interface WithType {
+    private @interface WithType {
         Class<?> type();
     }
 
+    @SuppressWarnings("unused")
     @Retention(RUNTIME)
-    @interface WithNestedAnnotations {
+    private @interface WithOtherType {
+        Class<?> typeWithDefault() default SomeTypeAsDefaultParameter.class;
+    }
+
+    @SuppressWarnings("unused")
+    @Retention(RUNTIME)
+    private @interface WithNestedAnnotations {
         Class<?> outerType();
 
         WithType[] nested();
 
+        WithOtherType typeWithDefaults();
+
         WithEnum withEnum();
+
+        WithOtherEnum annotationWithDefault() default @WithOtherEnum(
+                someEnum = SomeOtherEnumAsAnnotationParameter.OTHER_ANNOTATION_PARAMETER,
+                enumArray = {SomeOtherEnumAsAnnotationArrayParameter.OTHER_ANNOTATION_ARRAY_PARAMETER, SomeOtherEnumAsAnnotationArrayParameter.OTHER_ANNOTATION_ARRAY_PARAMETER});
     }
 
     @Retention(RUNTIME)
     @MetaAnnotation
-    @interface MetaAnnotation {
+    private @interface MetaAnnotation {
     }
 
     @Retention(RUNTIME)
     @MetaAnnotation
-    @interface MetaAnnotated {
+    private @interface MetaAnnotated {
     }
 
-    @interface WithEnum {
+    @SuppressWarnings("unused")
+    private @interface WithEnum {
         SomeEnumAsDefaultParameter enumWithDefault() default SomeEnumAsDefaultParameter.DEFAULT_PARAMETER;
 
         SomeEnumAsNestedAnnotationParameter someEnum();
@@ -1467,8 +1489,17 @@ public class JavaClassTest {
         SomeEnumAsAnnotationArrayParameter[] enumArray();
     }
 
+    @SuppressWarnings("unused")
+    private @interface WithOtherEnum {
+        SomeOtherEnumAsDefaultParameter enumWithDefault() default SomeOtherEnumAsDefaultParameter.OTHER_DEFAULT_PARAMETER;
+
+        SomeOtherEnumAsAnnotationParameter someEnum();
+
+        SomeOtherEnumAsAnnotationArrayParameter[] enumArray();
+    }
+
     @Retention(RUNTIME)
-    @interface WithPrimitive {
+    private @interface WithPrimitive {
         int someInt();
 
         int[] someInts();
@@ -1478,30 +1509,45 @@ public class JavaClassTest {
         String[] someStrings();
     }
 
-    enum SomeEnumAsAnnotationParameter {
+    private enum SomeEnumAsAnnotationParameter {
         ANNOTATION_PARAMETER
     }
 
-    enum SomeEnumAsNestedAnnotationParameter {
+    private enum SomeOtherEnumAsAnnotationParameter {
+        OTHER_ANNOTATION_PARAMETER
+    }
+
+    private enum SomeEnumAsNestedAnnotationParameter {
         NESTED_ANNOTATION_PARAMETER
     }
 
-    enum SomeEnumAsDefaultParameter {
+    private enum SomeEnumAsDefaultParameter {
         DEFAULT_PARAMETER
     }
 
-    enum SomeEnumAsAnnotationArrayParameter {
+    private enum SomeOtherEnumAsDefaultParameter {
+        OTHER_DEFAULT_PARAMETER
+    }
+
+    private enum SomeEnumAsAnnotationArrayParameter {
         ANNOTATION_ARRAY_PARAMETER
+    }
+
+    private enum SomeOtherEnumAsAnnotationArrayParameter {
+        OTHER_ANNOTATION_ARRAY_PARAMETER
+    }
+
+    private static class SomeTypeAsDefaultParameter {
     }
 
     @AnnotationWithCyclicAnnotation
     @Retention(RUNTIME)
-    @interface MetaAnnotationWithCyclicAnnotation {
+    private @interface MetaAnnotationWithCyclicAnnotation {
     }
 
     @AnnotationWithCyclicAnnotation
     @MetaAnnotationWithCyclicAnnotation
-    @interface AnnotationWithCyclicAnnotation {
+    private @interface AnnotationWithCyclicAnnotation {
     }
 
     @AnnotationWithCyclicAnnotation

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -2,7 +2,6 @@ package com.tngtech.archunit.core.domain;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,7 +21,6 @@ import com.tngtech.archunit.core.domain.Source.Md5sum;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.ImportTestUtils;
-import com.tngtech.archunit.core.importer.ImportTestUtils.ImportedTestClasses;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
@@ -131,14 +129,6 @@ public class TestUtils {
             result.add(javaClass.reflect());
         }
         return result.toArray(new Class<?>[0]);
-    }
-
-    static ImportedTestClasses simpleImportedClasses() {
-        return ImportTestUtils.simpleImportedClasses();
-    }
-
-    static JavaAnnotation<?> javaAnnotationFrom(Annotation annotation, Class<?> annotatedClass) {
-        return ImportTestUtils.javaAnnotationFrom(annotation, annotatedClass);
     }
 
     public static FieldAccessTarget targetFrom(JavaField javaField) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -34,7 +34,10 @@ public class ClassFileImporterAnnotationsTest {
     @DataProvider
     public static Object[][] elementsAnnotatedWithSomeAnnotation() {
         return testForEach(
-                new ClassFileImporter().importClass(MetaAnnotatedClass.class)
+                new ClassFileImporter().importClass(MetaAnnotatedClass.class),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedField.class).getField("metaAnnotatedField"),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedMethod.class).getMethod("metaAnnotatedMethod"),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedConstructor.class).getConstructor()
         );
     }
 
@@ -136,6 +139,26 @@ public class ClassFileImporterAnnotationsTest {
 
     @SomeAnnotation
     private static class MetaAnnotatedClass {
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedField {
+        @SomeAnnotation
+        int metaAnnotatedField;
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedMethod {
+        @SomeAnnotation
+        void metaAnnotatedMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedConstructor {
+        @SomeAnnotation
+        ClassWithMetaAnnotatedConstructor() {
+        }
     }
 
     private static class SomeMetaMetaMetaAnnotationClassParameter {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -1,0 +1,155 @@
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.properties.HasAnnotations;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotation;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion.annotationProperty;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterAnnotationsTest {
+
+    @Test
+    public void meta_annotation_types_are_transitively_imported() {
+        JavaClass javaClass = new ClassFileImporter().importClass(MetaAnnotatedClass.class);
+        JavaAnnotation<JavaClass> someAnnotation = javaClass.getAnnotationOfType(SomeAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaAnnotation = someAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaMetaAnnotation = someMetaAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaMetaAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaMetaMetaAnnotation = someMetaMetaAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
+
+        assertThatType(someMetaMetaMetaAnnotation.getType()).matches(SomeMetaMetaMetaAnnotationWithParameters.class);
+    }
+
+    @DataProvider
+    public static Object[][] elementsAnnotatedWithSomeAnnotation() {
+        return testForEach(
+                new ClassFileImporter().importClass(MetaAnnotatedClass.class)
+        );
+    }
+
+    @Test
+    @UseDataProvider("elementsAnnotatedWithSomeAnnotation")
+    public void parameters_of_meta_annotations_are_transitively_imported(HasAnnotations<?> annotatedWithSomeAnnotation) {
+        JavaAnnotation<?> someAnnotation = annotatedWithSomeAnnotation
+                .getAnnotationOfType(SomeAnnotation.class.getName());
+        JavaAnnotation<?> metaAnnotationWithParameters = someAnnotation.getRawType()
+                .getAnnotationOfType(MetaAnnotationWithParameters.class.getName());
+
+        assertThatAnnotation(metaAnnotationWithParameters)
+                .hasEnumProperty("someEnum", SomeEnum.CONSTANT)
+                .hasEnumProperty("someEnumDefault", SomeEnum.VARIABLE)
+                .hasAnnotationProperty("parameterAnnotation",
+                        annotationProperty()
+                                .withAnnotationType(ParameterAnnotation.class)
+                                .withClassProperty("value", SomeAnnotationParameterType.class))
+                .hasAnnotationProperty("parameterAnnotationDefault",
+                        annotationProperty()
+                                .withAnnotationType(ParameterAnnotation.class)
+                                .withClassProperty("value", Integer.class));
+
+        JavaAnnotation<JavaClass> metaMetaMetaAnnotation = someAnnotation
+                .getRawType().getAnnotationOfType(SomeMetaAnnotation.class.getName())
+                .getRawType().getAnnotationOfType(SomeMetaMetaAnnotation.class.getName())
+                .getRawType().getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
+
+        assertThatAnnotation(metaMetaMetaAnnotation)
+                .hasClassProperty("classParam", SomeMetaMetaMetaAnnotationClassParameter.class)
+                .hasClassProperty("classParamDefault", String.class)
+                .hasEnumProperty("enumParam", SomeMetaMetaMetaAnnotationEnumParameter.VALUE)
+                .hasEnumProperty("enumParamDefault", SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT)
+                .hasAnnotationProperty("annotationParam",
+                        annotationProperty()
+                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class)
+                                .withClassProperty("value", SomeMetaMetaMetaParameterAnnotationClassParameter.class))
+                .hasAnnotationProperty("annotationParamDefault",
+                        annotationProperty()
+                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class));
+    }
+
+    @SuppressWarnings("unused")
+    private @interface MetaAnnotationWithParameters {
+        SomeEnum someEnum();
+
+        SomeEnum someEnumDefault() default SomeEnum.VARIABLE;
+
+        ParameterAnnotation parameterAnnotation();
+
+        ParameterAnnotation parameterAnnotationDefault() default @ParameterAnnotation(Integer.class);
+    }
+
+    private @interface SomeMetaMetaMetaAnnotationWithParameters {
+        Class<?> classParam();
+
+        Class<?> classParamDefault() default String.class;
+
+        SomeMetaMetaMetaAnnotationEnumParameter enumParam();
+
+        SomeMetaMetaMetaAnnotationEnumParameter enumParamDefault() default SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT;
+
+        SomeMetaMetaMetaParameterAnnotation annotationParam();
+
+        SomeMetaMetaMetaParameterAnnotation annotationParamDefault() default @SomeMetaMetaMetaParameterAnnotation(Boolean.class);
+    }
+
+    @SomeMetaMetaMetaAnnotationWithParameters(
+            classParam = SomeMetaMetaMetaAnnotationClassParameter.class,
+            enumParam = SomeMetaMetaMetaAnnotationEnumParameter.VALUE,
+            annotationParam = @SomeMetaMetaMetaParameterAnnotation(SomeMetaMetaMetaParameterAnnotationClassParameter.class)
+    )
+    private @interface SomeMetaMetaAnnotation {
+    }
+
+    @SomeMetaMetaAnnotation
+    private @interface SomeMetaAnnotation {
+    }
+
+    @MetaAnnotationWithParameters(
+            someEnum = SomeEnum.CONSTANT,
+            parameterAnnotation = @ParameterAnnotation(SomeAnnotationParameterType.class)
+    )
+    @SomeMetaAnnotation
+    private @interface SomeAnnotation {
+    }
+
+    private enum SomeEnum {
+        CONSTANT,
+        VARIABLE
+    }
+
+    private @interface ParameterAnnotation {
+        Class<?> value();
+    }
+
+    private static class SomeAnnotationParameterType {
+    }
+
+    @SomeAnnotation
+    private static class MetaAnnotatedClass {
+    }
+
+    private static class SomeMetaMetaMetaAnnotationClassParameter {
+    }
+
+    private enum SomeMetaMetaMetaAnnotationEnumParameter {
+        VALUE,
+        CONSTANT
+    }
+
+    private @interface SomeMetaMetaMetaParameterAnnotation {
+        Class<?> value();
+    }
+
+    private static class SomeMetaMetaMetaParameterAnnotationClassParameter {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -165,6 +165,7 @@ import com.tngtech.archunit.core.importer.testexamples.pathone.Class11;
 import com.tngtech.archunit.core.importer.testexamples.pathone.Class12;
 import com.tngtech.archunit.core.importer.testexamples.pathtwo.Class21;
 import com.tngtech.archunit.core.importer.testexamples.pathtwo.Class22;
+import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationParameter;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationToImport;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.ClassToImportOne;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.ClassToImportTwo;
@@ -250,7 +251,12 @@ public class ClassFileImporterTest {
     @Test
     public void imports_simple_package() throws Exception {
         Set<String> expectedClassNames = Sets.newHashSet(
-                ClassToImportOne.class.getName(), ClassToImportTwo.class.getName(), InterfaceToImport.class.getName(), EnumToImport.class.getName(), AnnotationToImport.class.getName());
+                ClassToImportOne.class.getName(),
+                ClassToImportTwo.class.getName(),
+                InterfaceToImport.class.getName(),
+                EnumToImport.class.getName(),
+                AnnotationToImport.class.getName(),
+                AnnotationParameter.class.getName());
 
         Iterable<JavaClass> classes = classesIn("testexamples/simpleimport");
 
@@ -321,7 +327,7 @@ public class ClassFileImporterTest {
         assertThat(getAnnotationDefaultValue(javaClass, "someStringMethod", String.class)).isEqualTo("DEFAULT");
         assertThatType(getAnnotationDefaultValue(javaClass, "someTypeMethod", JavaClass.class)).matches(List.class);
         assertThat(getAnnotationDefaultValue(javaClass, "someEnumMethod", JavaEnumConstant.class)).isEquivalentTo(EnumToImport.SECOND);
-        assertThatType(getAnnotationDefaultValue(javaClass, "someAnnotationMethod", JavaAnnotation.class).getRawType()).matches(Deprecated.class);
+        assertThatType(getAnnotationDefaultValue(javaClass, "someAnnotationMethod", JavaAnnotation.class).getRawType()).matches(AnnotationParameter.class);
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -708,8 +708,7 @@ public class ClassFileImporterTest {
                 .getAnnotationOfType(SomeAnnotation.class.getName());
 
         assertThat(annotation.get("mandatory")).contains("mandatory");
-        // NOTE: If we haven't imported the annotation itself, the import can't determine default values
-        assertThat(annotation.get("optional")).isAbsent();
+        assertThat(annotation.get("optional")).contains("optional");
 
         SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
         assertThat(reflected.mandatory()).isEqualTo("mandatory");
@@ -902,8 +901,7 @@ public class ClassFileImporterTest {
                 .getAnnotationOfType(SomeAnnotation.class.getName());
 
         assertThat(annotation.get("mandatory")).contains("mandatory");
-        // NOTE: If we haven't imported the annotation itself, the import can't determine default values
-        assertThat(annotation.get("optional")).isAbsent();
+        assertThat(annotation.get("optional")).contains("optional");
 
         SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
         assertThat(reflected.mandatory()).isEqualTo("mandatory");

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -992,10 +992,9 @@ public class ClassFileImporterTest {
         JavaAnnotation<?> annotation = clazz.getAnnotationOfType(SomeAnnotation.class.getName());
 
         assertThat(annotation.get("mandatory")).contains("mandatory");
-        // NOTE: If we haven't imported the annotation itself, the import can't determine default values
-        assertThat(annotation.get("optional")).isAbsent();
+        assertThat(annotation.get("optional")).contains("optional");
         assertThat((JavaEnumConstant) annotation.get("mandatoryEnum").get()).isEquivalentTo(SOME_VALUE);
-        assertThat(annotation.get("optionalEnum")).isAbsent();
+        assertThat((JavaEnumConstant) annotation.get("optionalEnum").get()).isEquivalentTo(OTHER_VALUE);
 
         SomeAnnotation reflected = clazz.getAnnotationOfType(SomeAnnotation.class);
         assertThat(reflected.mandatory()).isEqualTo("mandatory");

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -34,6 +34,7 @@ import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -48,33 +49,30 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 public class ImportTestUtils {
 
     private static Set<JavaConstructor> createConstructors(JavaClass owner, Class<?> inputClass, ClassesByTypeName importedClasses) {
-        return finish(constructorBuildersFor(inputClass, importedClasses), owner, importedClasses);
+        return finish(constructorBuildersFor(inputClass), owner, importedClasses);
     }
 
     private static Set<JavaMethod> createMethods(JavaClass owner, Class<?> inputClass, ClassesByTypeName importedClasses) {
-        return finish(methodBuildersFor(inputClass, importedClasses), owner, importedClasses);
+        return finish(methodBuildersFor(inputClass), owner, importedClasses);
     }
 
     private static Set<JavaField> createFields(JavaClass owner, Class<?> inputClass, ClassesByTypeName importedClasses) {
-        return finish(fieldBuildersFor(inputClass, importedClasses), owner, importedClasses);
+        return finish(fieldBuildersFor(inputClass), owner, importedClasses);
     }
 
-    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaField>> fieldBuildersFor(Class<?> inputClass,
-            ClassesByTypeName importedClasses) {
+    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaField>> fieldBuildersFor(Class<?> inputClass) {
         final Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaField>> fieldBuilders = new HashSet<>();
         for (Field field : inputClass.getDeclaredFields()) {
             fieldBuilders.add(new DomainBuilders.JavaFieldBuilder()
                     .withName(field.getName())
                     .withDescriptor(Type.getDescriptor(field.getType()))
-                    .withAnnotations(javaAnnotationBuildersFrom(field.getAnnotations(), inputClass, importedClasses))
                     .withModifiers(JavaModifier.getModifiersForField(field.getModifiers()))
                     .withType(JavaClassDescriptor.From.name(field.getType().getName())));
         }
         return fieldBuilders;
     }
 
-    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaMethod>> methodBuildersFor(Class<?> inputClass,
-            ClassesByTypeName importedClasses) {
+    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaMethod>> methodBuildersFor(Class<?> inputClass) {
         final Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaMethod>> methodBuilders = new HashSet<>();
         for (Method method : inputClass.getDeclaredMethods()) {
             methodBuilders.add(new DomainBuilders.JavaMethodBuilder()
@@ -82,15 +80,13 @@ public class ImportTestUtils {
                     .withParameters(typesFrom(method.getParameterTypes()))
                     .withName(method.getName())
                     .withDescriptor(Type.getMethodDescriptor(method))
-                    .withAnnotations(javaAnnotationBuildersFrom(method.getAnnotations(), inputClass, importedClasses))
                     .withModifiers(JavaModifier.getModifiersForMethod(method.getModifiers()))
                     .withThrowsClause(typesFrom(method.getExceptionTypes())));
         }
         return methodBuilders;
     }
 
-    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaConstructor>> constructorBuildersFor(Class<?> inputClass,
-            ClassesByTypeName importedClasses) {
+    private static Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaConstructor>> constructorBuildersFor(Class<?> inputClass) {
         final Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaConstructor>> constructorBuilders = new HashSet<>();
         for (Constructor<?> constructor : inputClass.getDeclaredConstructors()) {
             constructorBuilders.add(new DomainBuilders.JavaConstructorBuilder()
@@ -98,7 +94,6 @@ public class ImportTestUtils {
                     .withParameters(typesFrom(constructor.getParameterTypes()))
                     .withName(CONSTRUCTOR_NAME)
                     .withDescriptor(Type.getConstructorDescriptor(constructor))
-                    .withAnnotations(javaAnnotationBuildersFrom(constructor.getAnnotations(), inputClass, importedClasses))
                     .withModifiers(JavaModifier.getModifiersForMethod(constructor.getModifiers()))
                     .withThrowsClause(typesFrom(constructor.getExceptionTypes())));
         }
@@ -110,15 +105,6 @@ public class ImportTestUtils {
         ImmutableSet.Builder<T> result = ImmutableSet.builder();
         for (DomainBuilders.BuilderWithBuildParameter<JavaClass, T> builder : builders) {
             result.add(builder.build(owner, importedClasses));
-        }
-        return result.build();
-    }
-
-    private static Set<DomainBuilders.JavaAnnotationBuilder> javaAnnotationBuildersFrom(Annotation[] reflectionAnnotations,
-            Class<?> annotatedClass, ClassesByTypeName importedClasses) {
-        ImmutableSet.Builder<DomainBuilders.JavaAnnotationBuilder> result = ImmutableSet.builder();
-        for (Annotation annotation : reflectionAnnotations) {
-            result.add(javaAnnotationBuilderFrom(annotation, annotatedClass, importedClasses));
         }
         return result.build();
     }
@@ -384,6 +370,11 @@ public class ImportTestUtils {
 
         @Override
         public Map<String, JavaAnnotation<JavaClass>> createAnnotations(JavaClass owner) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, JavaAnnotation<JavaMember>> createAnnotations(JavaMember owner) {
             return Collections.emptyMap();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/JavaAnnotationTestBuilder.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/JavaAnnotationTestBuilder.java
@@ -1,5 +1,6 @@
 package com.tngtech.archunit.core.importer;
 
+import com.tngtech.archunit.core.domain.ImportContext;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
@@ -19,7 +20,7 @@ public class JavaAnnotationTestBuilder {
         return this;
     }
 
-    public JavaAnnotation<?> build(JavaClass owner, ClassesByTypeName byTypeName) {
-        return delegate.build(owner, byTypeName);
+    public JavaAnnotation<?> build(JavaClass owner, ImportContext importContext) {
+        return delegate.build(owner, importContext);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationParameter.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationParameter.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.simpleimport;
+
+public @interface AnnotationParameter {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationToImport.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationToImport.java
@@ -10,5 +10,5 @@ public @interface AnnotationToImport {
 
     EnumToImport someEnumMethod() default EnumToImport.SECOND;
 
-    Deprecated someAnnotationMethod() default @Deprecated;
+    AnnotationParameter someAnnotationMethod() default @AnnotationParameter;
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
@@ -15,6 +16,7 @@ import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.domain.JavaClassList;
@@ -42,6 +44,7 @@ import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
 import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaClassDescriptorAssertion;
+import com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaCodeUnitAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaConstructorAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldAssertion;
@@ -61,6 +64,7 @@ import org.assertj.core.api.Condition;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.ObjectAssertFactory;
 
+import static com.google.common.base.Strings.emptyToNull;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethodSimple;
 import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
@@ -168,6 +172,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new ThrowsClauseAssertion(throwsClause);
     }
 
+    public static JavaAnnotationAssertion assertThatAnnotation(JavaAnnotation<?> annotation) {
+        return new JavaAnnotationAssertion(annotation);
+    }
+
     @SuppressWarnings("unchecked") // covariant
     public static AccessesAssertion assertThatAccesses(Collection<? extends JavaAccess<?>> accesses) {
         return new AccessesAssertion((Collection<JavaAccess<?>>) accesses);
@@ -272,9 +280,17 @@ public class Assertions extends org.assertj.core.api.Assertions {
         }
 
         public void isEquivalentTo(Enum<?> enumConstant) {
-            assertThat(actual).as(JavaEnumConstant.class.getSimpleName()).isNotNull();
-            assertThat(actual.getDeclaringClass().getName()).isEqualTo(enumConstant.getDeclaringClass().getName());
-            assertThat(actual.name()).isEqualTo(enumConstant.name());
+            assertThat(actual).as(describePartialAssertion()).isNotNull();
+            assertThat(actual.getDeclaringClass().getName()).as(describePartialAssertion("type")).isEqualTo(enumConstant.getDeclaringClass().getName());
+            assertThat(actual.name()).as(describePartialAssertion("name")).isEqualTo(enumConstant.name());
+        }
+
+        private String describePartialAssertion() {
+            return describePartialAssertion("");
+        }
+
+        private String describePartialAssertion(String partialAssertionDescription) {
+            return Joiner.on(": ").skipNulls().join(emptyToNull(descriptionText()), emptyToNull(partialAssertionDescription));
         }
     }
 


### PR DESCRIPTION
Often users are confused, why meta-annotations (like Spring's `@Component` on `@Service`) are not detected, because the original annotation has not been part of the import. 
So far if ArchUnit imported a class annotated with some annotation outside of the import context (e.g. a class in imported package `com.myapp` annotated with `@Service`) it would only create a stub without further information. I.e. if in this case a user would check for meta-annotated with `@Component` ArchUnit would not know about it. The workaround was quite tedious (adding `@Service` to the import context in some way).
On the other hand for a long time ArchUnit has e.g. resolved the class hierarchy automatically using the configured `ClassResolver`, so all superclasses and interfaces would automatically be part of the import context.
With this change ArchUnit will now do the same for annotations, i.e. resolve all annotations on imported classes using the configured `ClassResolver` and furthermore transitively resolving all meta-annotations. So for the example above both `@Service` and `@Component` would automatically be imported as well, as long as the `ClassResolver` can find them (e.g. because they are on the classpath).

Resolves: #342 
Resolves: #450