### PR TITLE
Add JavaClass type parameters to dependencies

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/ServiceHelper.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/ServiceHelper.java
@@ -1,11 +1,20 @@
 package com.tngtech.archunit.example.layers.service;
 
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.example.layers.controller.SomeUtility;
+import com.tngtech.archunit.example.layers.controller.one.SomeEnum;
 import com.tngtech.archunit.example.layers.security.Secured;
 
 /**
  * Well modelled code always has lots of 'helpers' ;-)
  */
-public class ServiceHelper {
+@SuppressWarnings("unused")
+public class ServiceHelper<
+        TYPE_PARAMETER_VIOLATING_LAYER_RULE extends SomeUtility,
+        ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE extends Map<?, Set<? super SomeEnum>>> {
+
     public Object insecure = new Object();
     @Secured
     public Object properlySecured = new Object();

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -166,6 +166,7 @@ import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
 import static com.tngtech.archunit.testutils.ExpectedDependency.method;
+import static com.tngtech.archunit.testutils.ExpectedDependency.typeParameter;
 import static com.tngtech.archunit.testutils.ExpectedLocation.javaClass;
 import static com.tngtech.archunit.testutils.ExpectedNaming.simpleNameOf;
 import static com.tngtech.archunit.testutils.ExpectedNaming.simpleNameOfAnonymousClassOf;
@@ -739,6 +740,8 @@ class ExamplesIntegrationTest {
                 .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .toMethod(UseCaseTwoController.class, doSomethingTwo)
                         .inLine(25).asDependency())
+                .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
+                .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -796,6 +799,8 @@ class ExamplesIntegrationTest {
                 .by(callFromMethod(ServiceViolatingLayerRules.class, illegalAccessToController)
                         .toMethod(UseCaseTwoController.class, doSomethingTwo)
                         .inLine(25).asDependency())
+                .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
+                .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -863,6 +868,8 @@ class ExamplesIntegrationTest {
                                         .inLine(27)
                                         .asDependency())
 
+                                .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
+                                .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -25,6 +25,10 @@ public class ExpectedDependency implements ExpectedRelation {
         return new InheritanceCreator(clazz);
     }
 
+    public static TypeParameterCreator typeParameter(Class<?> clazz, String typeParameterName) {
+        return new TypeParameterCreator(clazz, typeParameterName);
+    }
+
     public static AnnotationDependencyCreator annotatedClass(Class<?> clazz) {
         return new AnnotationDependencyCreator(clazz);
     }
@@ -82,6 +86,21 @@ public class ExpectedDependency implements ExpectedRelation {
         public ExpectedDependency implementing(Class<?> anInterface) {
             return new ExpectedDependency(clazz, anInterface,
                     getDependencyPattern(clazz.getName(), "implements", anInterface.getName(), 0));
+        }
+    }
+
+    public static class TypeParameterCreator {
+        private final Class<?> clazz;
+        private final String typeParameterName;
+
+        private TypeParameterCreator(Class<?> clazz, String typeParameterName) {
+            this.clazz = clazz;
+            this.typeParameterName = typeParameterName;
+        }
+
+        public ExpectedDependency dependingOn(Class<?> typeParameterDependency) {
+            return new ExpectedDependency(clazz, typeParameterDependency,
+                    getDependencyPattern(clazz.getName(), "has type parameter '" + typeParameterName + "' depending on", typeParameterDependency.getName(), 0));
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -150,11 +150,11 @@ public class DomainObjectCreationContext {
         return InstanceofCheck.from(codeUnit, target, lineNumber);
     }
 
-    public static JavaTypeVariable createTypeVariable(String name, JavaClass erasure) {
-        return new JavaTypeVariable(name, erasure);
+    public static <OWNER extends HasDescription> JavaTypeVariable<OWNER> createTypeVariable(String name, OWNER owner, JavaClass erasure) {
+        return new JavaTypeVariable<>(name, owner, erasure);
     }
 
-    public static void completeTypeVariable(JavaTypeVariable variable, List<JavaType> upperBounds) {
+    public static void completeTypeVariable(JavaTypeVariable<?> variable, List<JavaType> upperBounds) {
         variable.setUpperBounds(upperBounds);
     }
 
@@ -164,7 +164,7 @@ public class DomainObjectCreationContext {
         return new JavaGenericArrayType(componentType.getName() + "[]", componentType, erasure);
     }
 
-    public static JavaWildcardType createWildcardType(JavaWildcardTypeBuilder builder) {
+    public static JavaWildcardType createWildcardType(JavaWildcardTypeBuilder<?> builder) {
         return new JavaWildcardType(builder);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -28,7 +28,7 @@ public interface ImportContext {
 
     Set<JavaClass> createInterfaces(JavaClass owner);
 
-    List<JavaTypeVariable> createTypeParameters(JavaClass owner);
+    List<JavaTypeVariable<JavaClass>> createTypeParameters(JavaClass owner);
 
     Set<JavaField> createFields(JavaClass owner);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -72,7 +72,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     private final boolean isAnonymousClass;
     private final boolean isMemberClass;
     private final Set<JavaModifier> modifiers;
-    private List<JavaTypeVariable> typeParameters = emptyList();
+    private List<JavaTypeVariable<JavaClass>> typeParameters = emptyList();
     private final Supplier<Class<?>> reflectSupplier;
     private Set<JavaField> fields = emptySet();
     private Set<JavaCodeUnit> codeUnits = emptySet();
@@ -644,7 +644,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     }
 
     @PublicAPI(usage = ACCESS)
-    public List<JavaTypeVariable> getTypeParameters() {
+    public List<JavaTypeVariable<JavaClass>> getTypeParameters() {
         return typeParameters;
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
@@ -21,6 +21,8 @@ import java.util.List;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasUpperBounds;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -42,13 +44,15 @@ import static java.util.Collections.emptyList;
  * {@code SomeInterfaceOne} and {@code SomeInterfaceTwo}.
  */
 @PublicAPI(usage = ACCESS)
-public final class JavaTypeVariable implements JavaType, HasUpperBounds {
+public final class JavaTypeVariable<OWNER extends HasDescription> implements JavaType, HasOwner<OWNER>, HasUpperBounds {
     private final String name;
+    private final OWNER owner;
     private List<JavaType> upperBounds = emptyList();
     private JavaClass erasure;
 
-    JavaTypeVariable(String name, JavaClass erasure) {
+    JavaTypeVariable(String name, OWNER owner, JavaClass erasure) {
         this.name = name;
+        this.owner = owner;
         this.erasure = erasure;
     }
 
@@ -65,6 +69,27 @@ public final class JavaTypeVariable implements JavaType, HasUpperBounds {
     @PublicAPI(usage = ACCESS)
     public String getName() {
         return name;
+    }
+
+    /**
+     * This method is simply an alias for {@link #getOwner()} that is more familiar to users
+     * of the Java Reflection API.
+     *
+     * @see TypeVariable#getGenericDeclaration()
+     */
+    @PublicAPI(usage = ACCESS)
+    public OWNER getGenericDeclaration() {
+        return getOwner();
+    }
+
+    /**
+     * @return The 'owner' of this type parameter, i.e. the Java object that declared this
+     *         {@link TypeVariable} as a type parameter. For type parameter {@code T} of
+     *         {@code SomeClass<T>} this would be the {@code JavaClass} representing {@code SomeClass}
+     */
+    @Override
+    public OWNER getOwner() {
+        return owner;
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
@@ -15,6 +15,7 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import java.lang.reflect.TypeVariable;
 import java.util.List;
 
 import com.google.common.base.Joiner;
@@ -67,7 +68,10 @@ public final class JavaTypeVariable implements JavaType, HasUpperBounds {
     }
 
     /**
-     * @see #getUpperBounds()
+     * This method is simply an alias for {@link #getUpperBounds()} that is more familiar to users
+     * of the Java Reflection API.
+     *
+     * @see TypeVariable#getBounds()
      */
     @PublicAPI(usage = ACCESS)
     public List<JavaType> getBounds() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -46,7 +46,7 @@ public class JavaWildcardType implements JavaType, HasUpperBounds {
     private final List<JavaType> lowerBounds;
     private final JavaClass erasure;
 
-    JavaWildcardType(JavaWildcardTypeBuilder builder) {
+    JavaWildcardType(JavaWildcardTypeBuilder<?> builder) {
         upperBounds = builder.getUpperBounds();
         lowerBounds = builder.getLowerBounds();
         erasure = builder.getUnboundErasureType(upperBounds);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -41,7 +41,7 @@ class ClassFileImportRecord {
     private static final Logger LOG = LoggerFactory.getLogger(ClassFileImportRecord.class);
 
     private static final TypeParametersBuilder NO_TYPE_PARAMETERS =
-            new TypeParametersBuilder(Collections.<JavaTypeParameterBuilder>emptySet());
+            new TypeParametersBuilder(Collections.<JavaTypeParameterBuilder<JavaClass>>emptySet());
 
     private final Map<String, JavaClass> classes = new HashMap<>();
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -237,7 +237,7 @@ class ClassGraphCreator implements ImportContext {
     }
 
     @Override
-    public List<JavaTypeVariable> createTypeParameters(JavaClass owner) {
+    public List<JavaTypeVariable<JavaClass>> createTypeParameters(JavaClass owner) {
         TypeParametersBuilder typeParametersBuilder = importRecord.getTypeParameterBuildersFor(owner.getName());
         return typeParametersBuilder.build(owner, classes.byTypeName());
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -258,6 +258,24 @@ public class DependencyTest {
     }
 
     @Test
+    public void Dependency_from_type_parameter() {
+        @SuppressWarnings("unused")
+        class ClassWithTypeParameters<T extends String> {
+        }
+
+        JavaClass javaClass = importClassesWithContext(ClassWithTypeParameters.class, String.class).get(ClassWithTypeParameters.class);
+        JavaTypeVariable<?> typeParameter = javaClass.getTypeParameters().get(0);
+
+        Dependency dependency = getOnlyElement(Dependency.tryCreateFromTypeParameter(typeParameter, typeParameter.getUpperBounds().get(0).toErasure()));
+
+        assertThatType(dependency.getOriginClass()).matches(ClassWithTypeParameters.class);
+        assertThatType(dependency.getTargetClass()).matches(String.class);
+        assertThat(dependency.getDescription()).as("description").contains(String.format(
+                "Class <%s> has type parameter '%s' depending on <%s> in (%s.java:0)",
+                ClassWithTypeParameters.class.getName(), typeParameter.getName(), String.class.getName(), getClass().getSimpleName()));
+    }
+
+    @Test
     public void origin_predicates_match() {
         assertThatDependency(Origin.class, Target.class)
                 .matchesOrigin(Origin.class)

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
@@ -19,9 +19,22 @@ public class JavaTypeVariableTest {
         class ClassWithUnboundTypeParameter<SOME_NAME> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
 
         assertThat(type.getName()).isEqualTo("SOME_NAME");
+    }
+
+    @Test
+    public void type_variable_class_owner() {
+        @SuppressWarnings("unused")
+        class ClassWithUnboundTypeParameter<SOME_NAME> {
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class);
+        JavaTypeVariable<JavaClass> type = javaClass.getTypeParameters().get(0);
+
+        assertThat(type.getOwner()).isSameAs(javaClass);
+        assertThat(type.getGenericDeclaration()).isSameAs(javaClass);
     }
 
     @Test
@@ -30,7 +43,7 @@ public class JavaTypeVariableTest {
         class ClassWithUnboundTypeParameter<T extends HashMap<Object, Object> & Serializable> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
 
         assertThatTypes(type.getBounds()).matchExactly(HashMap.class, Serializable.class);
         assertThatTypes(type.getUpperBounds()).matchExactly(HashMap.class, Serializable.class);
@@ -42,7 +55,7 @@ public class JavaTypeVariableTest {
         class ClassWithUnboundTypeParameter<T> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithUnboundTypeParameter.class).getTypeParameters().get(0);
 
         assertThatType(type.toErasure()).matches(Object.class);
     }
@@ -53,7 +66,7 @@ public class JavaTypeVariableTest {
         class ClassWithBoundTypeParameterWithSingleClassBound<T extends Serializable> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleClassBound.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleClassBound.class).getTypeParameters().get(0);
 
         assertThatType(type.toErasure()).matches(Serializable.class);
     }
@@ -64,7 +77,7 @@ public class JavaTypeVariableTest {
         class ClassWithBoundTypeParameterWithSingleGenericClassBound<T extends List<String>> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleGenericClassBound.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleGenericClassBound.class).getTypeParameters().get(0);
 
         assertThatType(type.toErasure()).matches(List.class);
     }
@@ -75,7 +88,7 @@ public class JavaTypeVariableTest {
         class ClassWithBoundTypeParameterWithMultipleGenericClassAndInterfaceBounds<T extends HashMap<String, String> & Iterable<String> & Serializable> {
         }
 
-        JavaTypeVariable type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithMultipleGenericClassAndInterfaceBounds.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> type = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithMultipleGenericClassAndInterfaceBounds.class).getTypeParameters().get(0);
 
         assertThatType(type.toErasure()).matches(HashMap.class);
     }
@@ -86,7 +99,7 @@ public class JavaTypeVariableTest {
         class ClassWithBoundTypeParameterWithSingleGenericArrayBound<T extends List<Object[]>, U extends List<String[][]>, V extends List<List<?>[][][]>> {
         }
 
-        List<JavaTypeVariable> typeParameters = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleGenericArrayBound.class).getTypeParameters();
+        List<JavaTypeVariable<JavaClass>> typeParameters = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithSingleGenericArrayBound.class).getTypeParameters();
 
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(0)).toErasure()).matches(Object[].class);
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(1)).toErasure()).matches(String[][].class);
@@ -99,7 +112,7 @@ public class JavaTypeVariableTest {
         class ClassWithBoundTypeParameterWithGenericArrayBounds<A, B extends String, C extends List<?>, T extends List<A[]>, U extends List<B[][]>, V extends List<C[][][]>> {
         }
 
-        List<JavaTypeVariable> typeParameters = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithGenericArrayBounds.class).getTypeParameters();
+        List<JavaTypeVariable<JavaClass>> typeParameters = new ClassFileImporter().importClass(ClassWithBoundTypeParameterWithGenericArrayBounds.class).getTypeParameters();
 
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(3)).toErasure()).matches(Object[].class);
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(4)).toErasure()).matches(String[][].class);
@@ -112,7 +125,7 @@ public class JavaTypeVariableTest {
         class Unbounded<NAME> {
         }
 
-        JavaTypeVariable typeVariable = new ClassFileImporter().importClass(Unbounded.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> typeVariable = new ClassFileImporter().importClass(Unbounded.class).getTypeParameters().get(0);
 
         assertThat(typeVariable.toString())
                 .contains(JavaTypeVariable.class.getSimpleName())
@@ -126,7 +139,7 @@ public class JavaTypeVariableTest {
         class BoundedBySingleBound<NAME extends String> {
         }
 
-        JavaTypeVariable typeVariable = new ClassFileImporter().importClass(BoundedBySingleBound.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> typeVariable = new ClassFileImporter().importClass(BoundedBySingleBound.class).getTypeParameters().get(0);
 
         assertThat(typeVariable.toString())
                 .contains(JavaTypeVariable.class.getSimpleName())
@@ -139,14 +152,14 @@ public class JavaTypeVariableTest {
         class BoundedByMultipleBounds<NAME extends String & Serializable> {
         }
 
-        JavaTypeVariable typeVariable = new ClassFileImporter().importClass(BoundedByMultipleBounds.class).getTypeParameters().get(0);
+        JavaTypeVariable<JavaClass> typeVariable = new ClassFileImporter().importClass(BoundedByMultipleBounds.class).getTypeParameters().get(0);
 
         assertThat(typeVariable.toString())
                 .contains(JavaTypeVariable.class.getSimpleName())
                 .contains("NAME extends java.lang.String & java.io.Serializable");
     }
 
-    private static JavaType getTypeArgumentOfFirstBound(JavaTypeVariable typeParameter) {
+    private static JavaType getTypeArgumentOfFirstBound(JavaTypeVariable<JavaClass> typeParameter) {
         JavaParameterizedType firstBound = (JavaParameterizedType) typeParameter.getBounds().get(0);
         return firstBound.getActualTypeArguments().get(0);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -342,7 +342,7 @@ public class ImportTestUtils {
         }
 
         @Override
-        public List<JavaTypeVariable> createTypeParameters(JavaClass owner) {
+        public List<JavaTypeVariable<JavaClass>> createTypeParameters(JavaClass owner) {
             return Collections.emptyList();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -96,7 +96,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new JavaTypeAssertion(javaType);
     }
 
-    public static JavaTypeVariableAssertion assertThatTypeVariable(JavaTypeVariable typeVariable) {
+    public static JavaTypeVariableAssertion assertThatTypeVariable(JavaTypeVariable<?> typeVariable) {
         return new JavaTypeVariableAssertion(typeVariable);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
@@ -166,13 +166,10 @@ public class DependenciesAssertion extends AbstractIterableAssert<
         }
 
         boolean matches(Dependency dependency) {
-            if (!dependency.getOriginClass().isEquivalentTo(origin) || !dependency.getTargetClass().isEquivalentTo(target)) {
-                return false;
-            }
-            if (descriptionPattern.isPresent() && !descriptionPattern.get().matcher(dependency.getDescription()).matches()) {
-                return false;
-            }
-            return !locationPart.isPresent() || dependency.getDescription().endsWith(locationPart.get());
+            return dependency.getOriginClass().isEquivalentTo(origin)
+                    && dependency.getTargetClass().isEquivalentTo(target)
+                    && (!descriptionPattern.isPresent() || descriptionPattern.get().matcher(dependency.getDescription()).matches())
+                    && (!locationPart.isPresent() || dependency.getDescription().endsWith(locationPart.get()));
         }
 
         public void descriptionContaining(String descriptionTemplate, Object[] args) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
@@ -75,9 +75,9 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
 
     @SuppressWarnings("OptionalGetWithoutIsPresent") // checked via AssertJ
     public JavaTypeVariableOfClassAssertion hasTypeParameter(String name) {
-        List<JavaTypeVariable> typeVariables = actualClass().getTypeParameters();
+        List<JavaTypeVariable<JavaClass>> typeVariables = actualClass().getTypeParameters();
 
-        Optional<JavaTypeVariable> variable = FluentIterable.from(typeVariables).firstMatch(toGuava(name(name)));
+        Optional<JavaTypeVariable<JavaClass>> variable = FluentIterable.from(typeVariables).firstMatch(toGuava(name(name)));
         assertThat(variable).as("Type variable with name '%s'", name).isPresent();
 
         return new JavaTypeVariableOfClassAssertion(variable.get());
@@ -109,8 +109,8 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
         return getExpectedPackageName(clazz.getComponentType());
     }
 
-    public class JavaTypeVariableOfClassAssertion extends AbstractObjectAssert<JavaTypeVariableOfClassAssertion, JavaTypeVariable> {
-        private JavaTypeVariableOfClassAssertion(JavaTypeVariable actual) {
+    public class JavaTypeVariableOfClassAssertion extends AbstractObjectAssert<JavaTypeVariableOfClassAssertion, JavaTypeVariable<JavaClass>> {
+        private JavaTypeVariableOfClassAssertion(JavaTypeVariable<JavaClass> actual) {
             super(actual, JavaTypeVariableOfClassAssertion.class);
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeVariableAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeVariableAssertion.java
@@ -23,8 +23,8 @@ import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.JavaTypeVariableAssertion.ExpectedConcreteWildcardType.wildcardType;
 import static java.util.Collections.emptyList;
 
-public class JavaTypeVariableAssertion extends AbstractObjectAssert<JavaTypeVariableAssertion, JavaTypeVariable> {
-    public JavaTypeVariableAssertion(JavaTypeVariable actual) {
+public class JavaTypeVariableAssertion extends AbstractObjectAssert<JavaTypeVariableAssertion, JavaTypeVariable<?>> {
+    public JavaTypeVariableAssertion(JavaTypeVariable<?> actual) {
         super(actual, JavaTypeVariableAssertion.class);
     }
 
@@ -215,7 +215,7 @@ public class JavaTypeVariableAssertion extends AbstractObjectAssert<JavaTypeVari
         @Override
         public void assertMatchWith(JavaType actual, DescriptionContext context) {
             assertThat(actual).as(context.step("JavaType").toString()).isInstanceOf(JavaTypeVariable.class);
-            JavaTypeVariable actualTypeVariable = (JavaTypeVariable) actual;
+            JavaTypeVariable<?> actualTypeVariable = (JavaTypeVariable<?>) actual;
             assertThat(actualTypeVariable.getName()).as(context.step("type variable name").toString()).isEqualTo(name);
 
             if (upperBounds != null) {


### PR DESCRIPTION
This is the next step of #398. It will make the imported type parameters of `JavaClass` widely useful by adding type parameter dependencies (e.g. `Bar` for `class Foo<T extends Bar>`) to the `JavaClass.directDependencies{From/To}Self`.
This way type parameter dependencies will now cause violations in all dependency based `ArchRules` like `LayeredArchitecture` or any `classes()...dependOn...()` fluent API methods.