### PR TITLE
Add is annotation to `JavaClass` and fluent API

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -69,6 +69,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     private JavaPackage javaPackage;
     private final boolean isInterface;
     private final boolean isEnum;
+    private final boolean isAnnotation;
     private final boolean isAnonymousClass;
     private final boolean isMemberClass;
     private final Set<JavaModifier> modifiers;
@@ -106,6 +107,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         descriptor = checkNotNull(builder.getDescriptor());
         isInterface = builder.isInterface();
         isEnum = builder.isEnum();
+        isAnnotation = builder.isAnnotation();
         isAnonymousClass = builder.isAnonymousClass();
         isMemberClass = builder.isMemberClass();
         modifiers = checkNotNull(builder.getModifiers());
@@ -184,6 +186,11 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     @PublicAPI(usage = ACCESS)
     public boolean isEnum() {
         return isEnum;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public boolean isAnnotation() {
+        return isAnnotation;
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1433,6 +1433,14 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         };
 
         @PublicAPI(usage = ACCESS)
+        public static final DescribedPredicate<JavaClass> ANNOTATIONS = new DescribedPredicate<JavaClass>("annotations") {
+            @Override
+            public boolean apply(JavaClass input) {
+                return input.isAnnotation();
+            }
+        };
+
+        @PublicAPI(usage = ACCESS)
         public static final DescribedPredicate<JavaClass> TOP_LEVEL_CLASSES = new DescribedPredicate<JavaClass>("top level classes") {
             @Override
             public boolean apply(JavaClass input) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -349,6 +349,7 @@ public final class DomainBuilders {
         private JavaClassDescriptor descriptor;
         private boolean isInterface;
         private boolean isEnum;
+        private boolean isAnnotation;
         private boolean isAnonymousClass;
         private boolean isMemberClass;
         private Set<JavaModifier> modifiers = new HashSet<>();
@@ -391,6 +392,11 @@ public final class DomainBuilders {
             return this;
         }
 
+        public JavaClassBuilder withAnnotation(boolean isAnnotation) {
+            this.isAnnotation = isAnnotation;
+            return this;
+        }
+
         JavaClassBuilder withModifiers(Set<JavaModifier> modifiers) {
             this.modifiers = modifiers;
             return this;
@@ -421,6 +427,10 @@ public final class DomainBuilders {
 
         public boolean isEnum() {
             return isEnum;
+        }
+
+        public boolean isAnnotation() {
+            return isAnnotation;
         }
 
         public boolean isAnonymousClass() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -100,6 +100,7 @@ class JavaClassProcessor extends ClassVisitor {
         LOG.trace("Found interfaces {} on class '{}'", interfaceNames, name);
         boolean opCodeForInterfaceIsPresent = (access & Opcodes.ACC_INTERFACE) != 0;
         boolean opCodeForEnumIsPresent = (access & Opcodes.ACC_ENUM) != 0;
+        boolean opCodeForAnnotationIsPresent = (access & Opcodes.ACC_ANNOTATION) != 0;
         Optional<String> superClassName = getSuperClassName(superName, opCodeForInterfaceIsPresent);
         LOG.trace("Found superclass {} on class '{}'", superClassName.orNull(), name);
 
@@ -108,6 +109,7 @@ class JavaClassProcessor extends ClassVisitor {
                 .withDescriptor(descriptor)
                 .withInterface(opCodeForInterfaceIsPresent)
                 .withEnum(opCodeForEnumIsPresent)
+                .withAnnotation(opCodeForAnnotationIsPresent)
                 .withModifiers(JavaModifier.getModifiersForClass(access));
 
         className = descriptor.getFullyQualifiedClassName();

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANNOTATIONS;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INNER_CLASSES;
@@ -280,6 +281,16 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
     @Override
     public CONJUNCTION areNotEnums() {
         return givenWith(are(not(ENUMS)));
+    }
+
+    @Override
+    public CONJUNCTION areAnnotations() {
+        return givenWith(are(ANNOTATIONS));
+    }
+
+    @Override
+    public CONJUNCTION areNotAnnotations() {
+        return givenWith(are(not(ANNOTATIONS)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -28,6 +28,7 @@ import com.tngtech.archunit.lang.syntax.elements.GivenMembersConjunction;
 
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANNOTATIONS;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INNER_CLASSES;
@@ -353,6 +354,16 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
     @Override
     public CONJUNCTION areNotEnums() {
         return givenWith(are(not(ENUMS)));
+    }
+
+    @Override
+    public CONJUNCTION areAnnotations() {
+        return givenWith(are(ANNOTATIONS));
+    }
+
+    @Override
+    public CONJUNCTION areNotAnnotations() {
+        return givenWith(are(not(ANNOTATIONS)));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -600,6 +600,22 @@ public interface ClassesThat<CONJUNCTION> {
     @PublicAPI(usage = ACCESS)
     CONJUNCTION areNotEnums();
 
+    /**
+     * Matches annotations.
+     *
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areAnnotations();
+
+    /**
+     * Matches everything except annotations.
+     *
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION areNotAnnotations();
+
     @PublicAPI(usage = ACCESS)
     CONJUNCTION areTopLevelClasses();
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationToImport.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/simpleimport/AnnotationToImport.java
@@ -1,0 +1,14 @@
+package com.tngtech.archunit.core.importer.testexamples.simpleimport;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public @interface AnnotationToImport {
+    String someStringMethod() default "DEFAULT";
+
+    Class<?> someTypeMethod() default List.class;
+
+    EnumToImport someEnumMethod() default EnumToImport.SECOND;
+
+    Deprecated someAnnotationMethod() default @Deprecated;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -608,6 +608,22 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void areAnnotations_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areAnnotations())
+                .on(Deprecated.class, Collection.class, SafeVarargs.class, Integer.class);
+
+        assertThatTypes(classes).matchInAnyOrder(Deprecated.class, SafeVarargs.class);
+    }
+
+    @Test
+    public void areNotAnnotations_predicate() {
+        List<JavaClass> classes = filterResultOf(classes().that().areNotAnnotations())
+                .on(Deprecated.class, Collection.class, SafeVarargs.class, Integer.class);
+
+        assertThatTypes(classes).matchInAnyOrder(Collection.class, Integer.class);
+    }
+
+    @Test
     public void areTopLevelClasses_predicate() {
         List<JavaClass> classes = filterResultOf(classes().that().areTopLevelClasses())
                 .on(List.class, Map.class, Map.Entry.class, NestedClassWithSomeMoreClasses.class,

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -604,6 +604,22 @@ public class GivenMembersDeclaredInClassesThatTest {
     }
 
     @Test
+    public void areAnnotations_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areAnnotations())
+                .on(Deprecated.class, Collection.class, SafeVarargs.class, Integer.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(Deprecated.class, SafeVarargs.class);
+    }
+
+    @Test
+    public void areNotAnnotations_predicate() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areNotAnnotations())
+                .on(Deprecated.class, Collection.class, SafeVarargs.class, Integer.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(Collection.class, Integer.class);
+    }
+
+    @Test
     public void areTopLevelClasses_predicate() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().areTopLevelClasses())
                 .on(String.class, NestedClassWithSomeMoreClasses.class, NestedClassWithSomeMoreClasses.StaticNestedClass.class,

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -714,6 +714,26 @@ public class ShouldClassesThatTest {
 
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areAnnotations_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areAnnotations())
+                .on(ClassAccessingAnnotation.class, ClassAccessingString.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingAnnotation.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void areNotAnnotations_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.areNotAnnotations())
+                .on(ClassAccessingAnnotation.class, ClassAccessingString.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingString.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
     public void areTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.areTopLevelClasses())
@@ -1565,7 +1585,7 @@ public class ShouldClassesThatTest {
     }
 
     private static class ClassAccessingList {
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "ResultOfMethodCallIgnored"})
         void call(List<?> list) {
             list.size();
         }
@@ -1577,7 +1597,7 @@ public class ShouldClassesThatTest {
     }
 
     private static class ClassAccessingArrayList {
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "ResultOfMethodCallIgnored"})
         void call(ArrayList<?> list) {
             list.size();
         }
@@ -1604,7 +1624,7 @@ public class ShouldClassesThatTest {
     }
 
     private static class ClassAccessingCollection {
-        @SuppressWarnings("unused")
+        @SuppressWarnings({"unused", "ResultOfMethodCallIgnored"})
         void call(Collection<?> collection) {
             collection.size();
         }
@@ -1739,6 +1759,15 @@ public class ShouldClassesThatTest {
         @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
         void access() {
             StandardCopyOption.ATOMIC_MOVE.name();
+        }
+    }
+
+    private static class ClassAccessingAnnotation {
+        Deprecated deprecated;
+
+        @SuppressWarnings({"unused"})
+        void access() {
+            deprecated.annotationType();
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -823,6 +823,26 @@ public class ShouldOnlyByClassesThatTest {
 
     @Test
     @UseDataProvider("should_only_be_by_rule_starts")
+    public void areAnnotations_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areAnnotations())
+                .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByAnnotation.class, AnnotationAccessingAClass.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingSimpleClass.class, SimpleClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void areNotAnnotations_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.areNotAnnotations())
+                .on(ClassAccessingSimpleClass.class, SimpleClass.class, ClassBeingAccessedByAnnotation.class, AnnotationAccessingAClass.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassBeingAccessedByAnnotation.class, AnnotationAccessingAClass.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
     public void areTopLevelClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areTopLevelClasses())
@@ -1241,6 +1261,14 @@ public class ShouldOnlyByClassesThatTest {
         static void access() {
             new ClassBeingAccessedByEnum();
         }
+    }
+
+    private static class ClassBeingAccessedByAnnotation {
+    }
+
+    @SuppressWarnings({"unused"})
+    private @interface AnnotationAccessingAClass {
+        ClassBeingAccessedByAnnotation access = new ClassBeingAccessedByAnnotation();
     }
 
     private static class ClassAccessingStaticNestedClass {

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -92,3 +92,80 @@ configure(subprojects.findAll { it.name != 'docs' }) {
         }
     }
 }
+
+// Add some better test failure reporting on the console
+
+List<TestFailureReport> testReports = []
+configure(subprojects.findAll { it.name != 'docs' }) {
+    TestFailureReport testReport = new TestFailureReport(project: name)
+    testReports << testReport
+
+    afterEvaluate { project ->
+        project.tasks.withType(Test) {
+            afterTest { TestDescriptor descriptor, TestResult result ->
+                if (result.resultType == TestResult.ResultType.FAILURE) {
+                    testReport.addFailure(new TestFailure(descriptor, result.exception))
+                }
+            }
+        }
+    }
+}
+
+gradle.buildFinished {
+    testReports.each { it.printFailures() }
+}
+
+class TestFailureReport {
+    String project
+    private Map<String, TestClassFailureReport> reports = [:].withDefault { testClassName -> new TestClassFailureReport(className: testClassName) }
+
+    void addFailure(TestFailure testFailure) {
+        reports[testFailure.className].testFailures << testFailure
+    }
+
+    void printFailures() {
+        def failureReports = reports.values().findAll { !it.testFailures.empty }
+        if (failureReports.empty) {
+            return
+        }
+
+        String redX = "\033[1;31m\u2718 \033[0m"
+        String heading = "Failed tests for ${project}"
+        int headingBoxWidth = heading.length() + 4
+        println """
+        ${'-' * headingBoxWidth}
+        | ${heading} |
+        ${'-' * headingBoxWidth}
+        """.stripIndent()
+        failureReports.each { TestClassFailureReport failureReport ->
+            println "- ${failureReport.className} --> ${failureReport.location}"
+            failureReport.testFailures.each { TestFailure failure ->
+                println "  ${redX}.${failure.testDescription} --> ${failure.location}"
+            }
+        }
+        println "${'-' * headingBoxWidth}"
+    }
+}
+
+class TestClassFailureReport {
+    String className
+    List<TestFailure> testFailures = []
+
+    String getLocation() {
+        return "(${className.replaceAll(/.*\./, '')}.java:0)"
+    }
+}
+
+class TestFailure {
+    String className
+    String testDescription
+    String location = 'Unknown'
+
+    TestFailure(TestDescriptor descriptor, Throwable failure) {
+        className = descriptor.className
+        testDescription = descriptor.displayName
+        failure?.stackTrace?.find { it.className == className }?.each {
+            location = "(${it.fileName}:${it.lineNumber})"
+        }
+    }
+}


### PR DESCRIPTION
The bytecode provides the opcode `ACC_ANNOTATION` which denotes those classes that are annotations (e.g. the annotation type of `@Deprecated`). Same as for the Java Reflection API (which offers `Class.isAnnotation()`) we should provide this information through `JavaClass`.
Furthermore we should expose this information through the fluent API to allow easy creation of `ArchRules` about annotation types.