### PR TITLE
Automatically resolve member signature types

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.base.Optional;
+
+import static com.google.common.collect.Iterables.concat;
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static com.tngtech.archunit.core.domain.JavaModifier.ENUM;
+
+class JavaClassMembers {
+    private final JavaClass owner;
+    private final Set<JavaField> fields;
+    private final Set<JavaCodeUnit> codeUnits;
+    private final Set<JavaMethod> methods;
+    private final Set<JavaMember> members;
+    private final Set<JavaConstructor> constructors;
+    private final Optional<JavaStaticInitializer> staticInitializer;
+    private final Supplier<Set<JavaMethod>> allMethods;
+    private final Supplier<Set<JavaConstructor>> allConstructors;
+    private final Supplier<Set<JavaField>> allFields;
+    private final Supplier<Set<JavaMember>> allMembers = Suppliers.memoize(new Supplier<Set<JavaMember>>() {
+        @Override
+        public Set<JavaMember> get() {
+            return ImmutableSet.<JavaMember>builder()
+                    .addAll(getAllFields())
+                    .addAll(getAllMethods())
+                    .addAll(getAllConstructors())
+                    .build();
+        }
+    });
+
+    JavaClassMembers(final JavaClass owner, Set<JavaField> fields, Set<JavaMethod> methods, Set<JavaConstructor> constructors, Optional<JavaStaticInitializer> staticInitializer) {
+        this.owner = owner;
+        this.fields = fields;
+        this.methods = methods;
+        this.constructors = constructors;
+        this.staticInitializer = staticInitializer;
+        this.codeUnits = ImmutableSet.<JavaCodeUnit>builder()
+                .addAll(methods).addAll(constructors).addAll(staticInitializer.asSet())
+                .build();
+        this.members = ImmutableSet.<JavaMember>builder()
+                .addAll(fields)
+                .addAll(methods)
+                .addAll(constructors)
+                .build();
+        allFields = Suppliers.memoize(new Supplier<Set<JavaField>>() {
+            @Override
+            public Set<JavaField> get() {
+                ImmutableSet.Builder<JavaField> result = ImmutableSet.builder();
+                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllInterfaces())) {
+                    result.addAll(javaClass.getFields());
+                }
+                return result.build();
+            }
+        });
+        allMethods = Suppliers.memoize(new Supplier<Set<JavaMethod>>() {
+            @Override
+            public Set<JavaMethod> get() {
+                ImmutableSet.Builder<JavaMethod> result = ImmutableSet.builder();
+                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllInterfaces())) {
+                    result.addAll(javaClass.getMethods());
+                }
+                return result.build();
+            }
+        });
+        allConstructors = Suppliers.memoize(new Supplier<Set<JavaConstructor>>() {
+            @Override
+            public Set<JavaConstructor> get() {
+                ImmutableSet.Builder<JavaConstructor> result = ImmutableSet.builder();
+                for (JavaClass javaClass : owner.getClassHierarchy()) {
+                    result.addAll(javaClass.getConstructors());
+                }
+                return result.build();
+            }
+        });
+    }
+
+    Set<JavaMember> get() {
+        return members;
+    }
+
+    Set<JavaMember> getAll() {
+        return allMembers.get();
+    }
+
+    Set<JavaField> getFields() {
+        return fields;
+    }
+
+    Set<JavaField> getAllFields() {
+        return allFields.get();
+    }
+
+    public JavaField getField(String name) {
+        Optional<JavaField> field = tryGetField(name);
+        if (!field.isPresent()) {
+            throw new IllegalArgumentException("No field with name '" + name + " in class " + owner.getName());
+        }
+        return field.get();
+    }
+
+    Optional<JavaField> tryGetField(String name) {
+        for (JavaField field : fields) {
+            if (name.equals(field.getName())) {
+                return Optional.of(field);
+            }
+        }
+        return Optional.absent();
+    }
+
+    Set<JavaCodeUnit> getCodeUnits() {
+        return codeUnits;
+    }
+
+    JavaCodeUnit getCodeUnitWithParameterTypeNames(String name, List<String> parameters) {
+        return findMatchingCodeUnit(codeUnits, name, parameters);
+    }
+
+    JavaMethod getMethod(String name, List<String> parameterTypeNames) {
+        return findMatchingCodeUnit(methods, name, ImmutableList.copyOf(parameterTypeNames));
+    }
+
+    Optional<JavaMethod> tryGetMethod(String name, List<String> parameterTypeNames) {
+        return tryFindMatchingCodeUnit(methods, name, parameterTypeNames);
+    }
+
+    Set<JavaMethod> getMethods() {
+        return methods;
+    }
+
+    Set<JavaMethod> getAllMethods() {
+        return allMethods.get();
+    }
+
+    JavaConstructor getConstructor(List<String> parameterTypeNames) {
+        return findMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, parameterTypeNames);
+    }
+
+    Optional<JavaConstructor> tryGetConstructor(List<String> parameterTypeNames) {
+        return tryFindMatchingCodeUnit(constructors, CONSTRUCTOR_NAME, parameterTypeNames);
+    }
+
+    Set<JavaConstructor> getConstructors() {
+        return constructors;
+    }
+
+    Set<JavaConstructor> getAllConstructors() {
+        return allConstructors.get();
+    }
+
+    Optional<JavaStaticInitializer> getStaticInitializer() {
+        return staticInitializer;
+    }
+
+    Set<JavaEnumConstant> getEnumConstants() {
+        ImmutableSet.Builder<JavaEnumConstant> result = ImmutableSet.builder();
+        for (JavaField field : fields) {
+            if (field.getModifiers().contains(ENUM)) {
+                result.add(new JavaEnumConstant(owner, field.getName()));
+            }
+        }
+        return result.build();
+    }
+
+    Set<ReferencedClassObject> getReferencedClassObjects() {
+        ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getReferencedClassObjects());
+        }
+        return result.build();
+    }
+
+    Set<JavaFieldAccess> getFieldAccessesFromSelf() {
+        ImmutableSet.Builder<JavaFieldAccess> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getFieldAccesses());
+        }
+        return result.build();
+    }
+
+    Set<JavaMethodCall> getMethodCallsFromSelf() {
+        ImmutableSet.Builder<JavaMethodCall> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getMethodCallsFromSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaConstructorCall> getConstructorCallsFromSelf() {
+        ImmutableSet.Builder<JavaConstructorCall> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getConstructorCallsFromSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaFieldAccess> getFieldAccessesToSelf() {
+        ImmutableSet.Builder<JavaFieldAccess> result = ImmutableSet.builder();
+        for (JavaField field : fields) {
+            result.addAll(field.getAccessesToSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaMethodCall> getMethodCallsToSelf() {
+        ImmutableSet.Builder<JavaMethodCall> result = ImmutableSet.builder();
+        for (JavaMethod method : methods) {
+            result.addAll(method.getCallsOfSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaConstructorCall> getConstructorCallsToSelf() {
+        ImmutableSet.Builder<JavaConstructorCall> result = ImmutableSet.builder();
+        for (JavaConstructor constructor : constructors) {
+            result.addAll(constructor.getCallsOfSelf());
+        }
+        return result.build();
+    }
+
+    private <T extends JavaCodeUnit> T findMatchingCodeUnit(Set<T> codeUnits, String name, List<String> parameters) {
+        Optional<T> codeUnit = tryFindMatchingCodeUnit(codeUnits, name, parameters);
+        if (!codeUnit.isPresent()) {
+            throw new IllegalArgumentException(
+                    String.format("No code unit with name '%s' and parameters %s in codeUnits %s of class %s",
+                            name, parameters, codeUnits, owner.getName()));
+        }
+        return codeUnit.get();
+    }
+
+    private <T extends JavaCodeUnit> Optional<T> tryFindMatchingCodeUnit(Set<T> codeUnits, String name, List<String> parameters) {
+        for (T codeUnit : codeUnits) {
+            if (name.equals(codeUnit.getName()) && parameters.equals(codeUnit.getRawParameterTypes().getNames())) {
+                return Optional.of(codeUnit);
+            }
+        }
+        return Optional.absent();
+    }
+
+    void completeAnnotations(ImportContext context) {
+        for (JavaMember member : members) {
+            member.completeAnnotations(context);
+        }
+    }
+
+    void completeAccessesFrom(ImportContext context) {
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            codeUnit.completeAccessesFrom(context);
+        }
+    }
+
+    void setReverseDependencies(ReverseDependencies reverseDependencies) {
+        for (JavaMember member : members) {
+            member.setReverseDependencies(reverseDependencies);
+        }
+    }
+
+    static JavaClassMembers empty(JavaClass owner) {
+        return new JavaClassMembers(
+                owner,
+                Collections.<JavaField>emptySet(),
+                Collections.<JavaMethod>emptySet(),
+                Collections.<JavaConstructor>emptySet(),
+                Optional.<JavaStaticInitializer>absent());
+    }
+
+    static JavaClassMembers create(JavaClass owner, ImportContext context) {
+        return new JavaClassMembers(
+                owner,
+                context.createFields(owner),
+                context.createMethods(owner),
+                context.createConstructors(owner),
+                context.createStaticInitializer(owner));
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -163,7 +163,7 @@ public abstract class JavaCodeUnit extends JavaMember implements HasParameterTyp
         return (Optional<? extends JavaAnnotation<? extends JavaCodeUnit>>) super.tryGetAnnotationOfType(typeName);
     }
 
-    void completeFrom(ImportContext context) {
+    void completeAccessesFrom(ImportContext context) {
         fieldAccesses = context.createFieldAccessesFor(this);
         methodCalls = context.createMethodCallsFor(this);
         constructorCalls = context.createConstructorCallsFor(this);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -135,6 +135,25 @@ class ClassFileImportRecord {
         return Optional.fromNullable(genericSuperclassBuilderByOwner.get(owner.getName()));
     }
 
+    Set<String> getMemberSignatureTypeNames() {
+        ImmutableSet.Builder<String> result = ImmutableSet.builder();
+        for (DomainBuilders.JavaFieldBuilder fieldBuilder : fieldBuildersByOwner.values()) {
+            result.add(fieldBuilder.getTypeName());
+        }
+        for (DomainBuilders.JavaConstructorBuilder constructorBuilder : constructorBuildersByOwner.values()) {
+            for (String parameterTypeName : constructorBuilder.getParameterTypeNames()) {
+                result.add(parameterTypeName);
+            }
+        }
+        for (DomainBuilders.JavaMethodBuilder methodBuilder : methodBuildersByOwner.values()) {
+            result.add(methodBuilder.getReturnTypeName());
+            for (String parameterTypeName : methodBuilder.getParameterTypeNames()) {
+                result.add(parameterTypeName);
+            }
+        }
+        return result.build();
+    }
+
     Set<DomainBuilders.JavaFieldBuilder> getFieldBuildersFor(String ownerName) {
         return fieldBuildersByOwner.get(ownerName);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -101,12 +101,19 @@ class ClassGraphCreator implements ImportContext {
     }
 
     JavaClasses complete() {
+        ensureMemberTypesArePresent();
         ensureCallTargetsArePresent();
         ensureClassesOfInheritanceHierarchiesArePresent();
         ensureMetaAnnotationsArePresent();
         completeClasses();
         completeAccesses();
         return createJavaClasses(classes.getDirectlyImported(), classes.getAllWithOuterClassesSortedBeforeInnerClasses(), this);
+    }
+
+    private void ensureMemberTypesArePresent() {
+        for (String typeName : importRecord.getMemberSignatureTypeNames()) {
+            classes.ensurePresent(typeName);
+        }
     }
 
     private void ensureCallTargetsArePresent() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -204,6 +204,10 @@ public final class DomainBuilders {
             return self();
         }
 
+        String getTypeName() {
+            return type.getFullyQualifiedClassName();
+        }
+
         public JavaClass getType() {
             return get(type.getFullyQualifiedClassName());
         }
@@ -248,6 +252,14 @@ public final class DomainBuilders {
         SELF addInstanceOfCheck(RawInstanceofCheck rawInstanceOfChecks) {
             this.instanceOfChecks.add(rawInstanceOfChecks);
             return self();
+        }
+
+        List<String> getParameterTypeNames() {
+            ImmutableList.Builder<String> result = ImmutableList.builder();
+            for (JavaClassDescriptor parameter : parameters) {
+                result.add(parameter.getFullyQualifiedClassName());
+            }
+            return result.build();
         }
 
         String getReturnTypeName() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -182,7 +182,7 @@ public class TestUtils {
                 calls.add(newMethodCall(method, target, lineNumber));
             }
             when(context.createMethodCallsFor(method)).thenReturn(ImmutableSet.copyOf(calls));
-            method.completeFrom(context);
+            method.completeAccessesFrom(context);
             return getCallToTarget(methodCallTarget);
         }
 
@@ -210,7 +210,7 @@ public class TestUtils {
                     .thenReturn(ImmutableSet.of(
                             newFieldAccess(method, target, lineNumber, accessType)
                     ));
-            method.completeFrom(context);
+            method.completeAccessesFrom(context);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
@@ -1,0 +1,955 @@
+package com.tngtech.archunit.core.importer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClassList;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsExternalMethod;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsMethodReturningArray;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOtherConstructor;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOtherMethod;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOwnConstructor;
+import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOwnMethod;
+import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalInterfaceMethodCall;
+import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalOverriddenMethodCall;
+import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalSubtypeConstructorCall;
+import com.tngtech.archunit.core.importer.testexamples.complexexternal.ChildClass;
+import com.tngtech.archunit.core.importer.testexamples.complexexternal.ParentClass;
+import com.tngtech.archunit.core.importer.testexamples.dependents.ClassHoldingDependencies;
+import com.tngtech.archunit.core.importer.testexamples.dependents.FirstClassWithDependency;
+import com.tngtech.archunit.core.importer.testexamples.dependents.SecondClassWithDependency;
+import com.tngtech.archunit.core.importer.testexamples.diamond.ClassCallingDiamond;
+import com.tngtech.archunit.core.importer.testexamples.diamond.ClassImplementingD;
+import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceB;
+import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceC;
+import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceD;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ExternalFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ExternalShadowedFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccessFromConstructor;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccessFromStaticInitializer;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignStaticFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.MultipleFieldAccessInSameMethod;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.OwnFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.OwnStaticFieldAccess;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ClassAccessingInterfaceFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.InterfaceWithFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.OtherInterfaceWithFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ParentInterfaceWithFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldimport.ClassWithIntAndObjectFields;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.AccessToSuperAndSubclassField;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.SubclassWithAccessedField;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.SuperclassWithAccessedField;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.CallOfSuperAndSubclassMethod;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.SubclassWithCalledMethod;
+import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.SuperclassWithCalledMethod;
+import com.tngtech.archunit.core.importer.testexamples.integration.ClassA;
+import com.tngtech.archunit.core.importer.testexamples.integration.ClassBDependingOnClassA;
+import com.tngtech.archunit.core.importer.testexamples.integration.ClassCDependingOnClassB_SuperclassOfX;
+import com.tngtech.archunit.core.importer.testexamples.integration.ClassD;
+import com.tngtech.archunit.core.importer.testexamples.integration.ClassXDependingOnClassesABCD;
+import com.tngtech.archunit.core.importer.testexamples.integration.InterfaceOfClassX;
+import com.tngtech.archunit.core.importer.testexamples.specialtargets.ClassCallingSpecialTarget;
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.GET;
+import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.SET;
+import static com.tngtech.archunit.core.domain.JavaStaticInitializer.STATIC_INITIALIZER_NAME;
+import static com.tngtech.archunit.core.domain.TestUtils.asClasses;
+import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.findAnyByName;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.getByName;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
+import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.constructor;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
+
+public class ClassFileImporterAccessesTest {
+
+    @Test
+    public void imports_own_get_field_access() {
+        JavaClass classWithOwnFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(OwnFieldAccess.class);
+
+        JavaMethod getStringValue = classWithOwnFieldAccess.getMethod("getStringValue");
+
+        JavaFieldAccess access = getOnlyElement(getStringValue.getFieldAccesses());
+        assertThatAccess(access)
+                .isOfType(GET)
+                .isFrom(getStringValue)
+                .isTo("stringValue")
+                .inLineNumber(8);
+    }
+
+    @Test
+    public void imports_own_set_field_access() {
+        JavaClass classWithOwnFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(OwnFieldAccess.class);
+
+        JavaMethod setStringValue = classWithOwnFieldAccess.getMethod("setStringValue", String.class);
+
+        JavaFieldAccess access = getOnlyElement(setStringValue.getFieldAccesses());
+        assertThatAccess(access)
+                .isOfType(SET)
+                .isFrom(setStringValue)
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(12);
+    }
+
+    @Test
+    public void imports_multiple_own_accesses() {
+        JavaClass classWithOwnFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(OwnFieldAccess.class);
+
+        Set<JavaFieldAccess> fieldAccesses = classWithOwnFieldAccess.getFieldAccessesFromSelf();
+
+        assertThat(fieldAccesses).hasSize(4);
+        assertThat(getOnly(fieldAccesses, "stringValue", GET).getLineNumber())
+                .as("Line number of get stringValue").isEqualTo(8);
+        assertThat(getOnly(fieldAccesses, "stringValue", SET).getLineNumber())
+                .as("Line number of set stringValue").isEqualTo(12);
+        assertThat(getOnly(fieldAccesses, "intValue", GET).getLineNumber())
+                .as("Line number of get intValue").isEqualTo(16);
+        assertThat(getOnly(fieldAccesses, "intValue", SET).getLineNumber())
+                .as("Line number of set intValue").isEqualTo(20);
+    }
+
+    @Test
+    public void imports_own_static_field_accesses() {
+        JavaClass classWithOwnFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(OwnStaticFieldAccess.class);
+
+        Set<JavaFieldAccess> accesses = classWithOwnFieldAccess.getFieldAccessesFromSelf();
+
+        assertThat(accesses).hasSize(2);
+
+        JavaFieldAccess getAccess = getOnly(accesses, "staticStringValue", GET);
+
+        assertThatAccess(getAccess)
+                .isFrom("getStaticStringValue")
+                .isTo("staticStringValue")
+                .inLineNumber(7);
+
+        JavaFieldAccess setAccess = getOnly(accesses, "staticStringValue", SET);
+
+        assertThatAccess(setAccess)
+                .isFrom("setStaticStringValue", String.class)
+                .isTo("staticStringValue")
+                .inLineNumber(11);
+    }
+
+    @Test
+    public void imports_other_field_accesses() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport"));
+        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
+        JavaClass classWithForeignFieldAccess = classes.get(ForeignFieldAccess.class);
+
+        Set<JavaFieldAccess> accesses = classWithForeignFieldAccess.getFieldAccessesFromSelf();
+
+        assertThat(accesses).hasSize(4);
+
+        assertThatAccess(getOnly(accesses, "stringValue", GET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getStringFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(5);
+
+        assertThatAccess(getOnly(accesses, "stringValue", SET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setStringFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(9);
+
+        assertThatAccess(getOnly(accesses, "intValue", GET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getIntFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(13);
+
+        assertThatAccess(getOnly(accesses, "intValue", SET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setIntFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(17);
+    }
+
+    @Test
+    public void imports_other_static_field_accesses() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport"));
+        JavaClass classWithOwnFieldAccess = classes.get(OwnStaticFieldAccess.class);
+        JavaClass classWithForeignFieldAccess = classes.get(ForeignStaticFieldAccess.class);
+
+        Set<JavaFieldAccess> accesses = classWithForeignFieldAccess.getFieldAccessesFromSelf();
+
+        assertThat(accesses).as("Number of field accesses from " + classWithForeignFieldAccess.getName()).hasSize(2);
+
+        assertThatAccess(getOnly(accesses, "staticStringValue", GET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getStaticStringFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("staticStringValue"))
+                .inLineNumber(5);
+
+        assertThatAccess(getOnly(accesses, "staticStringValue", SET))
+                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setStaticStringFromOther"))
+                .isTo(classWithOwnFieldAccess.getField("staticStringValue"))
+                .inLineNumber(9);
+    }
+
+    @Test
+    public void imports_multiple_accesses_from_same_method() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport"));
+        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
+        JavaClass multipleFieldAccesses = classes.get(MultipleFieldAccessInSameMethod.class);
+
+        Set<JavaFieldAccess> accesses = multipleFieldAccesses.getFieldAccessesFromSelf();
+
+        assertThat(accesses).as("Number of field accesses from " + multipleFieldAccesses.getName()).hasSize(5);
+
+        Set<JavaFieldAccess> setStringValues = getByNameAndAccessType(accesses, "stringValue", SET);
+        assertThat(setStringValues).hasSize(2);
+        assertThat(targetsOf(setStringValues)).containsOnly(targetFrom(classWithOwnFieldAccess.getField("stringValue")));
+        assertThat(lineNumbersOf(setStringValues)).containsOnly(6, 8);
+
+        assertThatAccess(getOnly(accesses, "stringValue", GET))
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(7);
+
+        assertThatAccess(getOnly(accesses, "intValue", GET))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(10);
+
+        assertThatAccess(getOnly(accesses, "intValue", SET))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(11);
+    }
+
+    @Test
+    public void imports_other_field_accesses_from_constructor() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport"));
+        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
+        JavaClass fieldAccessFromConstructor = classes.get(ForeignFieldAccessFromConstructor.class);
+
+        Set<JavaFieldAccess> accesses = fieldAccessFromConstructor.getFieldAccessesFromSelf();
+
+        assertThat(accesses).as("Number of field accesses from " + fieldAccessFromConstructor.getName()).hasSize(2);
+
+        assertThatAccess(getOnly(accesses, "stringValue", GET))
+                .isFrom(fieldAccessFromConstructor.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME))
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(5);
+
+        assertThatAccess(getOnly(accesses, "intValue", SET))
+                .isFrom(fieldAccessFromConstructor.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(6);
+    }
+
+    @Test
+    public void imports_other_field_accesses_from_static_initializer() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport"));
+        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
+        JavaClass fieldAccessFromInitializer = classes.get(ForeignFieldAccessFromStaticInitializer.class);
+
+        Set<JavaFieldAccess> accesses = fieldAccessFromInitializer.getFieldAccessesFromSelf();
+
+        assertThat(accesses).as("Number of field accesses from " + fieldAccessFromInitializer.getName()).hasSize(2);
+
+        assertThatAccess(getOnly(accesses, "stringValue", GET))
+                .isFrom(fieldAccessFromInitializer.getCodeUnitWithParameterTypes(STATIC_INITIALIZER_NAME))
+                .isTo(classWithOwnFieldAccess.getField("stringValue"))
+                .inLineNumber(5);
+
+        assertThatAccess(getOnly(accesses, "intValue", SET))
+                .isFrom(fieldAccessFromInitializer.getCodeUnitWithParameterTypes(STATIC_INITIALIZER_NAME))
+                .isTo(classWithOwnFieldAccess.getField("intValue"))
+                .inLineNumber(6);
+    }
+
+    @Test
+    public void imports_external_field_access() {
+        JavaClass classWithExternalFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(ExternalFieldAccess.class);
+
+        JavaFieldAccess access = getOnlyElement(classWithExternalFieldAccess.getMethod("access").getFieldAccesses());
+
+        assertThatAccess(access)
+                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("access"))
+                .inLineNumber(8);
+
+        assertThat(access.getTarget()).isEquivalentTo(field(ClassWithIntAndObjectFields.class, "objectField"));
+
+        access = getOnlyElement(classWithExternalFieldAccess.getMethod("accessInheritedExternalField").getFieldAccesses());
+
+        assertThatAccess(access)
+                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("accessInheritedExternalField"))
+                .inLineNumber(12);
+
+        assertThat(access.getTarget()).isEquivalentTo(field(ParentClass.class, "someParentField"));
+    }
+
+    @Test
+    public void imports_external_field_access_with_shadowed_field() {
+        JavaClass classWithExternalFieldAccess = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccessimport")).get(ExternalShadowedFieldAccess.class);
+
+        JavaFieldAccess access = getOnlyElement(classWithExternalFieldAccess.getFieldAccessesFromSelf());
+
+        assertThatAccess(access)
+                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("accessField"))
+                .inLineNumber(7);
+
+        assertThat(access.getTarget()).isEquivalentTo(field(ChildClass.class, "someField"));
+    }
+
+    @Test
+    public void imports_shadowed_and_superclass_field_access() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/hierarchicalfieldaccess"));
+        JavaClass classThatAccessesFieldOfSuperClass = classes.get(AccessToSuperAndSubclassField.class);
+        JavaClass superClassWithAccessedField = classes.get(SuperclassWithAccessedField.class);
+        JavaClass subClassWithAccessedField = classes.get(SubclassWithAccessedField.class);
+
+        Set<JavaFieldAccess> accesses = classThatAccessesFieldOfSuperClass.getFieldAccessesFromSelf();
+
+        assertThat(accesses).hasSize(2);
+        JavaField field = superClassWithAccessedField.getField("field");
+        AccessTarget.FieldAccessTarget expectedSuperClassFieldAccess = new DomainBuilders.FieldAccessTargetBuilder()
+                .withOwner(subClassWithAccessedField)
+                .withName(field.getName())
+                .withType(field.getRawType())
+                .withField(Suppliers.ofInstance(Optional.of(field)))
+                .build();
+        assertThatAccess(getOnly(accesses, "field", GET))
+                .isFrom("accessSuperclassField")
+                .isTo(expectedSuperClassFieldAccess)
+                .inLineNumber(5);
+        assertThatAccess(getOnly(accesses, "maskedField", GET))
+                .isFrom("accessSubclassField")
+                .isTo(subClassWithAccessedField.getField("maskedField"))
+                .inLineNumber(9);
+    }
+
+    @Test
+    public void imports_field_accesses_to_fields_from_interfaces() {
+        Set<JavaFieldAccess> accesses = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldaccesstointerfaces"))
+                .get(ClassAccessingInterfaceFields.class).getFieldAccessesFromSelf();
+
+        assertThat(findAnyByName(accesses, "" + InterfaceWithFields.objectFieldOne).getTarget().resolveField().get())
+                .isEquivalentTo(field(InterfaceWithFields.class, "" + InterfaceWithFields.objectFieldOne));
+        assertThat(findAnyByName(accesses, "" + InterfaceWithFields.objectFieldTwo).getTarget().resolveField().get())
+                .isEquivalentTo(field(InterfaceWithFields.class, "" + InterfaceWithFields.objectFieldTwo));
+        assertThat(findAnyByName(accesses, "" + OtherInterfaceWithFields.otherObjectFieldOne).getTarget().resolveField().get())
+                .isEquivalentTo(field(OtherInterfaceWithFields.class, "" + OtherInterfaceWithFields.otherObjectFieldOne));
+        assertThat(findAnyByName(accesses, "" + OtherInterfaceWithFields.otherObjectFieldTwo).getTarget().resolveField().get())
+                .isEquivalentTo(field(OtherInterfaceWithFields.class, "" + OtherInterfaceWithFields.otherObjectFieldTwo));
+        assertThat(findAnyByName(accesses, "" + ParentInterfaceWithFields.parentObjectFieldOne).getTarget().resolveField().get())
+                .isEquivalentTo(field(ParentInterfaceWithFields.class, "" + ParentInterfaceWithFields.parentObjectFieldOne));
+        assertThat(findAnyByName(accesses, "" + ParentInterfaceWithFields.parentObjectFieldTwo).getTarget().resolveField().get())
+                .isEquivalentTo(field(ParentInterfaceWithFields.class, "" + ParentInterfaceWithFields.parentObjectFieldTwo));
+    }
+
+    @Test
+    public void imports_shadowed_and_superclass_method_calls() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/hierarchicalmethodcall"));
+        JavaClass classThatCallsMethodOfSuperClass = classes.get(CallOfSuperAndSubclassMethod.class);
+        JavaClass superClassWithCalledMethod = classes.get(SuperclassWithCalledMethod.class);
+        JavaClass subClassWithCalledMethod = classes.get(SubclassWithCalledMethod.class);
+
+        Set<JavaMethodCall> calls = classThatCallsMethodOfSuperClass.getMethodCallsFromSelf();
+
+        assertThat(calls).hasSize(2);
+
+        JavaCodeUnit callSuperclassMethod = classThatCallsMethodOfSuperClass
+                .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSuperclassMethod);
+        JavaMethod expectedSuperClassMethod = superClassWithCalledMethod.getMethod(SuperclassWithCalledMethod.method);
+        AccessTarget.MethodCallTarget expectedSuperClassCall = new DomainBuilders.MethodCallTargetBuilder()
+                .withOwner(subClassWithCalledMethod)
+                .withName(expectedSuperClassMethod.getName())
+                .withParameters(expectedSuperClassMethod.getRawParameterTypes())
+                .withReturnType(expectedSuperClassMethod.getRawReturnType())
+                .withMethods(Suppliers.ofInstance(Collections.singleton(expectedSuperClassMethod)))
+                .build();
+        assertThatCall(getOnlyByCaller(calls, callSuperclassMethod))
+                .isFrom(callSuperclassMethod)
+                .isTo(expectedSuperClassCall)
+                .inLineNumber(CallOfSuperAndSubclassMethod.callSuperclassLineNumber);
+
+        JavaCodeUnit callSubclassMethod = classThatCallsMethodOfSuperClass
+                .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSubclassMethod);
+        assertThatCall(getOnlyByCaller(calls, callSubclassMethod))
+                .isFrom(callSubclassMethod)
+                .isTo(subClassWithCalledMethod.getMethod(SubclassWithCalledMethod.maskedMethod))
+                .inLineNumber(CallOfSuperAndSubclassMethod.callSubclassLineNumber);
+    }
+
+    @Test
+    public void imports_constructor_calls_on_self() {
+        JavaClass classThatCallsOwnConstructor = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(CallsOwnConstructor.class);
+        JavaCodeUnit caller = classThatCallsOwnConstructor.getCodeUnitWithParameterTypes("copy");
+
+        Set<JavaConstructorCall> calls = classThatCallsOwnConstructor.getConstructorCallsFromSelf();
+
+        assertThatCall(getOnlyByCaller(calls, caller))
+                .isFrom(caller)
+                .isTo(classThatCallsOwnConstructor.getConstructor(String.class))
+                .inLineNumber(8);
+    }
+
+    @Test
+    public void imports_method_calls_on_self() {
+        JavaClass classThatCallsOwnMethod = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(CallsOwnMethod.class);
+
+        JavaMethodCall call = getOnlyElement(classThatCallsOwnMethod.getMethodCallsFromSelf());
+
+        assertThatCall(call)
+                .isFrom(classThatCallsOwnMethod.getCodeUnitWithParameterTypes("getString"))
+                .isTo(classThatCallsOwnMethod.getMethod("string"))
+                .inLineNumber(6);
+    }
+
+    @Test
+    public void imports_constructor_calls_on_other() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport"));
+        JavaClass classThatCallsOtherConstructor = classes.get(CallsOtherConstructor.class);
+        JavaClass otherClass = classes.get(CallsOwnConstructor.class);
+        JavaCodeUnit caller = classThatCallsOtherConstructor.getCodeUnitWithParameterTypes("createOther");
+
+        Set<JavaConstructorCall> calls = classThatCallsOtherConstructor.getConstructorCallsFromSelf();
+
+        assertThatCall(getOnlyByCaller(calls, caller))
+                .isFrom(caller)
+                .isTo(otherClass.getConstructor(String.class))
+                .inLineNumber(5);
+    }
+
+    @Test
+    public void imports_method_calls_on_other() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport"));
+        JavaClass classThatCallsOtherMethod = classes.get(CallsOtherMethod.class);
+        JavaClass other = classes.get(CallsOwnMethod.class);
+
+        JavaMethodCall call = getOnlyElement(classThatCallsOtherMethod.getMethodCallsFromSelf());
+
+        assertThatCall(call)
+                .isFrom(classThatCallsOtherMethod.getCodeUnitWithParameterTypes("getFromOther"))
+                .isTo(other.getMethod("getString"))
+                .inLineNumber(7);
+    }
+
+    @Test
+    public void imports_constructor_calls_on_external_class() throws Exception {
+        JavaClass classThatCallsOwnConstructor = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(CallsOwnConstructor.class);
+        JavaCodeUnit constructorCallingObjectInit = classThatCallsOwnConstructor.getConstructor(String.class);
+
+        JavaConstructorCall objectInitCall = getOnlyElement(constructorCallingObjectInit.getConstructorCallsFromSelf());
+
+        assertThatCall(objectInitCall)
+                .isFrom(constructorCallingObjectInit)
+                .inLineNumber(4);
+
+        AccessTarget.ConstructorCallTarget target = objectInitCall.getTarget();
+        assertThat(target.getFullName()).isEqualTo(Object.class.getName() + ".<init>()");
+        assertThat(reflect(target)).isEqualTo(Object.class.getConstructor());
+    }
+
+    @Test
+    public void imports_constructor_calls_to_sub_type_constructor_on_external_class() {
+        JavaClass classWithExternalConstructorCall = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(ExternalSubtypeConstructorCall.class);
+
+        assertConstructorCall(classWithExternalConstructorCall.getCodeUnitWithParameterTypes("call"), ChildClass.class, 9);
+        assertConstructorCall(classWithExternalConstructorCall.getCodeUnitWithParameterTypes("newHashMap"), HashMap.class, 13);
+    }
+
+    private void assertConstructorCall(JavaCodeUnit call, Class<?> constructorOwner, int lineNumber) {
+        JavaConstructorCall callToExternalClass =
+                getOnlyElement(getByTargetOwner(call.getConstructorCallsFromSelf(), constructorOwner));
+
+        assertThatCall(callToExternalClass)
+                .isFrom(call)
+                .inLineNumber(lineNumber);
+
+        AccessTarget.ConstructorCallTarget target = callToExternalClass.getTarget();
+        assertThat(target.getFullName()).isEqualTo(constructorOwner.getName() + ".<init>()");
+        assertThat(reflect(target)).isEqualTo(constructor(constructorOwner));
+    }
+
+    @Test
+    public void imports_method_calls_on_external_class() {
+        JavaClass classThatCallsExternalMethod = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(CallsExternalMethod.class);
+
+        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
+
+        assertThatCall(call)
+                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("getString"))
+                .inLineNumber(7);
+
+        AccessTarget.MethodCallTarget target = call.getTarget();
+        assertThat(target.getOwner().reflect()).isEqualTo(ArrayList.class);
+        assertThat(target.getFullName()).isEqualTo(ArrayList.class.getName() + ".toString()");
+    }
+
+    @Test
+    public void imports_method_calls_on_overridden_external_class() {
+        JavaClass classThatCallsExternalMethod = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(ExternalOverriddenMethodCall.class);
+
+        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
+
+        assertThatCall(call)
+                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("call"))
+                .inLineNumber(9);
+
+        AccessTarget.MethodCallTarget target = call.getTarget();
+        assertThat(target.getFullName()).isEqualTo(ChildClass.class.getName() + ".overrideMe()");
+        assertThat(getOnlyElement(target.resolve()).getFullName()).isEqualTo(ChildClass.class.getName() + ".overrideMe()");
+        assertThat(reflect(target)).isEqualTo(method(ChildClass.class, "overrideMe"));
+    }
+
+    @Test
+    public void imports_method_calls_on_external_interface_hierarchies() {
+        JavaClass classThatCallsExternalMethod = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(ExternalInterfaceMethodCall.class);
+
+        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
+
+        assertThatCall(call)
+                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("call"))
+                .inLineNumber(9);
+
+        AccessTarget.MethodCallTarget target = call.getTarget();
+        assertThat(reflect(target)).isEqualTo(method(Map.class, "put", Object.class, Object.class));
+    }
+
+    @Test
+    public void imports_non_unique_targets_for_diamond_scenarios() {
+        JavaClasses diamondScenario = new ClassFileImporter().importUrl(getClass().getResource("testexamples/diamond"));
+        JavaClass classCallingDiamond = diamondScenario.get(ClassCallingDiamond.class);
+        JavaClass diamondLeftInterface = diamondScenario.get(InterfaceB.class);
+        JavaClass diamondRightInterface = diamondScenario.get(InterfaceC.class);
+        JavaClass diamondPeakInterface = diamondScenario.get(InterfaceD.class);
+        JavaClass diamondPeakClass = diamondScenario.get(ClassImplementingD.class);
+
+        Set<JavaMethodCall> calls = classCallingDiamond.getMethodCallsFromSelf();
+
+        assertThat(calls).hasSize(2);
+
+        JavaCodeUnit callInterface = classCallingDiamond
+                .getCodeUnitWithParameterTypes(ClassCallingDiamond.callInterface);
+        JavaMethodCall callToInterface = getOnlyByCaller(calls, callInterface);
+        assertThatCall(callToInterface)
+                .isFrom(callInterface)
+                .inLineNumber(ClassCallingDiamond.callInterfaceLineNumber);
+        // NOTE: There is no java.lang.reflect.Method InterfaceD.implementMe(), because the method is inherited
+        assertThat(callToInterface.getTarget().getName()).isEqualTo(InterfaceD.implementMe);
+        assertThat(callToInterface.getTarget().getOwner()).isEqualTo(diamondPeakInterface);
+        assertThat(callToInterface.getTarget().getRawParameterTypes()).isEmpty();
+        assertThat(callToInterface.getTarget().resolve()).extracting("fullName")
+                .containsOnly(
+                        diamondLeftInterface.getMethod(InterfaceB.implementMe).getFullName(),
+                        diamondRightInterface.getMethod(InterfaceB.implementMe).getFullName());
+
+        JavaCodeUnit callImplementation = classCallingDiamond
+                .getCodeUnitWithParameterTypes(ClassCallingDiamond.callImplementation);
+        assertThatCall(getOnlyByCaller(calls, callImplementation))
+                .isFrom(callImplementation)
+                .isTo(diamondPeakClass.getMethod(InterfaceD.implementMe))
+                .inLineNumber(ClassCallingDiamond.callImplementationLineNumber);
+    }
+
+    @Test
+    public void imports_method_calls_that_return_Arrays() {
+        JavaClass classThatCallsMethodReturningArray = new ClassFileImporter().importUrl(getClass().getResource("testexamples/callimport")).get(CallsMethodReturningArray.class);
+
+        AccessTarget.MethodCallTarget target = getOnlyElement(classThatCallsMethodReturningArray.getMethodCallsFromSelf()).getTarget();
+        assertThatType(target.getOwner()).matches(CallsMethodReturningArray.SomeEnum.class);
+        assertThatType(target.getRawReturnType()).matches(CallsMethodReturningArray.SomeEnum[].class);
+    }
+
+    @Test
+    public void dependency_target_classes_are_derived_correctly() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/integration"));
+        JavaClass javaClass = classes.get(ClassXDependingOnClassesABCD.class);
+        Set<JavaClass> expectedTargetClasses = ImmutableSet.of(
+                classes.get(ClassA.class),
+                classes.get(ClassBDependingOnClassA.class),
+                classes.get(ClassCDependingOnClassB_SuperclassOfX.class),
+                classes.get(ClassD.class),
+                classes.get(InterfaceOfClassX.class)
+        );
+
+        Set<JavaClass> targetClasses = new HashSet<>();
+        for (Dependency dependency : withoutJavaLangTargets(javaClass.getDirectDependenciesFromSelf())) {
+            targetClasses.add(dependency.getTargetClass());
+        }
+
+        assertThat(targetClasses).isEqualTo(expectedTargetClasses);
+    }
+
+    @Test
+    public void getDirectDependencies_does_not_return_transitive_dependencies() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/integration"));
+        JavaClass javaClass = classes.get(ClassCDependingOnClassB_SuperclassOfX.class);
+        JavaClass expectedTargetClass = classes.get(ClassBDependingOnClassA.class);
+
+        Set<JavaClass> targetClasses = new HashSet<>();
+        for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
+            if (dependency.getTargetClass().getPackageName().contains("testexamples")) {
+                targetClasses.add(dependency.getTargetClass());
+            }
+        }
+
+        assertThat(targetClasses).containsOnly(expectedTargetClass);
+    }
+
+    @Test
+    public void fields_know_their_accesses() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaFieldAccess> accesses = classHoldingDependencies.getField("someInt").getAccessesToSelf();
+        Set<JavaFieldAccess> expected = ImmutableSet.<JavaFieldAccess>builder()
+                .addAll(getByName(classHoldingDependencies.getFieldAccessesFromSelf(), "someInt"))
+                .addAll(getByName(firstClassWithDependency.getFieldAccessesFromSelf(), "someInt"))
+                .addAll(getByName(secondClassWithDependency.getFieldAccessesFromSelf(), "someInt"))
+                .build();
+        assertThat(accesses).as("Field Accesses to someInt").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_the_field_accesses_to_them() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaFieldAccess> accesses = classHoldingDependencies.getFieldAccessesToSelf();
+        Set<JavaFieldAccess> expected = ImmutableSet.<JavaFieldAccess>builder()
+                .addAll(classHoldingDependencies.getFieldAccessesFromSelf())
+                .addAll(firstClassWithDependency.getFieldAccessesFromSelf())
+                .addAll(secondClassWithDependency.getFieldAccessesFromSelf())
+                .build();
+        assertThat(accesses).as("Field Accesses to class").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_shadowed_field_accesses_to_themselves() {
+        @SuppressWarnings("unused")
+        class Base {
+            String shadowed;
+            String nonShadowed;
+        }
+        class Child extends Base {
+            String shadowed;
+        }
+        @SuppressWarnings("unused")
+        class Accessor {
+            void access(Child child) {
+                consume(child.shadowed);
+                consume(child.nonShadowed);
+            }
+
+            void consume(String string) {
+            }
+        }
+        JavaClasses classes = new ClassFileImporter().importClasses(Accessor.class, Base.class, Child.class);
+
+        JavaFieldAccess access = getOnlyByCaller(
+                classes.get(Base.class).getFieldAccessesToSelf(), classes.get(Accessor.class).getMethod("access", Child.class));
+        assertThatAccess(access).isFrom("access", Child.class).isTo("nonShadowed");
+        access = getOnlyByCaller(
+                classes.get(Child.class).getFieldAccessesToSelf(), classes.get(Accessor.class).getMethod("access", Child.class));
+        assertThatAccess(access).isFrom("access", Child.class).isTo("shadowed");
+    }
+
+    @Test
+    public void methods_know_callers() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaMethodCall> calls = classHoldingDependencies.getMethod("setSomeInt", int.class).getCallsOfSelf();
+        Set<JavaMethodCall> expected = ImmutableSet.<JavaMethodCall>builder()
+                .addAll(getByName(classHoldingDependencies.getMethodCallsFromSelf(), "setSomeInt"))
+                .addAll(getByName(firstClassWithDependency.getMethodCallsFromSelf(), "setSomeInt"))
+                .addAll(getByName(secondClassWithDependency.getMethodCallsFromSelf(), "setSomeInt"))
+                .build();
+        assertThat(calls).as("Method calls to setSomeInt").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_method_calls_to_themselves() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaMethodCall> calls = classHoldingDependencies.getMethodCallsToSelf();
+        Set<JavaMethodCall> expected = ImmutableSet.<JavaMethodCall>builder()
+                .addAll(classHoldingDependencies.getMethodCallsFromSelf())
+                .addAll(getByTargetOwner(firstClassWithDependency.getMethodCallsFromSelf(), classHoldingDependencies))
+                .addAll(getByTargetOwner(secondClassWithDependency.getMethodCallsFromSelf(), classHoldingDependencies))
+                .build();
+        assertThat(calls).as("Method calls to class").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_overridden_method_calls_to_themselves() {
+        @SuppressWarnings("unused")
+        class Base {
+            void overridden() {
+            }
+
+            void nonOverridden() {
+            }
+        }
+        class Child extends Base {
+            @Override
+            void overridden() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class Caller {
+            void call(Child child) {
+                child.overridden();
+                child.nonOverridden();
+            }
+        }
+        JavaClasses classes = new ClassFileImporter().importClasses(Caller.class, Base.class, Child.class);
+
+        assertThatCall(getOnlyElement(classes.get(Base.class).getMethodCallsToSelf())).isFrom("call", Child.class).isTo("nonOverridden");
+        assertThatCall(getOnlyElement(classes.get(Child.class).getMethodCallsToSelf())).isFrom("call", Child.class).isTo("overridden");
+    }
+
+    @Test
+    public void constructors_know_callers() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        JavaConstructor targetConstructur = classHoldingDependencies.getConstructor();
+        Set<JavaConstructorCall> calls = targetConstructur.getCallsOfSelf();
+        Set<JavaConstructorCall> expected = ImmutableSet.<JavaConstructorCall>builder()
+                .addAll(getByTarget(classHoldingDependencies.getConstructorCallsFromSelf(), targetConstructur))
+                .addAll(getByTarget(firstClassWithDependency.getConstructorCallsFromSelf(), targetConstructur))
+                .addAll(getByTarget(secondClassWithDependency.getConstructorCallsFromSelf(), targetConstructur))
+                .build();
+        assertThat(calls).as("Default Constructor calls to ClassWithDependents").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_constructor_calls_to_themselves() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaConstructorCall> calls = classHoldingDependencies.getConstructorCallsToSelf();
+        Set<JavaConstructorCall> expected = ImmutableSet.<JavaConstructorCall>builder()
+                .addAll(getByTargetOwner(classHoldingDependencies.getConstructorCallsFromSelf(), classHoldingDependencies))
+                .addAll(getByTargetOwner(firstClassWithDependency.getConstructorCallsFromSelf(), classHoldingDependencies))
+                .addAll(getByTargetOwner(secondClassWithDependency.getConstructorCallsFromSelf(), classHoldingDependencies))
+                .build();
+        assertThat(calls).as("Constructor calls to ClassWithDependents").isEqualTo(expected);
+    }
+
+    @Test
+    public void classes_know_constructor_calls_to_themselves_for_subclass_default_constructors() {
+        // For constructors it's impossible to be accessed via a subclass,
+        // since the byte code always holds an explicitly declared constructor.
+        // Thus we do expect a call to the constructor of the subclass and one from subclass to super class
+        @SuppressWarnings("unused")
+        class Base {
+            Base() {
+            }
+        }
+        class Child extends Base {
+        }
+        @SuppressWarnings("unused")
+        class Caller {
+            void call() {
+                new Child();
+            }
+        }
+        JavaClasses classes = new ClassFileImporter().importClasses(Caller.class, Base.class, Child.class);
+
+        assertThatCall(getOnlyElement(classes.get(Base.class).getConstructorCallsToSelf())).isFrom(Child.class, CONSTRUCTOR_NAME, getClass()).isTo(Base.class);
+        assertThatCall(getOnlyElement(classes.get(Child.class).getConstructorCallsToSelf())).isFrom(Caller.class, "call").isTo(Child.class);
+    }
+
+    @Test
+    public void classes_know_accesses_to_themselves() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/dependents"));
+        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
+        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
+        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
+
+        Set<JavaAccess<?>> accesses = classHoldingDependencies.getAccessesToSelf();
+        Set<JavaAccess<?>> expected = ImmutableSet.<JavaAccess<?>>builder()
+                .addAll(getByTargetOwner(classHoldingDependencies.getAccessesFromSelf(), classHoldingDependencies))
+                .addAll(getByTargetOwner(firstClassWithDependency.getAccessesFromSelf(), classHoldingDependencies))
+                .addAll(getByTargetOwner(secondClassWithDependency.getAccessesFromSelf(), classHoldingDependencies))
+                .build();
+        assertThat(accesses).as("Accesses to ClassWithDependents").isEqualTo(expected);
+    }
+
+    // NOTE: This provokes the scenario where the target type can't be determined uniquely due to a diamond
+    //       scenario and thus a fallback to (primitive and array) type names by ASM descriptors occurs.
+    //       Unfortunately those ASM type names for example are the canonical name instead of the class name.
+    @Test
+    public void imports_special_target_parameters() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/specialtargets"));
+        Set<JavaMethodCall> calls = classes.get(ClassCallingSpecialTarget.class).getMethodCallsFromSelf();
+
+        assertThat(targetParametersOf(calls, "primitiveArgs")).matches(byte.class, long.class);
+        assertThatType(returnTypeOf(calls, "primitiveReturnType")).matches(byte.class);
+        assertThat(targetParametersOf(calls, "arrayArgs")).matches(byte[].class, Object[].class);
+        assertThatType(returnTypeOf(calls, "primitiveArrayReturnType")).matches(short[].class);
+        assertThatType(returnTypeOf(calls, "objectArrayReturnType")).matches(String[].class);
+        assertThat(targetParametersOf(calls, "twoDimArrayArgs")).matches(float[][].class, Object[][].class);
+        assertThatType(returnTypeOf(calls, "primitiveTwoDimArrayReturnType")).matches(double[][].class);
+        assertThatType(returnTypeOf(calls, "objectTwoDimArrayReturnType")).matches(String[][].class);
+    }
+
+    private Set<Dependency> withoutJavaLangTargets(Set<Dependency> dependencies) {
+        Set<Dependency> result = new HashSet<>();
+        for (Dependency dependency : dependencies) {
+            if (!dependency.getTargetClass().getPackageName().startsWith("java.lang")) {
+                result.add(dependency);
+            }
+        }
+        return result;
+    }
+
+    private Constructor<?> reflect(AccessTarget.ConstructorCallTarget target) {
+        return reflect(target.resolveConstructor().get());
+    }
+
+    private Constructor<?> reflect(JavaConstructor javaConstructor) {
+        try {
+            return javaConstructor.getOwner().reflect().getConstructor(asClasses(javaConstructor.getRawParameterTypes()));
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Method reflect(AccessTarget.MethodCallTarget target) {
+        return reflect(getOnlyElement(target.resolve()));
+    }
+
+    private Method reflect(JavaMethod javaMethod) {
+        try {
+            return javaMethod.getOwner().reflect().getMethod(javaMethod.getName(), asClasses(javaMethod.getRawParameterTypes()));
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JavaClassList targetParametersOf(Set<JavaMethodCall> calls, String name) {
+        return findAnyByName(calls, name).getTarget().getRawParameterTypes();
+    }
+
+    private JavaClass returnTypeOf(Set<JavaMethodCall> calls, String name) {
+        return findAnyByName(calls, name).getTarget().getRawReturnType();
+    }
+
+    private JavaFieldAccess getOnly(Set<JavaFieldAccess> fieldAccesses, String name, JavaFieldAccess.AccessType accessType) {
+        return getOnlyElement(getByNameAndAccessType(fieldAccesses, name, accessType));
+    }
+
+    private Set<JavaFieldAccess> getByNameAndAccessType(Set<JavaFieldAccess> fieldAccesses, String name, JavaFieldAccess.AccessType accessType) {
+        Set<JavaFieldAccess> result = new HashSet<>();
+        for (JavaFieldAccess access : fieldAccesses) {
+            if (name.equals(access.getName()) && access.getAccessType() == accessType) {
+                result.add(access);
+            }
+        }
+        return result;
+    }
+
+    private <T extends HasOwner<JavaCodeUnit>> T getOnlyByCaller(Set<T> calls, JavaCodeUnit caller) {
+        return getOnlyElement(getByCaller(calls, caller));
+    }
+
+    private <T extends JavaAccess<?>> Set<T> getByTarget(Set<T> calls, final JavaConstructor target) {
+        return getBy(calls, new Predicate<JavaAccess<?>>() {
+            @Override
+            public boolean apply(JavaAccess<?> input) {
+                return targetFrom(target).getFullName().equals(input.getTarget().getFullName());
+            }
+        });
+    }
+
+    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, Class<?> targetOwner) {
+        return getByTargetOwner(calls, targetOwner.getName());
+    }
+
+    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final String targetOwnerName) {
+        return getBy(calls, targetOwnerNameEquals(targetOwnerName));
+    }
+
+    private Predicate<JavaAccess<?>> targetOwnerNameEquals(final String targetFqn) {
+        return new Predicate<JavaAccess<?>>() {
+            @Override
+            public boolean apply(JavaAccess<?> input) {
+                return targetFqn.equals(input.getTarget().getOwner().getName());
+            }
+        };
+    }
+
+    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final JavaClass targetOwner) {
+        return getBy(calls, new Predicate<T>() {
+            @Override
+            public boolean apply(T input) {
+                return targetOwner.equals(input.getTarget().getOwner());
+            }
+        });
+    }
+
+    private <T extends HasOwner<JavaCodeUnit>> Set<T> getByCaller(Set<T> calls, final JavaCodeUnit caller) {
+        return getBy(calls, new Predicate<T>() {
+            @Override
+            public boolean apply(T input) {
+                return caller.equals(input.getOwner());
+            }
+        });
+    }
+
+    private <T extends HasOwner<JavaCodeUnit>> Set<T> getBy(Set<T> calls, Predicate<? super T> predicate) {
+        return FluentIterable.from(calls).filter(predicate).toSet();
+    }
+
+    private Set<AccessTarget.FieldAccessTarget> targetsOf(Set<JavaFieldAccess> fieldAccesses) {
+        Set<AccessTarget.FieldAccessTarget> result = new HashSet<>();
+        for (JavaFieldAccess access : fieldAccesses) {
+            result.add(access.getTarget());
+        }
+        return result;
+    }
+
+    private Set<Integer> lineNumbersOf(Set<JavaFieldAccess> fieldAccesses) {
+        Set<Integer> result = new HashSet<>();
+        for (JavaFieldAccess access : fieldAccesses) {
+            result.add(access.getLineNumber());
+        }
+        return result;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -51,7 +51,6 @@ import static com.tngtech.archunit.core.importer.testexamples.annotationmethodim
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotation;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
-import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion.annotationProperty;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
@@ -62,16 +61,16 @@ public class ClassFileImporterAnnotationsTest {
     public void imports_simple_annotation() {
         JavaClass javaClass = new ClassFileImporter().importPackagesOf(AnnotationToImport.class).get(AnnotationToImport.class);
 
-        assertThat(javaClass.getName()).as("full name").isEqualTo(AnnotationToImport.class.getName());
-        assertThat(javaClass.getSimpleName()).as("simple name").isEqualTo(AnnotationToImport.class.getSimpleName());
-        assertThat(javaClass.getPackageName()).as("package name").isEqualTo(AnnotationToImport.class.getPackage().getName());
-        assertThat(javaClass.getModifiers()).as("modifiers").containsOnly(JavaModifier.PUBLIC, JavaModifier.ABSTRACT);
-        assertThat(javaClass.getRawSuperclass()).as("super class").isAbsent();
-        assertThatTypes(javaClass.getInterfaces()).as("interfaces").matchInAnyOrder(Annotation.class);
-        assertThat(javaClass.isInterface()).as("is interface").isTrue();
-        assertThat(javaClass.isEnum()).as("is enum").isFalse();
-        assertThat(javaClass.isAnnotation()).as("is annotation").isTrue();
-
+        assertThat(javaClass)
+                .hasName(AnnotationToImport.class.getName())
+                .hasSimpleName(AnnotationToImport.class.getSimpleName())
+                .hasPackageName(AnnotationToImport.class.getPackage().getName())
+                .hasOnlyModifiers(JavaModifier.PUBLIC, JavaModifier.ABSTRACT)
+                .hasNoSuperclass()
+                .hasInterfacesMatchingInAnyOrder(Annotation.class)
+                .isInterface(true)
+                .isEnum(false)
+                .isAnnotation(true);
         assertThat(getAnnotationDefaultValue(javaClass, "someStringMethod", String.class)).isEqualTo("DEFAULT");
         assertThatType(getAnnotationDefaultValue(javaClass, "someTypeMethod", JavaClass.class)).matches(List.class);
         assertThat(getAnnotationDefaultValue(javaClass, "someEnumMethod", JavaEnumConstant.class)).isEquivalentTo(EnumToImport.SECOND);

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -16,7 +16,6 @@ import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
-import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassAnnotationWithArrays;
@@ -62,10 +61,7 @@ public class ClassFileImporterAnnotationsTest {
         JavaClass javaClass = new ClassFileImporter().importPackagesOf(AnnotationToImport.class).get(AnnotationToImport.class);
 
         assertThat(javaClass)
-                .hasName(AnnotationToImport.class.getName())
-                .hasSimpleName(AnnotationToImport.class.getSimpleName())
-                .hasPackageName(AnnotationToImport.class.getPackage().getName())
-                .hasOnlyModifiers(JavaModifier.PUBLIC, JavaModifier.ABSTRACT)
+                .matches(AnnotationToImport.class)
                 .hasNoSuperclass()
                 .hasInterfacesMatchingInAnyOrder(Annotation.class)
                 .isInterface(true)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
@@ -361,8 +361,7 @@ public class ClassFileImporterMembersTest {
 
         JavaClass javaClass = new ClassFileImporter().importClass(FieldTypeWithoutAnyFurtherReference.class);
 
-        assertThat(javaClass.getField("field").getRawType().isFullyImported())
-                .as("field type is fully imported").isTrue();
+        assertThat(javaClass.getField("field").getRawType()).as("field type").isFullyImported(true);
     }
 
     @Test
@@ -376,10 +375,8 @@ public class ClassFileImporterMembersTest {
         JavaClass javaClass = new ClassFileImporter().importClass(ConstructorParameterTypesWithoutAnyFurtherReference.class);
 
         JavaConstructor constructor = javaClass.getConstructor(getClass(), FileSystem.class, Buffer.class);
-        assertThat(constructor.getRawParameterTypes().get(0).isFullyImported())
-                .as("constructor parameter type is fully imported").isTrue();
-        assertThat(constructor.getRawParameterTypes().get(1).isFullyImported())
-                .as("constructor parameter type is fully imported").isTrue();
+        assertThat(constructor.getRawParameterTypes().get(0)).as("constructor parameter type").isFullyImported(true);
+        assertThat(constructor.getRawParameterTypes().get(1)).as("constructor parameter type").isFullyImported(true);
     }
 
     @Test
@@ -393,8 +390,7 @@ public class ClassFileImporterMembersTest {
 
         JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
 
-        assertThat(javaClass.getMethod("returnType").getRawReturnType().isFullyImported())
-                .as("method return type is fully imported").isTrue();
+        assertThat(javaClass.getMethod("returnType").getRawReturnType()).as("method return type").isFullyImported(true);
     }
 
     @Test
@@ -408,9 +404,7 @@ public class ClassFileImporterMembersTest {
         JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
 
         JavaMethod method = javaClass.getMethod("methodParameters", Path.class, PrintStream.class);
-        assertThat(method.getRawParameterTypes().get(0).isFullyImported())
-                .as("method parameter type is fully imported").isTrue();
-        assertThat(method.getRawParameterTypes().get(1).isFullyImported())
-                .as("method parameter type is fully imported").isTrue();
+        assertThat(method.getRawParameterTypes().get(0)).as("method parameter type").isFullyImported(true);
+        assertThat(method.getRawParameterTypes().get(1)).as("method parameter type").isFullyImported(true);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
@@ -1,0 +1,353 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.Buffer;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.ThrowsDeclaration;
+import com.tngtech.archunit.core.importer.testexamples.FirstCheckedException;
+import com.tngtech.archunit.core.importer.testexamples.OtherClass;
+import com.tngtech.archunit.core.importer.testexamples.SecondCheckedException;
+import com.tngtech.archunit.core.importer.testexamples.SomeClass;
+import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
+import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.BaseClass;
+import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.Subclass;
+import com.tngtech.archunit.core.importer.testexamples.complexmethodimport.ClassWithComplexMethod;
+import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithComplexConstructor;
+import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithSimpleConstructors;
+import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithThrowingConstructor;
+import com.tngtech.archunit.core.importer.testexamples.fieldimport.ClassWithIntAndObjectFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldimport.ClassWithStringField;
+import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInConstructor;
+import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInMethod;
+import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInStaticInitializer;
+import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.InstanceofChecked;
+import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithMultipleMethods;
+import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithObjectVoidAndIntIntSerializableMethod;
+import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithStringStringMethod;
+import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithThrowingMethod;
+import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjects;
+import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion;
+import org.assertj.core.util.Objects;
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.domain.JavaModifier.FINAL;
+import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
+import static com.tngtech.archunit.core.domain.JavaModifier.PROTECTED;
+import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
+import static com.tngtech.archunit.core.domain.JavaModifier.STATIC;
+import static com.tngtech.archunit.core.domain.JavaModifier.TRANSIENT;
+import static com.tngtech.archunit.core.domain.JavaModifier.VOLATILE;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.findAnyByName;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.getCodeUnits;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.getFields;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.getMethods;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
+import static com.tngtech.archunit.testutil.TestUtils.namesOf;
+import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
+
+public class ClassFileImporterMembersTest {
+
+    @Test
+    public void imports_fields() {
+        Set<JavaField> fields = getFields(new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldimport")));
+
+        assertThat(namesOf(fields)).containsOnly("stringField", "serializableField", "objectField");
+        assertThat(findAnyByName(fields, "stringField"))
+                .isEquivalentTo(field(ClassWithStringField.class, "stringField"));
+        assertThat(findAnyByName(fields, "serializableField"))
+                .isEquivalentTo(field(ClassWithIntAndObjectFields.class, "serializableField"));
+        assertThat(findAnyByName(fields, "objectField"))
+                .isEquivalentTo(field(ClassWithIntAndObjectFields.class, "objectField"));
+    }
+
+    @Test
+    public void imports_primitive_fields() {
+        Set<JavaField> fields = getFields(new ClassFileImporter().importUrl(getClass().getResource("testexamples/primitivefieldimport")));
+
+        assertThatType(findAnyByName(fields, "aBoolean").getRawType()).matches(boolean.class);
+        assertThatType(findAnyByName(fields, "anInt").getRawType()).matches(int.class);
+        assertThatType(findAnyByName(fields, "aByte").getRawType()).matches(byte.class);
+        assertThatType(findAnyByName(fields, "aChar").getRawType()).matches(char.class);
+        assertThatType(findAnyByName(fields, "aShort").getRawType()).matches(short.class);
+        assertThatType(findAnyByName(fields, "aLong").getRawType()).matches(long.class);
+        assertThatType(findAnyByName(fields, "aFloat").getRawType()).matches(float.class);
+        assertThatType(findAnyByName(fields, "aDouble").getRawType()).matches(double.class);
+    }
+
+    @Test
+    public void attaches_correct_owner_to_fields() {
+        Iterable<JavaClass> classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/fieldimport"));
+
+        for (JavaClass clazz : classes) {
+            for (JavaField field : clazz.getFields()) {
+                assertThat(field.getOwner()).isSameAs(clazz);
+            }
+        }
+    }
+
+    @Test
+    public void imports_fields_with_correct_modifiers() {
+        Set<JavaField> fields = getFields(new ClassFileImporter().importUrl(getClass().getResource("testexamples/modifierfieldimport")));
+
+        assertThat(findAnyByName(fields, "privateField").getModifiers()).containsOnly(PRIVATE);
+        assertThat(findAnyByName(fields, "defaultField").getModifiers()).isEmpty();
+        assertThat(findAnyByName(fields, "privateFinalField").getModifiers()).containsOnly(PRIVATE, FINAL);
+        assertThat(findAnyByName(fields, "privateStaticField").getModifiers()).containsOnly(PRIVATE, STATIC);
+        assertThat(findAnyByName(fields, "privateStaticFinalField").getModifiers()).containsOnly(PRIVATE, STATIC, FINAL);
+        assertThat(findAnyByName(fields, "staticDefaultField").getModifiers()).containsOnly(STATIC);
+        assertThat(findAnyByName(fields, "protectedField").getModifiers()).containsOnly(PROTECTED);
+        assertThat(findAnyByName(fields, "protectedFinalField").getModifiers()).containsOnly(PROTECTED, FINAL);
+        assertThat(findAnyByName(fields, "publicField").getModifiers()).containsOnly(PUBLIC);
+        assertThat(findAnyByName(fields, "publicStaticFinalField").getModifiers()).containsOnly(PUBLIC, STATIC, FINAL);
+        assertThat(findAnyByName(fields, "volatileField").getModifiers()).containsOnly(VOLATILE);
+        assertThat(findAnyByName(fields, "synchronizedField").getModifiers()).containsOnly(TRANSIENT);
+    }
+
+    @Test
+    public void imports_simple_methods_with_correct_parameters() throws Exception {
+        Set<JavaMethod> methods = getMethods(new ClassFileImporter().importUrl(getClass().getResource("testexamples/methodimport")));
+        assertThat(methods).extractingResultOf("getDefaultValue").containsOnly(Optional.absent());
+
+        assertThat(findAnyByName(methods, "createString")).isEquivalentTo(
+                ClassWithStringStringMethod.class.getDeclaredMethod("createString", String.class));
+        assertThat(findAnyByName(methods, "consume")).isEquivalentTo(
+                ClassWithObjectVoidAndIntIntSerializableMethod.class.getDeclaredMethod("consume", Object.class));
+        assertThat(findAnyByName(methods, "createSerializable")).isEquivalentTo(
+                ClassWithObjectVoidAndIntIntSerializableMethod.class
+                        .getDeclaredMethod("createSerializable", int.class, int.class));
+    }
+
+    @Test
+    public void imports_complex_method_with_correct_parameters() throws Exception {
+        JavaClass clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/complexmethodimport")).get(ClassWithComplexMethod.class);
+
+        assertThat(clazz.getMethods()).as("Methods of %s", ClassWithComplexMethod.class.getSimpleName()).hasSize(1);
+
+        Class<?>[] parameterTypes = {String.class, long.class, long.class, Serializable.class, Serializable.class};
+        Method expectedMethod = ClassWithComplexMethod.class.getDeclaredMethod("complex", parameterTypes);
+
+        assertThat(clazz.getMethod("complex", parameterTypes)).isEquivalentTo(expectedMethod);
+        assertThat(clazz.tryGetMethod("complex", parameterTypes).get()).isEquivalentTo(expectedMethod);
+        assertThat(clazz.getMethod("complex", Objects.namesOf(parameterTypes))).isEquivalentTo(expectedMethod);
+        assertThat(clazz.tryGetMethod("complex", Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedMethod);
+    }
+
+    @Test
+    public void imports_methods_with_correct_return_types() {
+        Set<JavaCodeUnit> methods = getCodeUnits(new ClassFileImporter().importUrl(getClass().getResource("testexamples/methodimport")));
+
+        assertThatType(findAnyByName(methods, "createString").getRawReturnType())
+                .as("Return type of method 'createString'").matches(String.class);
+        assertThatType(findAnyByName(methods, "consume").getRawReturnType())
+                .as("Return type of method 'consume'").matches(void.class);
+        assertThatType(findAnyByName(methods, "createSerializable").getRawReturnType())
+                .as("Return type of method 'createSerializable'").matches(Serializable.class);
+    }
+
+    @Test
+    public void imports_methods_with_correct_throws_declarations() {
+        JavaMethod method = new ClassFileImporter().importUrl(getClass().getResource("testexamples/methodimport")).get(ClassWithThrowingMethod.class).getMethod("throwExceptions");
+
+        assertThat(method.getThrowsClause())
+                .as("Throws types of method 'throwsExceptions'")
+                .matches(FirstCheckedException.class, SecondCheckedException.class);
+        assertThat(method.getExceptionTypes()).matches(FirstCheckedException.class, SecondCheckedException.class);
+    }
+
+    @Test
+    public void imports_members_with_sourceCodeLocation() {
+        JavaClasses importedClasses = new ClassFileImporter().importUrl(getClass().getResource("testexamples/methodimport"));
+        String sourceFileName = "ClassWithMultipleMethods.java";
+
+        JavaClass javaClass = importedClasses.get(ClassWithMultipleMethods.class);
+        assertThat(javaClass.getField("usage").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":0)");  // the byte code has no line number associated with a field
+        assertThat(javaClass.getConstructor().getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":3)");  // auto-generated constructor seems to get line of class definition
+        assertThat(javaClass.getStaticInitializer().get().getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":5)");  // auto-generated static initializer seems to get line of first static variable definition
+        assertThat(javaClass.getMethod("methodDefinedInLine7").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":7)");
+        assertThat(javaClass.getMethod("methodWithBodyStartingInLine10").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":10)");
+        assertThat(javaClass.getMethod("emptyMethodDefinedInLine15").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":15)");
+        assertThat(javaClass.getMethod("emptyMethodEndingInLine19").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":19)");
+
+        javaClass = importedClasses.get(ClassWithMultipleMethods.InnerClass.class);
+        assertThat(javaClass.getMethod("methodWithBodyStartingInLine24").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":24)");
+
+        javaClass = importedClasses.get(ClassWithMultipleMethods.InnerClass.class.getName() + "$1");
+        assertThat(javaClass.getMethod("run").getSourceCodeLocation())
+                .hasToString("(" + sourceFileName + ":27)");
+    }
+
+    @Test
+    public void imports_simple_constructors_with_correct_parameters() throws Exception {
+        JavaClass clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/constructorimport")).get(ClassWithSimpleConstructors.class);
+
+        assertThat(clazz.getConstructors()).as("Constructors").hasSize(3);
+
+        Constructor<ClassWithSimpleConstructors> expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor();
+        assertThat(clazz.getConstructor()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor().get()).isEquivalentTo(expectedConstructor);
+
+        Class<?>[] parameterTypes = {Object.class};
+        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
+        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
+
+        parameterTypes = new Class[]{int.class, int.class};
+        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
+        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
+        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
+    }
+
+    @Test
+    public void imports_complex_constructor_with_correct_parameters() throws Exception {
+        JavaClass clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/constructorimport")).get(ClassWithComplexConstructor.class);
+
+        assertThat(clazz.getConstructors()).as("Constructors").hasSize(1);
+        assertThat(clazz.getConstructor(String.class, long.class, long.class, Serializable.class, Serializable.class))
+                .isEquivalentTo(ClassWithComplexConstructor.class.getDeclaredConstructor(
+                        String.class, long.class, long.class, Serializable.class, Serializable.class));
+    }
+
+    @Test
+    public void imports_constructor_with_correct_throws_declarations() {
+        JavaClass clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/constructorimport")).get(ClassWithThrowingConstructor.class);
+
+        JavaConstructor constructor = getOnlyElement(clazz.getConstructors());
+        assertThat(constructor.getThrowsClause()).as("Throws types of sole constructor")
+                .matches(FirstCheckedException.class, SecondCheckedException.class);
+        assertThat(constructor.getExceptionTypes()).matches(FirstCheckedException.class, SecondCheckedException.class);
+    }
+
+    @Test
+    public void imports_overridden_methods_correctly() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
+        JavaClass baseClass = classes.get(BaseClass.class);
+        JavaClass subClass = classes.get(Subclass.class);
+
+        assertThat(baseClass.getCodeUnitWithParameterTypes("getSomeField").getModifiers()).containsOnly(PROTECTED);
+        assertThat(subClass.getCodeUnitWithParameterTypes("getSomeField").getModifiers()).containsOnly(PUBLIC);
+    }
+
+    @Test
+    public void imports_referenced_class_objects() {
+        JavaClass javaClass = new ClassFileImporter().importClass(ReferencingClassObjects.class);
+
+        Set<ReferencedClassObjectsAssertion.ExpectedReferencedClassObject> expectedInConstructor =
+                ImmutableSet.of(referencedClassObject(File.class, 19), referencedClassObject(Path.class, 19));
+        Set<ReferencedClassObjectsAssertion.ExpectedReferencedClassObject> expectedInMethod =
+                ImmutableSet.of(referencedClassObject(FileSystem.class, 22), referencedClassObject(Charset.class, 22));
+        Set<ReferencedClassObjectsAssertion.ExpectedReferencedClassObject> expectedInStaticInitializer =
+                ImmutableSet.of(referencedClassObject(FilterInputStream.class, 16), referencedClassObject(Buffer.class, 16));
+
+        assertThatReferencedClassObjects(javaClass.getConstructor().getReferencedClassObjects())
+                .hasSize(2)
+                .containReferencedClassObjects(expectedInConstructor);
+        assertThatReferencedClassObjects(javaClass.getMethod("referencedClassObjectsInMethod").getReferencedClassObjects())
+                .hasSize(2)
+                .containReferencedClassObjects(expectedInMethod);
+        assertThatReferencedClassObjects(javaClass.getStaticInitializer().get().getReferencedClassObjects())
+                .hasSize(2)
+                .containReferencedClassObjects(expectedInStaticInitializer);
+        assertThatReferencedClassObjects(javaClass.getReferencedClassObjects())
+                .hasSize(6)
+                .containReferencedClassObjects(concat(expectedInConstructor, expectedInMethod, expectedInStaticInitializer));
+    }
+
+    @Test
+    public void classes_know_which_fields_have_their_type() {
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
+
+        assertThat(classes.get(SomeEnum.class).getFieldsWithTypeOfSelf())
+                .extracting("name").contains("other", "someEnum");
+    }
+
+    @Test
+    public void classes_know_which_methods_have_their_type_as_parameter() {
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
+
+        assertThat(classes.get(SomeEnum.class).getMethodsWithParameterTypeOfSelf())
+                .extracting("name").contains("methodWithSomeEnumParameter", "otherMethodWithSomeEnumParameter");
+    }
+
+    @Test
+    public void classes_know_which_methods_have_their_type_as_return_type() {
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
+
+        assertThat(classes.get(SomeEnum.class).getMethodsWithReturnTypeOfSelf())
+                .extracting("name").contains("methodWithSomeEnumReturnType", "otherMethodWithSomeEnumReturnType");
+    }
+
+    @Test
+    public void classes_know_which_method_throws_clauses_contain_their_type() {
+        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThrowingMethod.class, FirstCheckedException.class);
+
+        Set<ThrowsDeclaration<JavaMethod>> throwsDeclarations = classes.get(FirstCheckedException.class).getMethodThrowsDeclarationsWithTypeOfSelf();
+        assertThatType(getOnlyElement(throwsDeclarations).getDeclaringClass()).matches(ClassWithThrowingMethod.class);
+        assertThat(classes.get(FirstCheckedException.class).getConstructorsWithParameterTypeOfSelf()).isEmpty();
+    }
+
+    @Test
+    public void classes_know_which_constructors_have_their_type_as_parameter() {
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
+
+        assertThat(classes.get(SomeEnum.class).getConstructorsWithParameterTypeOfSelf())
+                .extracting("owner").extracting("name")
+                .contains(SomeClass.class.getName(), OtherClass.class.getName());
+    }
+
+    @Test
+    public void classes_know_which_constructor_throws_clauses_contain_their_type() {
+        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThrowingConstructor.class, FirstCheckedException.class);
+
+        Set<ThrowsDeclaration<JavaConstructor>> throwsDeclarations =
+                classes.get(FirstCheckedException.class).getConstructorsWithThrowsDeclarationTypeOfSelf();
+        assertThatType(getOnlyElement(throwsDeclarations).getDeclaringClass()).matches(ClassWithThrowingConstructor.class);
+        assertThat(classes.get(FirstCheckedException.class).getMethodThrowsDeclarationsWithTypeOfSelf()).isEmpty();
+    }
+
+    @Test
+    public void classes_know_which_instanceof_checks_check_their_type() {
+        JavaClass clazz = new ClassFileImporter().importPackagesOf(InstanceofChecked.class).get(InstanceofChecked.class);
+
+        Set<JavaClass> origins = new HashSet<>();
+        for (InstanceofCheck instanceofCheck : clazz.getInstanceofChecksWithTypeOfSelf()) {
+            origins.add(instanceofCheck.getOwner().getOwner());
+        }
+        assertThatTypes(origins).matchInAnyOrder(ChecksInstanceofInMethod.class, ChecksInstanceofInConstructor.class, ChecksInstanceofInStaticInitializer.class);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -22,7 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
-import static com.tngtech.archunit.core.importer.ClassFileImporterTest.jarFileOf;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.jarFileOf;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
 import static com.tngtech.archunit.core.importer.UrlSourceTest.JAVA_CLASS_PATH_PROP;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -1,87 +1,40 @@
 package com.tngtech.archunit.core.importer;
 
 import java.io.File;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.net.JarURLConnection;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
-import java.nio.Buffer;
-import java.nio.charset.Charset;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.jar.JarFile;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Suppliers;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.base.ForwardingCollection;
-import com.tngtech.archunit.base.Optional;
-import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
-import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
-import com.tngtech.archunit.core.domain.Dependency;
-import com.tngtech.archunit.core.domain.InstanceofCheck;
-import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClassList;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.domain.JavaCodeUnit;
-import com.tngtech.archunit.core.domain.JavaConstructor;
-import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
-import com.tngtech.archunit.core.domain.JavaFieldAccess;
-import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaPackage;
 import com.tngtech.archunit.core.domain.Source;
-import com.tngtech.archunit.core.domain.ThrowsDeclaration;
-import com.tngtech.archunit.core.domain.properties.HasName;
-import com.tngtech.archunit.core.domain.properties.HasOwner;
-import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.MethodCallTargetBuilder;
-import com.tngtech.archunit.core.importer.testexamples.FirstCheckedException;
 import com.tngtech.archunit.core.importer.testexamples.OtherClass;
-import com.tngtech.archunit.core.importer.testexamples.SecondCheckedException;
 import com.tngtech.archunit.core.importer.testexamples.SomeClass;
 import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 import com.tngtech.archunit.core.importer.testexamples.arrays.ClassAccessingOneDimensionalArray;
 import com.tngtech.archunit.core.importer.testexamples.arrays.ClassAccessingTwoDimensionalArray;
 import com.tngtech.archunit.core.importer.testexamples.arrays.ClassUsedInArray;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsExternalMethod;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsMethodReturningArray;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOtherConstructor;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOtherMethod;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOwnConstructor;
-import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOwnMethod;
-import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalInterfaceMethodCall;
-import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalOverriddenMethodCall;
-import com.tngtech.archunit.core.importer.testexamples.callimport.ExternalSubtypeConstructorCall;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.BaseClass;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.CollectionInterface;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.GrandParentInterface;
@@ -95,63 +48,13 @@ import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.SubS
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.Subclass;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.Subinterface;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.YetAnotherInterface;
-import com.tngtech.archunit.core.importer.testexamples.complexexternal.ChildClass;
-import com.tngtech.archunit.core.importer.testexamples.complexexternal.ParentClass;
-import com.tngtech.archunit.core.importer.testexamples.complexmethodimport.ClassWithComplexMethod;
-import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithComplexConstructor;
-import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithSimpleConstructors;
-import com.tngtech.archunit.core.importer.testexamples.constructorimport.ClassWithThrowingConstructor;
-import com.tngtech.archunit.core.importer.testexamples.dependents.ClassHoldingDependencies;
-import com.tngtech.archunit.core.importer.testexamples.dependents.FirstClassWithDependency;
-import com.tngtech.archunit.core.importer.testexamples.dependents.SecondClassWithDependency;
-import com.tngtech.archunit.core.importer.testexamples.diamond.ClassCallingDiamond;
-import com.tngtech.archunit.core.importer.testexamples.diamond.ClassImplementingD;
-import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceB;
-import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceC;
-import com.tngtech.archunit.core.importer.testexamples.diamond.InterfaceD;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ExternalFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ExternalShadowedFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccessFromConstructor;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignFieldAccessFromStaticInitializer;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.ForeignStaticFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.MultipleFieldAccessInSameMethod;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.OwnFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccessimport.OwnStaticFieldAccess;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ClassAccessingInterfaceFields;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.InterfaceWithFields;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.OtherInterfaceWithFields;
-import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ParentInterfaceWithFields;
-import com.tngtech.archunit.core.importer.testexamples.fieldimport.ClassWithIntAndObjectFields;
-import com.tngtech.archunit.core.importer.testexamples.fieldimport.ClassWithStringField;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.AccessToSuperAndSubclassField;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.SubclassWithAccessedField;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalfieldaccess.SuperclassWithAccessedField;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.CallOfSuperAndSubclassMethod;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.SubclassWithCalledMethod;
-import com.tngtech.archunit.core.importer.testexamples.hierarchicalmethodcall.SuperclassWithCalledMethod;
 import com.tngtech.archunit.core.importer.testexamples.innerclassimport.CalledClass;
 import com.tngtech.archunit.core.importer.testexamples.innerclassimport.ClassWithInnerClass;
-import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInConstructor;
-import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInMethod;
-import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.ChecksInstanceofInStaticInitializer;
-import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.InstanceofChecked;
-import com.tngtech.archunit.core.importer.testexamples.integration.ClassA;
-import com.tngtech.archunit.core.importer.testexamples.integration.ClassBDependingOnClassA;
-import com.tngtech.archunit.core.importer.testexamples.integration.ClassCDependingOnClassB_SuperclassOfX;
-import com.tngtech.archunit.core.importer.testexamples.integration.ClassD;
-import com.tngtech.archunit.core.importer.testexamples.integration.ClassXDependingOnClassesABCD;
-import com.tngtech.archunit.core.importer.testexamples.integration.InterfaceOfClassX;
-import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithMultipleMethods;
-import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithObjectVoidAndIntIntSerializableMethod;
-import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithStringStringMethod;
-import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithThrowingMethod;
 import com.tngtech.archunit.core.importer.testexamples.nestedimport.ClassWithNestedClass;
 import com.tngtech.archunit.core.importer.testexamples.pathone.Class11;
 import com.tngtech.archunit.core.importer.testexamples.pathone.Class12;
 import com.tngtech.archunit.core.importer.testexamples.pathtwo.Class21;
 import com.tngtech.archunit.core.importer.testexamples.pathtwo.Class22;
-import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjects;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationParameter;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationToImport;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.ClassToImportOne;
@@ -159,62 +62,43 @@ import com.tngtech.archunit.core.importer.testexamples.simpleimport.ClassToImpor
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.EnumToImport;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.InterfaceToImport;
 import com.tngtech.archunit.core.importer.testexamples.simplenames.SimpleNameExamples;
-import com.tngtech.archunit.core.importer.testexamples.specialtargets.ClassCallingSpecialTarget;
 import com.tngtech.archunit.core.importer.testexamples.syntheticimport.ClassWithSynthetics;
 import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.archunit.testutil.LogTestRule;
 import com.tngtech.archunit.testutil.OutsideOfClassPathRule;
-import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.ExpectedReferencedClassObject;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.logging.log4j.Level;
 import org.assertj.core.api.Condition;
-import org.assertj.core.util.Objects;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.containsPattern;
 import static com.google.common.base.Predicates.not;
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.getFirst;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
-import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.GET;
-import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.SET;
 import static com.tngtech.archunit.core.domain.JavaModifier.BRIDGE;
-import static com.tngtech.archunit.core.domain.JavaModifier.FINAL;
-import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
-import static com.tngtech.archunit.core.domain.JavaModifier.PROTECTED;
-import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
 import static com.tngtech.archunit.core.domain.JavaModifier.STATIC;
 import static com.tngtech.archunit.core.domain.JavaModifier.SYNTHETIC;
-import static com.tngtech.archunit.core.domain.JavaModifier.TRANSIENT;
-import static com.tngtech.archunit.core.domain.JavaModifier.VOLATILE;
-import static com.tngtech.archunit.core.domain.JavaStaticInitializer.STATIC_INITIALIZER_NAME;
 import static com.tngtech.archunit.core.domain.SourceTest.bytesAt;
 import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
 import static com.tngtech.archunit.core.domain.TestUtils.MD5_SUM_DISABLED;
-import static com.tngtech.archunit.core.domain.TestUtils.asClasses;
 import static com.tngtech.archunit.core.domain.TestUtils.md5sumOf;
-import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.findAnyByName;
+import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.jarFileOf;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
-import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
-import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.constructor;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 import static com.tngtech.archunit.testutil.TestUtils.namesOf;
-import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
@@ -235,7 +119,7 @@ public class ClassFileImporterTest {
     public final ArchConfigurationRule archConfigurationRule = new ArchConfigurationRule();
 
     @Test
-    public void imports_simple_package() throws Exception {
+    public void imports_simple_package() {
         Set<String> expectedClassNames = Sets.newHashSet(
                 ClassToImportOne.class.getName(),
                 ClassToImportTwo.class.getName(),
@@ -244,14 +128,14 @@ public class ClassFileImporterTest {
                 AnnotationToImport.class.getName(),
                 AnnotationParameter.class.getName());
 
-        Iterable<JavaClass> classes = classesIn("testexamples/simpleimport");
+        Iterable<JavaClass> classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport"));
 
         assertThat(namesOf(classes)).containsOnlyElementsOf(expectedClassNames);
     }
 
     @Test
-    public void imports_simple_class_details() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/simpleimport");
+    public void imports_simple_class_details() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport"));
         JavaClass javaClass = classes.get(ClassToImportOne.class);
 
         assertThat(javaClass.isFullyImported()).isTrue();
@@ -276,8 +160,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_simple_enum() throws Exception {
-        JavaClass javaClass = classesIn("testexamples/simpleimport").get(EnumToImport.class);
+    public void imports_simple_enum() {
+        JavaClass javaClass = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(EnumToImport.class);
 
         assertThat(javaClass.getName()).as("full name").isEqualTo(EnumToImport.class.getName());
         assertThat(javaClass.getSimpleName()).as("simple name").isEqualTo(EnumToImport.class.getSimpleName());
@@ -304,8 +188,8 @@ public class ClassFileImporterTest {
 
     @Test
     @UseDataProvider("nested_static_classes")
-    public void imports_simple_static_nested_class(Class<?> nestedStaticClass) throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+    public void imports_simple_static_nested_class(Class<?> nestedStaticClass) {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass staticNestedClass = classes.get(nestedStaticClass);
 
         assertThatType(staticNestedClass).matches(nestedStaticClass);
@@ -318,8 +202,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_simple_inner_class() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+    public void imports_simple_inner_class() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass innerClass = classes.get(ClassWithInnerClass.Inner.class);
 
         assertThatType(innerClass).matches(ClassWithInnerClass.Inner.class);
@@ -333,7 +217,7 @@ public class ClassFileImporterTest {
 
     @Test
     public void imports_simple_anonymous_class() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass anonymousClass = classes.get(ClassWithInnerClass.class.getName() + "$1");
 
         assertThatType(anonymousClass).matches(Class.forName(anonymousClass.getName()));
@@ -347,7 +231,7 @@ public class ClassFileImporterTest {
 
     @Test
     public void imports_simple_local_class() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass localClass = classes.get(ClassWithInnerClass.class.getName() + "$1LocalCaller");
 
         assertThatType(localClass).matches(Class.forName(localClass.getName()));
@@ -361,7 +245,7 @@ public class ClassFileImporterTest {
 
     @Test
     public void imports_simple_class_names_of_generated_types_correctly() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/simplenames");
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simplenames"));
 
         assertSameSimpleNameOfArchUnitAndReflection(classes, SimpleNameExamples.class);
         assertSameSimpleNameOfArchUnitAndReflection(classes, SimpleNameExamples.Crazy$InnerClass$$LikeAByteCodeGenerator_might_create.class);
@@ -376,8 +260,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_interfaces() throws Exception {
-        JavaClass simpleInterface = classesIn("testexamples/simpleimport").get(InterfaceToImport.class);
+    public void imports_interfaces() {
+        JavaClass simpleInterface = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(InterfaceToImport.class);
 
         assertThat(simpleInterface.getName()).as("full name").isEqualTo(InterfaceToImport.class.getName());
         assertThat(simpleInterface.getSimpleName()).as("simple name").isEqualTo(InterfaceToImport.class.getSimpleName());
@@ -390,7 +274,7 @@ public class ClassFileImporterTest {
 
     @Test
     public void imports_nested_classes() throws Exception {
-        JavaClasses classes = classesIn("testexamples/nestedimport").classes;
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/nestedimport"));
 
         assertThatTypes(classes).matchInAnyOrder(
                 ClassWithNestedClass.class,
@@ -402,8 +286,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void handles_static_modifier_of_nested_classes() throws Exception {
-        JavaClasses classes = classesIn("testexamples/nestedimport").classes;
+    public void handles_static_modifier_of_nested_classes() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/nestedimport"));
 
         assertThat(classes.get(ClassWithNestedClass.class).getModifiers()).as("modifiers of ClassWithNestedClass").doesNotContain(STATIC);
         assertThat(classes.get(ClassWithNestedClass.NestedClass.class).getModifiers()).as("modifiers of ClassWithNestedClass.NestedClass").doesNotContain(STATIC);
@@ -413,8 +297,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void handles_synthetic_modifiers() throws Exception {
-        JavaClasses classes = classesIn("testexamples/syntheticimport").classes;
+    public void handles_synthetic_modifiers() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/syntheticimport"));
 
         JavaField syntheticField = getOnlyElement(classes.get(ClassWithSynthetics.ClassWithSyntheticField.class).getFields());
         assertThat(syntheticField.getModifiers()).as("modifiers of field in ClassWithSynthetics.ClassWithSyntheticField").contains(SYNTHETIC);
@@ -470,208 +354,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_fields() throws Exception {
-        Set<JavaField> fields = classesIn("testexamples/fieldimport").getFields();
-
-        assertThat(namesOf(fields)).containsOnly("stringField", "serializableField", "objectField");
-        assertThat(findAnyByName(fields, "stringField"))
-                .isEquivalentTo(field(ClassWithStringField.class, "stringField"));
-        assertThat(findAnyByName(fields, "serializableField"))
-                .isEquivalentTo(field(ClassWithIntAndObjectFields.class, "serializableField"));
-        assertThat(findAnyByName(fields, "objectField"))
-                .isEquivalentTo(field(ClassWithIntAndObjectFields.class, "objectField"));
-    }
-
-    @Test
-    public void imports_primitive_fields() throws Exception {
-        Set<JavaField> fields = classesIn("testexamples/primitivefieldimport").getFields();
-
-        assertThatType(findAnyByName(fields, "aBoolean").getRawType()).matches(boolean.class);
-        assertThatType(findAnyByName(fields, "anInt").getRawType()).matches(int.class);
-        assertThatType(findAnyByName(fields, "aByte").getRawType()).matches(byte.class);
-        assertThatType(findAnyByName(fields, "aChar").getRawType()).matches(char.class);
-        assertThatType(findAnyByName(fields, "aShort").getRawType()).matches(short.class);
-        assertThatType(findAnyByName(fields, "aLong").getRawType()).matches(long.class);
-        assertThatType(findAnyByName(fields, "aFloat").getRawType()).matches(float.class);
-        assertThatType(findAnyByName(fields, "aDouble").getRawType()).matches(double.class);
-    }
-
-    // NOTE: This provokes the scenario where the target type can't be determined uniquely due to a diamond
-    //       scenario and thus a fallback to (primitive and array) type names by ASM descriptors occurs.
-    //       Unfortunately those ASM type names for example are the canonical name instead of the class name.
-    @Test
-    public void imports_special_target_parameters() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/specialtargets");
-        Set<JavaMethodCall> calls = classes.get(ClassCallingSpecialTarget.class).getMethodCallsFromSelf();
-
-        assertThat(targetParametersOf(calls, "primitiveArgs")).matches(byte.class, long.class);
-        assertThatType(returnTypeOf(calls, "primitiveReturnType")).matches(byte.class);
-        assertThat(targetParametersOf(calls, "arrayArgs")).matches(byte[].class, Object[].class);
-        assertThatType(returnTypeOf(calls, "primitiveArrayReturnType")).matches(short[].class);
-        assertThatType(returnTypeOf(calls, "objectArrayReturnType")).matches(String[].class);
-        assertThat(targetParametersOf(calls, "twoDimArrayArgs")).matches(float[][].class, Object[][].class);
-        assertThatType(returnTypeOf(calls, "primitiveTwoDimArrayReturnType")).matches(double[][].class);
-        assertThatType(returnTypeOf(calls, "objectTwoDimArrayReturnType")).matches(String[][].class);
-    }
-
-    @Test
-    public void attaches_correct_owner_to_fields() throws Exception {
-        Iterable<JavaClass> classes = classesIn("testexamples/fieldimport");
-
-        for (JavaClass clazz : classes) {
-            for (JavaField field : clazz.getFields()) {
-                assertThatType(field.getOwner()).isSameAs(clazz);
-            }
-        }
-    }
-
-    @Test
-    public void imports_fields_with_correct_modifiers() throws Exception {
-        Set<JavaField> fields = classesIn("testexamples/modifierfieldimport").getFields();
-
-        assertThat(findAnyByName(fields, "privateField").getModifiers()).containsOnly(PRIVATE);
-        assertThat(findAnyByName(fields, "defaultField").getModifiers()).isEmpty();
-        assertThat(findAnyByName(fields, "privateFinalField").getModifiers()).containsOnly(PRIVATE, FINAL);
-        assertThat(findAnyByName(fields, "privateStaticField").getModifiers()).containsOnly(PRIVATE, STATIC);
-        assertThat(findAnyByName(fields, "privateStaticFinalField").getModifiers()).containsOnly(PRIVATE, STATIC, FINAL);
-        assertThat(findAnyByName(fields, "staticDefaultField").getModifiers()).containsOnly(STATIC);
-        assertThat(findAnyByName(fields, "protectedField").getModifiers()).containsOnly(PROTECTED);
-        assertThat(findAnyByName(fields, "protectedFinalField").getModifiers()).containsOnly(PROTECTED, FINAL);
-        assertThat(findAnyByName(fields, "publicField").getModifiers()).containsOnly(PUBLIC);
-        assertThat(findAnyByName(fields, "publicStaticFinalField").getModifiers()).containsOnly(PUBLIC, STATIC, FINAL);
-        assertThat(findAnyByName(fields, "volatileField").getModifiers()).containsOnly(VOLATILE);
-        assertThat(findAnyByName(fields, "synchronizedField").getModifiers()).containsOnly(TRANSIENT);
-    }
-
-    @Test
-    public void imports_simple_methods_with_correct_parameters() throws Exception {
-        Set<JavaMethod> methods = classesIn("testexamples/methodimport").getMethods();
-        assertThat(methods).extractingResultOf("getDefaultValue").containsOnly(Optional.absent());
-
-        assertThat(findAnyByName(methods, "createString")).isEquivalentTo(
-                ClassWithStringStringMethod.class.getDeclaredMethod("createString", String.class));
-        assertThat(findAnyByName(methods, "consume")).isEquivalentTo(
-                ClassWithObjectVoidAndIntIntSerializableMethod.class.getDeclaredMethod("consume", Object.class));
-        assertThat(findAnyByName(methods, "createSerializable")).isEquivalentTo(
-                ClassWithObjectVoidAndIntIntSerializableMethod.class
-                        .getDeclaredMethod("createSerializable", int.class, int.class));
-    }
-
-    @Test
-    public void imports_complex_method_with_correct_parameters() throws Exception {
-        JavaClass clazz = classesIn("testexamples/complexmethodimport").get(ClassWithComplexMethod.class);
-
-        assertThat(clazz.getMethods()).as("Methods of %s", ClassWithComplexMethod.class.getSimpleName()).hasSize(1);
-
-        Class<?>[] parameterTypes = {String.class, long.class, long.class, Serializable.class, Serializable.class};
-        Method expectedMethod = ClassWithComplexMethod.class.getDeclaredMethod("complex", parameterTypes);
-
-        assertThat(clazz.getMethod("complex", parameterTypes)).isEquivalentTo(expectedMethod);
-        assertThat(clazz.tryGetMethod("complex", parameterTypes).get()).isEquivalentTo(expectedMethod);
-        assertThat(clazz.getMethod("complex", Objects.namesOf(parameterTypes))).isEquivalentTo(expectedMethod);
-        assertThat(clazz.tryGetMethod("complex", Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedMethod);
-    }
-
-    @Test
-    public void imports_methods_with_correct_return_types() throws Exception {
-        Set<JavaCodeUnit> methods = classesIn("testexamples/methodimport").getCodeUnits();
-
-        assertThatType(findAnyByName(methods, "createString").getRawReturnType())
-                .as("Return type of method 'createString'").matches(String.class);
-        assertThatType(findAnyByName(methods, "consume").getRawReturnType())
-                .as("Return type of method 'consume'").matches(void.class);
-        assertThatType(findAnyByName(methods, "createSerializable").getRawReturnType())
-                .as("Return type of method 'createSerializable'").matches(Serializable.class);
-    }
-
-    @Test
-    public void imports_methods_with_correct_throws_declarations() throws Exception {
-        JavaMethod method = classesIn("testexamples/methodimport").get(ClassWithThrowingMethod.class).getMethod("throwExceptions");
-
-        assertThat(method.getThrowsClause())
-                .as("Throws types of method 'throwsExceptions'")
-                .matches(FirstCheckedException.class, SecondCheckedException.class);
-        assertThat(method.getExceptionTypes()).matches(FirstCheckedException.class, SecondCheckedException.class);
-    }
-
-    @Test
-    public void imports_members_with_sourceCodeLocation() throws Exception {
-        ImportedClasses importedClasses = classesIn("testexamples/methodimport");
-        String sourceFileName = "ClassWithMultipleMethods.java";
-
-        JavaClass javaClass = importedClasses.get(ClassWithMultipleMethods.class);
-        assertThat(javaClass.getField("usage").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":0)");  // the byte code has no line number associated with a field
-        assertThat(javaClass.getConstructor().getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":3)");  // auto-generated constructor seems to get line of class definition
-        assertThat(javaClass.getStaticInitializer().get().getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":5)");  // auto-generated static initializer seems to get line of first static variable definition
-        assertThat(javaClass.getMethod("methodDefinedInLine7").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":7)");
-        assertThat(javaClass.getMethod("methodWithBodyStartingInLine10").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":10)");
-        assertThat(javaClass.getMethod("emptyMethodDefinedInLine15").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":15)");
-        assertThat(javaClass.getMethod("emptyMethodEndingInLine19").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":19)");
-
-        javaClass = importedClasses.get(ClassWithMultipleMethods.InnerClass.class);
-        assertThat(javaClass.getMethod("methodWithBodyStartingInLine24").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":24)");
-
-        javaClass = importedClasses.get(ClassWithMultipleMethods.InnerClass.class.getName() + "$1");
-        assertThat(javaClass.getMethod("run").getSourceCodeLocation())
-                .hasToString("(" + sourceFileName + ":27)");
-    }
-
-    @Test
-    public void imports_simple_constructors_with_correct_parameters() throws Exception {
-        JavaClass clazz = classesIn("testexamples/constructorimport").get(ClassWithSimpleConstructors.class);
-
-        assertThat(clazz.getConstructors()).as("Constructors").hasSize(3);
-
-        Constructor<ClassWithSimpleConstructors> expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor();
-        assertThat(clazz.getConstructor()).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.tryGetConstructor().get()).isEquivalentTo(expectedConstructor);
-
-        Class<?>[] parameterTypes = {Object.class};
-        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
-        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
-
-        parameterTypes = new Class[]{int.class, int.class};
-        expectedConstructor = ClassWithSimpleConstructors.class.getDeclaredConstructor(parameterTypes);
-        assertThat(clazz.getConstructor(parameterTypes)).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.getConstructor(Objects.namesOf(parameterTypes))).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.tryGetConstructor(parameterTypes).get()).isEquivalentTo(expectedConstructor);
-        assertThat(clazz.tryGetConstructor(Objects.namesOf(parameterTypes)).get()).isEquivalentTo(expectedConstructor);
-    }
-
-    @Test
-    public void imports_complex_constructor_with_correct_parameters() throws Exception {
-        JavaClass clazz = classesIn("testexamples/constructorimport").get(ClassWithComplexConstructor.class);
-
-        assertThat(clazz.getConstructors()).as("Constructors").hasSize(1);
-        assertThat(clazz.getConstructor(String.class, long.class, long.class, Serializable.class, Serializable.class))
-                .isEquivalentTo(ClassWithComplexConstructor.class.getDeclaredConstructor(
-                        String.class, long.class, long.class, Serializable.class, Serializable.class));
-    }
-
-    @Test
-    public void imports_constructor_with_correct_throws_declarations() throws Exception {
-        JavaClass clazz = classesIn("testexamples/constructorimport").get(ClassWithThrowingConstructor.class);
-
-        JavaConstructor constructor = getOnlyElement(clazz.getConstructors());
-        assertThat(constructor.getThrowsClause()).as("Throws types of sole constructor")
-                .matches(FirstCheckedException.class, SecondCheckedException.class);
-        assertThat(constructor.getExceptionTypes()).matches(FirstCheckedException.class, SecondCheckedException.class);
-    }
-
-    @Test
-    public void imports_interfaces_and_classes() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
+    public void imports_interfaces_and_classes() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
         JavaClass baseClass = classes.get(BaseClass.class);
         JavaClass parentInterface = classes.get(ParentInterface.class);
 
@@ -680,8 +364,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_base_class_in_class_hierarchy_correctly() throws Exception {
-        JavaClass baseClass = classesIn("testexamples/classhierarchyimport").get(BaseClass.class);
+    public void imports_base_class_in_class_hierarchy_correctly() {
+        JavaClass baseClass = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport")).get(BaseClass.class);
 
         assertThat(baseClass.getConstructors()).as("Constructors of " + BaseClass.class.getSimpleName()).hasSize(2);
         assertThat(baseClass.getFields()).as("Fields of " + BaseClass.class.getSimpleName()).hasSize(1);
@@ -691,8 +375,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_subclass_in_class_hierarchy_correctly() throws Exception {
-        JavaClass subclass = classesIn("testexamples/classhierarchyimport").get(Subclass.class);
+    public void imports_subclass_in_class_hierarchy_correctly() {
+        JavaClass subclass = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport")).get(Subclass.class);
 
         assertThat(subclass.getConstructors()).hasSize(3);
         assertThat(subclass.getFields()).hasSize(1);
@@ -701,8 +385,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void creates_relations_between_super_and_subclasses() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
+    public void creates_relations_between_super_and_subclasses() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
         JavaClass baseClass = classes.get(BaseClass.class);
         JavaClass subclass = classes.get(Subclass.class);
         JavaClass otherSubclass = classes.get(OtherSubclass.class);
@@ -722,8 +406,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void creates_relations_between_classes_and_interfaces() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
+    public void creates_relations_between_classes_and_interfaces() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
         JavaClass baseClass = classes.get(BaseClass.class);
         JavaClass otherInterface = classes.get(OtherInterface.class);
         JavaClass subclass = classes.get(Subclass.class);
@@ -748,8 +432,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void creates_relations_between_interfaces_and_interfaces() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
+    public void creates_relations_between_interfaces_and_interfaces() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
         JavaClass subinterface = classes.get(Subinterface.class);
         JavaClass parentInterface = classes.get(ParentInterface.class);
         JavaClass grandParentInterface = classes.get(GrandParentInterface.class);
@@ -764,8 +448,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void creates_relations_between_interfaces_and_subclasses() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
+    public void creates_relations_between_interfaces_and_subclasses() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/classhierarchyimport"));
         JavaClass baseClass = classes.get(BaseClass.class);
         JavaClass otherInterface = classes.get(OtherInterface.class);
         JavaClass subclass = classes.get(Subclass.class);
@@ -813,8 +497,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_enclosing_classes() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+    public void imports_enclosing_classes() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass classWithInnerClass = classes.get(ClassWithInnerClass.class);
         JavaClass innerClass = classes.get(ClassWithInnerClass.Inner.class);
         JavaClass anonymousClass = classes.get(ClassWithInnerClass.class.getName() + "$1");
@@ -836,822 +520,8 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void imports_overridden_methods_correctly() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/classhierarchyimport");
-        JavaClass baseClass = classes.get(BaseClass.class);
-        JavaClass subclass = classes.get(Subclass.class);
-
-        assertThat(baseClass.getCodeUnitWithParameterTypes("getSomeField").getModifiers()).containsOnly(PROTECTED);
-        assertThat(subclass.getCodeUnitWithParameterTypes("getSomeField").getModifiers()).containsOnly(PUBLIC);
-    }
-
-    @Test
-    public void imports_referenced_class_objects() {
-        JavaClass javaClass = new ClassFileImporter().importClass(ReferencingClassObjects.class);
-
-        Set<ExpectedReferencedClassObject> expectedInConstructor =
-                ImmutableSet.of(referencedClassObject(File.class, 19), referencedClassObject(Path.class, 19));
-        Set<ExpectedReferencedClassObject> expectedInMethod =
-                ImmutableSet.of(referencedClassObject(FileSystem.class, 22), referencedClassObject(Charset.class, 22));
-        Set<ExpectedReferencedClassObject> expectedInStaticInitializer =
-                ImmutableSet.of(referencedClassObject(FilterInputStream.class, 16), referencedClassObject(Buffer.class, 16));
-
-        assertThatReferencedClassObjects(javaClass.getConstructor().getReferencedClassObjects())
-                .hasSize(2)
-                .containReferencedClassObjects(expectedInConstructor);
-        assertThatReferencedClassObjects(javaClass.getMethod("referencedClassObjectsInMethod").getReferencedClassObjects())
-                .hasSize(2)
-                .containReferencedClassObjects(expectedInMethod);
-        assertThatReferencedClassObjects(javaClass.getStaticInitializer().get().getReferencedClassObjects())
-                .hasSize(2)
-                .containReferencedClassObjects(expectedInStaticInitializer);
-        assertThatReferencedClassObjects(javaClass.getReferencedClassObjects())
-                .hasSize(6)
-                .containReferencedClassObjects(concat(expectedInConstructor, expectedInMethod, expectedInStaticInitializer));
-    }
-
-    @Test
-    public void imports_own_get_field_access() throws Exception {
-        JavaClass classWithOwnFieldAccess = classesIn("testexamples/fieldaccessimport").get(OwnFieldAccess.class);
-
-        JavaMethod getStringValue = classWithOwnFieldAccess.getMethod("getStringValue");
-
-        JavaFieldAccess access = getOnlyElement(getStringValue.getFieldAccesses());
-        assertThatAccess(access)
-                .isOfType(GET)
-                .isFrom(getStringValue)
-                .isTo("stringValue")
-                .inLineNumber(8);
-    }
-
-    @Test
-    public void imports_own_set_field_access() throws Exception {
-        JavaClass classWithOwnFieldAccess = classesIn("testexamples/fieldaccessimport").get(OwnFieldAccess.class);
-
-        JavaMethod setStringValue = classWithOwnFieldAccess.getMethod("setStringValue", String.class);
-
-        JavaFieldAccess access = getOnlyElement(setStringValue.getFieldAccesses());
-        assertThatAccess(access)
-                .isOfType(SET)
-                .isFrom(setStringValue)
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(12);
-    }
-
-    @Test
-    public void imports_multiple_own_accesses() throws Exception {
-        JavaClass classWithOwnFieldAccess = classesIn("testexamples/fieldaccessimport").get(OwnFieldAccess.class);
-
-        Set<JavaFieldAccess> fieldAccesses = classWithOwnFieldAccess.getFieldAccessesFromSelf();
-
-        assertThat(fieldAccesses).hasSize(4);
-        assertThat(getOnly(fieldAccesses, "stringValue", GET).getLineNumber())
-                .as("Line number of get stringValue").isEqualTo(8);
-        assertThat(getOnly(fieldAccesses, "stringValue", SET).getLineNumber())
-                .as("Line number of set stringValue").isEqualTo(12);
-        assertThat(getOnly(fieldAccesses, "intValue", GET).getLineNumber())
-                .as("Line number of get intValue").isEqualTo(16);
-        assertThat(getOnly(fieldAccesses, "intValue", SET).getLineNumber())
-                .as("Line number of set intValue").isEqualTo(20);
-    }
-
-    @Test
-    public void imports_own_static_field_accesses() throws Exception {
-        JavaClass classWithOwnFieldAccess = classesIn("testexamples/fieldaccessimport").get(OwnStaticFieldAccess.class);
-
-        Set<JavaFieldAccess> accesses = classWithOwnFieldAccess.getFieldAccessesFromSelf();
-
-        assertThat(accesses).hasSize(2);
-
-        JavaFieldAccess getAccess = getOnly(accesses, "staticStringValue", GET);
-
-        assertThatAccess(getAccess)
-                .isFrom("getStaticStringValue")
-                .isTo("staticStringValue")
-                .inLineNumber(7);
-
-        JavaFieldAccess setAccess = getOnly(accesses, "staticStringValue", SET);
-
-        assertThatAccess(setAccess)
-                .isFrom("setStaticStringValue", String.class)
-                .isTo("staticStringValue")
-                .inLineNumber(11);
-    }
-
-    @Test
-    public void imports_other_field_accesses() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/fieldaccessimport");
-        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
-        JavaClass classWithForeignFieldAccess = classes.get(ForeignFieldAccess.class);
-
-        Set<JavaFieldAccess> accesses = classWithForeignFieldAccess.getFieldAccessesFromSelf();
-
-        assertThat(accesses).hasSize(4);
-
-        assertThatAccess(getOnly(accesses, "stringValue", GET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getStringFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(5);
-
-        assertThatAccess(getOnly(accesses, "stringValue", SET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setStringFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(9);
-
-        assertThatAccess(getOnly(accesses, "intValue", GET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getIntFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(13);
-
-        assertThatAccess(getOnly(accesses, "intValue", SET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setIntFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(17);
-    }
-
-    @Test
-    public void imports_other_static_field_accesses() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/fieldaccessimport");
-        JavaClass classWithOwnFieldAccess = classes.get(OwnStaticFieldAccess.class);
-        JavaClass classWithForeignFieldAccess = classes.get(ForeignStaticFieldAccess.class);
-
-        Set<JavaFieldAccess> accesses = classWithForeignFieldAccess.getFieldAccessesFromSelf();
-
-        assertThat(accesses).as("Number of field accesses from " + classWithForeignFieldAccess.getName()).hasSize(2);
-
-        assertThatAccess(getOnly(accesses, "staticStringValue", GET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("getStaticStringFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("staticStringValue"))
-                .inLineNumber(5);
-
-        assertThatAccess(getOnly(accesses, "staticStringValue", SET))
-                .isFrom(classWithForeignFieldAccess.getCodeUnitWithParameterTypes("setStaticStringFromOther"))
-                .isTo(classWithOwnFieldAccess.getField("staticStringValue"))
-                .inLineNumber(9);
-    }
-
-    @Test
-    public void imports_multiple_accesses_from_same_method() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/fieldaccessimport");
-        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
-        JavaClass multipleFieldAccesses = classes.get(MultipleFieldAccessInSameMethod.class);
-
-        Set<JavaFieldAccess> accesses = multipleFieldAccesses.getFieldAccessesFromSelf();
-
-        assertThat(accesses).as("Number of field accesses from " + multipleFieldAccesses.getName()).hasSize(5);
-
-        Set<JavaFieldAccess> setStringValues = getByNameAndAccessType(accesses, "stringValue", SET);
-        assertThat(setStringValues).hasSize(2);
-        assertThat(targetsOf(setStringValues)).containsOnly(targetFrom(classWithOwnFieldAccess.getField("stringValue")));
-        assertThat(lineNumbersOf(setStringValues)).containsOnly(6, 8);
-
-        assertThatAccess(getOnly(accesses, "stringValue", GET))
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(7);
-
-        assertThatAccess(getOnly(accesses, "intValue", GET))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(10);
-
-        assertThatAccess(getOnly(accesses, "intValue", SET))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(11);
-    }
-
-    @Test
-    public void imports_other_field_accesses_from_constructor() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/fieldaccessimport");
-        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
-        JavaClass fieldAccessFromConstructor = classes.get(ForeignFieldAccessFromConstructor.class);
-
-        Set<JavaFieldAccess> accesses = fieldAccessFromConstructor.getFieldAccessesFromSelf();
-
-        assertThat(accesses).as("Number of field accesses from " + fieldAccessFromConstructor.getName()).hasSize(2);
-
-        assertThatAccess(getOnly(accesses, "stringValue", GET))
-                .isFrom(fieldAccessFromConstructor.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME))
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(5);
-
-        assertThatAccess(getOnly(accesses, "intValue", SET))
-                .isFrom(fieldAccessFromConstructor.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(6);
-    }
-
-    @Test
-    public void imports_other_field_accesses_from_static_initializer() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/fieldaccessimport");
-        JavaClass classWithOwnFieldAccess = classes.get(OwnFieldAccess.class);
-        JavaClass fieldAccessFromInitializer = classes.get(ForeignFieldAccessFromStaticInitializer.class);
-
-        Set<JavaFieldAccess> accesses = fieldAccessFromInitializer.getFieldAccessesFromSelf();
-
-        assertThat(accesses).as("Number of field accesses from " + fieldAccessFromInitializer.getName()).hasSize(2);
-
-        assertThatAccess(getOnly(accesses, "stringValue", GET))
-                .isFrom(fieldAccessFromInitializer.getCodeUnitWithParameterTypes(STATIC_INITIALIZER_NAME))
-                .isTo(classWithOwnFieldAccess.getField("stringValue"))
-                .inLineNumber(5);
-
-        assertThatAccess(getOnly(accesses, "intValue", SET))
-                .isFrom(fieldAccessFromInitializer.getCodeUnitWithParameterTypes(STATIC_INITIALIZER_NAME))
-                .isTo(classWithOwnFieldAccess.getField("intValue"))
-                .inLineNumber(6);
-    }
-
-    @Test
-    public void imports_external_field_access() throws Exception {
-        JavaClass classWithExternalFieldAccess = classesIn("testexamples/fieldaccessimport").get(ExternalFieldAccess.class);
-
-        JavaFieldAccess access = getOnlyElement(classWithExternalFieldAccess.getMethod("access").getFieldAccesses());
-
-        assertThatAccess(access)
-                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("access"))
-                .inLineNumber(8);
-
-        assertThat(access.getTarget()).isEquivalentTo(field(ClassWithIntAndObjectFields.class, "objectField"));
-
-        access = getOnlyElement(classWithExternalFieldAccess.getMethod("accessInheritedExternalField").getFieldAccesses());
-
-        assertThatAccess(access)
-                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("accessInheritedExternalField"))
-                .inLineNumber(12);
-
-        assertThat(access.getTarget()).isEquivalentTo(field(ParentClass.class, "someParentField"));
-    }
-
-    @Test
-    public void imports_external_field_access_with_shadowed_field() throws Exception {
-        JavaClass classWithExternalFieldAccess = classesIn("testexamples/fieldaccessimport").get(ExternalShadowedFieldAccess.class);
-
-        JavaFieldAccess access = getOnlyElement(classWithExternalFieldAccess.getFieldAccessesFromSelf());
-
-        assertThatAccess(access)
-                .isFrom(classWithExternalFieldAccess.getCodeUnitWithParameterTypes("accessField"))
-                .inLineNumber(7);
-
-        assertThat(access.getTarget()).isEquivalentTo(field(ChildClass.class, "someField"));
-    }
-
-    @Test
-    public void imports_shadowed_and_superclass_field_access() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/hierarchicalfieldaccess");
-        JavaClass classThatAccessesFieldOfSuperclass = classes.get(AccessToSuperAndSubclassField.class);
-        JavaClass superclassWithAccessedField = classes.get(SuperclassWithAccessedField.class);
-        JavaClass subclassWithAccessedField = classes.get(SubclassWithAccessedField.class);
-
-        Set<JavaFieldAccess> accesses = classThatAccessesFieldOfSuperclass.getFieldAccessesFromSelf();
-
-        assertThat(accesses).hasSize(2);
-        JavaField field = superclassWithAccessedField.getField("field");
-        FieldAccessTarget expectedSuperclassFieldAccess = new FieldAccessTargetBuilder()
-                .withOwner(subclassWithAccessedField)
-                .withName(field.getName())
-                .withType(field.getRawType())
-                .withField(Suppliers.ofInstance(Optional.of(field)))
-                .build();
-        assertThatAccess(getOnly(accesses, "field", GET))
-                .isFrom("accessSuperclassField")
-                .isTo(expectedSuperclassFieldAccess)
-                .inLineNumber(5);
-        assertThatAccess(getOnly(accesses, "maskedField", GET))
-                .isFrom("accessSubclassField")
-                .isTo(subclassWithAccessedField.getField("maskedField"))
-                .inLineNumber(9);
-    }
-
-    @Test
-    public void imports_field_accesses_to_fields_from_interfaces() throws Exception {
-        Set<JavaFieldAccess> accesses = classesIn("testexamples/fieldaccesstointerfaces")
-                .get(ClassAccessingInterfaceFields.class).getFieldAccessesFromSelf();
-
-        assertThat(findAnyByName(accesses, "" + InterfaceWithFields.objectFieldOne).getTarget().resolveField().get())
-                .isEquivalentTo(field(InterfaceWithFields.class, "" + InterfaceWithFields.objectFieldOne));
-        assertThat(findAnyByName(accesses, "" + InterfaceWithFields.objectFieldTwo).getTarget().resolveField().get())
-                .isEquivalentTo(field(InterfaceWithFields.class, "" + InterfaceWithFields.objectFieldTwo));
-        assertThat(findAnyByName(accesses, "" + OtherInterfaceWithFields.otherObjectFieldOne).getTarget().resolveField().get())
-                .isEquivalentTo(field(OtherInterfaceWithFields.class, "" + OtherInterfaceWithFields.otherObjectFieldOne));
-        assertThat(findAnyByName(accesses, "" + OtherInterfaceWithFields.otherObjectFieldTwo).getTarget().resolveField().get())
-                .isEquivalentTo(field(OtherInterfaceWithFields.class, "" + OtherInterfaceWithFields.otherObjectFieldTwo));
-        assertThat(findAnyByName(accesses, "" + ParentInterfaceWithFields.parentObjectFieldOne).getTarget().resolveField().get())
-                .isEquivalentTo(field(ParentInterfaceWithFields.class, "" + ParentInterfaceWithFields.parentObjectFieldOne));
-        assertThat(findAnyByName(accesses, "" + ParentInterfaceWithFields.parentObjectFieldTwo).getTarget().resolveField().get())
-                .isEquivalentTo(field(ParentInterfaceWithFields.class, "" + ParentInterfaceWithFields.parentObjectFieldTwo));
-    }
-
-    @Test
-    public void imports_shadowed_and_superclass_method_calls() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/hierarchicalmethodcall");
-        JavaClass classThatCallsMethodOfSuperclass = classes.get(CallOfSuperAndSubclassMethod.class);
-        JavaClass superclassWithCalledMethod = classes.get(SuperclassWithCalledMethod.class);
-        JavaClass subclassWithCalledMethod = classes.get(SubclassWithCalledMethod.class);
-
-        Set<JavaMethodCall> calls = classThatCallsMethodOfSuperclass.getMethodCallsFromSelf();
-
-        assertThat(calls).hasSize(2);
-
-        JavaCodeUnit callSuperclassMethod = classThatCallsMethodOfSuperclass
-                .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSuperclassMethod);
-        JavaMethod expectedSuperclassMethod = superclassWithCalledMethod.getMethod(SuperclassWithCalledMethod.method);
-        MethodCallTarget expectedSuperclassCall = new MethodCallTargetBuilder()
-                .withOwner(subclassWithCalledMethod)
-                .withName(expectedSuperclassMethod.getName())
-                .withParameters(expectedSuperclassMethod.getRawParameterTypes())
-                .withReturnType(expectedSuperclassMethod.getRawReturnType())
-                .withMethods(Suppliers.ofInstance(Collections.singleton(expectedSuperclassMethod)))
-                .build();
-        assertThatCall(getOnlyByCaller(calls, callSuperclassMethod))
-                .isFrom(callSuperclassMethod)
-                .isTo(expectedSuperclassCall)
-                .inLineNumber(CallOfSuperAndSubclassMethod.callSuperclassLineNumber);
-
-        JavaCodeUnit callSubclassMethod = classThatCallsMethodOfSuperclass
-                .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSubclassMethod);
-        assertThatCall(getOnlyByCaller(calls, callSubclassMethod))
-                .isFrom(callSubclassMethod)
-                .isTo(subclassWithCalledMethod.getMethod(SubclassWithCalledMethod.maskedMethod))
-                .inLineNumber(CallOfSuperAndSubclassMethod.callSubclassLineNumber);
-    }
-
-    @Test
-    public void imports_constructor_calls_on_self() throws Exception {
-        JavaClass classThatCallsOwnConstructor = classesIn("testexamples/callimport").get(CallsOwnConstructor.class);
-        JavaCodeUnit caller = classThatCallsOwnConstructor.getCodeUnitWithParameterTypes("copy");
-
-        Set<JavaConstructorCall> calls = classThatCallsOwnConstructor.getConstructorCallsFromSelf();
-
-        assertThatCall(getOnlyByCaller(calls, caller))
-                .isFrom(caller)
-                .isTo(classThatCallsOwnConstructor.getConstructor(String.class))
-                .inLineNumber(8);
-    }
-
-    @Test
-    public void imports_method_calls_on_self() throws Exception {
-        JavaClass classThatCallsOwnMethod = classesIn("testexamples/callimport").get(CallsOwnMethod.class);
-
-        JavaMethodCall call = getOnlyElement(classThatCallsOwnMethod.getMethodCallsFromSelf());
-
-        assertThatCall(call)
-                .isFrom(classThatCallsOwnMethod.getCodeUnitWithParameterTypes("getString"))
-                .isTo(classThatCallsOwnMethod.getMethod("string"))
-                .inLineNumber(6);
-    }
-
-    @Test
-    public void imports_constructor_calls_on_other() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/callimport");
-        JavaClass classThatCallsOtherConstructor = classes.get(CallsOtherConstructor.class);
-        JavaClass otherClass = classes.get(CallsOwnConstructor.class);
-        JavaCodeUnit caller = classThatCallsOtherConstructor.getCodeUnitWithParameterTypes("createOther");
-
-        Set<JavaConstructorCall> calls = classThatCallsOtherConstructor.getConstructorCallsFromSelf();
-
-        assertThatCall(getOnlyByCaller(calls, caller))
-                .isFrom(caller)
-                .isTo(otherClass.getConstructor(String.class))
-                .inLineNumber(5);
-    }
-
-    @Test
-    public void imports_method_calls_on_other() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/callimport");
-        JavaClass classThatCallsOtherMethod = classes.get(CallsOtherMethod.class);
-        JavaClass other = classes.get(CallsOwnMethod.class);
-
-        JavaMethodCall call = getOnlyElement(classThatCallsOtherMethod.getMethodCallsFromSelf());
-
-        assertThatCall(call)
-                .isFrom(classThatCallsOtherMethod.getCodeUnitWithParameterTypes("getFromOther"))
-                .isTo(other.getMethod("getString"))
-                .inLineNumber(7);
-    }
-
-    @Test
-    public void imports_constructor_calls_on_external_class() throws Exception {
-        JavaClass classThatCallsOwnConstructor = classesIn("testexamples/callimport").get(CallsOwnConstructor.class);
-        JavaCodeUnit constructorCallingObjectInit = classThatCallsOwnConstructor.getConstructor(String.class);
-
-        JavaConstructorCall objectInitCall = getOnlyElement(constructorCallingObjectInit.getConstructorCallsFromSelf());
-
-        assertThatCall(objectInitCall)
-                .isFrom(constructorCallingObjectInit)
-                .inLineNumber(4);
-
-        ConstructorCallTarget target = objectInitCall.getTarget();
-        assertThat(target.getFullName()).isEqualTo(Object.class.getName() + ".<init>()");
-        assertThat(reflect(target)).isEqualTo(Object.class.getConstructor());
-    }
-
-    @Test
-    public void imports_constructor_calls_to_sub_type_constructor_on_external_class() throws Exception {
-        JavaClass classWithExternalConstructorCall = classesIn("testexamples/callimport").get(ExternalSubtypeConstructorCall.class);
-
-        assertConstructorCall(classWithExternalConstructorCall.getCodeUnitWithParameterTypes("call"), ChildClass.class, 9);
-        assertConstructorCall(classWithExternalConstructorCall.getCodeUnitWithParameterTypes("newHashMap"), HashMap.class, 13);
-    }
-
-    private void assertConstructorCall(JavaCodeUnit call, Class<?> constructorOwner, int lineNumber) {
-        JavaConstructorCall callToExternalClass =
-                getOnlyElement(getByTargetOwner(call.getConstructorCallsFromSelf(), constructorOwner));
-
-        assertThatCall(callToExternalClass)
-                .isFrom(call)
-                .inLineNumber(lineNumber);
-
-        ConstructorCallTarget target = callToExternalClass.getTarget();
-        assertThat(target.getFullName()).isEqualTo(constructorOwner.getName() + ".<init>()");
-        assertThat(reflect(target)).isEqualTo(constructor(constructorOwner));
-    }
-
-    @Test
-    public void imports_method_calls_on_external_class() throws Exception {
-        JavaClass classThatCallsExternalMethod = classesIn("testexamples/callimport").get(CallsExternalMethod.class);
-
-        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
-
-        assertThatCall(call)
-                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("getString"))
-                .inLineNumber(7);
-
-        MethodCallTarget target = call.getTarget();
-        assertThat(target.getOwner().reflect()).isEqualTo(ArrayList.class);
-        assertThat(target.getFullName()).isEqualTo(ArrayList.class.getName() + ".toString()");
-    }
-
-    @Test
-    public void imports_method_calls_on_overridden_external_class() throws Exception {
-        JavaClass classThatCallsExternalMethod = classesIn("testexamples/callimport").get(ExternalOverriddenMethodCall.class);
-
-        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
-
-        assertThatCall(call)
-                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("call"))
-                .inLineNumber(9);
-
-        MethodCallTarget target = call.getTarget();
-        assertThat(target.getFullName()).isEqualTo(ChildClass.class.getName() + ".overrideMe()");
-        assertThat(getOnlyElement(target.resolve()).getFullName()).isEqualTo(ChildClass.class.getName() + ".overrideMe()");
-        assertThat(reflect(target)).isEqualTo(method(ChildClass.class, "overrideMe"));
-    }
-
-    @Test
-    public void imports_method_calls_on_external_interface_hierarchies() throws Exception {
-        JavaClass classThatCallsExternalMethod = classesIn("testexamples/callimport").get(ExternalInterfaceMethodCall.class);
-
-        JavaMethodCall call = getOnlyElement(classThatCallsExternalMethod.getMethodCallsFromSelf());
-
-        assertThatCall(call)
-                .isFrom(classThatCallsExternalMethod.getCodeUnitWithParameterTypes("call"))
-                .inLineNumber(9);
-
-        MethodCallTarget target = call.getTarget();
-        assertThat(reflect(target)).isEqualTo(method(Map.class, "put", Object.class, Object.class));
-    }
-
-    @Test
-    public void imports_non_unique_targets_for_diamond_scenarios() throws Exception {
-        ImportedClasses diamondScenario = classesIn("testexamples/diamond");
-        JavaClass classCallingDiamond = diamondScenario.get(ClassCallingDiamond.class);
-        JavaClass diamondLeftInterface = diamondScenario.get(InterfaceB.class);
-        JavaClass diamondRightInterface = diamondScenario.get(InterfaceC.class);
-        JavaClass diamondPeakInterface = diamondScenario.get(InterfaceD.class);
-        JavaClass diamondPeakClass = diamondScenario.get(ClassImplementingD.class);
-
-        Set<JavaMethodCall> calls = classCallingDiamond.getMethodCallsFromSelf();
-
-        assertThat(calls).hasSize(2);
-
-        JavaCodeUnit callInterface = classCallingDiamond
-                .getCodeUnitWithParameterTypes(ClassCallingDiamond.callInterface);
-        JavaMethodCall callToInterface = getOnlyByCaller(calls, callInterface);
-        assertThatCall(callToInterface)
-                .isFrom(callInterface)
-                .inLineNumber(ClassCallingDiamond.callInterfaceLineNumber);
-        // NOTE: There is no java.lang.reflect.Method InterfaceD.implementMe(), because the method is inherited
-        assertThat(callToInterface.getTarget().getName()).isEqualTo(InterfaceD.implementMe);
-        assertThatType(callToInterface.getTarget().getOwner()).isEqualTo(diamondPeakInterface);
-        assertThat(callToInterface.getTarget().getRawParameterTypes()).isEmpty();
-        assertThat(callToInterface.getTarget().resolve()).extracting("fullName")
-                .containsOnly(
-                        diamondLeftInterface.getMethod(InterfaceB.implementMe).getFullName(),
-                        diamondRightInterface.getMethod(InterfaceB.implementMe).getFullName());
-
-        JavaCodeUnit callImplementation = classCallingDiamond
-                .getCodeUnitWithParameterTypes(ClassCallingDiamond.callImplementation);
-        assertThatCall(getOnlyByCaller(calls, callImplementation))
-                .isFrom(callImplementation)
-                .isTo(diamondPeakClass.getMethod(InterfaceD.implementMe))
-                .inLineNumber(ClassCallingDiamond.callImplementationLineNumber);
-    }
-
-    @Test
-    public void imports_method_calls_that_return_Arrays() throws Exception {
-        JavaClass classThatCallsMethodReturningArray = classesIn("testexamples/callimport").get(CallsMethodReturningArray.class);
-
-        MethodCallTarget target = getOnlyElement(classThatCallsMethodReturningArray.getMethodCallsFromSelf()).getTarget();
-        assertThatType(target.getOwner()).matches(CallsMethodReturningArray.SomeEnum.class);
-        assertThatType(target.getRawReturnType()).matches(CallsMethodReturningArray.SomeEnum[].class);
-    }
-
-    @Test
-    public void dependency_target_classes_are_derived_correctly() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/integration");
-        JavaClass javaClass = classes.get(ClassXDependingOnClassesABCD.class);
-        Set<JavaClass> expectedTargetClasses = ImmutableSet.of(
-                classes.get(ClassA.class),
-                classes.get(ClassBDependingOnClassA.class),
-                classes.get(ClassCDependingOnClassB_SuperclassOfX.class),
-                classes.get(ClassD.class),
-                classes.get(InterfaceOfClassX.class)
-        );
-
-        Set<JavaClass> targetClasses = new HashSet<>();
-        for (Dependency dependency : withoutJavaLangTargets(javaClass.getDirectDependenciesFromSelf())) {
-            targetClasses.add(dependency.getTargetClass());
-        }
-
-        assertThat(targetClasses).isEqualTo(expectedTargetClasses);
-    }
-
-    @Test
-    public void getDirectDependencies_does_not_return_transitive_dependencies() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/integration");
-        JavaClass javaClass = classes.get(ClassCDependingOnClassB_SuperclassOfX.class);
-        JavaClass expectedTargetClass = classes.get(ClassBDependingOnClassA.class);
-
-        Set<JavaClass> targetClasses = new HashSet<>();
-        for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
-            if (dependency.getTargetClass().getPackageName().contains("testexamples")) {
-                targetClasses.add(dependency.getTargetClass());
-            }
-        }
-
-        assertThat(targetClasses).containsOnly(expectedTargetClass);
-    }
-
-    @Test
-    public void fields_know_their_accesses() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaFieldAccess> accesses = classHoldingDependencies.getField("someInt").getAccessesToSelf();
-        Set<JavaFieldAccess> expected = ImmutableSet.<JavaFieldAccess>builder()
-                .addAll(getByName(classHoldingDependencies.getFieldAccessesFromSelf(), "someInt"))
-                .addAll(getByName(firstClassWithDependency.getFieldAccessesFromSelf(), "someInt"))
-                .addAll(getByName(secondClassWithDependency.getFieldAccessesFromSelf(), "someInt"))
-                .build();
-        assertThat(accesses).as("Field Accesses to someInt").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_the_field_accesses_to_them() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaFieldAccess> accesses = classHoldingDependencies.getFieldAccessesToSelf();
-        Set<JavaFieldAccess> expected = ImmutableSet.<JavaFieldAccess>builder()
-                .addAll(classHoldingDependencies.getFieldAccessesFromSelf())
-                .addAll(firstClassWithDependency.getFieldAccessesFromSelf())
-                .addAll(secondClassWithDependency.getFieldAccessesFromSelf())
-                .build();
-        assertThat(accesses).as("Field Accesses to class").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_shadowed_field_accesses_to_themselves() {
-        @SuppressWarnings("unused")
-        class Base {
-            String shadowed;
-            String nonShadowed;
-        }
-        class Child extends Base {
-            String shadowed;
-        }
-        @SuppressWarnings("unused")
-        class Accessor {
-            void access(Child child) {
-                consume(child.shadowed);
-                consume(child.nonShadowed);
-            }
-
-            void consume(String string) {
-            }
-        }
-        JavaClasses classes = new ClassFileImporter().importClasses(Accessor.class, Base.class, Child.class);
-
-        JavaFieldAccess access = getOnlyByCaller(
-                classes.get(Base.class).getFieldAccessesToSelf(), classes.get(Accessor.class).getMethod("access", Child.class));
-        assertThatAccess(access).isFrom("access", Child.class).isTo("nonShadowed");
-        access = getOnlyByCaller(
-                classes.get(Child.class).getFieldAccessesToSelf(), classes.get(Accessor.class).getMethod("access", Child.class));
-        assertThatAccess(access).isFrom("access", Child.class).isTo("shadowed");
-    }
-
-    @Test
-    public void methods_know_callers() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaMethodCall> calls = classHoldingDependencies.getMethod("setSomeInt", int.class).getCallsOfSelf();
-        Set<JavaMethodCall> expected = ImmutableSet.<JavaMethodCall>builder()
-                .addAll(getByName(classHoldingDependencies.getMethodCallsFromSelf(), "setSomeInt"))
-                .addAll(getByName(firstClassWithDependency.getMethodCallsFromSelf(), "setSomeInt"))
-                .addAll(getByName(secondClassWithDependency.getMethodCallsFromSelf(), "setSomeInt"))
-                .build();
-        assertThat(calls).as("Method calls to setSomeInt").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_method_calls_to_themselves() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaMethodCall> calls = classHoldingDependencies.getMethodCallsToSelf();
-        Set<JavaMethodCall> expected = ImmutableSet.<JavaMethodCall>builder()
-                .addAll(classHoldingDependencies.getMethodCallsFromSelf())
-                .addAll(getByTargetOwner(firstClassWithDependency.getMethodCallsFromSelf(), classHoldingDependencies))
-                .addAll(getByTargetOwner(secondClassWithDependency.getMethodCallsFromSelf(), classHoldingDependencies))
-                .build();
-        assertThat(calls).as("Method calls to class").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_overridden_method_calls_to_themselves() {
-        @SuppressWarnings("unused")
-        class Base {
-            void overridden() {
-            }
-
-            void nonOverridden() {
-            }
-        }
-        class Child extends Base {
-            @Override
-            void overridden() {
-            }
-        }
-        @SuppressWarnings("unused")
-        class Caller {
-            void call(Child child) {
-                child.overridden();
-                child.nonOverridden();
-            }
-        }
-        JavaClasses classes = new ClassFileImporter().importClasses(Caller.class, Base.class, Child.class);
-
-        assertThatCall(getOnlyElement(classes.get(Base.class).getMethodCallsToSelf())).isFrom("call", Child.class).isTo("nonOverridden");
-        assertThatCall(getOnlyElement(classes.get(Child.class).getMethodCallsToSelf())).isFrom("call", Child.class).isTo("overridden");
-    }
-
-    @Test
-    public void constructors_know_callers() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        JavaConstructor targetConstructur = classHoldingDependencies.getConstructor();
-        Set<JavaConstructorCall> calls = targetConstructur.getCallsOfSelf();
-        Set<JavaConstructorCall> expected = ImmutableSet.<JavaConstructorCall>builder()
-                .addAll(getByTarget(classHoldingDependencies.getConstructorCallsFromSelf(), targetConstructur))
-                .addAll(getByTarget(firstClassWithDependency.getConstructorCallsFromSelf(), targetConstructur))
-                .addAll(getByTarget(secondClassWithDependency.getConstructorCallsFromSelf(), targetConstructur))
-                .build();
-        assertThat(calls).as("Default Constructor calls to ClassWithDependents").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_constructor_calls_to_themselves() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaConstructorCall> calls = classHoldingDependencies.getConstructorCallsToSelf();
-        Set<JavaConstructorCall> expected = ImmutableSet.<JavaConstructorCall>builder()
-                .addAll(getByTargetOwner(classHoldingDependencies.getConstructorCallsFromSelf(), classHoldingDependencies))
-                .addAll(getByTargetOwner(firstClassWithDependency.getConstructorCallsFromSelf(), classHoldingDependencies))
-                .addAll(getByTargetOwner(secondClassWithDependency.getConstructorCallsFromSelf(), classHoldingDependencies))
-                .build();
-        assertThat(calls).as("Constructor calls to ClassWithDependents").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_constructor_calls_to_themselves_for_subclass_default_constructors() {
-        // For constructors it's impossible to be accessed via a subclass,
-        // since the byte code always holds an explicitly declared constructor.
-        // Thus we do expect a call to the constructor of the subclass and one from subclass to super class
-        @SuppressWarnings("unused")
-        class Base {
-            Base() {
-            }
-        }
-        class Child extends Base {
-        }
-        @SuppressWarnings("unused")
-        class Caller {
-            void call() {
-                new Child();
-            }
-        }
-        JavaClasses classes = new ClassFileImporter().importClasses(Caller.class, Base.class, Child.class);
-
-        assertThatCall(getOnlyElement(classes.get(Base.class).getConstructorCallsToSelf())).isFrom(Child.class, CONSTRUCTOR_NAME, getClass()).isTo(Base.class);
-        assertThatCall(getOnlyElement(classes.get(Child.class).getConstructorCallsToSelf())).isFrom(Caller.class, "call").isTo(Child.class);
-    }
-
-    @Test
-    public void classes_know_accesses_to_themselves() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/dependents");
-        JavaClass classHoldingDependencies = classes.get(ClassHoldingDependencies.class);
-        JavaClass firstClassWithDependency = classes.get(FirstClassWithDependency.class);
-        JavaClass secondClassWithDependency = classes.get(SecondClassWithDependency.class);
-
-        Set<JavaAccess<?>> accesses = classHoldingDependencies.getAccessesToSelf();
-        Set<JavaAccess<?>> expected = ImmutableSet.<JavaAccess<?>>builder()
-                .addAll(getByTargetOwner(classHoldingDependencies.getAccessesFromSelf(), classHoldingDependencies))
-                .addAll(getByTargetOwner(firstClassWithDependency.getAccessesFromSelf(), classHoldingDependencies))
-                .addAll(getByTargetOwner(secondClassWithDependency.getAccessesFromSelf(), classHoldingDependencies))
-                .build();
-        assertThat(accesses).as("Accesses to ClassWithDependents").isEqualTo(expected);
-    }
-
-    @Test
-    public void classes_know_which_fields_have_their_type() {
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
-
-        assertThat(classes.get(SomeEnum.class).getFieldsWithTypeOfSelf())
-                .extracting("name").contains("other", "someEnum");
-    }
-
-    @Test
-    public void classes_know_which_methods_have_their_type_as_parameter() {
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
-
-        assertThat(classes.get(SomeEnum.class).getMethodsWithParameterTypeOfSelf())
-                .extracting("name").contains("methodWithSomeEnumParameter", "otherMethodWithSomeEnumParameter");
-    }
-
-    @Test
-    public void classes_know_which_methods_have_their_type_as_return_type() {
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
-
-        assertThat(classes.get(SomeEnum.class).getMethodsWithReturnTypeOfSelf())
-                .extracting("name").contains("methodWithSomeEnumReturnType", "otherMethodWithSomeEnumReturnType");
-    }
-
-    @Test
-    public void classes_know_which_method_throws_clauses_contain_their_type() {
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThrowingMethod.class, FirstCheckedException.class);
-
-        Set<ThrowsDeclaration<JavaMethod>> throwsDeclarations = classes.get(FirstCheckedException.class).getMethodThrowsDeclarationsWithTypeOfSelf();
-        assertThatType(getOnlyElement(throwsDeclarations).getDeclaringClass()).matches(ClassWithThrowingMethod.class);
-        assertThat(classes.get(FirstCheckedException.class).getConstructorsWithParameterTypeOfSelf()).isEmpty();
-    }
-
-    @Test
-    public void classes_know_which_constructors_have_their_type_as_parameter() {
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class, SomeEnum.class);
-
-        assertThat(classes.get(SomeEnum.class).getConstructorsWithParameterTypeOfSelf())
-                .extracting("owner").extracting("name")
-                .contains(SomeClass.class.getName(), OtherClass.class.getName());
-    }
-
-    @Test
-    public void classes_know_which_constructor_throws_clauses_contain_their_type() {
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThrowingConstructor.class, FirstCheckedException.class);
-
-        Set<ThrowsDeclaration<JavaConstructor>> throwsDeclarations =
-                classes.get(FirstCheckedException.class).getConstructorsWithThrowsDeclarationTypeOfSelf();
-        assertThatType(getOnlyElement(throwsDeclarations).getDeclaringClass()).matches(ClassWithThrowingConstructor.class);
-        assertThat(classes.get(FirstCheckedException.class).getMethodThrowsDeclarationsWithTypeOfSelf()).isEmpty();
-    }
-
-    @Test
-    public void classes_know_which_instanceof_checks_check_their_type() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(InstanceofChecked.class).get(InstanceofChecked.class);
-
-        Set<JavaClass> origins = new HashSet<>();
-        for (InstanceofCheck instanceofCheck : clazz.getInstanceofChecksWithTypeOfSelf()) {
-            origins.add(instanceofCheck.getOwner().getOwner());
-        }
-        assertThatTypes(origins).matchInAnyOrder(ChecksInstanceofInMethod.class, ChecksInstanceofInConstructor.class, ChecksInstanceofInStaticInitializer.class);
-    }
-
-    @Test
-    public void reflect_works() throws Exception {
-        ImportedClasses classes = classesIn("testexamples/innerclassimport");
+    public void reflect_works() {
+        JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
 
         JavaClass calledClass = classes.get(CalledClass.class);
         assertThat(calledClass.reflect()).isEqualTo(CalledClass.class);
@@ -1739,15 +609,15 @@ public class ClassFileImporterTest {
     }
 
     @Test
-    public void resolve_missing_dependencies_from_classpath_can_be_toogled() throws Exception {
+    public void resolve_missing_dependencies_from_classpath_can_be_toggled() {
         ArchConfiguration.get().unsetClassResolver();
         ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(true);
-        JavaClass clazz = classesIn("testexamples/simpleimport").get(ClassToImportOne.class);
+        JavaClass clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(ClassToImportOne.class);
 
         assertThat(clazz.getRawSuperclass().get().getMethods()).isNotEmpty();
 
         ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-        clazz = classesIn("testexamples/simpleimport").get(ClassToImportOne.class);
+        clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(ClassToImportOne.class);
 
         assertThat(clazz.getRawSuperclass().get().getMethods()).isEmpty();
     }
@@ -1916,32 +786,16 @@ public class ClassFileImporterTest {
         assertThat(classes).isEmpty();
     }
 
-    private void assertSameSimpleNameOfArchUnitAndReflection(ImportedClasses classes, String className) throws ClassNotFoundException {
+    private void assertSameSimpleNameOfArchUnitAndReflection(JavaClasses classes, String className) throws ClassNotFoundException {
         assertSameSimpleNameOfArchUnitAndReflection(classes, Class.forName(className));
     }
 
-    private void assertSameSimpleNameOfArchUnitAndReflection(ImportedClasses classes, Class<?> clazz) {
+    private void assertSameSimpleNameOfArchUnitAndReflection(JavaClasses classes, Class<?> clazz) {
         assertThat(classes.get(clazz.getName()).getSimpleName()).isEqualTo(clazz.getSimpleName());
-    }
-
-    private Set<Dependency> withoutJavaLangTargets(Set<Dependency> dependencies) {
-        Set<Dependency> result = new HashSet<>();
-        for (Dependency dependency : dependencies) {
-            if (!dependency.getTargetClass().getPackageName().startsWith("java.lang")) {
-                result.add(dependency);
-            }
-        }
-        return result;
     }
 
     private void copyClassFile(Class<?> clazz, File targetFolder) throws IOException, URISyntaxException {
         Files.copy(Paths.get(urlOf(clazz).toURI()), new File(targetFolder, clazz.getSimpleName() + ".class").toPath());
-    }
-
-    static JarFile jarFileOf(Class<?> clazzInJar) throws IOException {
-        URLConnection connection = urlOf(clazzInJar).openConnection();
-        checkArgument(connection instanceof JarURLConnection, "Class %s is not contained in a JAR", clazzInJar.getName());
-        return ((JarURLConnection) connection).getJarFile();
     }
 
     private ImportOption importOnly(final Class<?>... classes) {
@@ -1965,184 +819,5 @@ public class ClassFileImporterTest {
                 return value.getFullName().equals(name);
             }
         };
-    }
-
-    private Constructor<?> reflect(ConstructorCallTarget target) {
-        return reflect(target.resolveConstructor().get());
-    }
-
-    private Constructor<?> reflect(JavaConstructor javaConstructor) {
-        try {
-            return javaConstructor.getOwner().reflect().getConstructor(asClasses(javaConstructor.getRawParameterTypes()));
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Method reflect(MethodCallTarget target) {
-        return reflect(getOnlyElement(target.resolve()));
-    }
-
-    private Method reflect(JavaMethod javaMethod) {
-        try {
-            return javaMethod.getOwner().reflect().getMethod(javaMethod.getName(), asClasses(javaMethod.getRawParameterTypes()));
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private JavaClassList targetParametersOf(Set<JavaMethodCall> calls, String name) {
-        return findAnyByName(calls, name).getTarget().getRawParameterTypes();
-    }
-
-    private JavaClass returnTypeOf(Set<JavaMethodCall> calls, String name) {
-        return findAnyByName(calls, name).getTarget().getRawReturnType();
-    }
-
-    private JavaFieldAccess getOnly(Set<JavaFieldAccess> fieldAccesses, String name, AccessType accessType) {
-        return getOnlyElement(getByNameAndAccessType(fieldAccesses, name, accessType));
-    }
-
-    private Set<JavaFieldAccess> getByNameAndAccessType(Set<JavaFieldAccess> fieldAccesses, String name, AccessType accessType) {
-        Set<JavaFieldAccess> result = new HashSet<>();
-        for (JavaFieldAccess access : fieldAccesses) {
-            if (name.equals(access.getName()) && access.getAccessType() == accessType) {
-                result.add(access);
-            }
-        }
-        return result;
-    }
-
-    private <T extends HasOwner<JavaCodeUnit>> T getOnlyByCaller(Set<T> calls, JavaCodeUnit caller) {
-        return getOnlyElement(getByCaller(calls, caller));
-    }
-
-    private <T extends JavaAccess<?>> Set<T> getByTarget(Set<T> calls, final JavaConstructor target) {
-        return getBy(calls, new Predicate<JavaAccess<?>>() {
-            @Override
-            public boolean apply(JavaAccess<?> input) {
-                return targetFrom(target).getFullName().equals(input.getTarget().getFullName());
-            }
-        });
-    }
-
-    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, Class<?> targetOwner) {
-        return getByTargetOwner(calls, targetOwner.getName());
-    }
-
-    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final String targetOwnerName) {
-        return getBy(calls, targetOwnerNameEquals(targetOwnerName));
-    }
-
-    private Predicate<JavaAccess<?>> targetOwnerNameEquals(final String targetFqn) {
-        return new Predicate<JavaAccess<?>>() {
-            @Override
-            public boolean apply(JavaAccess<?> input) {
-                return targetFqn.equals(input.getTarget().getOwner().getName());
-            }
-        };
-    }
-
-    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final JavaClass targetOwner) {
-        return getBy(calls, new Predicate<T>() {
-            @Override
-            public boolean apply(T input) {
-                return targetOwner.equals(input.getTarget().getOwner());
-            }
-        });
-    }
-
-    private <T extends HasOwner<JavaCodeUnit>> Set<T> getByCaller(Set<T> calls, final JavaCodeUnit caller) {
-        return getBy(calls, new Predicate<T>() {
-            @Override
-            public boolean apply(T input) {
-                return caller.equals(input.getOwner());
-            }
-        });
-    }
-
-    private <T extends HasOwner<JavaCodeUnit>> Set<T> getBy(Set<T> calls, Predicate<? super T> predicate) {
-        return FluentIterable.from(calls).filter(predicate).toSet();
-    }
-
-    private Set<FieldAccessTarget> targetsOf(Set<JavaFieldAccess> fieldAccesses) {
-        Set<FieldAccessTarget> result = new HashSet<>();
-        for (JavaFieldAccess access : fieldAccesses) {
-            result.add(access.getTarget());
-        }
-        return result;
-    }
-
-    private Set<Integer> lineNumbersOf(Set<JavaFieldAccess> fieldAccesses) {
-        Set<Integer> result = new HashSet<>();
-        for (JavaFieldAccess access : fieldAccesses) {
-            result.add(access.getLineNumber());
-        }
-        return result;
-    }
-
-    private <T extends HasName> Set<T> getByName(Iterable<T> thingsWithName, String name) {
-        Set<T> result = new HashSet<>();
-        for (T hasName : thingsWithName) {
-            if (name.equals(hasName.getName())) {
-                result.add(hasName);
-            }
-        }
-        return result;
-    }
-
-    private <T extends HasName> T findAnyByName(Iterable<T> thingsWithName, String name) {
-        T result = getFirst(getByName(thingsWithName, name), null);
-        return checkNotNull(result, "No object with name '" + name + "' is present in " + thingsWithName);
-    }
-
-    private ImportedClasses classesIn(String path) throws Exception {
-        return new ImportedClasses(path);
-    }
-
-    private class ImportedClasses extends ForwardingCollection<JavaClass> {
-        private final ClassFileImporter importer = new ClassFileImporter();
-        private final JavaClasses classes;
-
-        private ImportedClasses(String path) throws Exception {
-            classes = importer.importPath(Paths.get(ClassFileImporterTest.this.getClass().getResource(path).toURI()));
-        }
-
-        JavaClass get(Class<?> clazz) {
-            return get(clazz.getName());
-        }
-
-        private JavaClass get(String className) {
-            return findAnyByName(classes, className);
-        }
-
-        @Override
-        protected Collection<JavaClass> delegate() {
-            return classes;
-        }
-
-        Set<JavaCodeUnit> getCodeUnits() {
-            Set<JavaCodeUnit> codeUnits = new HashSet<>();
-            for (JavaClass clazz : classes) {
-                codeUnits.addAll(clazz.getCodeUnits());
-            }
-            return codeUnits;
-        }
-
-        Set<JavaMethod> getMethods() {
-            Set<JavaMethod> methods = new HashSet<>();
-            for (JavaClass clazz : classes) {
-                methods.addAll(clazz.getMethods());
-            }
-            return methods;
-        }
-
-        Set<JavaField> getFields() {
-            Set<JavaField> fields = new HashSet<>();
-            for (JavaClass clazz : classes) {
-                fields.addAll(clazz.getFields());
-            }
-            return fields;
-        }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -139,10 +139,7 @@ public class ClassFileImporterTest {
 
         assertThat(classes.get(ClassToImportOne.class))
                 .isFullyImported(true)
-                .hasName(ClassToImportOne.class.getName())
-                .hasSimpleName(ClassToImportOne.class.getSimpleName())
-                .hasPackageName(ClassToImportOne.class.getPackage().getName())
-                .hasOnlyModifiers(JavaModifier.PUBLIC)
+                .matches(ClassToImportOne.class)
                 .hasRawSuperclassMatching(Object.class)
                 .hasNoInterfaces()
                 .isInterface(false)
@@ -164,10 +161,7 @@ public class ClassFileImporterTest {
         JavaClass javaClass = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(EnumToImport.class);
 
         assertThat(javaClass)
-                .hasName(EnumToImport.class.getName())
-                .hasSimpleName(EnumToImport.class.getSimpleName())
-                .hasPackageName(EnumToImport.class.getPackage().getName())
-                .hasOnlyModifiers(JavaModifier.PUBLIC, JavaModifier.FINAL)
+                .matches(EnumToImport.class)
                 .hasRawSuperclassMatching(Enum.class)
                 .hasNoInterfaces()
                 .hasAllInterfacesMatchingInAnyOrder(Enum.class.getInterfaces())
@@ -267,9 +261,7 @@ public class ClassFileImporterTest {
         JavaClass simpleInterface = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(InterfaceToImport.class);
 
         assertThat(simpleInterface)
-                .hasName(InterfaceToImport.class.getName())
-                .hasSimpleName(InterfaceToImport.class.getSimpleName())
-                .hasPackageName(InterfaceToImport.class.getPackage().getName())
+                .matches(InterfaceToImport.class)
                 .hasNoSuperclass()
                 .hasNoInterfaces()
                 .isInterface(true)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -136,43 +136,44 @@ public class ClassFileImporterTest {
     @Test
     public void imports_simple_class_details() {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport"));
-        JavaClass javaClass = classes.get(ClassToImportOne.class);
 
-        assertThat(javaClass.isFullyImported()).isTrue();
-        assertThat(javaClass.getName()).as("full name").isEqualTo(ClassToImportOne.class.getName());
-        assertThat(javaClass.getSimpleName()).as("simple name").isEqualTo(ClassToImportOne.class.getSimpleName());
-        assertThat(javaClass.getPackageName()).as("package name").isEqualTo(ClassToImportOne.class.getPackage().getName());
-        assertThat(javaClass.getModifiers()).as("modifiers").containsOnly(JavaModifier.PUBLIC);
-        assertThatType(javaClass.getRawSuperclass().get()).as("super class").matches(Object.class);
-        assertThat(javaClass.getInterfaces()).as("interfaces").isEmpty();
-        assertThat(javaClass.isInterface()).as("is interface").isFalse();
-        assertThat(javaClass.isEnum()).as("is enum").isFalse();
-        assertThat(javaClass.isAnnotation()).as("is annotation").isFalse();
-        assertThat(javaClass.getEnclosingClass()).as("enclosing class").isAbsent();
-        assertThat(javaClass.isTopLevelClass()).as("is top level class").isTrue();
-        assertThat(javaClass.isNestedClass()).as("is nested class").isFalse();
-        assertThat(javaClass.isMemberClass()).as("is member class").isFalse();
-        assertThat(javaClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(javaClass.isLocalClass()).as("is local class").isFalse();
-        assertThat(javaClass.isAnonymousClass()).as("is anonymous class").isFalse();
-
-        assertThat(classes.get(ClassToImportTwo.class).getModifiers()).containsOnly(JavaModifier.PUBLIC, JavaModifier.FINAL);
+        assertThat(classes.get(ClassToImportOne.class))
+                .isFullyImported(true)
+                .hasName(ClassToImportOne.class.getName())
+                .hasSimpleName(ClassToImportOne.class.getSimpleName())
+                .hasPackageName(ClassToImportOne.class.getPackage().getName())
+                .hasOnlyModifiers(JavaModifier.PUBLIC)
+                .hasRawSuperclassMatching(Object.class)
+                .hasNoInterfaces()
+                .isInterface(false)
+                .isEnum(false)
+                .isAnnotation(false)
+                .hasNoEnclosingClass()
+                .isTopLevelClass(true)
+                .isNestedClass(false)
+                .isMemberClass(false)
+                .isInnerClass(false)
+                .isLocalClass(false)
+                .isAnonymousClass(false);
+        assertThat(classes.get(ClassToImportTwo.class))
+                .hasOnlyModifiers(JavaModifier.PUBLIC, JavaModifier.FINAL);
     }
 
     @Test
     public void imports_simple_enum() {
         JavaClass javaClass = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(EnumToImport.class);
 
-        assertThat(javaClass.getName()).as("full name").isEqualTo(EnumToImport.class.getName());
-        assertThat(javaClass.getSimpleName()).as("simple name").isEqualTo(EnumToImport.class.getSimpleName());
-        assertThat(javaClass.getPackageName()).as("package name").isEqualTo(EnumToImport.class.getPackage().getName());
-        assertThat(javaClass.getModifiers()).as("modifiers").containsOnly(JavaModifier.PUBLIC, JavaModifier.FINAL);
-        assertThatType(javaClass.getRawSuperclass().get()).as("super class").matches(Enum.class);
-        assertThat(javaClass.getInterfaces()).as("interfaces").isEmpty();
-        assertThatTypes(javaClass.getAllInterfaces()).matchInAnyOrder(Enum.class.getInterfaces());
-        assertThat(javaClass.isInterface()).as("is interface").isFalse();
-        assertThat(javaClass.isEnum()).as("is enum").isTrue();
-        assertThat(javaClass.isAnnotation()).as("is annotation").isFalse();
+        assertThat(javaClass)
+                .hasName(EnumToImport.class.getName())
+                .hasSimpleName(EnumToImport.class.getSimpleName())
+                .hasPackageName(EnumToImport.class.getPackage().getName())
+                .hasOnlyModifiers(JavaModifier.PUBLIC, JavaModifier.FINAL)
+                .hasRawSuperclassMatching(Enum.class)
+                .hasNoInterfaces()
+                .hasAllInterfacesMatchingInAnyOrder(Enum.class.getInterfaces())
+                .isInterface(false)
+                .isEnum(true)
+                .isAnnotation(false);
 
         JavaEnumConstant constant = javaClass.getEnumConstant(EnumToImport.FIRST.name());
         assertThatType(constant.getDeclaringClass()).as("declaring class").isEqualTo(javaClass);
@@ -190,29 +191,29 @@ public class ClassFileImporterTest {
     @UseDataProvider("nested_static_classes")
     public void imports_simple_static_nested_class(Class<?> nestedStaticClass) {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
-        JavaClass staticNestedClass = classes.get(nestedStaticClass);
 
-        assertThatType(staticNestedClass).matches(nestedStaticClass);
-        assertThat(staticNestedClass.isTopLevelClass()).as("is top level class").isFalse();
-        assertThat(staticNestedClass.isNestedClass()).as("is nested class").isTrue();
-        assertThat(staticNestedClass.isMemberClass()).as("is member class").isTrue();
-        assertThat(staticNestedClass.isInnerClass()).as("is inner class").isFalse();
-        assertThat(staticNestedClass.isLocalClass()).as("is local class").isFalse();
-        assertThat(staticNestedClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(classes.get(nestedStaticClass))
+                .matches(nestedStaticClass)
+                .isTopLevelClass(false)
+                .isNestedClass(true)
+                .isMemberClass(true)
+                .isInnerClass(false)
+                .isLocalClass(false)
+                .isAnonymousClass(false);
     }
 
     @Test
     public void imports_simple_inner_class() {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
-        JavaClass innerClass = classes.get(ClassWithInnerClass.Inner.class);
 
-        assertThatType(innerClass).matches(ClassWithInnerClass.Inner.class);
-        assertThat(innerClass.isTopLevelClass()).as("is top level class").isFalse();
-        assertThat(innerClass.isNestedClass()).as("is nested class").isTrue();
-        assertThat(innerClass.isMemberClass()).as("is member class").isTrue();
-        assertThat(innerClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(innerClass.isLocalClass()).as("is local class").isFalse();
-        assertThat(innerClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(classes.get(ClassWithInnerClass.Inner.class))
+                .matches(ClassWithInnerClass.Inner.class)
+                .isTopLevelClass(false)
+                .isNestedClass(true)
+                .isMemberClass(true)
+                .isInnerClass(true)
+                .isLocalClass(false)
+                .isAnonymousClass(false);
     }
 
     @Test
@@ -220,13 +221,14 @@ public class ClassFileImporterTest {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass anonymousClass = classes.get(ClassWithInnerClass.class.getName() + "$1");
 
-        assertThatType(anonymousClass).matches(Class.forName(anonymousClass.getName()));
-        assertThat(anonymousClass.isTopLevelClass()).as("is top level class").isFalse();
-        assertThat(anonymousClass.isNestedClass()).as("is nested class").isTrue();
-        assertThat(anonymousClass.isMemberClass()).as("is member class").isFalse();
-        assertThat(anonymousClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(anonymousClass.isLocalClass()).as("is local class").isFalse();
-        assertThat(anonymousClass.isAnonymousClass()).as("is anonymous class").isTrue();
+        assertThat(anonymousClass)
+                .matches(Class.forName(anonymousClass.getName()))
+                .isTopLevelClass(false)
+                .isNestedClass(true)
+                .isMemberClass(false)
+                .isInnerClass(true)
+                .isLocalClass(false)
+                .isAnonymousClass(true);
     }
 
     @Test
@@ -234,13 +236,14 @@ public class ClassFileImporterTest {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/innerclassimport"));
         JavaClass localClass = classes.get(ClassWithInnerClass.class.getName() + "$1LocalCaller");
 
-        assertThatType(localClass).matches(Class.forName(localClass.getName()));
-        assertThat(localClass.isTopLevelClass()).as("is top level class").isFalse();
-        assertThat(localClass.isNestedClass()).as("is nested class").isTrue();
-        assertThat(localClass.isMemberClass()).as("is member class").isFalse();
-        assertThat(localClass.isInnerClass()).as("is inner class").isTrue();
-        assertThat(localClass.isLocalClass()).as("is local class").isTrue();
-        assertThat(localClass.isAnonymousClass()).as("is anonymous class").isFalse();
+        assertThat(localClass)
+                .matches(Class.forName(localClass.getName()))
+                .isTopLevelClass(false)
+                .isNestedClass(true)
+                .isMemberClass(false)
+                .isInnerClass(true)
+                .isLocalClass(true)
+                .isAnonymousClass(false);
     }
 
     @Test
@@ -263,13 +266,14 @@ public class ClassFileImporterTest {
     public void imports_interfaces() {
         JavaClass simpleInterface = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(InterfaceToImport.class);
 
-        assertThat(simpleInterface.getName()).as("full name").isEqualTo(InterfaceToImport.class.getName());
-        assertThat(simpleInterface.getSimpleName()).as("simple name").isEqualTo(InterfaceToImport.class.getSimpleName());
-        assertThat(simpleInterface.getPackageName()).as("package name").isEqualTo(InterfaceToImport.class.getPackage().getName());
-        assertThat(simpleInterface.getRawSuperclass()).as("super class").isAbsent();
-        assertThat(simpleInterface.getInterfaces()).as("interfaces").isEmpty();
-        assertThat(simpleInterface.isInterface()).as("is interface").isTrue();
-        assertThat(simpleInterface.isEnum()).as("is enum").isFalse();
+        assertThat(simpleInterface)
+                .hasName(InterfaceToImport.class.getName())
+                .hasSimpleName(InterfaceToImport.class.getSimpleName())
+                .hasPackageName(InterfaceToImport.class.getPackage().getName())
+                .hasNoSuperclass()
+                .hasNoInterfaces()
+                .isInterface(true)
+                .isEnum(false);
     }
 
     @Test
@@ -359,8 +363,8 @@ public class ClassFileImporterTest {
         JavaClass baseClass = classes.get(BaseClass.class);
         JavaClass parentInterface = classes.get(ParentInterface.class);
 
-        assertThat(baseClass.isInterface()).as(BaseClass.class.getSimpleName() + " is interface").isFalse();
-        assertThat(parentInterface.isInterface()).as(ParentInterface.class.getSimpleName() + " is interface").isTrue();
+        assertThat(baseClass).isInterface(false);
+        assertThat(parentInterface).isInterface(true);
     }
 
     @Test
@@ -370,8 +374,8 @@ public class ClassFileImporterTest {
         assertThat(baseClass.getConstructors()).as("Constructors of " + BaseClass.class.getSimpleName()).hasSize(2);
         assertThat(baseClass.getFields()).as("Fields of " + BaseClass.class.getSimpleName()).hasSize(1);
         assertThat(baseClass.getMethods()).as("Methods of " + BaseClass.class.getSimpleName()).hasSize(2);
-        assertThat(baseClass.getStaticInitializer().get().getMethodCallsFromSelf().size())
-                .as("Calls from %s.<clinit>()", BaseClass.class.getSimpleName()).isGreaterThan(0);
+        assertThat(baseClass.getStaticInitializer().get().getMethodCallsFromSelf())
+                .as("Calls from %s.<clinit>()", BaseClass.class.getSimpleName()).isNotEmpty();
     }
 
     @Test
@@ -381,7 +385,7 @@ public class ClassFileImporterTest {
         assertThat(subclass.getConstructors()).hasSize(3);
         assertThat(subclass.getFields()).hasSize(1);
         assertThat(subclass.getMethods()).hasSize(3);
-        assertThat(subclass.getStaticInitializer().get().getMethodCallsFromSelf().size()).isGreaterThan(0);
+        assertThat(subclass.getStaticInitializer().get().getMethodCallsFromSelf()).isNotEmpty();
     }
 
     @Test
@@ -590,8 +594,9 @@ public class ClassFileImporterTest {
 
         JavaClass middleClass = findAnyByName(classes,
                 "com.tngtech.archunit.core.importer.testexamples.outsideofclasspath.MiddleClass");
-        assertThat(middleClass.getSimpleName()).as("simple name").isEqualTo("MiddleClass");
-        assertThat(middleClass.isInterface()).as("is interface").isFalse();
+        assertThat(middleClass)
+                .hasSimpleName("MiddleClass")
+                .isInterface(false);
         assertThatCall(findAnyByName(middleClass.getMethodCallsFromSelf(), "println"))
                 .isFrom(middleClass.getMethod("overrideMe"))
                 .isTo(targetWithFullName(String.format("%s.println(%s)", PrintStream.class.getName(), String.class.getName())))
@@ -604,8 +609,9 @@ public class ClassFileImporterTest {
 
         JavaClass gimmeADescription = findAnyByName(classes,
                 "com.tngtech.archunit.core.importer.testexamples.outsideofclasspath.ExistingDependency$GimmeADescription");
-        assertThat(gimmeADescription.getSimpleName()).as("simple name").isEqualTo("GimmeADescription");
-        assertThat(gimmeADescription.isInterface()).as("is interface").isTrue();
+        assertThat(gimmeADescription)
+                .hasSimpleName("GimmeADescription")
+                .isInterface(true);
     }
 
     @Test
@@ -653,7 +659,7 @@ public class ClassFileImporterTest {
     @Test
     @UseDataProvider("classes_not_fully_imported")
     public void classes_not_fully_imported_have_flag_fullyImported_false_and_empty_dependencies(@SuppressWarnings("unused") String description, JavaClass notFullyImported) {
-        assertThat(notFullyImported.isFullyImported()).isFalse();
+        assertThat(notFullyImported).isFullyImported(false);
         assertThat(notFullyImported.getDirectDependenciesFromSelf()).isEmpty();
         assertThat(notFullyImported.getDirectDependenciesToSelf()).isEmpty();
         assertThat(notFullyImported.getFieldAccessesToSelf()).isEmpty();
@@ -791,7 +797,7 @@ public class ClassFileImporterTest {
     }
 
     private void assertSameSimpleNameOfArchUnitAndReflection(JavaClasses classes, Class<?> clazz) {
-        assertThat(classes.get(clazz.getName()).getSimpleName()).isEqualTo(clazz.getSimpleName());
+        assertThat(classes.get(clazz.getName())).hasSimpleName(clazz.getSimpleName());
     }
 
     private void copyClassFile(Class<?> clazz, File targetFolder) throws IOException, URISyntaxException {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTestUtils.java
@@ -1,0 +1,67 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URLConnection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.properties.HasName;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.getFirst;
+import static com.tngtech.archunit.core.domain.SourceTest.urlOf;
+
+class ClassFileImporterTestUtils {
+
+    static <T extends HasName> Set<T> getByName(Iterable<T> thingsWithName, String name) {
+        Set<T> result = new HashSet<>();
+        for (T hasName : thingsWithName) {
+            if (name.equals(hasName.getName())) {
+                result.add(hasName);
+            }
+        }
+        return result;
+    }
+
+    static <T extends HasName> T findAnyByName(Iterable<T> thingsWithName, String name) {
+        T result = getFirst(getByName(thingsWithName, name), null);
+        return checkNotNull(result, "No object with name '" + name + "' is present in " + thingsWithName);
+    }
+
+    static Set<JavaField> getFields(Iterable<JavaClass> classes) {
+        Set<JavaField> fields = new HashSet<>();
+        for (JavaClass clazz : classes) {
+            fields.addAll(clazz.getFields());
+        }
+        return fields;
+    }
+
+    static Set<JavaMethod> getMethods(Iterable<JavaClass> classes) {
+        Set<JavaMethod> methods = new HashSet<>();
+        for (JavaClass clazz : classes) {
+            methods.addAll(clazz.getMethods());
+        }
+        return methods;
+    }
+
+    static Set<JavaCodeUnit> getCodeUnits(Iterable<JavaClass> classes) {
+        Set<JavaCodeUnit> codeUnits = new HashSet<>();
+        for (JavaClass clazz : classes) {
+            codeUnits.addAll(clazz.getCodeUnits());
+        }
+        return codeUnits;
+    }
+
+    static JarFile jarFileOf(Class<?> clazzInJar) throws IOException {
+        URLConnection connection = urlOf(clazzInJar).openConnection();
+        checkArgument(connection instanceof JarURLConnection, "Class %s is not contained in a JAR", clazzInJar.getName());
+        return ((JarURLConnection) connection).getJarFile();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -13,6 +13,8 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.access.ClassAccessingOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.accessed.ClassBeingAccessedByOtherClass;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.anotheraccess.YetAnotherClassAccessingOtherClass;
+import com.tngtech.archunit.lang.syntax.elements.testclasses.innerclassaccess.ClassWithInnerClasses.ClassAccessingInnerMemberClass;
+import com.tngtech.archunit.lang.syntax.elements.testclasses.innerclassaccess.ClassWithInnerClasses.InnerMemberClassBeingAccessed;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.otheraccess.ClassAlsoAccessingOtherClass;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -926,7 +928,8 @@ public class ShouldOnlyByClassesThatTest {
                 .on(ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class,
                         ClassAccessingOtherClass.class, ClassBeingAccessedByOtherClass.class);
 
-        assertThatTypes(classes).matchInAnyOrder(ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class);
+        assertThatTypes(classes).matchInAnyOrder(
+                ClassAccessingInnerMemberClass.class, InnerMemberClassBeingAccessed.class);
     }
 
     @Test
@@ -1203,7 +1206,7 @@ public class ShouldOnlyByClassesThatTest {
     private static class ClassBeingAccessedByClassImplementingSomeInterface {
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
     private static class ClassAccessingItself {
         private final String field;
 
@@ -1301,17 +1304,6 @@ public class ShouldOnlyByClassesThatTest {
     }
 
     private static class StaticNestedClassBeingAccessed {
-    }
-
-    private class ClassAccessingInnerMemberClass {
-        @SuppressWarnings("unused")
-        void access() {
-            new InnerMemberClassBeingAccessed();
-        }
-    }
-
-    @SuppressWarnings("InnerClassMayBeStatic")
-    private class InnerMemberClassBeingAccessed {
     }
 
     // This must be loaded via Reflection, otherwise the test will be tainted by the dependency on the class object

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/innerclassaccess/ClassWithInnerClasses.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/innerclassaccess/ClassWithInnerClasses.java
@@ -1,0 +1,14 @@
+package com.tngtech.archunit.lang.syntax.elements.testclasses.innerclassaccess;
+
+public class ClassWithInnerClasses {
+    public class ClassAccessingInnerMemberClass {
+        @SuppressWarnings("unused")
+        void access() {
+            new InnerMemberClassBeingAccessed();
+        }
+    }
+
+    @SuppressWarnings("InnerClassMayBeStatic")
+    public class InnerMemberClassBeingAccessed {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -46,6 +46,7 @@ import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
 import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion;
+import com.tngtech.archunit.testutil.assertion.JavaClassAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaClassDescriptorAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaCodeUnitAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaConstructorAssertion;
@@ -149,6 +150,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static JavaTypesAssertion assertThat(JavaType[] javaTypes) {
         return new JavaTypesAssertion(javaTypes);
+    }
+
+    public static JavaClassAssertion assertThat(JavaClass javaClass) {
+        return new JavaClassAssertion(javaClass);
     }
 
     public static JavaClassListAssertion assertThat(JavaClassList javaClasses) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaClassAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaClassAssertion.java
@@ -1,0 +1,130 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static org.assertj.core.util.Strings.isNullOrEmpty;
+
+public class JavaClassAssertion extends AbstractObjectAssert<JavaClassAssertion, JavaClass> {
+    public JavaClassAssertion(JavaClass actual) {
+        super(actual, JavaClassAssertion.class);
+        describedAs(actual.getSimpleName());
+    }
+
+    public JavaClassAssertion matches(Class<?> clazz) {
+        assertThatType(actual).as(descriptionText()).matches(clazz);
+        return this;
+    }
+
+    public JavaClassAssertion hasName(String expectedName) {
+        assertThat(actual.getName()).as(describeAssertion("full name")).isEqualTo(expectedName);
+        return this;
+    }
+
+    public JavaClassAssertion hasSimpleName(String expectedSimpleName) {
+        assertThat(actual.getSimpleName()).as(describeAssertion("simple name")).isEqualTo(expectedSimpleName);
+        return this;
+    }
+
+    public JavaClassAssertion hasPackageName(String expectedPackageName) {
+        assertThat(actual.getPackageName()).as(describeAssertion("package name")).isEqualTo(expectedPackageName);
+        return this;
+    }
+
+    public JavaClassAssertion hasOnlyModifiers(JavaModifier... expectedModifiers) {
+        assertThat(actual.getModifiers()).as(describeAssertion("modifiers")).containsOnly(expectedModifiers);
+        return this;
+    }
+
+    public JavaClassAssertion hasNoSuperclass() {
+        assertThat(actual.getRawSuperclass()).as(describeAssertion("raw superclass")).isAbsent();
+        assertThat(actual.getSuperclass()).as(describeAssertion("superclass")).isAbsent();
+        return this;
+    }
+
+    public JavaClassAssertion hasRawSuperclassMatching(Class<?> expectedSuperclass) {
+        assertThat(actual.getRawSuperclass()).as(describeAssertion("super class")).isPresent();
+        assertThatType(actual.getRawSuperclass().get()).as(describeAssertion("super class")).matches(expectedSuperclass);
+        return this;
+    }
+
+    public JavaClassAssertion hasNoInterfaces() {
+        assertThat(actual.getInterfaces()).as(describeAssertion("interfaces")).isEmpty();
+        return this;
+    }
+
+    public JavaClassAssertion hasInterfacesMatchingInAnyOrder(Class<?>... expectedInterfaces) {
+        assertThatTypes(actual.getInterfaces()).as(describeAssertion("interfaces")).matchInAnyOrder(expectedInterfaces);
+        return this;
+    }
+
+    public JavaClassAssertion hasAllInterfacesMatchingInAnyOrder(Class<?>... expectedAllInterfaces) {
+        assertThatTypes(actual.getAllInterfaces()).as(describeAssertion("all interfaces")).matchInAnyOrder(expectedAllInterfaces);
+        return this;
+    }
+
+    public JavaClassAssertion isInterface(boolean expectedIsInterface) {
+        assertThat(actual.isInterface()).as(describeAssertion("is interface")).isEqualTo(expectedIsInterface);
+        return this;
+    }
+
+    public JavaClassAssertion isEnum(boolean expectedIsEnum) {
+        assertThat(actual.isEnum()).as(describeAssertion("is enum")).isEqualTo(expectedIsEnum);
+        return this;
+    }
+
+    public JavaClassAssertion isAnnotation(boolean expectedIsAnnotation) {
+        assertThat(actual.isAnnotation()).as(describeAssertion("is annotation")).isEqualTo(expectedIsAnnotation);
+        return this;
+    }
+
+    public JavaClassAssertion isFullyImported(boolean expectedIsFullyImported) {
+        assertThat(actual.isFullyImported()).as(describeAssertion("is fully imported")).isEqualTo(expectedIsFullyImported);
+        return this;
+    }
+
+    public JavaClassAssertion hasNoEnclosingClass() {
+        assertThat(actual.getEnclosingClass()).as(describeAssertion("enclosing class")).isAbsent();
+        return this;
+    }
+
+    public JavaClassAssertion isTopLevelClass(boolean expectedIsTopLevelClass) {
+        assertThat(actual.isTopLevelClass()).as(describeAssertion("is top level class")).isEqualTo(expectedIsTopLevelClass);
+        return this;
+    }
+
+    public JavaClassAssertion isNestedClass(boolean expectedIsNestedClass) {
+        assertThat(actual.isNestedClass()).as(describeAssertion("is nested class")).isEqualTo(expectedIsNestedClass);
+        return this;
+    }
+
+    public JavaClassAssertion isMemberClass(boolean expectedIsMemberClass) {
+        assertThat(actual.isMemberClass()).as(describeAssertion("is member class")).isEqualTo(expectedIsMemberClass);
+        return this;
+    }
+
+    public JavaClassAssertion isInnerClass(boolean expectedIsInnerClass) {
+        assertThat(actual.isInnerClass()).as(describeAssertion("is inner class")).isEqualTo(expectedIsInnerClass);
+        return this;
+    }
+
+    public JavaClassAssertion isLocalClass(boolean expectedIsLocalClass) {
+        assertThat(actual.isLocalClass()).as(describeAssertion("is local class")).isEqualTo(expectedIsLocalClass);
+        return this;
+    }
+
+    public JavaClassAssertion isAnonymousClass(boolean expectedIsAnonymousClass) {
+        assertThat(actual.isAnonymousClass()).as(describeAssertion("is anonymous class")).isEqualTo(expectedIsAnonymousClass);
+        return this;
+    }
+
+    private String describeAssertion(String partialAssertionDescription) {
+        return isNullOrEmpty(descriptionText())
+                ? partialAssertionDescription
+                : descriptionText() + " " + partialAssertionDescription;
+    }
+}


### PR DESCRIPTION
So far types that were part of a member signature (e.g. field types, method return types, etc.) were not resolved at the beginning of the class graph creation. This could lead to some strange behavior like in https://github.com/odrotbohm/moduliths/issues/146#issuecomment-776636703

Typically this could not be noticed, because ArchUnit resolves all access targets early enough, and normally every field type or method return type is accessed at some point (or irrelevant for the assertions). Also it would only show if certain methods are called on the partially finished `JavaClass`, like `getAllMethods()` which would rely on the inheritance hierarchy to be imported.

I have added now that all types that participate in any member signature will be automatically resolved at the beginning of the graph creation, so that this problem will not occur anymore. I have also adjusted the `getAll...()` methods for members to not fail anymore, if the full class hierarchy hasn't been imported. Missing information is always a possible case for any class import and should IMHO not lead to an exception.