### PR TITLE
ensure @PublicAPI members are accessible

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
 import com.tngtech.archunit.core.domain.properties.HasName;
@@ -68,7 +69,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
  * For further elaboration refer to the documentation of {@link #resolve()}. In particular {@link #resolve()} attempts to find
  * matching {@link JavaMember JavaMembers} for the respective {@link AccessTarget}.
  */
-public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotated, HasOwner<JavaClass> {
+public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotated, HasOwner<JavaClass>, HasDescription {
     private final String name;
     private final JavaClass owner;
     private final String fullName;
@@ -220,8 +221,6 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         return false;
     }
 
-    abstract String getDescription();
-
     public static final class Functions {
         private Functions() {
         }
@@ -283,7 +282,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
 
         @Override
         @PublicAPI(usage = ACCESS)
-        String getDescription() {
+        public String getDescription() {
             return "field <" + getFullName() + ">";
         }
 
@@ -411,7 +410,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
 
         @Override
         @PublicAPI(usage = ACCESS)
-        String getDescription() {
+        public String getDescription() {
             return "constructor <" + getFullName() + ">";
         }
 
@@ -485,7 +484,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
 
         @Override
         @PublicAPI(usage = ACCESS)
-        String getDescription() {
+        public String getDescription() {
             return "method <" + getFullName() + ">";
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -267,7 +267,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      * @return The component type, if this type is an array, otherwise {@link Optional#absent()}
      */
     @PublicAPI(usage = ACCESS)
-    Optional<JavaClass> tryGetComponentType() {
+    public Optional<JavaClass> tryGetComponentType() {
         return componentType;
     }
 
@@ -279,7 +279,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
      * @return The base component type of this class
      */
     @PublicAPI(usage = ACCESS)
-    JavaClass getBaseComponentType() {
+    public JavaClass getBaseComponentType() {
         JavaClass type = this;
         while (type.isArray()) {
             type = type.getComponentType();

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/GivenSlicesInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/GivenSlicesInternal.java
@@ -15,7 +15,6 @@
  */
 package com.tngtech.archunit.library.dependencies;
 
-import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -29,7 +28,6 @@ import com.tngtech.archunit.library.dependencies.syntax.GivenSlicesConjunction;
 import com.tngtech.archunit.library.dependencies.syntax.SlicesShould;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.Guava.Iterables.filter;
 
 class GivenSlicesInternal implements GivenSlices, SlicesShould, GivenSlicesConjunction {
@@ -74,7 +72,6 @@ class GivenSlicesInternal implements GivenSlices, SlicesShould, GivenSlicesConju
      * @see Slices#namingSlices(String)
      */
     @Override
-    @PublicAPI(usage = ACCESS)
     public GivenNamedSlices namingSlices(String pattern) {
         return new GivenSlicesInternal(priority, classesTransformer.namingSlices(pattern));
     }
@@ -85,7 +82,6 @@ class GivenSlicesInternal implements GivenSlices, SlicesShould, GivenSlicesConju
     }
 
     @Override
-    @PublicAPI(usage = ACCESS)
     public SliceRule beFreeOfCycles() {
         return new SliceRule(classesTransformer, priority, new SliceRule.ConditionFactory() {
             @Override
@@ -96,7 +92,6 @@ class GivenSlicesInternal implements GivenSlices, SlicesShould, GivenSlicesConju
     }
 
     @Override
-    @PublicAPI(usage = ACCESS)
     public SliceRule notDependOnEachOther() {
         return new SliceRule(classesTransformer, priority, new SliceRule.ConditionFactory() {
             @Override


### PR DESCRIPTION
This has now been the second time that we have released package-private members that were marked as `@PublicAPI`, but only accessed from tests in the same package, thus hiding the fact that these members can actually never be used as public API as intended. I have added an `ArchRule` to ensure that the owning class declares such member publicly through the whole enclosing class hierarchy.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>