### PR TITLE
Add library rule to check proxy bypasses

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/ProxyRulesTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/ProxyRulesTest.java
@@ -1,0 +1,23 @@
+package com.tngtech.archunit.exampletest.junit4;
+
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import com.tngtech.archunit.example.layers.service.Async;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.library.ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with;
+
+@Category(Example.class)
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packagesOf = ClassViolatingCodingRules.class)
+public class ProxyRulesTest {
+
+    @ArchTest
+    static ArchRule no_bypass_of_proxy_logic =
+            no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Async.class);
+
+}

--- a/archunit-example/example-junit4/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
+++ b/archunit-example/example-junit4/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
@@ -24,3 +24,4 @@ Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> calls 
 Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceType.$values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules.illegallyUseEntityManager()> calls method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules$MyEntityManager.persist(java.lang.Object)> in (ServiceViolatingDaoRules.java:27)
+Method <com.tngtech.archunit.example.layers.service.ServiceViolatingProxyRules.executeAsync()> is annotated with <com.tngtech.archunit.example.layers.service.Async> in (ServiceViolatingProxyRules.java:0)

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/ProxyRulesTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/ProxyRulesTest.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.exampletest.junit5;
+
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import com.tngtech.archunit.example.layers.service.Async;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTag;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.library.ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with;
+
+@ArchTag("example")
+@AnalyzeClasses(packagesOf = ClassViolatingCodingRules.class)
+public class ProxyRulesTest {
+
+    @ArchTest
+    static ArchRule no_bypass_of_proxy_logic =
+            no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Async.class);
+
+}

--- a/archunit-example/example-junit5/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
+++ b/archunit-example/example-junit5/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
@@ -24,3 +24,4 @@ Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> calls 
 Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceType.$values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules.illegallyUseEntityManager()> calls method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules$MyEntityManager.persist(java.lang.Object)> in (ServiceViolatingDaoRules.java:27)
+Method <com.tngtech.archunit.example.layers.service.ServiceViolatingProxyRules.executeAsync()> is annotated with <com.tngtech.archunit.example.layers.service.Async> in (ServiceViolatingProxyRules.java:0)

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/Async.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/Async.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.example.layers.service;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+public @interface Async {
+}

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/ServiceViolatingProxyRules.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/ServiceViolatingProxyRules.java
@@ -1,0 +1,13 @@
+package com.tngtech.archunit.example.layers.service;
+
+@SuppressWarnings("unused")
+public class ServiceViolatingProxyRules {
+    public void methodBypassingAsyncProxy() {
+        // Do some extra stuff, then
+        executeAsync();
+    }
+
+    @Async
+    public void executeAsync() {
+    }
+}

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/ProxyRulesTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/ProxyRulesTest.java
@@ -1,0 +1,22 @@
+package com.tngtech.archunit.exampletest;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.example.layers.ClassViolatingCodingRules;
+import com.tngtech.archunit.example.layers.service.Async;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.tngtech.archunit.library.ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with;
+
+@Category(Example.class)
+public class ProxyRulesTest {
+
+    private final JavaClasses classes = new ClassFileImporter().importPackagesOf(ClassViolatingCodingRules.class);
+
+    @Test
+    public void no_bypass_of_proxy_logic() {
+        no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Async.class)
+                .check(classes);
+    }
+}

--- a/archunit-example/example-plain/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
+++ b/archunit-example/example-plain/src/test/resources/frozen/a81a2b54-5a18-4145-b544-7a580aba0425
@@ -24,3 +24,4 @@ Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> calls 
 Method <com.tngtech.archunit.example.layers.service.ServiceType.values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceType.$values()> has return type <[Lcom.tngtech.archunit.example.layers.service.ServiceType;> in (ServiceType.java:0)
 Method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules.illegallyUseEntityManager()> calls method <com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules$MyEntityManager.persist(java.lang.Object)> in (ServiceViolatingDaoRules.java:27)
+Method <com.tngtech.archunit.example.layers.service.ServiceViolatingProxyRules.executeAsync()> is annotated with <com.tngtech.archunit.example.layers.service.Async> in (ServiceViolatingProxyRules.java:0)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -97,12 +97,14 @@ import com.tngtech.archunit.example.layers.persistence.layerviolation.DaoCalling
 import com.tngtech.archunit.example.layers.persistence.second.dao.OtherDao;
 import com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa;
 import com.tngtech.archunit.example.layers.security.Secured;
+import com.tngtech.archunit.example.layers.service.Async;
 import com.tngtech.archunit.example.layers.service.ComplexServiceAnnotation;
 import com.tngtech.archunit.example.layers.service.ProxiedConnection;
 import com.tngtech.archunit.example.layers.service.ServiceHelper;
 import com.tngtech.archunit.example.layers.service.ServiceInterface;
 import com.tngtech.archunit.example.layers.service.ServiceViolatingDaoRules;
 import com.tngtech.archunit.example.layers.service.ServiceViolatingLayerRules;
+import com.tngtech.archunit.example.layers.service.ServiceViolatingProxyRules;
 import com.tngtech.archunit.example.layers.service.SpecialServiceHelper;
 import com.tngtech.archunit.example.layers.service.impl.ServiceImplementation;
 import com.tngtech.archunit.example.layers.service.impl.SomeInterfacePlacedInTheWrongPackage;
@@ -1126,6 +1128,25 @@ class ExamplesIntegrationTest {
                         .withReturnType(Customer.class))
                 .by(method(Order.class, "report")
                         .withParameter(Address.class))
+
+                .toDynamicTests();
+    }
+
+    @TestFactory
+    Stream<DynamicTest> ProxyRulesTest() {
+        return ExpectedTestFailures
+                .forTests(
+                        com.tngtech.archunit.exampletest.ProxyRulesTest.class,
+                        com.tngtech.archunit.exampletest.junit4.ProxyRulesTest.class,
+                        com.tngtech.archunit.exampletest.junit5.ProxyRulesTest.class)
+
+                .ofRule(String.format(
+                        "no classes should directly call other methods declared in the same class that are annotated with @%s, "
+                                + "because it bypasses the proxy mechanism", Async.class.getSimpleName()))
+
+                .by(callFromMethod(ServiceViolatingProxyRules.class, "methodBypassingAsyncProxy")
+                        .toMethod(ServiceViolatingProxyRules.class, "executeAsync")
+                        .inLine(7))
 
                 .toDynamicTests();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.library;
+
+import java.lang.annotation.Annotation;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@PublicAPI(usage = ACCESS)
+public final class ProxyRules {
+    private ProxyRules() {
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchRule no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class<? extends Annotation> annotationType) {
+        return no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(are(annotatedWith(annotationType)));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchRule no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(DescribedPredicate<? super MethodCallTarget> predicate) {
+        return noClasses().should(directly_call_other_methods_declared_in_the_same_class_that(predicate))
+                .because("it bypasses the proxy mechanism");
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class<? extends Annotation> annotationType) {
+        return directly_call_other_methods_declared_in_the_same_class_that(are(annotatedWith(annotationType)));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that(final DescribedPredicate<? super MethodCallTarget> predicate) {
+        return new ArchCondition<JavaClass>("directly call other methods declared in the same class that " + predicate.getDescription()) {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                for (JavaMethodCall call : javaClass.getMethodCallsFromSelf()) {
+                    boolean satisfied = call.getOriginOwner().equals(call.getTargetOwner()) && predicate.apply(call.getTarget());
+                    events.add(new SimpleConditionEvent(call, satisfied, call.getDescription()));
+                }
+            }
+        };
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -72,6 +72,7 @@ import static com.tngtech.archunit.lang.conditions.ArchConditions.notHaveModifie
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
@@ -1718,7 +1719,7 @@ public class ClassesShouldTest {
     public void onlyCall_should_report_success_if_targets_are_non_resolvable(ArchRule rule, Class<?> classCallingUnresolvableTarget) {
         ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
 
-        assertThat(rule).checking(importClasses(classCallingUnresolvableTarget)).hasNoViolation();
+        assertThatRule(rule).checking(importClasses(classCallingUnresolvableTarget)).hasNoViolation();
     }
 
     static String locationPattern(Class<?> clazz) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
@@ -12,6 +12,7 @@ import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.RuntimeRet
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
+import com.tngtech.archunit.lang.syntax.elements.testclasses.ClassWithPublicAndPrivateConstructor;
 import com.tngtech.archunit.lang.syntax.elements.testclasses.SomeClass;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -34,6 +35,7 @@ import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.contai
 import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.locationPattern;
 import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.singleLineFailureReportOf;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
@@ -754,12 +756,13 @@ public class GivenClassShouldTest {
     @Test
     @UseDataProvider("classes_should_have_only_private_constructor_rules")
     public void classes_should_have_only_private_constructor(ArchRule rule) {
-        assertThat(rule).hasDescriptionContaining("classes should have only private constructors");
-        assertThat(rule).checking(importClasses(ClassWithPrivateConstructors.class))
+        assertThatRule(rule).hasDescriptionContaining("classes should have only private constructors");
+        assertThatRule(rule).checking(importClasses(ClassWithPrivateConstructors.class))
                 .hasNoViolation();
-        assertThat(rule).checking(importClasses(ClassWithPublicAndPrivateConstructor.class))
+        assertThatRule(rule).checking(importClasses(ClassWithPublicAndPrivateConstructor.class))
                 .hasOnlyViolations(String.format("Constructor <%s.<init>(%s)> is not private in (%s.java:%d)",
-                        ClassWithPublicAndPrivateConstructor.class.getName(), String.class.getName(), getClass().getSimpleName(), 1538));
+                        ClassWithPublicAndPrivateConstructor.class.getName(), String.class.getName(),
+                        ClassWithPublicAndPrivateConstructor.class.getSimpleName(), 5));
     }
 
     @DataProvider
@@ -1461,10 +1464,6 @@ public class GivenClassShouldTest {
         assertThat(result.hasViolation()).as("result has violation").isFalse();
     }
 
-    private static void assertViolation(EvaluationResult result) {
-        assertThat(result.hasViolation()).as("result has violation").isTrue();
-    }
-
     private static class ClassWithField {
         String field;
     }
@@ -1530,16 +1529,6 @@ public class GivenClassShouldTest {
         }
 
         private ClassWithPrivateConstructors(String foo) {
-        }
-    }
-
-    @SuppressWarnings({"unused", "WeakerAccess"})
-    private static class ClassWithPublicAndPrivateConstructor {
-        public ClassWithPublicAndPrivateConstructor(String s) {
-        }
-
-        private ClassWithPublicAndPrivateConstructor(Integer i) {
-            this(i.toString());
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/ClassWithPublicAndPrivateConstructor.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/testclasses/ClassWithPublicAndPrivateConstructor.java
@@ -1,0 +1,11 @@
+package com.tngtech.archunit.lang.syntax.elements.testclasses;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class ClassWithPublicAndPrivateConstructor {
+    public ClassWithPublicAndPrivateConstructor(String s) {
+    }
+
+    private ClassWithPublicAndPrivateConstructor(Integer i) {
+        this(i.toString());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/ProxyRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/ProxyRulesTest.java
@@ -1,0 +1,82 @@
+package com.tngtech.archunit.library;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.ProxyRules.directly_call_other_methods_declared_in_the_same_class_that;
+import static com.tngtech.archunit.library.ProxyRules.directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with;
+import static com.tngtech.archunit.library.ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that;
+import static com.tngtech.archunit.library.ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static java.util.regex.Pattern.quote;
+
+@RunWith(DataProviderRunner.class)
+public class ProxyRulesTest {
+
+    @DataProvider
+    public static Object[][] call_own_method_with_specific_annotation_rules() {
+        return $$(
+                $(no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(ProxyAnnotation.class), String.format(
+                        "no classes should directly call other methods declared in the same class that are annotated with @%s, because it bypasses the proxy mechanism",
+                        ProxyAnnotation.class.getSimpleName())),
+                $(noClasses().should(directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(ProxyAnnotation.class)), String.format(
+                        "no classes should directly call other methods declared in the same class that are annotated with @%s",
+                        ProxyAnnotation.class.getSimpleName())),
+                $(no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(have(name("selfProxied"))),
+                        "no classes should directly call other methods declared in the same class that have name 'selfProxied', because it bypasses the proxy mechanism"),
+                $(noClasses().should(directly_call_other_methods_declared_in_the_same_class_that(have(name("selfProxied")))),
+                        "no classes should directly call other methods declared in the same class that have name 'selfProxied'")
+        );
+    }
+
+    @Test
+    @UseDataProvider("call_own_method_with_specific_annotation_rules")
+    public void detects_direct_self_call_to_method_annotated_with_specific_annotation(ArchRule rule, String expectedDescription) {
+        class OtherClass {
+            @ProxyAnnotation
+            void otherProxied() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            void evil() {
+                selfProxied();
+            }
+
+            void okay() {
+                new OtherClass().otherProxied();
+                nonProxied();
+            }
+
+            void nonProxied() {
+            }
+
+            @ProxyAnnotation
+            void selfProxied() {
+            }
+        }
+
+        assertThatRule(rule)
+                .hasDescriptionContaining(expectedDescription)
+                .checking(new ClassFileImporter().importClasses(SomeClass.class, OtherClass.class))
+                .hasOnlyOneViolationMatching(String.format(".*%s.* calls method .*%s.*",
+                        quoteMethod(SomeClass.class, "evil"), quoteMethod(SomeClass.class, "selfProxied")));
+    }
+
+    private String quoteMethod(Class<?> owner, String methodName) {
+        return quote(owner.getSimpleName() + "." + methodName + "()");
+    }
+
+    private @interface ProxyAnnotation {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
@@ -42,6 +42,7 @@ import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.library.freeze.FreezingArchRule.freeze;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(DataProviderRunner.class)
@@ -85,7 +86,7 @@ public class FreezingArchRuleTest {
 
         rule = rule.as("new description");
 
-        assertThat(rule)
+        assertThatRule(rule)
                 .hasDescriptionContaining("new description");
     }
 
@@ -107,7 +108,7 @@ public class FreezingArchRuleTest {
         TestViolationStore violationStore = new TestViolationStore();
         ArchRule frozen = freeze(input).persistIn(violationStore);
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasNoViolation();
 
@@ -136,7 +137,7 @@ public class FreezingArchRuleTest {
         ArchRule anotherViolation = rule("some description").withViolations("first violation", "second violation").create();
         ArchRule frozenWithNewViolation = freeze(anotherViolation).persistIn(violationStore);
 
-        assertThat(frozenWithNewViolation)
+        assertThatRule(frozenWithNewViolation)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations("second violation");
     }
@@ -154,7 +155,7 @@ public class FreezingArchRuleTest {
                 new ViolatedEvent("first violation2", "second violation2")).create();
         ArchRule frozenWithNewViolation = freeze(anotherViolation).persistIn(violationStore);
 
-        assertThat(frozenWithNewViolation)
+        assertThatRule(frozenWithNewViolation)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations("third violation1");
     }
@@ -169,14 +170,14 @@ public class FreezingArchRuleTest {
         ArchRule secondViolationSolved = rule("some description").withViolations("first violation").create();
         ArchRule frozenWithLessViolation = freeze(secondViolationSolved).persistIn(violationStore);
 
-        assertThat(frozenWithLessViolation)
+        assertThatRule(frozenWithLessViolation)
                 .checking(importClasses(getClass()))
                 .hasNoViolation();
 
         ArchRule secondViolationIsBack = rule("some description").withViolations("first violation", secondViolation).create();
         ArchRule frozenWithOldViolationBack = freeze(secondViolationIsBack).persistIn(violationStore);
 
-        assertThat(frozenWithOldViolationBack)
+        assertThatRule(frozenWithOldViolationBack)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations(secondViolation);
     }
@@ -201,7 +202,7 @@ public class FreezingArchRuleTest {
                     }
                 });
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations("and new");
     }
@@ -223,7 +224,7 @@ public class FreezingArchRuleTest {
                     }
                 });
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasViolations(1)
                 .hasAnyViolationOf("violation", "equivalent one");
@@ -259,11 +260,11 @@ public class FreezingArchRuleTest {
                 .withViolations("some violation");
 
         ArchRule storedRule = freeze(ruleCreator.withStringReplace("${lineSeparator}", lineSeparatorOnFreeze).create());
-        assertThat(storedRule).checking(importClasses(getClass())).hasNoViolation();
+        assertThatRule(storedRule).checking(importClasses(getClass())).hasNoViolation();
 
         ArchRule ruleToCheck = ruleCreator.withStringReplace("${lineSeparator}", lineSeparatorOnCheck)
                 .withViolations("some violation", "new").create();
-        assertThat(freeze(ruleToCheck))
+        assertThatRule(freeze(ruleToCheck))
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations("new");
     }
@@ -286,7 +287,7 @@ public class FreezingArchRuleTest {
         createFrozen(violationStore, storedRule);
 
         ArchRule ruleToCheck = ruleCreator.withStringReplace("${lineSeparator}", lineSeparatorOnCheck).create();
-        assertThat(freeze(ruleToCheck).persistIn(violationStore))
+        assertThatRule(freeze(ruleToCheck).persistIn(violationStore))
                 .checking(importClasses(getClass()))
                 .hasNoViolation();
     }
@@ -326,21 +327,21 @@ public class FreezingArchRuleTest {
         FreezingArchRule frozen = freeze(rule("some description")
                 .withViolations(frozenViolations).create());
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasNoViolation();
 
         frozen = freeze(rule("some description")
                 .withViolations(frozenViolations[0], "third violation").create());
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations("third violation");
 
         frozen = freeze(rule("some description")
                 .withViolations(frozenViolations[0], frozenViolations[1], "third violation").create());
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations(frozenViolations[1], "third violation");
     }
@@ -354,9 +355,9 @@ public class FreezingArchRuleTest {
 
         ArchConfiguration.get().setProperty(ALLOW_STORE_CREATION_PROPERTY_NAME, "false");
         RuleCreator second = rule("second, store exists");
-        assertThat(freeze(second.withViolations("first").create())).checking(importClasses(getClass()))
+        assertThatRule(freeze(second.withViolations("first").create())).checking(importClasses(getClass()))
                 .hasNoViolation();
-        assertThat(freeze(second.withViolations("first", "second").create())).checking(importClasses(getClass()))
+        assertThatRule(freeze(second.withViolations("first", "second").create())).checking(importClasses(getClass()))
                 .hasOnlyViolations("second");
     }
 
@@ -373,7 +374,7 @@ public class FreezingArchRuleTest {
                 .withViolations("a different but counted same", "a nother too", "b too", "c also", onlyOneDifferentLineByFirstLetter).create())
                 .persistIn(violationStore);
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations(onlyOneDifferentLineByFirstLetter);
     }
@@ -408,7 +409,7 @@ public class FreezingArchRuleTest {
                 .withViolations(onlyLineNumberChanged, locationClassDoesNotMatch, descriptionDoesNotMatch, lambdaWithDifferentNumber).create())
                 .persistIn(violationStore);
 
-        assertThat(updatedViolations)
+        assertThatRule(updatedViolations)
                 .checking(importClasses(getClass()))
                 .hasOnlyViolations(locationClassDoesNotMatch, descriptionDoesNotMatch);
     }
@@ -471,7 +472,7 @@ public class FreezingArchRuleTest {
     private void createFrozen(TestViolationStore violationStore, ArchRule rule) {
         FreezingArchRule frozen = freeze(rule).persistIn(violationStore);
 
-        assertThat(frozen)
+        assertThatRule(frozen)
                 .checking(importClasses(getClass()))
                 .hasNoViolation();
     }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -84,7 +84,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new ConditionEventsAssertion(events);
     }
 
-    public static ArchRuleAssertion assertThat(ArchRule rule) {
+    public static ArchRuleAssertion assertThatRule(ArchRule rule) {
         return new ArchRuleAssertion(rule);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
@@ -6,6 +6,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
 
@@ -27,6 +28,14 @@ public class ArchRuleCheckAssertion {
         }
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public ArchRuleCheckAssertion hasOnlyOneViolationMatching(String regex) {
+        assertThat(getOnlyElement(evaluationResult.getFailureReport().getDetails())).matches(regex);
+        assertThat(error.get().getMessage()).containsPattern(regex);
+        return this;
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public ArchRuleCheckAssertion hasOnlyViolations(String... violations) {
         assertThat(evaluationResult.getFailureReport().getDetails()).containsOnly(violations);
         for (String violation : violations) {
@@ -35,6 +44,7 @@ public class ArchRuleCheckAssertion {
         return this;
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     public ArchRuleCheckAssertion hasAnyViolationOf(String... violations) {
         assertThat(evaluationResult.getFailureReport().getDetails()).containsAnyOf(violations);
         assertThat(error.get().getMessage()).containsPattern(Joiner.on("|").join(violations));


### PR DESCRIPTION
In frameworks like Spring there often are annotations that cause the framework to proxy specific classes and add some AOP behavior. For example `@Transactional` in Spring denoting a method to create/participate in a transaction on enter and commit it on leaving the method. This only works though, if all callers really call this method on the proxy and not the plain class itself (as long as it isn't weaved into the bytecode). It is a common error to call one of these decorated methods from within another method in the same class, thus bypassing the proxy.
I've added a new library class `ProxyRules` to encapsulate some rules that help with ensuring correct calls to proxies. At the moment it offers rules / conditions to check for self method calls to methods annotated with a certain annotation or more generally matching some predicate.

Issue: #209

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>