### PR TITLE
add doNotBelongToAnyOf(..) to syntax

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -359,6 +359,11 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
     }
 
     @Override
+    public CONJUNCTION doNotBelongToAnyOf(Class<?>... classes) {
+        return givenWith(doNot(JavaClass.Predicates.belongToAnyOf(classes)));
+    }
+
+    @Override
     public CONJUNCTION arePublic() {
         return givenWith(SyntaxPredicates.arePublic());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -431,6 +431,11 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
         return givenWith(JavaClass.Predicates.belongToAnyOf(classes));
     }
 
+    @Override
+    public CONJUNCTION doNotBelongToAnyOf(Class<?>... classes) {
+        return givenWith(doNot(JavaClass.Predicates.belongToAnyOf(classes)));
+    }
+
     private CONJUNCTION givenWith(DescribedPredicate<? super JavaClass> predicate) {
         return predicateAggregator.apply(predicate);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -675,4 +675,12 @@ public interface ClassesThat<CONJUNCTION> {
     @PublicAPI(usage = ACCESS)
     CONJUNCTION belongToAnyOf(Class<?>... classes);
 
+    /**
+     * Inverted form of {@link #belongToAnyOf belongToAnyOf(Outer.class)}
+     *
+     * @param classes List of {@link Class} objects.
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION doNotBelongToAnyOf(Class<?>... classes);
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -759,6 +759,16 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void doNotBelongToAnyOf() {
+        List<JavaClass> classes = filterResultOf(classes().that().doNotBelongToAnyOf(ClassWithInnerClasses.class, String.class))
+                .on(ClassWithInnerClasses.class, ClassWithInnerClasses.InnerClass.class, ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class,
+                        List.class, String.class, Iterable.class, StringBuilder.class);
+
+        assertThatTypes(classes).matchInAnyOrder(
+                List.class, Iterable.class, StringBuilder.class);
+    }
+
+    @Test
     public void and_conjunction() {
         List<JavaClass> classes = filterResultOf(
                 classes().that().haveNameMatching(".*\\..*i.*")

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -763,6 +763,19 @@ public class GivenMembersDeclaredInClassesThatTest {
     }
 
     @Test
+    public void doNotBelongToAnyOf() {
+        List<JavaMember> members =
+                filterResultOf(members().that().areDeclaredInClassesThat().doNotBelongToAnyOf(ClassWithInnerClasses.class, String.class))
+                        .on(ClassWithInnerClasses.class, ClassWithInnerClasses.InnerClass.class,
+                                ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class,
+                                List.class, String.class, Iterable.class, StringBuilder.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(
+                List.class, Iterable.class, StringBuilder.class
+        );
+    }
+
+    @Test
     public void and_conjunction() {
         List<JavaMember> members = filterResultOf(
                 members().that().areDeclaredInClassesThat().haveNameMatching(".*\\..*i.*")

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -866,6 +866,17 @@ public class ShouldClassesThatTest {
     }
 
     @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void doNotBelongToAnyOf(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.doNotBelongToAnyOf(ClassWithInnerClasses.class, String.class))
+                .on(ClassAccessingNestedInnerClass.class, ClassWithInnerClasses.class, ClassWithInnerClasses.InnerClass.class,
+                        ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingIterable.class);
+    }
+
+    @Test
     @UseDataProvider("classes_should_only_that_rule_starts")
     public void only_haveFullyQualifiedName(ClassesThat<ClassesShouldConjunction> classesShouldOnlyThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -987,6 +987,20 @@ public class ShouldOnlyByClassesThatTest {
         assertThatTypes(classes).matchInAnyOrder(AnotherClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class);
     }
 
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void doNotBelongToAnyOf(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterViolationCausesInFailureReport(
+                classesShouldOnlyBeBy.doNotBelongToAnyOf(ClassWithInnerClasses.class))
+                .on(ClassWithInnerClasses.class, ClassWithInnerClasses.InnerClass.class,
+                        ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class,
+                        AnotherClassWithInnerClasses.class, AnotherClassWithInnerClasses.InnerClass.class,
+                        AnotherClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class,
+                        ClassBeingAccessedByInnerClass.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassWithInnerClasses.InnerClass.EvenMoreInnerClass.class);
+    }
+
     @DataProvider
     public static Object[][] byClassesThat_predicate_rules() {
         return testForEach(
@@ -1183,7 +1197,7 @@ public class ShouldOnlyByClassesThatTest {
 
     @SuppressWarnings("unused")
     private static class ClassAccessingItself {
-        private String field;
+        private final String field;
 
         ClassAccessingItself(String field) {
             this.field = field;
@@ -1299,7 +1313,7 @@ public class ShouldOnlyByClassesThatTest {
         }
     }
 
-    private static Runnable anonymousClassBeingAccessed = new Runnable() {
+    private static final Runnable anonymousClassBeingAccessed = new Runnable() {
         @Override
         public void run() {
             new ClassAccessingAnonymousClass();


### PR DESCRIPTION
We have `belongToAnyOf()`, but the inverted form (`doesNotBelongToAnyOf()`) is missing and I couldn't find any easy way to just invert this in my ArchUnit invocations, so I concluded that perhaps it would make sense to add this to the framework proper?

The Javadocs are not really that great; feel free to suggest alternative wordings there. To the best of my knowledge, all tests should succeed including the tests for the functionality being added here.