### PR TITLE
read empty list of frozen violations correctly

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationStoreFactory.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationStoreFactory.java
@@ -183,7 +183,7 @@ class ViolationStoreFactory {
 
         private List<String> readLines(String ruleDetailsFileName) {
             String violationsText = readStoreFile(ruleDetailsFileName);
-            List<String> lines = Splitter.on(UNESCAPED_LINE_BREAK_PATTERN).splitToList(violationsText);
+            List<String> lines = Splitter.on(UNESCAPED_LINE_BREAK_PATTERN).omitEmptyStrings().splitToList(violationsText);
             return unescape(lines);
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
@@ -80,6 +80,15 @@ public class TextFileBasedViolationStoreTest {
     }
 
     @Test
+    public void reads_empty_list_of_violations() {
+        store.save(defaultRule(), ImmutableList.<String>of());
+
+        List<String> storedViolations = store.getViolations(defaultRule());
+
+        assertThat(storedViolations).isEmpty();
+    }
+
+    @Test
     public void stores_violations_of_multiple_rules() {
         ArchRule firstRule = rule("first rule");
         store.save(firstRule, ImmutableList.of("first violation1", "first violation2"));


### PR DESCRIPTION
By default `Splitter.on(..).splitToList("")` returns a list containing one element (the empty string). This leads to an inconsistent behavior, because saving no lines will in turn return one line on read. Configuring `Splitter` via `omitEmptyStrings()` we can fix this behavior by skipping all empty lines, which makes sense in general.

Resolves: #456

Signed-off-by: Manfred Hanke <Manfred.Hanke@tngtech.com>