### PR TITLE
introduce `ArchTests` instead of `ArchRules`

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleLibraryTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleLibraryTest.java
@@ -1,8 +1,8 @@
 package com.tngtech.archunit.exampletest.junit4;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.ArchUnitRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -12,11 +12,11 @@ import org.junit.runner.RunWith;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.layers")
 public class RuleLibraryTest {
     @ArchTest
-    public static final ArchRules LIBRARY = ArchRules.in(RuleSetsTest.class);
+    public static final ArchTests LIBRARY = ArchTests.in(RuleSetsTest.class);
 
     @ArchTest
-    public static final ArchRules FURTHER_CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    public static final ArchTests FURTHER_CODING_RULES = ArchTests.in(CodingRulesTest.class);
 
     @ArchTest
-    public static final ArchRules SLICES_ISOLATION_RULES = ArchRules.in(SlicesIsolationTest.class);
+    public static final ArchTests SLICES_ISOLATION_RULES = ArchTests.in(SlicesIsolationTest.class);
 }

--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleSetsTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/RuleSetsTest.java
@@ -1,8 +1,8 @@
 package com.tngtech.archunit.exampletest.junit4;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.ArchUnitRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -12,8 +12,8 @@ import org.junit.runner.RunWith;
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.layers")
 public class RuleSetsTest {
     @ArchTest
-    private final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    private final ArchTests CODING_RULES = ArchTests.in(CodingRulesTest.class);
 
     @ArchTest
-    private final ArchRules NAMING_CONVENTION_RULES = ArchRules.in(NamingConventionTest.class);
+    private final ArchTests NAMING_CONVENTION_RULES = ArchTests.in(NamingConventionTest.class);
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleLibraryTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleLibraryTest.java
@@ -1,19 +1,19 @@
 package com.tngtech.archunit.exampletest.junit5;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTag;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 
 @ArchTag("example")
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.layers")
 class RuleLibraryTest {
     @ArchTest
-    static final ArchRules LIBRARY = ArchRules.in(RuleSetsTest.class);
+    static final ArchTests LIBRARY = ArchTests.in(RuleSetsTest.class);
 
     @ArchTest
-    static final ArchRules FURTHER_CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    static final ArchTests FURTHER_CODING_RULES = ArchTests.in(CodingRulesTest.class);
 
     @ArchTest
-    static final ArchRules SLICES_ISOLATION_RULES = ArchRules.in(SlicesIsolationTest.class);
+    static final ArchTests SLICES_ISOLATION_RULES = ArchTests.in(SlicesIsolationTest.class);
 }

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleSetsTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/RuleSetsTest.java
@@ -1,16 +1,16 @@
 package com.tngtech.archunit.exampletest.junit5;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTag;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 
 @ArchTag("example")
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.layers")
 class RuleSetsTest {
     @ArchTest
-    private final ArchRules CODING_RULES = ArchRules.in(CodingRulesTest.class);
+    private final ArchTests CODING_RULES = ArchTests.in(CodingRulesTest.class);
 
     @ArchTest
-    private final ArchRules NAMING_CONVENTION_RULES = ArchRules.in(NamingConventionTest.class);
+    private final ArchTests NAMING_CONVENTION_RULES = ArchTests.in(NamingConventionTest.class);
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
@@ -16,8 +16,8 @@ import com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.ArchUnitRunner;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
@@ -57,7 +57,7 @@ public class ArchUnitArchitectureTest {
             .whereLayer("Base").mayOnlyBeAccessedByLayers("Root", "Core", "Lang", "Library", "JUnit");
 
     @ArchTest
-    public static final ArchRules importer_rules = ArchRules.in(ImporterRules.class);
+    public static final ArchTests importer_rules = ArchTests.in(ImporterRules.class);
 
     @ArchTest
     public static final ArchRule types_are_only_resolved_via_reflection_in_allowed_places =
@@ -66,7 +66,7 @@ public class ArchUnitArchitectureTest {
                     .as("no classes should illegally resolve classes via reflection");
 
     @ArchTest
-    public static final ArchRules public_API_rules = ArchRules.in(PublicAPIRules.class);
+    public static final ArchTests public_API_rules = ArchTests.in(PublicAPIRules.class);
 
     private static DescribedPredicate<JavaCall<?>> typeIsIllegallyResolvedViaReflection() {
         DescribedPredicate<JavaCall<?>> explicitlyAllowedUsage =

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleDeclaration.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleDeclaration.java
@@ -68,10 +68,10 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
     }
 
     static Set<ArchRuleDeclaration<?>> toDeclarations(
-            ArchRules rules, Class<?> testClass, Class<? extends Annotation> archTestAnnotationType, boolean forceIgnore) {
+            ArchTests archTests, Class<?> testClass, Class<? extends Annotation> archTestAnnotationType, boolean forceIgnore) {
 
         ImmutableSet.Builder<ArchRuleDeclaration<?>> result = ImmutableSet.builder();
-        Class<?> definitionLocation = rules.getDefinitionLocation();
+        Class<?> definitionLocation = archTests.getDefinitionLocation();
         for (Field field : getAllFields(definitionLocation, withAnnotation(archTestAnnotationType))) {
             result.addAll(archRuleDeclarationsFrom(testClass, field, definitionLocation, archTestAnnotationType, forceIgnore));
         }
@@ -84,13 +84,13 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
     private static Set<ArchRuleDeclaration<?>> archRuleDeclarationsFrom(Class<?> testClass, Field field, Class<?> fieldOwner,
             Class<? extends Annotation> archTestAnnotationType, boolean forceIgnore) {
 
-        return ArchRules.class.isAssignableFrom(field.getType()) ?
+        return ArchTests.class.isAssignableFrom(field.getType()) || ArchRules.class.isAssignableFrom(field.getType()) ?
                 toDeclarations(getArchRulesIn(field, fieldOwner), testClass, archTestAnnotationType, forceIgnore || elementShouldBeIgnored(field)) :
                 Collections.<ArchRuleDeclaration<?>>singleton(ArchRuleDeclaration.from(testClass, field, fieldOwner, forceIgnore));
     }
 
-    private static ArchRules getArchRulesIn(Field field, Class<?> fieldOwner) {
-        ArchRules value = getValue(field, fieldOwner);
+    private static ArchTests getArchRulesIn(Field field, Class<?> fieldOwner) {
+        ArchTests value = ArchTests.from(getValue(field, fieldOwner));
         return checkNotNull(value, "Field %s.%s is not initialized", fieldOwner.getName(), field.getName());
     }
 

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
@@ -111,22 +111,22 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
 
     private Set<ArchTestExecution> findArchRulesIn(FrameworkField ruleField) {
         boolean ignore = elementShouldBeIgnored(ruleField.getField());
-        if (ruleField.getType() == ArchRules.class) {
+        if (ruleField.getType() == ArchTests.class || ruleField.getType() == ArchRules.class) {
             return asTestExecutions(getArchRules(ruleField.getField()), ignore);
         }
         return Collections.<ArchTestExecution>singleton(new ArchRuleExecution(getTestClass().getJavaClass(), ruleField.getField(), ignore));
     }
 
-    private Set<ArchTestExecution> asTestExecutions(ArchRules archRules, boolean forceIgnore) {
+    private Set<ArchTestExecution> asTestExecutions(ArchTests archTests, boolean forceIgnore) {
         ExecutionTransformer executionTransformer = new ExecutionTransformer();
-        for (ArchRuleDeclaration<?> declaration : toDeclarations(archRules, getTestClass().getJavaClass(), ArchTest.class, forceIgnore)) {
+        for (ArchRuleDeclaration<?> declaration : toDeclarations(archTests, getTestClass().getJavaClass(), ArchTest.class, forceIgnore)) {
             declaration.handleWith(executionTransformer);
         }
         return executionTransformer.getExecutions();
     }
 
-    private ArchRules getArchRules(Field field) {
-        return getValue(field, field.getDeclaringClass());
+    private ArchTests getArchRules(Field field) {
+        return ArchTests.from(getValue(field, field.getDeclaringClass()));
     }
 
     private Collection<ArchTestExecution> findArchRuleMethods() {

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsLegacyArchRulesTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsLegacyArchRulesTest.java
@@ -42,7 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ArchUnitRunnerRunsRuleSetsTest {
+public class ArchUnitRunnerRunsLegacyArchRulesTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -69,7 +69,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @InjectMocks
     private ArchUnitRunner runnerForIgnoredRuleLibrary = newRunnerFor(ArchTestWithIgnoredRuleLibrary.class);
 
-    private JavaClasses cachedClasses = importClassesWithContext(ArchUnitRunnerRunsRuleSetsTest.class);
+    private JavaClasses cachedClasses = importClassesWithContext(ArchUnitRunnerRunsLegacyArchRulesTest.class);
 
     @Before
     public void setUp() {
@@ -236,7 +236,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
         static final String someOtherMethodRuleName = "someOtherMethodRule";
 
         @ArchTest
-        final ArchTests rules = ArchTests.in(ArchTestWithRuleSet.class);
+        final ArchRules rules = ArchRules.in(ArchTestWithRuleSet.class);
 
         @ArchTest
         public static void someOtherMethodRule(JavaClasses classes) {
@@ -246,20 +246,20 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithRuleSet {
         @ArchTest
-        final ArchTests rules = ArchTests.in(Rules.class);
+        final ArchRules rules = ArchRules.in(Rules.class);
     }
 
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithIgnoredRuleSet {
         @ArchTest
         @ArchIgnore
-        public static final ArchTests rules = ArchTests.in(Rules.class);
+        public static final ArchRules rules = ArchRules.in(Rules.class);
     }
 
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithIgnoredRuleLibrary {
         @ArchTest
-        public static final ArchTests rules = ArchTests.in(IgnoredRules.class);
+        public static final ArchRules rules = ArchRules.in(IgnoredRules.class);
     }
 
     public static class Rules {
@@ -288,11 +288,11 @@ public class ArchUnitRunnerRunsRuleSetsTest {
         }
 
         @ArchTest
-        public static final ArchTests subRules = ArchTests.in(IgnoredSubRules.class);
+        public static final ArchRules subRules = ArchRules.in(IgnoredSubRules.class);
 
         @ArchTest
         @ArchIgnore
-        public static final ArchTests ignoredSubRules = ArchTests.in(Rules.class);
+        public static final ArchRules ignoredSubRules = ArchRules.in(Rules.class);
     }
 
     public static class IgnoredSubRules {
@@ -329,8 +329,8 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithRulesWithAbstractBaseClass {
         @ArchTest
-        ArchTests fieldRules = ArchTests.in(ArchUnitRunnerRunsRuleFieldsTest.ArchTestWithAbstractBaseClass.class);
+        ArchRules fieldRules = ArchRules.in(ArchUnitRunnerRunsRuleFieldsTest.ArchTestWithAbstractBaseClass.class);
         @ArchTest
-        ArchTests methodRules = ArchTests.in(ArchUnitRunnerRunsMethodsTest.ArchTestWithAbstractBaseClass.class);
+        ArchRules methodRules = ArchRules.in(ArchUnitRunnerRunsMethodsTest.ArchTestWithAbstractBaseClass.class);
     }
 }

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
@@ -15,11 +15,13 @@ import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.ArchUnitTestEngine.SharedCache;
 import com.tngtech.archunit.junit.testexamples.ClassWithPrivateTests;
+import com.tngtech.archunit.junit.testexamples.ComplexLegacyRuleLibrary;
 import com.tngtech.archunit.junit.testexamples.ComplexMetaTags;
 import com.tngtech.archunit.junit.testexamples.ComplexRuleLibrary;
 import com.tngtech.archunit.junit.testexamples.ComplexTags;
 import com.tngtech.archunit.junit.testexamples.FullAnalyzeClassesSpec;
 import com.tngtech.archunit.junit.testexamples.LibraryWithPrivateTests;
+import com.tngtech.archunit.junit.testexamples.SimpleLegacyRuleLibrary;
 import com.tngtech.archunit.junit.testexamples.SimpleRuleLibrary;
 import com.tngtech.archunit.junit.testexamples.TestClassWithMetaTag;
 import com.tngtech.archunit.junit.testexamples.TestClassWithMetaTags;
@@ -100,7 +102,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("ConstantConditions")
 @ExtendWith(MockitoExtension.class)
 class ArchUnitTestEngineTest {
     @Mock
@@ -258,6 +259,17 @@ class ArchUnitTestEngineTest {
             assertThat(getAllLeafUniqueIds(rootDescriptor))
                     .as("all leaf unique ids of complex hierarchy")
                     .containsOnlyElementsOf(getExpectedIdsForComplexRuleLibrary(engineId));
+        }
+
+        @Test
+        void a_class_with_legacy_complex_hierarchy() {
+            EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest().withClass(ComplexLegacyRuleLibrary.class);
+
+            TestDescriptor rootDescriptor = testEngine.discover(discoveryRequest, engineId);
+
+            assertThat(getAllLeafUniqueIds(rootDescriptor))
+                    .as("all leaf unique ids of complex hierarchy")
+                    .containsOnlyElementsOf(getExpectedIdsForComplexLegacyRuleLibrary(engineId));
         }
 
         @Test
@@ -1162,6 +1174,23 @@ class ArchUnitTestEngineTest {
                 .append(FIELD_SEGMENT_TYPE, ComplexRuleLibrary.RULES_ONE_FIELD));
         Set<UniqueId> simpleRulesIds = getExpectedIdsForSimpleRules(complexRuleLibrary
                 .append(FIELD_SEGMENT_TYPE, ComplexRuleLibrary.RULES_TWO_FIELD));
+
+        return Stream.of(simpleRuleLibraryIds, simpleRulesIds).flatMap(Set::stream).collect(toSet());
+    }
+
+    private Set<UniqueId> getExpectedIdsForComplexLegacyRuleLibrary(UniqueId uniqueId) {
+        UniqueId complexLegacyRuleLibrary = uniqueId.append(CLASS_SEGMENT_TYPE, ComplexLegacyRuleLibrary.class.getName());
+        UniqueId simpleLegacyRuleLibrary = complexLegacyRuleLibrary
+                .append(FIELD_SEGMENT_TYPE, ComplexLegacyRuleLibrary.RULES_ONE_FIELD).append(CLASS_SEGMENT_TYPE, SimpleLegacyRuleLibrary.class.getName());
+        Set<UniqueId> simpleRulesIds1 = getExpectedIdsForSimpleRules(
+                simpleLegacyRuleLibrary.append(FIELD_SEGMENT_TYPE, SimpleLegacyRuleLibrary.RULES_ONE_FIELD));
+        Set<UniqueId> simpleRuleFieldIds = singleton(simpleRuleFieldTestId(
+                simpleLegacyRuleLibrary.append(FIELD_SEGMENT_TYPE, SimpleLegacyRuleLibrary.RULES_TWO_FIELD)));
+
+        Set<UniqueId> simpleRuleLibraryIds = Stream.of(simpleRulesIds1, simpleRuleFieldIds)
+                .flatMap(Set::stream).collect(toSet());
+        Set<UniqueId> simpleRulesIds = getExpectedIdsForSimpleRules(complexLegacyRuleLibrary
+                .append(FIELD_SEGMENT_TYPE, ComplexLegacyRuleLibrary.RULES_TWO_FIELD));
 
         return Stream.of(simpleRuleLibraryIds, simpleRulesIds).flatMap(Set::stream).collect(toSet());
     }

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexLegacyRuleLibrary.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexLegacyRuleLibrary.java
@@ -1,18 +1,17 @@
 package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.junit.ArchTests;
-import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
 import com.tngtech.archunit.junit.testexamples.subtwo.SimpleRules;
 
 @AnalyzeClasses(packages = "some.dummy.package")
-public class SimpleRuleLibrary {
+public class ComplexLegacyRuleLibrary {
     @ArchTest
-    public static final ArchTests rules_one = ArchTests.in(SimpleRules.class);
+    public static final ArchRules rules_one = ArchRules.in(SimpleLegacyRuleLibrary.class);
 
     @ArchTest
-    public static final ArchTests rules_two = ArchTests.in(SimpleRuleField.class);
+    public static final ArchRules rules_two = ArchRules.in(SimpleRules.class);
 
     public static final String RULES_ONE_FIELD = "rules_one";
     public static final String RULES_TWO_FIELD = "rules_two";

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexMetaTags.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexMetaTags.java
@@ -1,17 +1,19 @@
 package com.tngtech.archunit.junit.testexamples;
 
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
-import com.tngtech.archunit.junit.ArchTag;
-import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.lang.ArchRule;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.*;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTag;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @ComplexMetaTags.LibraryTag
@@ -22,11 +24,11 @@ public class ComplexMetaTags {
 
     @RulesTag
     @ArchTest
-    static final ArchRules classWithMetaTag = ArchRules.in(TestClassWithMetaTag.class);
+    static final ArchTests classWithMetaTag = ArchTests.in(TestClassWithMetaTag.class);
 
     @RulesTag
     @ArchTest
-    static final ArchRules classWithMetaTags = ArchRules.in(TestClassWithMetaTags.class);
+    static final ArchTests classWithMetaTags = ArchTests.in(TestClassWithMetaTags.class);
 
     @FieldTag
     @ArchTest

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexRuleLibrary.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexRuleLibrary.java
@@ -1,17 +1,17 @@
 package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.testexamples.subtwo.SimpleRules;
 
 @AnalyzeClasses(packages = "some.dummy.package")
 public class ComplexRuleLibrary {
     @ArchTest
-    public static final ArchRules rules_one = ArchRules.in(SimpleRuleLibrary.class);
+    public static final ArchTests rules_one = ArchTests.in(SimpleRuleLibrary.class);
 
     @ArchTest
-    public static final ArchRules rules_two = ArchRules.in(SimpleRules.class);
+    public static final ArchTests rules_two = ArchTests.in(SimpleRules.class);
 
     public static final String RULES_ONE_FIELD = "rules_one";
     public static final String RULES_TWO_FIELD = "rules_two";

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexTags.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ComplexTags.java
@@ -2,9 +2,9 @@ package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTag;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.lang.ArchRule;
 
 @ArchTag("library-tag")
@@ -15,7 +15,7 @@ public class ComplexTags {
 
     @ArchTag("rules-tag")
     @ArchTest
-    static final ArchRules classWithTags = ArchRules.in(TestClassWithTags.class);
+    static final ArchTests classWithTags = ArchTests.in(TestClassWithTags.class);
 
     @ArchTag("field-tag")
     @ArchTest

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/LibraryWithPrivateTests.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/LibraryWithPrivateTests.java
@@ -1,19 +1,19 @@
 package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 
 @AnalyzeClasses(packages = "some.dummy.package")
 public class LibraryWithPrivateTests {
     @ArchTest
-    private final ArchRules privateRulesField = ArchRules.in(SubRules.class);
+    private final ArchTests privateRulesField = ArchTests.in(SubRules.class);
 
     public static final String PRIVATE_RULES_FIELD_NAME = "privateRulesField";
 
     public static class SubRules {
         @ArchTest
-        private final ArchRules privateRulesField = ArchRules.in(ClassWithPrivateTests.class);
+        private final ArchTests privateRulesField = ArchTests.in(ClassWithPrivateTests.class);
 
         public static final String PRIVATE_RULES_FIELD_NAME = "privateRulesField";
     }

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/SimpleLegacyRuleLibrary.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/SimpleLegacyRuleLibrary.java
@@ -1,18 +1,18 @@
 package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
 import com.tngtech.archunit.junit.testexamples.subtwo.SimpleRules;
 
 @AnalyzeClasses(packages = "some.dummy.package")
-public class SimpleRuleLibrary {
+public class SimpleLegacyRuleLibrary {
     @ArchTest
-    public static final ArchTests rules_one = ArchTests.in(SimpleRules.class);
+    public static final ArchRules rules_one = ArchRules.in(SimpleRules.class);
 
     @ArchTest
-    public static final ArchTests rules_two = ArchTests.in(SimpleRuleField.class);
+    public static final ArchRules rules_two = ArchRules.in(SimpleRuleField.class);
 
     public static final String RULES_ONE_FIELD = "rules_one";
     public static final String RULES_TWO_FIELD = "rules_two";

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithMetaTag.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithMetaTag.java
@@ -1,18 +1,20 @@
 package com.tngtech.archunit.junit.testexamples;
 
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
-import com.tngtech.archunit.junit.ArchTag;
-import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
-import com.tngtech.archunit.lang.ArchRule;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.*;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTag;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @TestClassWithMetaTag.MetaTag
@@ -24,7 +26,7 @@ public class TestClassWithMetaTag {
     public static final ArchRule rule_in_class_with_meta_tag = RuleThatFails.on(UnwantedClass.class);
 
     @ArchTest
-    public static final ArchRules rules_in_class_with_meta_tag = ArchRules.in(SimpleRuleField.class);
+    public static final ArchTests rules_in_class_with_meta_tag = ArchTests.in(SimpleRuleField.class);
 
     @ArchTest
     static void method_in_class_with_meta_tag(JavaClasses classes) {

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithMetaTags.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithMetaTags.java
@@ -1,15 +1,21 @@
 package com.tngtech.archunit.junit.testexamples;
 
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.junit.*;
-import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
-import com.tngtech.archunit.lang.ArchRule;
-
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.*;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTag;
+import com.tngtech.archunit.junit.ArchTags;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @TestClassWithMetaTags.MetaTags
@@ -21,7 +27,7 @@ public class TestClassWithMetaTags {
     public static final ArchRule rule_in_class_with_meta_tags = RuleThatFails.on(UnwantedClass.class);
 
     @ArchTest
-    public static final ArchRules rules_in_class_with_meta_tags = ArchRules.in(SimpleRuleField.class);
+    public static final ArchTests rules_in_class_with_meta_tags = ArchTests.in(SimpleRuleField.class);
 
     @ArchTest
     static void method_in_class_with_meta_tags(JavaClasses classes) {

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithTags.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/TestClassWithTags.java
@@ -2,9 +2,9 @@ package com.tngtech.archunit.junit.testexamples;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTag;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.testexamples.subone.SimpleRuleField;
 import com.tngtech.archunit.lang.ArchRule;
 
@@ -18,7 +18,7 @@ public class TestClassWithTags {
     public static final ArchRule rule_in_class_with_tags = RuleThatFails.on(UnwantedClass.class);
 
     @ArchTest
-    public static final ArchRules rules_in_class_with_tags = ArchRules.in(SimpleRuleField.class);
+    public static final ArchTests rules_in_class_with_tags = ArchTests.in(SimpleRuleField.class);
 
     @ArchTest
     static void method_in_class_with_tags(JavaClasses classes) {

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ignores/IgnoredLibrary.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ignores/IgnoredLibrary.java
@@ -2,22 +2,22 @@ package com.tngtech.archunit.junit.testexamples.ignores;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchIgnore;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.testexamples.subtwo.SimpleRules;
 
 @AnalyzeClasses(packages = "some.dummy.package")
 public class IgnoredLibrary {
 
     @ArchTest
-    static final ArchRules unignored_lib_one = ArchRules.in(IgnoredClass.class);
+    static final ArchTests unignored_lib_one = ArchTests.in(IgnoredClass.class);
 
     @ArchTest
-    static final ArchRules unignored_lib_two = ArchRules.in(IgnoredMethod.class);
+    static final ArchTests unignored_lib_two = ArchTests.in(IgnoredMethod.class);
 
     @ArchTest
     @ArchIgnore
-    static final ArchRules ignored_lib = ArchRules.in(SimpleRules.class);
+    static final ArchTests ignored_lib = ArchTests.in(SimpleRules.class);
 
     public static final String UNIGNORED_LIB_ONE_FIELD = "unignored_lib_one";
     public static final String UNIGNORED_LIB_TWO_FIELD = "unignored_lib_two";

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ignores/MetaIgnoredLibrary.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/ignores/MetaIgnoredLibrary.java
@@ -1,22 +1,22 @@
 package com.tngtech.archunit.junit.testexamples.ignores;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchRules;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
 import com.tngtech.archunit.junit.testexamples.subtwo.SimpleRules;
 
 @AnalyzeClasses(packages = "some.dummy.package")
 public class MetaIgnoredLibrary {
 
     @ArchTest
-    static final ArchRules unignored_lib_one = ArchRules.in(MetaIgnoredClass.class);
+    static final ArchTests unignored_lib_one = ArchTests.in(MetaIgnoredClass.class);
 
     @ArchTest
-    static final ArchRules unignored_lib_two = ArchRules.in(MetaIgnoredMethod.class);
+    static final ArchTests unignored_lib_two = ArchTests.in(MetaIgnoredMethod.class);
 
     @ArchTest
     @ArchIgnoreMetaAnnotation
-    static final ArchRules ignored_lib = ArchRules.in(SimpleRules.class);
+    static final ArchTests ignored_lib = ArchTests.in(SimpleRules.class);
 
     public static final String UNIGNORED_LIB_ONE_FIELD = "unignored_lib_one";
     public static final String UNIGNORED_LIB_TWO_FIELD = "unignored_lib_two";

--- a/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchRules.java
+++ b/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchRules.java
@@ -19,14 +19,21 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * @deprecated Please use {@link ArchTests} instead
+ */
+@Deprecated
 public final class ArchRules {
     private final Class<?> definitionLocation;
 
-    @SuppressWarnings("unchecked")
     private ArchRules(Class<?> definitionLocation) {
         this.definitionLocation = definitionLocation;
     }
 
+    /**
+     * @deprecated Please use {@link ArchTests} instead
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static ArchRules in(Class<?> definitionLocation) {
         return new ArchRules(definitionLocation);

--- a/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchTests.java
+++ b/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.junit;
+
+import com.tngtech.archunit.PublicAPI;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+/**
+ * Includes all {@code @ArchTest} annotated members of another class into this ArchUnit test. For example
+ * <pre>{@code
+ * class MyArchRuleSuite1 {
+ *     @ArchTest
+ *     static final ArchRule suite1Rule1 = classes()...
+ *
+ *     @ArchTest
+ *     static void suite1Rule2(JavaClasses classes) {
+ *         // ...
+ *     }
+ * }
+ *
+ * class MyArchRuleSuite2 {
+ *     @ArchTest
+ *     static final ArchRule suite2Rule1 = classes()...
+ * }
+ *
+ * @AnalyzeClasses(..)
+ * class MyArchitectureTest {
+ *     // includes all @ArchTest members from MyArchRuleSuite1
+ *     @ArchTest
+ *     static final ArchTests includedRules1 = ArchTests.in(MyArchRuleSuite1.class);
+ *
+ *     // includes all @ArchTest members from MyArchRuleSuite2
+ *     @ArchTest
+ *     static final ArchTests includedRules2 = ArchTests.in(MyArchRuleSuite2.class);
+ * }
+ * }</pre>
+ */
+public final class ArchTests {
+    private final Class<?> definitionLocation;
+
+    private ArchTests(Class<?> definitionLocation) {
+        this.definitionLocation = definitionLocation;
+    }
+
+    /**
+     * @param definitionLocation The class whose `@ArchTest` members should be included in this test
+     * @return the {@link ArchTests} of the supplied class
+     */
+    @PublicAPI(usage = ACCESS)
+    public static ArchTests in(Class<?> definitionLocation) {
+        return new ArchTests(definitionLocation);
+    }
+
+    Class<?> getDefinitionLocation() {
+        return definitionLocation;
+    }
+
+    static ArchTests from(Object object) {
+        if (object instanceof ArchRules) {
+            return ArchTests.in(((ArchRules) object).getDefinitionLocation());
+        }
+        return (ArchTests) object;
+    }
+}

--- a/archunit-maven-test/verification/TestResultTest.java
+++ b/archunit-maven-test/verification/TestResultTest.java
@@ -261,13 +261,13 @@ public class TestResultTest {
 
     private static class JUnitSingleTestProvider implements SingleTestProvider {
         private final Class<? extends Annotation> archTestAnnotation;
-        private final Class<?> archRulesClass;
+        private final Class<?> archTestsClass;
 
         @SuppressWarnings("unchecked")
         private JUnitSingleTestProvider() {
             try {
                 this.archTestAnnotation = (Class<? extends Annotation>) Class.forName("com.tngtech.archunit.junit.ArchTest");
-                this.archRulesClass = Class.forName("com.tngtech.archunit.junit.ArchRules");
+                this.archTestsClass = Class.forName("com.tngtech.archunit.junit.ArchTests");
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
@@ -299,15 +299,15 @@ public class TestResultTest {
             if (ArchRule.class.isAssignableFrom(field.getType())) {
                 return Collections.singleton(new SingleTest(field.getDeclaringClass().getName(), field.getName()));
             }
-            if (archRulesClass.isAssignableFrom(field.getType())) {
+            if (archTestsClass.isAssignableFrom(field.getType())) {
                 return getTestsFrom(getValue(field, null));
             }
             throw new IllegalStateException("Unknown @ArchTest: " + field);
         }
 
-        private Set<SingleTest> getTestsFrom(Object archRules) {
+        private Set<SingleTest> getTestsFrom(Object archTests) {
             Set<SingleTest> result = new HashSet<>();
-            Class<?> definitionLocation = getValue("definitionLocation", archRules);
+            Class<?> definitionLocation = getValue("definitionLocation", archTests);
             result.addAll(getTestFields(asList(definitionLocation.getDeclaredFields())));
             result.addAll(getTestMethods(asList(definitionLocation.getDeclaredMethods())));
             return result;

--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -186,14 +186,14 @@ public class PersistenceRules {
 public class ArchitectureTest {
 
     @ArchTest
-    public static final ArchRules serviceRules = ArchRules.in(ServiceRules.class);
+    static final ArchTests serviceRules = ArchTests.in(ServiceRules.class);
 
     @ArchTest
-    public static final ArchRules persistenceRules = ArchRules.in(PersistenceRules.class);
+    static final ArchTests persistenceRules = ArchTests.in(PersistenceRules.class);
 
 }
 ----
 
-The runner will evaluate all rules within `ServiceRules` and `PersistenceRules` against
-the classes declared at `ArchitectureTest`. This also allows an easy reuse of a rule library
-in different projects or modules.
+The runner will include all `@ArchTest` annotated members within `ServiceRules` and `PersistenceRules` and evaluate
+them against the classes declared within `@AnalyzeClasses` on `ArchitectureTest`.
+This also allows an easy reuse of a rule library in different projects or modules.


### PR DESCRIPTION
The term `ArchRules` is misleading, because it suggests that the class collects instances of `ArchRule`, while in fact it looks for members annotated with `@ArchTest`. This becomes particular clear, if you look at method declarations like `@ArchTest static void rule_method(JavaClasses classes) {..}`. I have thus introduced `ArchTests.in(someClass)` as a new version that makes this clearer (including some Javadoc this time) and kept the old `ArchRules` as a deprecated version for now to be backwards compatible.
I have duplicated quite some code (like whole test classes) and not unified much of the additional complexity by having `ArchTests` as well as `ArchRules`, since this is only temporary and we can kick it out in the near future.

Resolves: #525

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>