### PR TITLE
upgrade ASM to 9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     googleRelocationPackage = "${thirdPartyRelocationPackage}.com.google"
 
     dependency = [
-            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '8.0.1'],
+            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.0'],
             guava               : [group: 'com.google.guava', name: 'guava', version: '20.0'],
             slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'],
             log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1'],
@@ -98,7 +98,13 @@ allprojects {
     version = '0.15.0-SNAPSHOT'
 
     repositories {
-        mavenCentral()
+        mavenCentral {
+            metadataSources {
+                mavenPom()
+                artifact()
+                ignoreGradleMetadataRedirection()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Unfortunately with ASM 9.0 there were some additional Gradle meta-data files published to Maven Central that contained wrong information that ASM 9.0 would target Java version >= 8. This broke the ArchUnit build, since ArchUnit still supports Java 7. The symptom was an error like

```
No matching variant of org.ow2.asm:asm:9.0 was found. The consumer was configured to find a runtime of a library compatible with Java 7, packaged as a jar, and its dependencies declared externally but: ... > Incompatible because this component declares an API of a component compatible with Java 8 and the consumer needed a runtime of a component compatible with Java 7
```

Since ASM in fact supports even older Java versions than Java 7 I have switched off Gradle meta-data resolution that has been enabled since Gradle 5.3 (compare https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:supported_metadata_sources).