### PR TITLE
improve Javadoc for 'implement' vs 'assignable'

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1637,50 +1637,124 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
             return new SimpleNameEndingWithPredicate(suffix);
         }
 
+        /**
+         * @param type the type to check for assignability
+         * @return a {@link DescribedPredicate} that returns {@code true}, if the respective {@link JavaClass}
+         *         is assignable to the supplied {@code type}. I.e. the type represented by the tested {@link JavaClass}
+         *         could be casted to the supplied {@code type}.<br>
+         *         This is the opposite of {@link #assignableFrom(Class)}:
+         *         some class {@code A} is assignable to a class {@code B} if and only if {@code B} is assignable from {@code A}.
+         *
+         * @see #assignableTo(String)
+         * @see #assignableTo(DescribedPredicate)
+         * @see #assignableFrom(Class)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableTo(final Class<?> type) {
             return assignableTo(type.getName());
         }
 
+        /**
+         * @param type the type to check for assignability
+         * @return a {@link DescribedPredicate} that returns {@code true}, if the respective {@link JavaClass}
+         *         is assignable from the supplied {@code type}. I.e. the supplied {@code type}
+         *         could be casted to the type represented by the tested {@link JavaClass}.<br>
+         *         This is the opposite of {@link #assignableTo(Class)}:
+         *         some class {@code B} is assignable from a class {@code A} if and only if {@code A} is assignable to {@code B}.
+         *
+         * @see #assignableFrom(String)
+         * @see #assignableFrom(DescribedPredicate)
+         * @see #assignableTo(Class)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableFrom(final Class<?> type) {
             return assignableFrom(type.getName());
         }
 
+        /**
+         * Same as {@link #assignableTo(Class)} but takes a fully qualified class name as an argument instead of a class object.
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableTo(final String typeName) {
             return assignableTo(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
+        /**
+         * Same as {@link #assignableFrom(Class)} but takes a fully qualified class name as an argument instead of a class object.
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableFrom(final String typeName) {
             return assignableFrom(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
+        /**
+         * Same as {@link #assignableTo(Class)}, but returns {@code true} whenever the tested {@link JavaClass}
+         * is assignable to a class that matches the supplied predicate.<br>
+         * This is the opposite of {@link #assignableFrom(DescribedPredicate)}:
+         * some class {@code A} is assignable to a class {@code B} if and only if {@code B} is assignable from {@code A}.
+         *
+         * @see #assignableTo(Class)
+         * @see #assignableTo(String)
+         * @see #assignableFrom(DescribedPredicate)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableTo(final DescribedPredicate<? super JavaClass> predicate) {
             return new AssignableToPredicate(predicate);
         }
 
+        /**
+         * Same as {@link #assignableFrom(Class)}, but returns {@code true} whenever the tested {@link JavaClass}
+         * is assignable from a class that matches the supplied predicate.<br>
+         * This is the opposite of {@link #assignableTo(DescribedPredicate)}:
+         * some class {@code B} is assignable from a class {@code A} if and only if {@code A} is assignable to {@code A}.
+         *
+         * @see #assignableFrom(Class)
+         * @see #assignableFrom(String)
+         * @see #assignableTo(DescribedPredicate)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> assignableFrom(final DescribedPredicate<? super JavaClass> predicate) {
             return new AssignableFromPredicate(predicate);
         }
 
+        /**
+         * @param type the interface type to check for
+         * @return a {@link DescribedPredicate} that returns {@code true} if the tested {@link JavaClass} implements the supplied
+         *         interface {@code type}. I.e. the supplied {@code type} must be an interface and the tested {@link JavaClass}
+         *         must be a class (it resembles delarations like {@code class A implements B},
+         *         which only works for a class {@code A} and an interface {@code B}).
+         * @throws InvalidSyntaxUsageException if {@code type} is not an interface
+         *
+         * @see #implement(String)
+         * @see #implement(DescribedPredicate)
+         * @see #assignableTo(Class)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> implement(final Class<?> type) {
             if (!type.isInterface()) {
                 throw new InvalidSyntaxUsageException(String.format(
-                        "implement(type) can only ever be true, if type is an interface, but type %s is not", type.getName()));
+                        "implement(type) can only ever be true, if type is an interface, but type %s is not. "
+                                + "Do you maybe want to use the more generic assignableTo(type)?", type.getName()));
             }
             return implement(type.getName());
         }
 
+        /**
+         * Same as {@link #implement(Class)} but takes a fully qualified class name as an argument instead of a class object.
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> implement(final String typeName) {
             return implement(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
+        /**
+         * Same as {@link #implement(Class)} but returns {@code true} whenever the tested {@link JavaClass} implements
+         * an interface that matches the supplied predicate.
+         *
+         * @see #implement(Class)
+         * @see #implement(String)
+         * @see #assignableTo(DescribedPredicate)
+         */
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaClass> implement(final DescribedPredicate<? super JavaClass> predicate) {
             DescribedPredicate<JavaClass> selfIsImplementation = not(INTERFACES);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -775,91 +775,145 @@ public final class ArchConditions {
         return not(ArchConditions.<HAS_ANNOTATIONS>beMetaAnnotatedWith(predicate));
     }
 
+    /**
+     * @return a condition matching classes analogously to {@link JavaClass.Predicates#implement(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(Class<?> interfaceType) {
         return new ImplementsCondition(JavaClass.Predicates.implement(interfaceType));
     }
 
+    /**
+     * @return negation of {@link #implement(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notImplement(Class<?> interfaceType) {
         return not(implement(interfaceType));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#implement(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(String interfaceTypeName) {
         return new ImplementsCondition(JavaClass.Predicates.implement(interfaceTypeName));
     }
 
+    /**
+     * @return negation of {@link #implement(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notImplement(String interfaceTypeName) {
         return not(implement(interfaceTypeName));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#implement(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(DescribedPredicate<? super JavaClass> predicate) {
         return new ImplementsCondition(JavaClass.Predicates.implement(predicate));
     }
 
+    /**
+     * @return negation of {@link #implement(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notImplement(DescribedPredicate<? super JavaClass> predicate) {
         return not(implement(predicate));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableTo(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(Class<?> type) {
         return new IsConditionByPredicate<>(assignableTo(type));
     }
 
+    /**
+     * @return negation of {@link #beAssignableTo(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableTo(Class<?> type) {
         return not(beAssignableTo(type));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableTo(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(String typeName) {
         return new IsConditionByPredicate<>(assignableTo(typeName));
     }
 
+    /**
+     * @return negation of {@link #beAssignableTo(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableTo(String typeName) {
         return not(beAssignableTo(typeName));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableTo(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(DescribedPredicate<? super JavaClass> predicate) {
         return new IsConditionByPredicate<>(assignableTo(predicate));
     }
 
+    /**
+     * @return negation of {@link #beAssignableTo(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableTo(DescribedPredicate<? super JavaClass> predicate) {
         return not(beAssignableTo(predicate));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableFrom(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(Class<?> type) {
         return new IsConditionByPredicate<>(assignableFrom(type));
     }
 
+    /**
+     * @return negation of {@link #beAssignableFrom(Class)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableFrom(Class<?> type) {
         return not(beAssignableFrom(type));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableFrom(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(String typeName) {
         return new IsConditionByPredicate<>(assignableFrom(typeName));
     }
 
+    /**
+     * @return negation of {@link #beAssignableFrom(String)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableFrom(String typeName) {
         return not(beAssignableFrom(typeName));
     }
 
+    /**
+     * @return A condition matching classes analogously to {@link JavaClass.Predicates#assignableFrom(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(DescribedPredicate<? super JavaClass> predicate) {
         return new IsConditionByPredicate<>(assignableFrom(predicate));
     }
 
+    /**
+     * @return negation of {@link #beAssignableFrom(DescribedPredicate)}
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeAssignableFrom(DescribedPredicate<? super JavaClass> predicate) {
         return not(beAssignableFrom(predicate));

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -35,6 +35,7 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.properties.HasName.Predicates;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -399,9 +400,14 @@ public interface ClassesShould {
 
     /**
      * Asserts that classes implement a certain interface.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement the supplied interface {@code type}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #beAssignableTo(Class)}
      *
      * @param type An interface imported classes should implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#implement(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction implement(Class<?> type);
@@ -411,6 +417,8 @@ public interface ClassesShould {
      *
      * @param type An interface imported classes should NOT implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notImplement(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notImplement(Class<?> type);
@@ -418,9 +426,14 @@ public interface ClassesShould {
     /**
      * Asserts that classes implement a certain interface with the given type name. This is equivalent to
      * {@link #implement(Class)}, but does not depend on having a certain type on the classpath.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement the supplied interface {@code typeName}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #beAssignableTo(String)}
      *
      * @param typeName Name of an interface imported classes should implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#implement(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction implement(String typeName);
@@ -432,6 +445,8 @@ public interface ClassesShould {
      *
      * @param typeName Name of an interface imported classes should NOT implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notImplement(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notImplement(String typeName);
@@ -440,9 +455,14 @@ public interface ClassesShould {
      * Asserts that classes implement a certain interface matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #implement(String)}, but the approach is a lot more generic.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement an interface matching the {@code predicate}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #beAssignableTo(DescribedPredicate)}
      *
      * @param predicate A predicate identifying an interface imported classes should implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#implement(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction implement(DescribedPredicate<? super JavaClass> predicate);
@@ -453,6 +473,8 @@ public interface ClassesShould {
      *
      * @param predicate A predicate identifying an interface imported classes should NOT implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notImplement(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notImplement(DescribedPredicate<? super JavaClass> predicate);
@@ -468,6 +490,8 @@ public interface ClassesShould {
      *
      * @param type An upper type bound to match imported classes against (imported subtypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableTo(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableTo(Class<?> type);
@@ -477,6 +501,8 @@ public interface ClassesShould {
      *
      * @param type An upper type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableTo(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableTo(Class<?> type);
@@ -487,6 +513,8 @@ public interface ClassesShould {
      *
      * @param typeName Name of an upper type bound to match imported classes against (imported subtypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableTo(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableTo(String typeName);
@@ -498,6 +526,8 @@ public interface ClassesShould {
      *
      * @param typeName Name of an upper type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableTo(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableTo(String typeName);
@@ -510,6 +540,8 @@ public interface ClassesShould {
      * @param predicate A predicate identifying an upper type bound to match imported classes against
      *                  (imported subtypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableTo(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableTo(DescribedPredicate<? super JavaClass> predicate);
@@ -520,6 +552,8 @@ public interface ClassesShould {
      *
      * @param predicate A predicate identifying an upper type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableTo(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableTo(DescribedPredicate<? super JavaClass> predicate);
@@ -539,6 +573,8 @@ public interface ClassesShould {
      *
      * @param type A lower type bound to match imported classes against (imported supertypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableFrom(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableFrom(Class<?> type);
@@ -548,6 +584,8 @@ public interface ClassesShould {
      *
      * @param type A lower type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableFrom(Class)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableFrom(Class<?> type);
@@ -558,6 +596,8 @@ public interface ClassesShould {
      *
      * @param typeName Name of a lower type bound to match imported classes against (imported supertypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableFrom(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableFrom(String typeName);
@@ -569,6 +609,8 @@ public interface ClassesShould {
      *
      * @param typeName Name of a lower type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableFrom(String)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableFrom(String typeName);
@@ -581,6 +623,8 @@ public interface ClassesShould {
      * @param predicate A predicate identifying a lower type bound to match imported classes against
      *                  (imported supertypes will match)
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#beAssignableFrom(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction beAssignableFrom(DescribedPredicate<? super JavaClass> predicate);
@@ -591,6 +635,8 @@ public interface ClassesShould {
      *
      * @param predicate A predicate identifying a lower type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     *
+     * @see ArchConditions#notBeAssignableFrom(DescribedPredicate)
      */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction notBeAssignableFrom(DescribedPredicate<? super JavaClass> predicate);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -372,6 +372,9 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that implement a certain interface.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement the supplied interface {@code type}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #areAssignableTo(Class)}
      *
      * @param type An interface type matching classes must implement
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -391,6 +394,9 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes that implement a certain interface with the given type name. This is equivalent to
      * {@link #implement(Class)}, but does not depend on having a certain type on the classpath.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement the supplied interface {@code typeName}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #areAssignableTo(String)}
      *
      * @param typeName Name of an interface type matching classes must implement
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -413,6 +419,9 @@ public interface ClassesThat<CONJUNCTION> {
      * Matches classes that implement a certain interface matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #implement(String)}, but the approach is a lot more generic.
+     * Note that this only matches non-interface {@link JavaClass classes} that implement an interface matching the {@code predicate}
+     * (compare {@link JavaClass.Predicates#implement(Class)}.
+     * For general assignability see {@link #areAssignableTo(DescribedPredicate)}
      *
      * @param predicate A predicate identifying interfaces matching classes must implement
      * @return A syntax conjunction element, which can be completed to form a full rule


### PR DESCRIPTION
In the past there has been repeatedly confusion about the methods `..that().implement(..)` / `.should().implement(..)`. Users do not always realize that 'implements' really only refers to the Java syntax, i.e. `A implements B` is only valid, if `A` is a class and `B` is an interface. Otherwise it can only be `extends`, which is not meant here. A while ago I had added some rejection for `implement(clazz)` to throw an exception, if `clazz` is not an interface, because this predicate can never match anything. Unfortunately this is still not clear enough. I think in many cases people actually want `assignableTo(..)`, which is very close to the naming of the Java Reflection API, but still not widely spread as it seems. To make it easier to find `assignableTo(..)` for users that simply want to test for some inheritance relation I have extended the Javadoc to explain the `implements` vs `assignableTo` case in more detail and also added a hint "do you maybe want to use assignableTo(..)" to the exception of `implement(type)`. I hope this will provide more guidance which method to use in which case and makes it easier to find what is needed.

Resolves: #469

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>