### PR TITLE
Add referenced class objects to `JavaClass`

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -972,6 +972,9 @@ class ExamplesIntegrationTest {
                                 .by(field(ShoppingService.class, "productRepository").ofType(ProductRepository.class))
                                 .by(field(ShoppingService.class, "shoppingCartRepository").ofType(ShoppingCartRepository.class))
 
+                                .by(method(AdministrationCLI.class, "handle")
+                                        .referencingClassObject(ProductRepository.class)
+                                        .inLine(16))
                                 .by(callFromMethod(AdministrationCLI.class, "handle", String[].class, AdministrationPort.class)
                                         .toMethod(ProductRepository.class, "getTotalCount")
                                         .inLine(17).asDependency())

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -190,7 +190,11 @@ public class ExpectedDependency implements ExpectedRelation {
         }
 
         public AddsLineNumber checkingInstanceOf(Class<?> target) {
-            return new AddsLineNumber(owner, getOriginName(), target);
+            return new AddsLineNumber(owner, getOriginName(), "checks instanceof", target);
+        }
+
+        public AddsLineNumber referencingClassObject(Class<?> target) {
+            return new AddsLineNumber(owner, getOriginName(), "references class object", target);
         }
 
         private String getOriginName() {
@@ -201,15 +205,17 @@ public class ExpectedDependency implements ExpectedRelation {
             private final Class<?> owner;
             private final String origin;
             private final Class<?> target;
+            private final String dependencyType;
 
-            private AddsLineNumber(Class<?> owner, String origin, Class<?> target) {
+            private AddsLineNumber(Class<?> owner, String origin, String dependencyType, Class<?> target) {
                 this.owner = owner;
                 this.origin = origin;
                 this.target = target;
+                this.dependencyType = dependencyType;
             }
 
             public ExpectedDependency inLine(int lineNumber) {
-                String dependencyPattern = getDependencyPattern(origin, "checks instanceof", target.getName(), lineNumber);
+                String dependencyPattern = getDependencyPattern(origin, dependencyType, target.getName(), lineNumber);
                 return new ExpectedDependency(owner, target, dependencyPattern);
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -122,6 +122,12 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
                 instanceofCheck.getRawType(), instanceofCheck.getSourceCodeLocation());
     }
 
+    static Set<Dependency> tryCreateFromReferencedClassObject(ReferencedClassObject referencedClassObject) {
+        return tryCreateDependency(
+                referencedClassObject.getOwner(), "references class object",
+                referencedClassObject.getRawType(), referencedClassObject.getSourceCodeLocation());
+    }
+
     static Set<Dependency> tryCreateFromAnnotation(JavaAnnotation<?> target) {
         Origin origin = findSuitableOrigin(target, target.getAnnotatedElement());
         return tryCreateDependency(origin, "is annotated with", target.getRawType());

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -28,6 +28,7 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -100,44 +101,46 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
     }
 
     static Set<Dependency> tryCreateFromField(JavaField field) {
-        return tryCreateDependencyFromJavaMember(field, "has type", field.getRawType());
+        return tryCreateDependency(field, "has type", field.getRawType());
     }
 
     static Set<Dependency> tryCreateFromReturnType(JavaMethod method) {
-        return tryCreateDependencyFromJavaMember(method, "has return type", method.getRawReturnType());
+        return tryCreateDependency(method, "has return type", method.getRawReturnType());
     }
 
     static Set<Dependency> tryCreateFromParameter(JavaCodeUnit codeUnit, JavaClass parameter) {
-        return tryCreateDependencyFromJavaMember(codeUnit, "has parameter of type", parameter);
+        return tryCreateDependency(codeUnit, "has parameter of type", parameter);
     }
 
     static Set<Dependency> tryCreateFromThrowsDeclaration(ThrowsDeclaration<? extends JavaCodeUnit> declaration) {
-        return tryCreateDependencyFromJavaMember(declaration.getLocation(), "throws type", declaration.getRawType());
+        return tryCreateDependency(declaration.getLocation(), "throws type", declaration.getRawType());
     }
 
     static Set<Dependency> tryCreateFromInstanceofCheck(InstanceofCheck instanceofCheck) {
-        return tryCreateDependencyFromJavaMemberWithLocation(instanceofCheck.getOwner(), "checks instanceof", instanceofCheck.getRawType(), instanceofCheck.getLineNumber());
+        return tryCreateDependency(
+                instanceofCheck.getOwner(), "checks instanceof",
+                instanceofCheck.getRawType(), instanceofCheck.getSourceCodeLocation());
     }
 
     static Set<Dependency> tryCreateFromAnnotation(JavaAnnotation<?> target) {
         Origin origin = findSuitableOrigin(target, target.getAnnotatedElement());
-        return tryCreateDependency(origin.originClass, origin.originDescription, "is annotated with", target.getRawType());
+        return tryCreateDependency(origin, "is annotated with", target.getRawType());
     }
 
     static Set<Dependency> tryCreateFromAnnotationMember(JavaAnnotation<?> annotation, JavaClass memberType) {
         Origin origin = findSuitableOrigin(annotation, annotation.getAnnotatedElement());
-        return tryCreateDependency(origin.originClass, origin.originDescription, "has annotation member of type", memberType);
+        return tryCreateDependency(origin, "has annotation member of type", memberType);
     }
 
     static Set<Dependency> tryCreateFromTypeParameter(JavaTypeVariable<?> typeParameter, JavaClass typeParameterDependency) {
         String dependencyType = "has type parameter '" + typeParameter.getName() + "' depending on";
         Origin origin = findSuitableOrigin(typeParameter, typeParameter.getOwner());
-        return tryCreateDependency(origin.originClass, origin.originDescription, dependencyType, typeParameterDependency);
+        return tryCreateDependency(origin, dependencyType, typeParameterDependency);
     }
 
     static Set<Dependency> tryCreateFromGenericSuperclassTypeArguments(JavaClass originClass, JavaType superclass, JavaClass typeArgumentDependency) {
         String dependencyType = "has generic superclass " + bracketFormat(superclass.getName()) + " with type argument depending on";
-        return tryCreateDependency(originClass, originClass.getDescription(), dependencyType, typeArgumentDependency);
+        return tryCreateDependency(originClass, originClass.getDescription(), dependencyType, typeArgumentDependency, originClass.getSourceCodeLocation());
     }
 
     private static Origin findSuitableOrigin(Object dependencyCause, Object originCandidate) {
@@ -152,22 +155,20 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         throw new IllegalStateException("Could not find suitable dependency origin for " + dependencyCause);
     }
 
-    private static Set<Dependency> tryCreateDependencyFromJavaMember(JavaMember origin, String dependencyType, JavaClass target) {
-        return tryCreateDependency(origin.getOwner(), origin.getDescription(), dependencyType, target);
+    private static <T extends HasOwner<JavaClass> & HasDescription> Set<Dependency> tryCreateDependency(
+            T origin, String dependencyType, JavaClass targetClass) {
+        return tryCreateDependency(origin, dependencyType, targetClass, origin.getOwner().getSourceCodeLocation());
     }
 
-    private static Set<Dependency> tryCreateDependencyFromJavaMemberWithLocation(JavaMember origin, String dependencyType, JavaClass target, int lineNumber) {
-        return tryCreateDependency(origin.getOwner(), origin.getDescription(), dependencyType, target, SourceCodeLocation.of(origin.getOwner(), lineNumber));
-    }
+    private static <T extends HasOwner<JavaClass> & HasDescription> Set<Dependency> tryCreateDependency(
+            T origin, String dependencyType, JavaClass targetClass, SourceCodeLocation sourceCodeLocation) {
 
-    private static Set<Dependency> tryCreateDependency(
-            JavaClass originClass, String originDescription, String dependencyType, JavaClass targetClass) {
-
-        return tryCreateDependency(originClass, originDescription, dependencyType, targetClass, originClass.getSourceCodeLocation());
+        return tryCreateDependency(origin.getOwner(), origin.getDescription(), dependencyType, targetClass, sourceCodeLocation);
     }
 
     private static Set<Dependency> tryCreateDependency(
             JavaClass originClass, String originDescription, String dependencyType, JavaClass targetClass, SourceCodeLocation sourceCodeLocation) {
+
         ImmutableSet.Builder<Dependency> dependencies = ImmutableSet.<Dependency>builder()
                 .addAll(createComponentTypeDependencies(originClass, originDescription, targetClass, sourceCodeLocation));
         String targetDescription = bracketFormat(targetClass.getName());
@@ -177,7 +178,9 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         return dependencies.build();
     }
 
-    private static Set<Dependency> createComponentTypeDependencies(JavaClass originClass, String originDescription, JavaClass targetClass, SourceCodeLocation sourceCodeLocation) {
+    private static Set<Dependency> createComponentTypeDependencies(
+            JavaClass originClass, String originDescription, JavaClass targetClass, SourceCodeLocation sourceCodeLocation) {
+
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
         Optional<JavaClass> componentType = targetClass.tryGetComponentType();
         while (componentType.isPresent()) {
@@ -271,13 +274,23 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         return JavaClasses.of(classes);
     }
 
-    private static class Origin {
+    private static class Origin implements HasOwner<JavaClass>, HasDescription {
         private final JavaClass originClass;
         private final String originDescription;
 
         private Origin(JavaClass originClass, String originDescription) {
             this.originClass = originClass;
             this.originDescription = originDescription;
+        }
+
+        @Override
+        public JavaClass getOwner() {
+            return originClass;
+        }
+
+        @Override
+        public String getDescription() {
+            return originDescription;
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -146,6 +146,10 @@ public class DomainObjectCreationContext {
         return new Source(uri, sourceFileName, md5InClassSourcesEnabled);
     }
 
+    public static ReferencedClassObject createReferencedClassObject(JavaCodeUnit codeUnit, JavaClass javaClass, int lineNumber) {
+        return ReferencedClassObject.from(codeUnit, javaClass, lineNumber);
+    }
+
     public static <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> createThrowsClause(CODE_UNIT codeUnit, List<JavaClass> types) {
         return ThrowsClause.from(codeUnit, types);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
@@ -17,22 +17,25 @@ package com.tngtech.archunit.core.domain;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.core.domain.properties.HasType;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit> {
+public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
 
     private final JavaCodeUnit owner;
     private final JavaClass target;
     private final int lineNumber;
+    private final SourceCodeLocation sourceCodeLocation;
 
     private InstanceofCheck(JavaCodeUnit owner, JavaClass target, int lineNumber) {
         this.owner = checkNotNull(owner);
         this.target = checkNotNull(target);
         this.lineNumber = lineNumber;
+        sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
     }
 
     @Override
@@ -56,6 +59,11 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit> {
     @PublicAPI(usage = ACCESS)
     public int getLineNumber() {
         return lineNumber;
+    }
+
+    @Override
+    public SourceCodeLocation getSourceCodeLocation() {
+        return sourceCodeLocation;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasType;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
@@ -55,6 +56,15 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit> {
     @PublicAPI(usage = ACCESS)
     public int getLineNumber() {
         return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("owner", owner)
+                .add("target", target)
+                .add("lineNumber", lineNumber)
+                .toString();
     }
 
     static InstanceofCheck from(JavaCodeUnit owner, JavaClass target, int lineNumber) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -648,6 +648,15 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         return typeParameters;
     }
 
+    @PublicAPI(usage = ACCESS)
+    public Set<ReferencedClassObject> getReferencedClassObjects() {
+        ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getReferencedClassObjects());
+        }
+        return result.build();
+    }
+
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -52,6 +52,7 @@ class JavaClassDependencies {
                 result.addAll(constructorParameterDependenciesFromSelf());
                 result.addAll(annotationDependenciesFromSelf());
                 result.addAll(instanceofCheckDependenciesFromSelf());
+                result.addAll(referencedClassObjectDependenciesFromSelf());
                 result.addAll(typeParameterDependenciesFromSelf());
                 return result.build();
             }
@@ -154,6 +155,14 @@ class JavaClassDependencies {
             for (InstanceofCheck instanceofCheck : codeUnit.getInstanceofChecks()) {
                 result.addAll(Dependency.tryCreateFromInstanceofCheck(instanceofCheck));
             }
+        }
+        return result.build();
+    }
+
+    private Set<Dependency> referencedClassObjectDependenciesFromSelf() {
+        ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
+        for (ReferencedClassObject referencedClassObject : javaClass.getReferencedClassObjects()) {
+            result.addAll(Dependency.tryCreateFromReferencedClassObject(referencedClassObject));
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -50,6 +50,7 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
     private final JavaClass returnType;
     private final JavaClassList parameters;
     private final String fullName;
+    private final Set<ReferencedClassObject> referencedClassObjects;
     private final Set<InstanceofCheck> instanceofChecks;
 
     private Set<JavaFieldAccess> fieldAccesses = Collections.emptySet();
@@ -61,7 +62,8 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
         this.returnType = builder.getReturnType();
         this.parameters = builder.getParameters();
         fullName = formatMethod(getOwner().getName(), getName(), getRawParameterTypes());
-        instanceofChecks = builder.getInstanceofChecks(this);
+        referencedClassObjects = ImmutableSet.copyOf(builder.getReferencedClassObjects(this));
+        instanceofChecks = ImmutableSet.copyOf(builder.getInstanceofChecks(this));
     }
 
     /**
@@ -110,6 +112,11 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
     @PublicAPI(usage = ACCESS)
     public Set<JavaConstructorCall> getConstructorCallsFromSelf() {
         return constructorCalls;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<ReferencedClassObject> getReferencedClassObjects() {
+        return referencedClassObjects;
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.ChainableFunction;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
+import com.tngtech.archunit.core.domain.properties.HasType;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
+    private final JavaCodeUnit owner;
+    private final JavaClass value;
+    private final int lineNumber;
+    private final SourceCodeLocation sourceCodeLocation;
+
+    private ReferencedClassObject(JavaCodeUnit owner, JavaClass value, int lineNumber) {
+        this.owner = checkNotNull(owner);
+        this.value = checkNotNull(value);
+        this.lineNumber = lineNumber;
+        sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaType getType() {
+        return getRawType();
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getRawType() {
+        return value;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaCodeUnit getOwner() {
+        return owner;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getValue() {
+        return value;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public SourceCodeLocation getSourceCodeLocation() {
+        return sourceCodeLocation;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("owner", owner)
+                .add("value", value)
+                .add("sourceCodeLocation", sourceCodeLocation)
+                .toString();
+    }
+
+    static ReferencedClassObject from(JavaCodeUnit owner, JavaClass javaClass, int lineNumber) {
+        return new ReferencedClassObject(owner, javaClass, lineNumber);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static final class Functions {
+        private Functions() {
+        }
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<ReferencedClassObject, JavaClass> GET_VALUE = new ChainableFunction<ReferencedClassObject, JavaClass>() {
+            @Override
+            public JavaClass apply(ReferencedClassObject input) {
+                return input.getValue();
+            }
+        };
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -233,7 +233,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
             @Override
             public FieldAccessTarget getTarget() {
                 Supplier<Optional<JavaField>> fieldSupplier = new FieldTargetSupplier(targetOwner.getAllFields(), record.target);
-                JavaClass fieldType = classes.getOrResolve(JavaClassDescriptorImporter.importAsmType(record.target.desc).getFullyQualifiedClassName());
+                JavaClass fieldType = classes.getOrResolve(JavaClassDescriptorImporter.importAsmTypeFromDescriptor(record.target.desc).getFullyQualifiedClassName());
                 return new FieldAccessTargetBuilder()
                         .withOwner(targetOwner)
                         .withName(record.target.name)

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -59,6 +59,7 @@ import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.JavaWildcardType;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.Source;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 
@@ -67,6 +68,7 @@ import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeVariable;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createInstanceofCheck;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createJavaClassList;
+import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createReferencedClassObject;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createSource;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createThrowsClause;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createTypeVariable;
@@ -217,6 +219,7 @@ public final class DomainBuilders {
         private JavaClassDescriptor returnType;
         private List<JavaClassDescriptor> parameters;
         private List<JavaClassDescriptor> throwsDeclarations;
+        private final Set<RawReferencedClassObject> rawReferencedClassObjects = new HashSet<>();
         private final List<RawInstanceofCheck> instanceOfChecks = new ArrayList<>();
 
         private JavaCodeUnitBuilder() {
@@ -234,6 +237,11 @@ public final class DomainBuilders {
 
         SELF withThrowsClause(List<JavaClassDescriptor> throwsDeclarations) {
             this.throwsDeclarations = throwsDeclarations;
+            return self();
+        }
+
+        SELF addReferencedClassObject(RawReferencedClassObject rawReferencedClassObject) {
+            rawReferencedClassObjects.add(rawReferencedClassObject);
             return self();
         }
 
@@ -260,6 +268,14 @@ public final class DomainBuilders {
 
         public <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> getThrowsClause(CODE_UNIT codeUnit) {
             return createThrowsClause(codeUnit, asJavaClasses(this.throwsDeclarations));
+        }
+
+        public Set<ReferencedClassObject> getReferencedClassObjects(JavaCodeUnit codeUnit) {
+            ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
+            for (RawReferencedClassObject rawReferencedClassObject : this.rawReferencedClassObjects) {
+                result.add(createReferencedClassObject(codeUnit, get(rawReferencedClassObject.getClassName()), rawReferencedClassObject.getLineNumber()));
+            }
+            return result.build();
         }
 
         public Set<InstanceofCheck> getInstanceofChecks(JavaCodeUnit codeUnit) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassDescriptorImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassDescriptorImporter.java
@@ -42,7 +42,7 @@ class JavaClassDescriptorImporter {
         return isAsmType(value) ? importAsmType((Type) value) : value;
     }
 
-    static JavaClassDescriptor importAsmType(String typeDescriptor) {
+    static JavaClassDescriptor importAsmTypeFromDescriptor(String typeDescriptor) {
         return importAsmType(Type.getType(typeDescriptor));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassDescriptorImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassDescriptorImporter.java
@@ -27,10 +27,14 @@ class JavaClassDescriptorImporter {
      * i.e. java/lang/Object (note that this is not a descriptor like Ljava/lang/Object;)
      */
     static JavaClassDescriptor createFromAsmObjectTypeName(String objectTypeName) {
-        return importAsmType(Type.getObjectType(objectTypeName));
+        return JavaClassDescriptor.From.name(Type.getObjectType(objectTypeName).getClassName());
     }
 
-    static JavaClassDescriptor importAsmType(Type type) {
+    static JavaClassDescriptor importAsmType(Object type) {
+        return importAsmType((Type) type);
+    }
+
+    private static JavaClassDescriptor importAsmType(Type type) {
         return JavaClassDescriptor.From.name(type.getClassName());
     }
 
@@ -39,7 +43,7 @@ class JavaClassDescriptorImporter {
     }
 
     static Object importAsmTypeIfPossible(Object value) {
-        return isAsmType(value) ? importAsmType((Type) value) : value;
+        return isAsmType(value) ? importAsmType(value) : value;
     }
 
     static JavaClassDescriptor importAsmTypeFromDescriptor(String typeDescriptor) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -206,7 +206,7 @@ class JavaClassProcessor extends ClassVisitor {
 
         DomainBuilders.JavaFieldBuilder fieldBuilder = new DomainBuilders.JavaFieldBuilder()
                 .withName(name)
-                .withType(JavaClassDescriptorImporter.importAsmType(desc))
+                .withType(JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc))
                 .withModifiers(JavaModifier.getModifiersForField(access))
                 .withDescriptor(desc);
         declarationHandler.onDeclaredField(fieldBuilder);
@@ -500,7 +500,7 @@ class JavaClassProcessor extends ClassVisitor {
     }
 
     private static DomainBuilders.JavaAnnotationBuilder annotationBuilderFor(String desc) {
-        return new DomainBuilders.JavaAnnotationBuilder().withType(JavaClassDescriptorImporter.importAsmType(desc));
+        return new DomainBuilders.JavaAnnotationBuilder().withType(JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc));
     }
 
     private static class AnnotationProcessor extends AnnotationVisitor {
@@ -736,7 +736,7 @@ class JavaClassProcessor extends ClassVisitor {
             public <T extends HasDescription> Optional<Object> build(T owner, ImportContext importContext) {
                 return Optional.<Object>of(
                         new DomainBuilders.JavaEnumConstantBuilder()
-                                .withDeclaringClass(importContext.resolveClass(JavaClassDescriptorImporter.importAsmType(desc).getFullyQualifiedClassName()))
+                                .withDeclaringClass(importContext.resolveClass(JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc).getFullyQualifiedClassName()))
                                 .withName(value)
                                 .build());
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -319,6 +319,14 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         @Override
+        public void visitLdcInsn(Object value) {
+            if (JavaClassDescriptorImporter.isAsmType(value)) {
+                codeUnitBuilder.addReferencedClassObject(
+                        RawReferencedClassObject.from(JavaClassDescriptorImporter.importAsmType(value), actualLineNumber));
+            }
+        }
+
+        @Override
         public void visitFieldInsn(int opcode, String owner, String name, String desc) {
             accessHandler.handleFieldInstruction(opcode, owner, name, desc);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawInstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawInstanceofCheck.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit.core.importer;
 
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 class RawInstanceofCheck {
@@ -28,15 +29,23 @@ class RawInstanceofCheck {
         this.lineNumber = lineNumber;
     }
 
-    public static RawInstanceofCheck from(JavaClassDescriptor target, int lineNumber) {
+    static RawInstanceofCheck from(JavaClassDescriptor target, int lineNumber) {
         return new RawInstanceofCheck(target, lineNumber);
     }
 
-    public JavaClassDescriptor getTarget() {
+    JavaClassDescriptor getTarget() {
         return target;
     }
 
-    public int getLineNumber() {
+    int getLineNumber() {
         return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("target", target)
+                .add("lineNumber", lineNumber)
+                .toString();
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawReferencedClassObject.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.core.domain.JavaClassDescriptor;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class RawReferencedClassObject {
+    private final JavaClassDescriptor type;
+    private final int lineNumber;
+
+    private RawReferencedClassObject(JavaClassDescriptor type, int lineNumber) {
+        this.type = checkNotNull(type);
+        this.lineNumber = lineNumber;
+    }
+
+    static RawReferencedClassObject from(JavaClassDescriptor target, int lineNumber) {
+        return new RawReferencedClassObject(target, lineNumber);
+    }
+
+    String getClassName() {
+        return type.getFullyQualifiedClassName();
+    }
+
+    int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("type", type)
+                .add("lineNumber", lineNumber)
+                .toString();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/ReferencedClassObjectTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/ReferencedClassObjectTest.java
@@ -1,0 +1,30 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.File;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.domain.ReferencedClassObject.Functions.GET_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReferencedClassObjectTest {
+
+    @Test
+    public void function_getValue() {
+        class SomeClass {
+            @SuppressWarnings("unused")
+            Class<?> call() {
+                return File.class;
+            }
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, File.class);
+        JavaMethod owner = classes.get(SomeClass.class).getMethod("call");
+
+        ReferencedClassObject referencedClassObject = getOnlyElement(owner.getReferencedClassObjects());
+
+        assertThat(GET_VALUE.apply(referencedClassObject)).isEqualTo(classes.get(File.class));
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/DependenciesOnClassObjects.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/DependenciesOnClassObjects.java
@@ -1,0 +1,30 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.nio.Buffer;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+@SuppressWarnings({"FieldMayBeFinal", "unused"})
+public class DependenciesOnClassObjects {
+    static {
+        List<Class<?>> referencedClassObjectsInStaticInitializer = ImmutableList.of(FilterInputStream.class, Buffer.class);
+    }
+
+    List<Class<?>> referencedClassObjectsInConstructor = ImmutableList.<Class<?>>of(File.class, Path.class);
+
+    List<Class<?>> referencedClassObjectsInMethod() {
+        return ImmutableList.of(FileSystem.class, Charset.class);
+    }
+
+    public static class MoreDependencies {
+        Class<?> moreReferencedClassObjectsInMethod() {
+            return Charset.class;
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/referencedclassobjects/ReferencingClassObjects.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/referencedclassobjects/ReferencingClassObjects.java
@@ -1,0 +1,24 @@
+package com.tngtech.archunit.core.importer.testexamples.referencedclassobjects;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.nio.Buffer;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+@SuppressWarnings({"FieldMayBeFinal", "unused"})
+public class ReferencingClassObjects {
+    static {
+        List<Class<?>> referencedClassObjectsInStaticInitializer = ImmutableList.of(FilterInputStream.class, Buffer.class);
+    }
+
+    List<Class<?>> referencedClassObjectsInConstructor = ImmutableList.<Class<?>>of(File.class, Path.class);
+
+    List<Class<?>> referencedClassObjectsInMethod() {
+        return ImmutableList.of(FileSystem.class, Charset.class);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -934,7 +934,7 @@ public class ShouldOnlyByClassesThatTest {
     public void areAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areAnonymousClasses())
-                .on(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass(),
+                .on(ClassAccessingAnonymousClass_Reference, anonymousClassBeingAccessed.getClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatTypes(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
@@ -945,10 +945,10 @@ public class ShouldOnlyByClassesThatTest {
     public void areNotAnonymousClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areNotAnonymousClasses())
-                .on(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass(),
+                .on(ClassAccessingAnonymousClass_Reference, anonymousClassBeingAccessed.getClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
-        assertThatTypes(classes).matchInAnyOrder(ClassAccessingAnonymousClass.class, anonymousClassBeingAccessed.getClass());
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingAnonymousClass_Reference, anonymousClassBeingAccessed.getClass());
     }
 
     @Test
@@ -956,7 +956,7 @@ public class ShouldOnlyByClassesThatTest {
     public void areLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areLocalClasses())
-                .on(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass(),
+                .on(ClassAccessingLocalClass_Reference, ClassBeingAccessedByLocalClass.getLocalClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
         assertThatTypes(classes).matchInAnyOrder(ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
@@ -967,10 +967,10 @@ public class ShouldOnlyByClassesThatTest {
     public void areNotLocalClasses_predicate(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.areNotLocalClasses())
-                .on(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass(),
+                .on(ClassAccessingLocalClass_Reference, ClassBeingAccessedByLocalClass.getLocalClass(),
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
-        assertThatTypes(classes).matchInAnyOrder(ClassBeingAccessedByLocalClass.class, ClassBeingAccessedByLocalClass.getLocalClass());
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingLocalClass_Reference, ClassBeingAccessedByLocalClass.getLocalClass());
     }
 
     @Test
@@ -1048,6 +1048,14 @@ public class ShouldOnlyByClassesThatTest {
 
     private static DescribedPredicate<HasName> classWithNameOf(Class<?> type) {
         return GET_NAME.is(equalTo(type.getName()));
+    }
+
+    private static Class<?> classForName(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static class ClassAccessedByFoo {
@@ -1306,6 +1314,8 @@ public class ShouldOnlyByClassesThatTest {
     private class InnerMemberClassBeingAccessed {
     }
 
+    // This must be loaded via Reflection, otherwise the test will be tainted by the dependency on the class object
+    private static final Class<?> ClassAccessingAnonymousClass_Reference = classForName("com.tngtech.archunit.lang.syntax.elements.ShouldOnlyByClassesThatTest$ClassAccessingAnonymousClass");
     private static class ClassAccessingAnonymousClass {
         @SuppressWarnings("unused")
         void access() {
@@ -1320,15 +1330,20 @@ public class ShouldOnlyByClassesThatTest {
         }
     };
 
+    // This must be loaded via Reflection, otherwise the test will be tainted by the dependency on the class object
+    private static final Class<?> ClassAccessingLocalClass_Reference = classForName("com.tngtech.archunit.lang.syntax.elements.ShouldOnlyByClassesThatTest$ClassBeingAccessedByLocalClass");
+
     private static class ClassBeingAccessedByLocalClass {
         static Class<?> getLocalClass() {
+            @SuppressWarnings({"unused", "InstantiationOfUtilityClass"})
             class LocalClass {
-                @SuppressWarnings("unused")
                 void access() {
                     new ClassBeingAccessedByLocalClass();
                 }
             }
-            return LocalClass.class;
+
+            // This must be loaded via Reflection, otherwise the test will be tainted by the dependency on the class object
+            return classForName("com.tngtech.archunit.lang.syntax.elements.ShouldOnlyByClassesThatTest$ClassBeingAccessedByLocalClass$1LocalClass");
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -33,6 +33,7 @@ import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaPackage;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -58,6 +59,7 @@ import com.tngtech.archunit.testutil.assertion.JavaPackagesAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaTypeAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaTypeVariableAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaTypesAssertion;
+import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.AbstractObjectAssert;
@@ -159,6 +161,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static JavaFieldAssertion assertThat(JavaField field) {
         return new JavaFieldAssertion(field);
+    }
+
+    public static ReferencedClassObjectsAssertion assertThatReferencedClassObjects(Set<ReferencedClassObject> referencedClassObjects) {
+        return new ReferencedClassObjectsAssertion(referencedClassObjects);
     }
 
     public static JavaEnumConstantAssertion assertThat(JavaEnumConstant enumConstant) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ReferencedClassObjectsAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ReferencedClassObjectsAssertion.java
@@ -1,0 +1,69 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.Set;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReferencedClassObjectsAssertion extends AbstractIterableAssert<ReferencedClassObjectsAssertion, Set<ReferencedClassObject>, ReferencedClassObject, ReferencedClassObjectsAssertion.ReferencedClassObjectAssertion> {
+    public ReferencedClassObjectsAssertion(Set<ReferencedClassObject> referencedClassObjects) {
+        super(referencedClassObjects, ReferencedClassObjectsAssertion.class);
+    }
+
+    @Override
+    protected ReferencedClassObjectAssertion toAssert(ReferencedClassObject value, String description) {
+        return new ReferencedClassObjectAssertion(value).as(description);
+    }
+
+    public void containReferencedClassObjects(Iterable<ExpectedReferencedClassObject> expectedReferencedClassObjects) {
+        final FluentIterable<ReferencedClassObject> actualReferencedClassObjects = FluentIterable.from(actual);
+        Set<ExpectedReferencedClassObject> unmatchedClassObjects = FluentIterable.from(expectedReferencedClassObjects)
+                .filter(new Predicate<ExpectedReferencedClassObject>() {
+                    @Override
+                    public boolean apply(ExpectedReferencedClassObject expectedReferencedClassObject) {
+                        return !actualReferencedClassObjects.anyMatch(expectedReferencedClassObject);
+                    }
+                }).toSet();
+        assertThat(unmatchedClassObjects).as("Referenced class objects not contained in " + actual).isEmpty();
+    }
+
+    static class ReferencedClassObjectAssertion extends AbstractObjectAssert<ReferencedClassObjectAssertion, ReferencedClassObject> {
+        public ReferencedClassObjectAssertion(ReferencedClassObject referencedClassObject) {
+            super(referencedClassObject, ReferencedClassObjectAssertion.class);
+        }
+    }
+
+    public static ExpectedReferencedClassObject referencedClassObject(Class<?> type, int lineNumber) {
+        return new ExpectedReferencedClassObject(type, lineNumber);
+    }
+
+    public static class ExpectedReferencedClassObject implements Predicate<ReferencedClassObject> {
+        private final Class<?> type;
+        private final int lineNumber;
+
+        private ExpectedReferencedClassObject(Class<?> type, int lineNumber) {
+            this.type = type;
+            this.lineNumber = lineNumber;
+        }
+
+        @Override
+        @SuppressWarnings("ConstantConditions")
+        public boolean apply(ReferencedClassObject input) {
+            return input.getValue().isEquivalentTo(type) && input.getLineNumber() == lineNumber;
+        }
+
+        @Override
+        public String toString() {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .add("lineNumber", lineNumber)
+                    .toString();
+        }
+    }
+}


### PR DESCRIPTION
So far ArchUnit has not been able to detect the pure usage of class objects as dependencies. E.g. the following example would not have detected a dependency on `Evil`, since besides the reference to the class object no further dependency on `Evil` (like a field access or method call) has occurred.

```
class Example {
  final Map<Class<?>, Object> association = Map.of(Evil.class, anything);
}
```

With this PR `JavaClass` now knows its `referencedClassObjects`, including the respective line number. Furthermore class objects are now parts of the `dependencies{From/To}Self` of a `JavaClass`.

Resolves: #309 
Issue: #446 
Resolves: #474 
Resolves: #515
