### PR TITLE
Add Optional.getOrThrow(Supplier) and replace deprecated method

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
@@ -42,7 +42,6 @@ public abstract class Optional<T> {
     }
 
     @PublicAPI(usage = ACCESS)
-    @SuppressWarnings("unchecked")
     public static <T> Optional<T> absent() {
         return Absent.getInstance();
     }
@@ -53,8 +52,15 @@ public abstract class Optional<T> {
     @PublicAPI(usage = ACCESS)
     public abstract T get();
 
+    /**
+     * @deprecated Use {@link #getOrThrow(Supplier)} instead (this version always instantiates the exception, no matter if needed)
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public abstract T getOrThrow(RuntimeException e);
+
+    @PublicAPI(usage = ACCESS)
+    public abstract T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier);
 
     @PublicAPI(usage = ACCESS)
     public abstract <U> Optional<U> transform(Function<? super T, U> function);
@@ -115,6 +121,11 @@ public abstract class Optional<T> {
         }
 
         @Override
+        public T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
+            throw exceptionSupplier.get();
+        }
+
+        @Override
         public <U> Optional<U> transform(Function<? super T, U> function) {
             return absent();
         }
@@ -169,6 +180,11 @@ public abstract class Optional<T> {
 
         @Override
         public T getOrThrow(RuntimeException e) {
+            return object;
+        }
+
+        @Override
+        public T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
             return object;
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/base/Supplier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Supplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014-2020 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.base;
+
+import com.tngtech.archunit.PublicAPI;
+
+import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+
+@PublicAPI(usage = INHERITANCE)
+public interface Supplier<T> {
+    T get();
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -233,8 +233,13 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      */
     @PublicAPI(usage = ACCESS)
     public JavaClass getComponentType() {
-        return tryGetComponentType().getOrThrow(new IllegalStateException(
-                String.format("Type %s is no array", getSimpleName())));
+        return tryGetComponentType().getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalStateException>() {
+            @Override
+            public IllegalStateException get() {
+                return new IllegalStateException(
+                        String.format("Type %s is no array", getSimpleName()));
+            }
+        });
     }
 
     /**
@@ -558,9 +563,14 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<JavaClass> getAnnotationOfType(String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new IllegalArgumentException(
-                String.format("Type %s is not annotated with @%s", getSimpleName(), typeName)));
+    public JavaAnnotation<JavaClass> getAnnotationOfType(final String typeName) {
+        return tryGetAnnotationOfType(typeName).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
+            @Override
+            public IllegalArgumentException get() {
+                return new IllegalArgumentException(
+                        String.format("Type %s is not annotated with @%s", getSimpleName(), typeName));
+            }
+        });
     }
 
     @Override
@@ -714,8 +724,13 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      * @throws IllegalArgumentException If this class does not have such a field.
      */
     @PublicAPI(usage = ACCESS)
-    public JavaField getField(String name) {
-        return tryGetField(name).getOrThrow(new IllegalArgumentException("No field with name '" + name + " in class " + getName()));
+    public JavaField getField(final String name) {
+        return tryGetField(name).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
+            @Override
+            public IllegalArgumentException get() {
+                return new IllegalArgumentException("No field with name '" + name + " in class " + getName());
+            }
+        });
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -233,13 +233,11 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      */
     @PublicAPI(usage = ACCESS)
     public JavaClass getComponentType() {
-        return tryGetComponentType().getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalStateException>() {
-            @Override
-            public IllegalStateException get() {
-                return new IllegalStateException(
-                        String.format("Type %s is no array", getSimpleName()));
-            }
-        });
+        Optional<JavaClass> componentType = tryGetComponentType();
+        if (!componentType.isPresent()) {
+            throw new IllegalStateException(String.format("Type %s is no array", getSimpleName()));
+        }
+        return componentType.get();
     }
 
     /**
@@ -563,14 +561,12 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<JavaClass> getAnnotationOfType(final String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
-            @Override
-            public IllegalArgumentException get() {
-                return new IllegalArgumentException(
-                        String.format("Type %s is not annotated with @%s", getSimpleName(), typeName));
-            }
-        });
+    public JavaAnnotation<JavaClass> getAnnotationOfType(String typeName) {
+        Optional<JavaAnnotation<JavaClass>> annotation = tryGetAnnotationOfType(typeName);
+        if (!annotation.isPresent()) {
+            throw new IllegalArgumentException(String.format("Type %s is not annotated with @%s", getSimpleName(), typeName));
+        }
+        return annotation.get();
     }
 
     @Override
@@ -724,13 +720,12 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      * @throws IllegalArgumentException If this class does not have such a field.
      */
     @PublicAPI(usage = ACCESS)
-    public JavaField getField(final String name) {
-        return tryGetField(name).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
-            @Override
-            public IllegalArgumentException get() {
-                return new IllegalArgumentException("No field with name '" + name + " in class " + getName());
-            }
-        });
+    public JavaField getField(String name) {
+        Optional<JavaField> field = tryGetField(name);
+        if (!field.isPresent()) {
+            throw new IllegalArgumentException("No field with name '" + name + " in class " + getName());
+        }
+        return field.get();
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.Internal;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.base.Supplier;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.domain.properties.HasDescriptor;
@@ -80,10 +81,15 @@ public abstract class JavaMember implements
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<? extends JavaMember> getAnnotationOfType(String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new IllegalArgumentException(String.format(
-                "Member %s is not annotated with @%s",
-                getFullName(), typeName)));
+    public JavaAnnotation<? extends JavaMember> getAnnotationOfType(final String typeName) {
+        return tryGetAnnotationOfType(typeName).getOrThrow(new Supplier<IllegalArgumentException>() {
+            @Override
+            public IllegalArgumentException get() {
+                return new IllegalArgumentException(String.format(
+                        "Member %s is not annotated with @%s",
+                        getFullName(), typeName));
+            }
+        });
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -26,7 +26,6 @@ import com.tngtech.archunit.Internal;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Optional;
-import com.tngtech.archunit.base.Supplier;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.domain.properties.HasDescriptor;
@@ -81,15 +80,12 @@ public abstract class JavaMember implements
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<? extends JavaMember> getAnnotationOfType(final String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new Supplier<IllegalArgumentException>() {
-            @Override
-            public IllegalArgumentException get() {
-                return new IllegalArgumentException(String.format(
-                        "Member %s is not annotated with @%s",
-                        getFullName(), typeName));
-            }
-        });
+    public JavaAnnotation<? extends JavaMember> getAnnotationOfType(String typeName) {
+        Optional<? extends JavaAnnotation<? extends JavaMember>> annotation = tryGetAnnotationOfType(typeName);
+        if (!annotation.isPresent()) {
+            throw new IllegalArgumentException(String.format("Member %s is not annotated with @%s", getFullName(), typeName));
+        }
+        return annotation.get();
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -86,8 +86,12 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
     @PublicAPI(usage = ACCESS)
     public HasAnnotations<?> getPackageInfo() {
-        return tryGetPackageInfo().getOrThrow(
-                new IllegalArgumentException(String.format("%s does not contain a package-info.java", getDescription())));
+        return tryGetPackageInfo().getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
+            @Override
+            public IllegalArgumentException get() {
+                return new IllegalArgumentException(String.format("%s does not contain a package-info.java", getDescription()));
+            }
+        });
     }
 
     @PublicAPI(usage = ACCESS)
@@ -112,9 +116,14 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<JavaPackage> getAnnotationOfType(String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new IllegalArgumentException(
-                String.format("%s is not annotated with @%s", getDescription(), typeName)));
+    public JavaAnnotation<JavaPackage> getAnnotationOfType(final String typeName) {
+        return tryGetAnnotationOfType(typeName).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
+            @Override
+            public IllegalArgumentException get() {
+                return new IllegalArgumentException(
+                        String.format("%s is not annotated with @%s", getDescription(), typeName));
+            }
+        });
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -86,12 +86,11 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
     @PublicAPI(usage = ACCESS)
     public HasAnnotations<?> getPackageInfo() {
-        return tryGetPackageInfo().getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
-            @Override
-            public IllegalArgumentException get() {
-                return new IllegalArgumentException(String.format("%s does not contain a package-info.java", getDescription()));
-            }
-        });
+        Optional<? extends HasAnnotations<?>> packageInfo = tryGetPackageInfo();
+        if (!packageInfo.isPresent()) {
+            throw new IllegalArgumentException(String.format("%s does not contain a package-info.java", getDescription()));
+        }
+        return packageInfo.get();
     }
 
     @PublicAPI(usage = ACCESS)
@@ -116,14 +115,12 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaAnnotation<JavaPackage> getAnnotationOfType(final String typeName) {
-        return tryGetAnnotationOfType(typeName).getOrThrow(new com.tngtech.archunit.base.Supplier<IllegalArgumentException>() {
-            @Override
-            public IllegalArgumentException get() {
-                return new IllegalArgumentException(
-                        String.format("%s is not annotated with @%s", getDescription(), typeName));
-            }
-        });
+    public JavaAnnotation<JavaPackage> getAnnotationOfType(String typeName) {
+        Optional<JavaAnnotation<JavaPackage>> annotation = tryGetAnnotationOfType(typeName);
+        if (!annotation.isPresent()) {
+            throw new IllegalArgumentException(String.format("%s is not annotated with @%s", getDescription(), typeName));
+        }
+        return annotation.get();
     }
 
     @Override

--- a/archunit/src/test/java/com/tngtech/archunit/base/OptionalTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/OptionalTest.java
@@ -34,6 +34,25 @@ public class OptionalTest {
     }
 
     @Test
+    public void getOrThrow_supplier_works() {
+        assertThat(Optional.of("test").getOrThrow(new Supplier<IllegalStateException>() {
+            @Override
+            public IllegalStateException get() {
+                return new IllegalStateException("SupplierBummer");
+            }
+        })).isEqualTo("test");
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("SupplierBummer");
+        Optional.absent().getOrThrow(new Supplier<IllegalStateException>() {
+            @Override
+            public IllegalStateException get() {
+                return new IllegalStateException("SupplierBummer");
+            }
+        });
+    }
+
+    @Test
     public void transform_works() {
         assertThat(Optional.of(5).transform(TO_STRING)).isEqualTo(Optional.of("5"));
 


### PR DESCRIPTION
The current implementation always forces the instantiation of an exception, which is unnecessary and expensive in most cases. Now there is a method `T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier)` which accepts a supplier that will only be invoked, if the exception really needs to be thrown (i.e. the `Optional` is absent even though it is assumed to be present).
Since we do not want Guava in the public API there is now a custom `Supplier` interface to be used as independent public API.

Resolves: #391