### PR TITLE
explicitly install Gradle JDK

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Gradle JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:


### PR DESCRIPTION
It seems like for the next Gradle version even the "update wrapper" task does some analysis of the Java bytecode version. The symptom now is something like

```
/usr/bin/gradle wrapper --gradle-version 6.8.2 --distribution-type bin --gradle-distribution-sha256-sum 8de6efc274ab52332a9c820366dd5cf5fc9d35ec7078fd70c8ec6913431ee610
...
  > Configure project :
  Configured JDK: 1.8

  FAILURE: Build failed with an exception.

  * What went wrong:
  java.lang.UnsupportedClassVersionError: org/javamodularity/moduleplugin/ModuleSystemPlugin has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
  > org/javamodularity/moduleplugin/ModuleSystemPlugin has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

Thus I've added an explicit install step to provide a JDK that is new enough. The concrete version should be irrelevant, since we won't execute a real build with this JDK, but only verify the wrapper.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>