### PR TITLE
Don't escape scheme specific part before resolving as URI #414

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
@@ -153,7 +153,7 @@ interface UrlSource extends Iterable<URL> {
 
         private static Optional<URI> parseUrl(Path parent, String classpathUrlEntry) {
             try {
-                return Optional.of(convertToJarUrlIfNecessary(parent.toUri().resolve(URI.create(classpathUrlEntry).getSchemeSpecificPart())));
+                return Optional.of(convertToJarUrlIfNecessary(parent.toUri().resolve(URI.create(classpathUrlEntry).getRawSchemeSpecificPart())));
             } catch (Exception e) {
                 LOG.warn("Cannot parse URL classpath entry " + classpathUrlEntry, e);
                 return Optional.absent();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
@@ -109,6 +109,20 @@ public class UrlSourceTest {
     }
 
     @Test
+    public void handles_jar_uri_with_spaces() throws Exception {
+        File folderWithSpaces = temporaryFolder.newFolder("folder with spaces");
+        File folder = temporaryFolder.newFolder();
+
+        WrittenJarFile jarInFolderWithSpaces = writeJarWithManifestClasspathAttribute(folderWithSpaces, "folder-with-spaces");
+        WrittenJarFile parentJar = writeJarWithManifestClasspathAttribute(folder, "parent", ManifestClasspathEntry.absoluteUrl(jarInFolderWithSpaces.path));
+
+        System.setProperty(JAVA_CLASS_PATH_PROP, parentJar.path.toString());
+        UrlSource urls = UrlSource.From.classPathSystemProperties();
+
+        assertThat(urls).containsAll(concat(parentJar.getExpectedClasspathUrls(), jarInFolderWithSpaces.getExpectedClasspathUrls()));
+    }
+
+    @Test
     public void recursively_resolves_classpath_attributes_in_manifests() throws Exception {
         File folder = temporaryFolder.newFolder();
         WrittenJarFile grandChildOne = writeJarWithManifestClasspathAttribute(folder, subPath("grandchild", "one"));


### PR DESCRIPTION
When using the non-raw getSchemeSpecificPart() method on an URI, it will
no longer be escaped, and the subsequent call to URI#resolve may fail.

Resolves #414 