### PR TITLE
Add workflow for Update Gradle Wrapper Action.

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,17 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action keeps Gradle Wrapper up-to-date to the latest release. It
will run every day at midnight (UTC) and create a pull request if a new
Gradle version is available. The updated Wrapper script is validated
(with checksum verification) during the update process, and the Wrapper
is setup so that it will validate the Gradle binary itself on first run
of the new version.

Signed-off-by: Cristian Greco <cristian@regolo.cc>

Original PR -> #426 (want to limit the communication round trips since I don't have permissions to clean up the history of the other PR)