### PR TITLE
upgrade ASM to version 9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     googleRelocationPackage = "${thirdPartyRelocationPackage}.com.google"
 
     dependency = [
-            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.0'],
+            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.1'],
             guava               : [group: 'com.google.guava', name: 'guava', version: '20.0'],
             slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'],
             log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1'],
@@ -98,13 +98,7 @@ allprojects {
     version = '0.17.0-SNAPSHOT'
 
     repositories {
-        mavenCentral {
-            metadataSources {
-                mavenPom()
-                artifact()
-                ignoreGradleMetadataRedirection()
-            }
-        }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
As the issue with Gradle metadata in Maven Central specifying a requirement for Java >= 8 has been solved (compare https://gitlab.ow2.org/asm/asm/-/issues/317920) I have also removed the workaround to ignore Gradle metadata for Maven Central.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>