### PR TITLE
Run task archunit:jdk9Test during multi-jdk-matrix-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           JAVA_HOME: ${{ env.build_jdk_path }}
         with:
-          arguments: testJre${{ matrix.test_java_version }} -PallTests -PmultiJdkTest -Pjava${{ matrix.test_java_version }}Home="${{ env.test_jdk_path }}"
+          arguments: testJre${{ matrix.test_java_version }} jdk9TestJre${{ matrix.test_java_version }} -PallTests -PmultiJdkTest -Pjava${{ matrix.test_java_version }}Home="${{ env.test_jdk_path }}"
 
   integration-test:
     strategy:

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -55,7 +55,6 @@ ext {
         testTask.enabled = false
 
         def taskMinimumJdkVersion = testTask.name.replaceAll(/jdk(\d+)Test/, '$1').with { it ==~ /\d+/ ? JavaVersion.toVersion(it) : proj.targetCompatibility }
-        def additionalJdksToTest = testJdks().findAll { it.javaVersion >= taskMinimumJdkVersion }
 
         def findJavaExecutable = { jdkPath ->
             def javaExecutableUnix = new File("${jdkPath}", 'bin/java')
@@ -65,13 +64,14 @@ ext {
             result
         }
 
-        additionalJdksToTest.each { jdk ->
+        testJdks().each { jdk ->
             def additionalTestTask = proj.tasks.create(name: "${testTask.name}${jdk.suffix}", type: Test) {
                 executable = findJavaExecutable(jdk.jdkPath)
 
                 testClassesDirs = testTask.testClassesDirs
                 classpath = testTask.classpath
             }
+            additionalTestTask.enabled = jdk.javaVersion >= taskMinimumJdkVersion
 
             testTask.dependsOn(additionalTestTask)
         }


### PR DESCRIPTION
The default CI build `gradlew build` didn't execute the task `jdk9Test` and therefore the tests located in src/jdk9test/java are not executed regularly.