### PR TITLE
add `jdk9Test` to default execution

### DIFF
--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -65,6 +65,7 @@ sourceSets {
 dependencies {
     jdk9mainImplementation sourceSets.main.output
     jdk9testImplementation sourceSets.test.output
+    jdk9testImplementation sourceSets.test.compileClasspath
     jdk9testImplementation sourceSets.jdk9main.output
 
     runtimeOnly sourceSets.jdk9main.output
@@ -92,6 +93,7 @@ task jdk9Test(type: Test) {
 [test, jdk9Test].each { testTask ->
     addMultiJdkTestsFor project, testTask
 }
+test.finalizedBy(jdk9Test)
 
 spotbugsJdk9test.enabled = false
 


### PR DESCRIPTION
It seems that some time between introduction and now (possibly with some Gradle upgrade?) `jdk9Test` started to not be executed by default anymore when `test` is executed. Also for some reason the `jdk9Test` classpath at the moment does not contain the `testCompile` dependencies anymore.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>