### PR TITLE
Add generic interfaces

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
@@ -1,10 +1,11 @@
 package com.tngtech.archunit.example.layers.service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 
 import com.tngtech.archunit.example.layers.controller.SomeUtility;
 import com.tngtech.archunit.example.layers.controller.one.SomeEnum;
 
-public class SpecialServiceHelper extends ServiceHelper<SomeUtility, HashMap<?, Set<? super SomeEnum>>> {
+public abstract class SpecialServiceHelper extends ServiceHelper<SomeUtility, HashMap<?, Set<? super SomeEnum>>> implements List<Set<? super SomeUtility>> {
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -175,6 +175,7 @@ import static com.tngtech.archunit.testutils.ExpectedAccess.callFromStaticInitia
 import static com.tngtech.archunit.testutils.ExpectedDependency.annotatedClass;
 import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterface;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclass;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
 import static com.tngtech.archunit.testutils.ExpectedDependency.method;
@@ -781,6 +782,7 @@ class ExamplesIntegrationTest {
                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
+                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -842,6 +844,7 @@ class ExamplesIntegrationTest {
                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
+                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -913,6 +916,7 @@ class ExamplesIntegrationTest {
                                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
                                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
                                 .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
+                                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -29,8 +29,12 @@ public class ExpectedDependency implements ExpectedRelation {
         return new TypeParameterCreator(clazz, typeParameterName);
     }
 
-    public static GenericSuperclassTypeArgumentCreator genericSuperclass(Class<?> clazz, Class<?> genericSuperclassErasure) {
-        return new GenericSuperclassTypeArgumentCreator(clazz, genericSuperclassErasure);
+    public static GenericSupertypeTypeArgumentCreator genericSuperclass(Class<?> clazz, Class<?> genericSuperclassErasure) {
+        return new GenericSupertypeTypeArgumentCreator(clazz, "superclass", genericSuperclassErasure);
+    }
+
+    public static GenericSupertypeTypeArgumentCreator genericInterface(Class<?> clazz, Class<?> genericInterfaceErasure) {
+        return new GenericSupertypeTypeArgumentCreator(clazz, "interface", genericInterfaceErasure);
     }
 
     public static AnnotationDependencyCreator annotatedClass(Class<?> clazz) {
@@ -108,19 +112,21 @@ public class ExpectedDependency implements ExpectedRelation {
         }
     }
 
-    public static class GenericSuperclassTypeArgumentCreator {
+    public static class GenericSupertypeTypeArgumentCreator {
         private final Class<?> childClass;
-        private final Class<?> genericSuperclassErasure;
+        private final Class<?> genericSupertypeErasure;
+        private final String genericTypeDescription;
 
-        private GenericSuperclassTypeArgumentCreator(Class<?> childClass, Class<?> genericSuperclassErasure) {
+        private GenericSupertypeTypeArgumentCreator(Class<?> childClass, String genericTypeDescription, Class<?> genericSupertypeErasure) {
             this.childClass = childClass;
-            this.genericSuperclassErasure = genericSuperclassErasure;
+            this.genericSupertypeErasure = genericSupertypeErasure;
+            this.genericTypeDescription = genericTypeDescription;
         }
 
         public ExpectedDependency dependingOn(Class<?> superclassTypeArgumentDependency) {
             return new ExpectedDependency(childClass, superclassTypeArgumentDependency,
                     getDependencyPattern(childClass.getName(),
-                            "has generic superclass <" + genericSuperclassErasure.getName() + "> with type argument depending on",
+                            "has generic " + genericTypeDescription + " <" + genericSupertypeErasure.getName() + "> with type argument depending on",
                             superclassTypeArgumentDependency.getName(),
                             0));
         }

--- a/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
@@ -140,6 +140,11 @@ public abstract class Optional<T> {
         public boolean equals(Object obj) {
             return obj instanceof Absent;
         }
+
+        @Override
+        public String toString() {
+            return Optional.class.getSimpleName() + ".absent()";
+        }
     }
 
     private static class Present<T> extends Optional<T> {
@@ -209,6 +214,11 @@ public abstract class Optional<T> {
             }
             final Present<?> other = (Present<?>) obj;
             return Objects.equals(this.object, other.object);
+        }
+
+        @Override
+        public String toString() {
+            return Optional.class.getSimpleName() + ".of(" + object + ")";
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -145,7 +145,15 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
     }
 
     static Set<Dependency> tryCreateFromGenericSuperclassTypeArguments(JavaClass originClass, JavaType superclass, JavaClass typeArgumentDependency) {
-        String dependencyType = "has generic superclass " + bracketFormat(superclass.getName()) + " with type argument depending on";
+        return createGenericDependency(originClass, "superclass", superclass, typeArgumentDependency);
+    }
+
+    static Set<Dependency> tryCreateFromGenericInterfaceTypeArgument(JavaClass originClass, JavaType genericInterface, JavaClass typeArgumentDependency) {
+        return createGenericDependency(originClass, "interface", genericInterface, typeArgumentDependency);
+    }
+
+    private static Set<Dependency> createGenericDependency(JavaClass originClass, String genericTypeDescription, JavaType genericSuperType, JavaClass typeArgumentDependency) {
+        String dependencyType = "has generic " + genericTypeDescription + " " + bracketFormat(genericSuperType.getName()) + " with type argument depending on";
         return tryCreateDependency(originClass, originClass.getDescription(), dependencyType, typeArgumentDependency, originClass.getSourceCodeLocation());
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -82,6 +82,10 @@ public class DomainObjectCreationContext {
         javaClass.completeGenericSuperclassFrom(importContext);
     }
 
+    public static void completeGenericInterfaces(JavaClass javaClass, ImportContext importContext) {
+        javaClass.completeGenericInterfacesFrom(importContext);
+    }
+
     public static void completeMembers(JavaClass javaClass, ImportContext importContext) {
         javaClass.completeMembers(importContext);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -28,6 +28,8 @@ public interface ImportContext {
 
     Optional<JavaType> createGenericSuperclass(JavaClass owner);
 
+    Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner);
+
     Set<JavaClass> createInterfaces(JavaClass owner);
 
     List<JavaTypeVariable<JavaClass>> createTypeParameters(JavaClass owner);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -88,15 +88,15 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         }
     });
     private final Set<JavaClass> interfaces = new HashSet<>();
-    private final Supplier<Set<JavaClass>> allInterfaces = Suppliers.memoize(new Supplier<Set<JavaClass>>() {
+    private final Supplier<Set<JavaClass>> allRawInterfaces = Suppliers.memoize(new Supplier<Set<JavaClass>>() {
         @Override
         public Set<JavaClass> get() {
             ImmutableSet.Builder<JavaClass> result = ImmutableSet.builder();
             for (JavaClass i : interfaces) {
                 result.add(i);
-                result.addAll(i.getAllInterfaces());
+                result.addAll(i.getAllRawInterfaces());
             }
-            result.addAll(superclass.getAllInterfaces());
+            result.addAll(superclass.getAllRawInterfaces());
             return result.build();
         }
     });
@@ -708,13 +708,13 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     }
 
     @PublicAPI(usage = ACCESS)
-    public Set<JavaClass> getInterfaces() {
+    public Set<JavaClass> getRawInterfaces() {
         return interfaces;
     }
 
     @PublicAPI(usage = ACCESS)
-    public Set<JavaClass> getAllInterfaces() {
-        return allInterfaces.get();
+    public Set<JavaClass> getAllRawInterfaces() {
+        return allRawInterfaces.get();
     }
 
     /**
@@ -730,7 +730,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         return ImmutableSet.<JavaClass>builder()
                 .add(this)
                 .addAll(getAllRawSuperclasses())
-                .addAll(getAllInterfaces())
+                .addAll(getAllRawInterfaces())
                 .build();
     }
 
@@ -1191,7 +1191,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     @PublicAPI(usage = ACCESS)
     public boolean isAssignableTo(DescribedPredicate<? super JavaClass> predicate) {
         List<JavaClass> possibleTargets = ImmutableList.<JavaClass>builder()
-                .addAll(getClassHierarchy()).addAll(getAllInterfaces()).build();
+                .addAll(getClassHierarchy()).addAll(getAllRawInterfaces()).build();
 
         return anyMatches(possibleTargets, predicate);
     }
@@ -1341,8 +1341,8 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
             return type.or(rawType);
         }
 
-        Set<JavaClass> getAllInterfaces() {
-            return rawType.isPresent() ? rawType.get().getAllInterfaces() : Collections.<JavaClass>emptySet();
+        Set<JavaClass> getAllRawInterfaces() {
+            return rawType.isPresent() ? rawType.get().getAllRawInterfaces() : Collections.<JavaClass>emptySet();
         }
 
         Superclass withRawType(JavaClass newRawType) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.PublicAPI;
@@ -50,6 +51,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.ClassLoaders.getCurrentClassLoader;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.base.Guava.toGuava;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_SIMPLE_NAME;
 import static com.tngtech.archunit.core.domain.JavaModifier.ENUM;
 import static com.tngtech.archunit.core.domain.JavaType.Functions.TO_ERASURE;
@@ -87,12 +89,12 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
             return result.build();
         }
     });
-    private final Set<JavaClass> interfaces = new HashSet<>();
+    private Interfaces interfaces = Interfaces.EMPTY;
     private final Supplier<Set<JavaClass>> allRawInterfaces = Suppliers.memoize(new Supplier<Set<JavaClass>>() {
         @Override
         public Set<JavaClass> get() {
             ImmutableSet.Builder<JavaClass> result = ImmutableSet.builder();
-            for (JavaClass i : interfaces) {
+            for (JavaClass i : interfaces.getRaw()) {
                 result.add(i);
                 result.addAll(i.getAllRawInterfaces());
             }
@@ -708,8 +710,13 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<JavaType> getInterfaces() {
+        return interfaces.get();
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<JavaClass> getRawInterfaces() {
-        return interfaces;
+        return interfaces.getRaw();
     }
 
     @PublicAPI(usage = ACCESS)
@@ -1233,10 +1240,11 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
     }
 
     private void completeInterfacesFrom(ImportContext context) {
-        interfaces.addAll(context.createInterfaces(this));
-        for (JavaClass i : interfaces) {
+        Set<JavaClass> rawInterfaces = context.createInterfaces(this);
+        for (JavaClass i : rawInterfaces) {
             i.subclasses.add(this);
         }
+        this.interfaces = this.interfaces.withRawTypes(rawInterfaces);
     }
 
     void completeEnclosingClassFrom(ImportContext context) {
@@ -1255,6 +1263,14 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
             superclass = superclass.withGenericType(genericSuperclass.get());
         }
         completionProcess.markGenericSuperclassComplete();
+    }
+
+    void completeGenericInterfacesFrom(ImportContext context) {
+        Optional<Set<JavaType>> genericInterfaces = context.createGenericInterfaces(this);
+        if (genericInterfaces.isPresent()) {
+            interfaces = interfaces.withGenericTypes(genericInterfaces.get());
+        }
+        completionProcess.markGenericInterfacesComplete();
     }
 
     void completeMembers(final ImportContext context) {
@@ -1354,11 +1370,42 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
         }
     }
 
+    private static class Interfaces {
+        static final Interfaces EMPTY = new Interfaces(Collections.<JavaType>emptySet());
+
+        private final Set<JavaClass> rawTypes;
+        private final Set<JavaType> types;
+
+        private Interfaces(Set<JavaType> types) {
+            this.rawTypes = FluentIterable.from(types).transform(toGuava(TO_ERASURE)).toSet();
+            this.types = ImmutableSet.copyOf(types);
+        }
+
+        Set<JavaClass> getRaw() {
+            return rawTypes;
+        }
+
+        Set<JavaType> get() {
+            return types;
+        }
+
+        // Set is covariant, so the cast is safe
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Interfaces withRawTypes(Set<JavaClass> rawTypes) {
+            return new Interfaces((Set) rawTypes);
+        }
+
+        Interfaces withGenericTypes(Set<JavaType> genericTypes) {
+            return new Interfaces(genericTypes);
+        }
+    }
+
     private static class CompletionProcess {
         private boolean classHierarchyComplete = false;
         private boolean enclosingClassComplete = false;
         private boolean typeParametersComplete = false;
         private boolean genericSuperclassComplete = false;
+        private boolean genericInterfacesComplete = false;
         private boolean membersComplete = false;
         private boolean annotationsComplete = false;
         private boolean dependenciesComplete = false;
@@ -1371,6 +1418,7 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
                     && enclosingClassComplete
                     && typeParametersComplete
                     && genericSuperclassComplete
+                    && genericInterfacesComplete
                     && membersComplete
                     && annotationsComplete
                     && dependenciesComplete;
@@ -1390,6 +1438,10 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
 
         public void markGenericSuperclassComplete() {
             this.genericSuperclassComplete = true;
+        }
+
+        public void markGenericInterfacesComplete() {
+            this.genericInterfacesComplete = true;
         }
 
         public void markMembersComplete() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -73,7 +73,7 @@ class JavaClassDependencies {
 
     private Set<Dependency> inheritanceDependenciesFromSelf() {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
-        for (JavaClass supertype : FluentIterable.from(javaClass.getInterfaces()).append(javaClass.getRawSuperclass().asSet())) {
+        for (JavaClass supertype : FluentIterable.from(javaClass.getRawInterfaces()).append(javaClass.getRawSuperclass().asSet())) {
             result.add(Dependency.fromInheritance(javaClass, supertype));
         }
         result.addAll(genericSuperclassTypeArgumentDependencies());

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -25,6 +25,7 @@ import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.core.domain.JavaAnnotation.DefaultParameterVisitor;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 
+import static com.google.common.base.Predicates.instanceOf;
 import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.Iterables.concat;
 import static java.util.Collections.emptySet;
@@ -77,6 +78,7 @@ class JavaClassDependencies {
             result.add(Dependency.fromInheritance(javaClass, supertype));
         }
         result.addAll(genericSuperclassTypeArgumentDependencies());
+        result.addAll(genericInterfaceTypeArgumentDependencies());
         return result.build();
     }
 
@@ -92,6 +94,23 @@ class JavaClassDependencies {
             result.addAll(Dependency.tryCreateFromGenericSuperclassTypeArguments(javaClass, genericSuperclass, superclassTypeArgumentDependency));
         }
         return result.build();
+    }
+
+    private Set<Dependency> genericInterfaceTypeArgumentDependencies() {
+        ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
+        for (JavaParameterizedType genericInterface : getGenericInterfacesOf(javaClass)) {
+            List<JavaType> actualTypeArguments = genericInterface.getActualTypeArguments();
+            for (JavaClass interfaceTypeArgumentDependency : dependenciesOfTypes(actualTypeArguments)) {
+                result.addAll(Dependency.tryCreateFromGenericInterfaceTypeArgument(javaClass, genericInterface, interfaceTypeArgumentDependency));
+            }
+        }
+        return result.build();
+    }
+
+    // the cast is safe since we are explicitly filtering instanceOf(..)
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Iterable<JavaParameterizedType> getGenericInterfacesOf(JavaClass javaClass) {
+        return (Iterable) FluentIterable.from(javaClass.getInterfaces()).filter(instanceOf(JavaParameterizedType.class));
     }
 
     private Set<Dependency> fieldDependenciesFromSelf() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -69,7 +69,7 @@ class JavaClassMembers {
             @Override
             public Set<JavaField> get() {
                 ImmutableSet.Builder<JavaField> result = ImmutableSet.builder();
-                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllInterfaces())) {
+                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllRawInterfaces())) {
                     result.addAll(javaClass.getFields());
                 }
                 return result.build();
@@ -79,7 +79,7 @@ class JavaClassMembers {
             @Override
             public Set<JavaMethod> get() {
                 ImmutableSet.Builder<JavaMethod> result = ImmutableSet.builder();
-                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllInterfaces())) {
+                for (JavaClass javaClass : concat(owner.getClassHierarchy(), owner.getAllRawInterfaces())) {
                     result.addAll(javaClass.getMethods());
                 }
                 return result.build();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
@@ -24,6 +24,20 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBu
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static java.util.Collections.emptySet;
 
+/**
+ * Represents the static initialization block of a class, e.g. a block like
+ * <br><br>
+ * <pre><code>
+ * class Example {
+ *     private static final String someStaticField;
+ *
+ *     static {
+ *         // this is the static initializer, it can for example initialize static fields
+ *         someStaticField = readSomeConfig();
+ *     }
+ * }
+ * </code></pre>
+ */
 public class JavaStaticInitializer extends JavaCodeUnit {
     @PublicAPI(usage = ACCESS)
     public static final String STATIC_INITIALIZER_NAME = "<clinit>";

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -461,7 +461,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
 
                 private Node(JavaClass child) {
                     this.child = child;
-                    for (JavaClass i : child.getInterfaces()) {
+                    for (JavaClass i : child.getRawInterfaces()) {
                         parents.add(new Node(i));
                     }
                 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -50,6 +50,7 @@ class ClassFileImportRecord {
     private final SetMultimap<String, String> interfaceNamesByOwner = HashMultimap.create();
     private final Map<String, TypeParametersBuilder> typeParametersBuilderByOwner = new HashMap<>();
     private final Map<String, JavaParameterizedTypeBuilder<JavaClass>> genericSuperclassBuilderByOwner = new HashMap<>();
+    private final Map<String, Set<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuildersByOwner = new HashMap<>();
     private final SetMultimap<String, DomainBuilders.JavaFieldBuilder> fieldBuildersByOwner = HashMultimap.create();
     private final SetMultimap<String, DomainBuilders.JavaMethodBuilder> methodBuildersByOwner = HashMultimap.create();
     private final SetMultimap<String, DomainBuilders.JavaConstructorBuilder> constructorBuildersByOwner = HashMultimap.create();
@@ -79,6 +80,10 @@ class ClassFileImportRecord {
 
     void addGenericSuperclass(String ownerName, JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder) {
         genericSuperclassBuilderByOwner.put(ownerName, genericSuperclassBuilder);
+    }
+
+    public void addGenericInterfaces(String ownerName, Set<JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
+        genericInterfaceBuildersByOwner.put(ownerName, genericInterfaceBuilders);
     }
 
     void addField(String ownerName, DomainBuilders.JavaFieldBuilder fieldBuilder) {
@@ -133,6 +138,10 @@ class ClassFileImportRecord {
 
     Optional<JavaParameterizedTypeBuilder<JavaClass>> getGenericSuperclassFor(JavaClass owner) {
         return Optional.fromNullable(genericSuperclassBuilderByOwner.get(owner.getName()));
+    }
+
+    Optional<Set<JavaParameterizedTypeBuilder<JavaClass>>> getGenericInterfacesFor(JavaClass owner) {
+        return Optional.fromNullable(genericInterfaceBuildersByOwner.get(owner.getName()));
     }
 
     Set<String> getMemberSignatureTypeNames() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -96,6 +96,11 @@ class ClassFileProcessor {
         }
 
         @Override
+        public void onGenericInterfaces(Set<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
+            importRecord.addGenericInterfaces(ownerName, genericInterfaceBuilders);
+        }
+
+        @Override
         public void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder) {
             importRecord.addField(ownerName, fieldBuilder);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -57,6 +57,7 @@ import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeAnnotations;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeClassHierarchy;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeEnclosingClass;
+import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeGenericInterfaces;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeGenericSuperclass;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeMembers;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeParameters;
@@ -144,6 +145,7 @@ class ClassGraphCreator implements ImportContext {
             completeEnclosingClass(javaClass, this);
             completeTypeParameters(javaClass, this);
             completeGenericSuperclass(javaClass, this);
+            completeGenericInterfaces(javaClass, this);
             completeMembers(javaClass, this);
             completeAnnotations(javaClass, this);
         }
@@ -245,6 +247,20 @@ class ClassGraphCreator implements ImportContext {
         return genericSuperclassBuilder.isPresent()
                 ? Optional.of(genericSuperclassBuilder.get().build(owner, getTypeParametersInContextOf(owner), classes.byTypeName()))
                 : Optional.<JavaType>absent();
+    }
+
+    @Override
+    public Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner) {
+        Optional<Set<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuilders = importRecord.getGenericInterfacesFor(owner);
+        if (!genericInterfaceBuilders.isPresent()) {
+            return Optional.absent();
+        }
+
+        ImmutableSet.Builder<JavaType> result = ImmutableSet.builder();
+        for (JavaParameterizedTypeBuilder<JavaClass> builder : genericInterfaceBuilders.get()) {
+            result.add(builder.build(owner, getTypeParametersInContextOf(owner), classes.byTypeName()));
+        }
+        return Optional.<Set<JavaType>>of(result.build());
     }
 
     private static Iterable<JavaTypeVariable<?>> getTypeParametersInContextOf(JavaClass javaClass) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -454,6 +454,8 @@ class JavaClassProcessor extends ClassVisitor {
 
         void onGenericSuperclass(DomainBuilders.JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder);
 
+        void onGenericInterfaces(Set<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders);
+
         void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder);
 
         void onDeclaredConstructor(DomainBuilders.JavaConstructorBuilder constructorBuilder);

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -1,0 +1,545 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.ref.Reference;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ClassFileImporterGenericInterfacesTest.Outer.SomeNestedInterface;
+import com.tngtech.archunit.core.importer.ClassFileImporterGenericInterfacesTest.Outer.SomeNestedInterface.SomeDeeplyNestedInterface;
+import com.tngtech.archunit.testutil.ArchConfigurationRule;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariable.typeVariable;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteWildcardType.wildcardType;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterGenericInterfacesTest {
+
+    @Rule
+    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
+
+    @Test
+    public void imports_non_generic_interface() {
+        class Child implements SomeInterface {
+        }
+
+        Set<JavaType> genericInterfaces = new ClassFileImporter().importClasses(Child.class, SomeInterface.class)
+                .get(Child.class).getInterfaces();
+
+        assertThatTypes(genericInterfaces).as("generic interfaces").matchExactly(SomeInterface.class);
+    }
+
+    @Test
+    public void imports_generic_interface_with_one_type_argument() {
+        class Child implements InterfaceWithOneTypeParameter<String> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(Child.class, InterfaceWithOneTypeParameter.class, String.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface")
+                .hasErasure(InterfaceWithOneTypeParameter.class)
+                .hasActualTypeArguments(String.class);
+    }
+
+    @Test
+    public void imports_generic_interface_with_multiple_type_arguments() {
+        @SuppressWarnings("unused")
+        class Child implements InterfaceWithThreeTypeParameters<String, Serializable, File> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithThreeTypeParameters.class, String.class, Serializable.class, File.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface")
+                .hasErasure(InterfaceWithThreeTypeParameters.class)
+                .hasActualTypeArguments(String.class, Serializable.class, File.class);
+    }
+
+    @Test
+    public void imports_generic_interface_with_single_actual_type_argument_parameterized_with_concrete_class() {
+        class Child implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<String>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithOneTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_interface_with_multiple_actual_type_arguments_parameterized_with_concrete_classes() {
+        class Child implements InterfaceWithThreeTypeParameters<
+                ClassParameterWithSingleTypeParameter<File>,
+                InterfaceWithOneTypeParameter<Serializable>,
+                InterfaceWithOneTypeParameter<String>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(new ClassFileImporter()
+                .importClasses(
+                        Child.class, ClassParameterWithSingleTypeParameter.class, InterfaceWithThreeTypeParameters.class,
+                        InterfaceWithOneTypeParameter.class, File.class, Serializable.class, String.class)
+                .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(File.class),
+                parameterizedType(InterfaceWithOneTypeParameter.class)
+                        .withTypeArguments(Serializable.class),
+                parameterizedType(InterfaceWithOneTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_interface_with_single_actual_type_argument_parameterized_with_unbound_wildcard() {
+        class Child implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<?>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithOneTypeParameter.class, ClassParameterWithSingleTypeParameter.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameter()
+        );
+    }
+
+    @Test
+    public void imports_generic_interface_with_actual_type_arguments_parameterized_with_bounded_wildcards() {
+        class Child implements InterfaceWithTwoTypeParameters<
+                ClassParameterWithSingleTypeParameter<? extends String>,
+                ClassParameterWithSingleTypeParameter<? super File>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(String.class),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(File.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_interface_with_actual_type_arguments_with_multiple_wildcards_with_various_bounds() {
+        class Child implements InterfaceWithTwoTypeParameters<
+                ClassParameterWithSingleTypeParameter<Map<? extends Serializable, ? super File>>,
+                ClassParameterWithSingleTypeParameter<Reference<? super String>>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(
+                                Child.class, ClassParameterWithSingleTypeParameter.class,
+                                Map.class, Serializable.class, File.class, Reference.class, String.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Map.class)
+                                .withWildcardTypeParameters(
+                                        wildcardType().withUpperBound(Serializable.class),
+                                        wildcardType().withLowerBound(File.class))),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Reference.class)
+                                .withWildcardTypeParameterWithLowerBound(String.class))
+        );
+    }
+
+    @Test
+    public void imports_generic_interface_with_actual_type_argument_parameterized_with_type_variable() {
+        class Child<SUB> implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<SUB>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithOneTypeParameter.class, ClassParameterWithSingleTypeParameter.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("SUB"))
+        );
+    }
+
+    @Test
+    public void references_type_variable_assigned_to_actual_type_argument_of_generic_interface() {
+        class Child<SUB extends String> implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<SUB>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithOneTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("SUB").withUpperBounds(String.class))
+        );
+    }
+
+    @Test
+    public void references_outer_type_variable_assigned_to_actual_type_argument_of_generic_interface_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class Child implements InterfaceWithOneTypeParameter<OUTER> {
+                }
+            }
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(
+                                OuterWithTypeParameter.class,
+                                OuterWithTypeParameter.SomeInner.class,
+                                OuterWithTypeParameter.SomeInner.Child.class,
+                                InterfaceWithOneTypeParameter.class,
+                                String.class)
+                        .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                typeVariable("OUTER").withUpperBounds(String.class)
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_type_variables_of_enclosing_classes_that_are_out_of_context_for_generic_interface_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class Child implements InterfaceWithOneTypeParameter<OUTER> {
+                }
+            }
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(OuterWithTypeParameter.SomeInner.Child.class, InterfaceWithOneTypeParameter.class, String.class)
+                        .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                typeVariable("OUTER").withoutUpperBounds()
+        );
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_interface_bound_by_type_variables() {
+        class Child<FIRST extends String, SECOND extends Serializable> implements InterfaceWithTwoTypeParameters<
+                ClassParameterWithSingleTypeParameter<? extends FIRST>,
+                ClassParameterWithSingleTypeParameter<? super SECOND>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, InterfaceWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("FIRST").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("SECOND").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_interface_bound_by_type_variables_of_enclosing_classes() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class Child implements InterfaceWithTwoTypeParameters<
+                        ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                        ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> {
+                }
+            }
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(
+                                OuterWithTypeParameter.class,
+                                OuterWithTypeParameter.SomeInner.class,
+                                OuterWithTypeParameter.SomeInner.Child.class,
+                                InterfaceWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                        .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_wildcards_bound_by_type_variables_of_enclosing_classes_that_are_out_of_context() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class Child implements InterfaceWithTwoTypeParameters<
+                        ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                        ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> {
+                }
+            }
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(
+                                OuterWithTypeParameter.SomeInner.Child.class,
+                                ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                        .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withoutUpperBounds()),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withoutUpperBounds())
+        );
+    }
+
+    private static class Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions {
+        static class ClassChild<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> implements InterfaceWithThreeTypeParameters<
+                // assigned to InterfaceWithThreeTypeParameters<A,_,_>
+                List<? extends FIRST>,
+                // assigned to InterfaceWithThreeTypeParameters<_,B,_>
+                Map<
+                        Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                        Map<? extends String,
+                                Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                // assigned to InterfaceWithThreeTypeParameters<_,_,C>
+                Comparable<ClassChild<FIRST, SECOND>>> {
+        }
+
+        interface InterfaceChild<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> extends InterfaceWithThreeTypeParameters<
+                // assigned to InterfaceWithThreeTypeParameters<A,_,_>
+                List<? extends FIRST>,
+                // assigned to InterfaceWithThreeTypeParameters<_,B,_>
+                Map<
+                        Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                        Map<? extends String,
+                                Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                // assigned to InterfaceWithThreeTypeParameters<_,_,C>
+                Comparable<InterfaceChild<FIRST, SECOND>>> {
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions() {
+        return testForEach(
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions.ClassChild.class,
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions.InterfaceChild.class
+        );
+    }
+
+    @Test
+    @UseDataProvider("data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions")
+    public void imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions(Class<?> testInput) {
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(testInput, String.class, Serializable.class, Cloneable.class,
+                                List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
+                        .get(testInput).getInterfaces());
+
+        // @formatter:off
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
+            // assigned to InterfaceWithThreeTypeParameters<A,_,_>
+            parameterizedType(List.class)
+                .withWildcardTypeParameterWithUpperBound(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class)),
+            // assigned to InterfaceWithThreeTypeParameters<_,B,_>
+            parameterizedType(Map.class).withTypeArguments(
+                parameterizedType(Map.Entry.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    parameterizedType(Map.Entry.class).withTypeArguments(
+                        concreteClass(String.class),
+                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))),
+                parameterizedType(Map.class).withTypeArguments(
+                    wildcardType().withUpperBound(String.class),
+                    parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withUpperBound(Serializable.class),
+                        parameterizedType(List.class).withTypeArguments(
+                            parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(
+                                    parameterizedType(Set.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                            parameterizedType(Iterable.class).withTypeArguments(
+                                                wildcardType().withLowerBound(
+                                                    parameterizedType(Map.class).withTypeArguments(
+                                                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class),
+                                                        wildcardType()))))))))))),
+            // assigned to InterfaceWithThreeTypeParameters<_,_,C>
+            parameterizedType(Comparable.class).withTypeArguments(
+                parameterizedType(testInput).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
+        // @formatter:on
+    }
+
+    private static class Data_of_imports_multiple_generic_interfaces {
+        @SuppressWarnings("unused")
+        static class ClassChild<T> implements
+                InterfaceWithOneTypeParameter<Path>,
+                InterfaceWithTwoTypeParameters<List<? extends T>, Map<? super T, String>>,
+                InterfaceWithThreeTypeParameters<String, Serializable, File> {
+        }
+
+        interface InterfaceChild<T> extends
+                InterfaceWithOneTypeParameter<Path>,
+                InterfaceWithTwoTypeParameters<List<? extends T>, Map<? super T, String>>,
+                InterfaceWithThreeTypeParameters<String, Serializable, File> {
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_of_imports_multiple_generic_interfaces() {
+        return testForEach(
+                Data_of_imports_multiple_generic_interfaces.ClassChild.class,
+                Data_of_imports_multiple_generic_interfaces.InterfaceChild.class);
+    }
+
+    @Test
+    @UseDataProvider("data_of_imports_multiple_generic_interfaces")
+    public void imports_multiple_generic_interfaces(Class<?> testInput) {
+        JavaClass child = new ClassFileImporter()
+                .importClasses(testInput,
+                        InterfaceWithOneTypeParameter.class, InterfaceWithTwoTypeParameters.class, InterfaceWithThreeTypeParameters.class,
+                        Path.class, List.class, Map.class, String.class, Serializable.class, File.class)
+                .get(testInput);
+
+        assertThatType(getGenericInterface(child, InterfaceWithOneTypeParameter.class)).as("generic interface")
+                .hasActualTypeArguments(Path.class);
+
+        assertThatType(getGenericInterface(child, InterfaceWithTwoTypeParameters.class)).as("generic interface")
+                .hasActualTypeArguments(
+                        parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(typeVariable("T"))),
+                        parameterizedType(Map.class).withTypeArguments(
+                                wildcardType().withLowerBound(typeVariable("T")),
+                                concreteClass(String.class)));
+
+        assertThatType(getGenericInterface(child, InterfaceWithThreeTypeParameters.class)).as("generic interface")
+                .hasActualTypeArguments(String.class, Serializable.class, File.class);
+    }
+
+    @Test
+    public void imports_generic_superclass_and_multiple_generic_interfaces_in_combination() {
+        @SuppressWarnings("unused")
+        class BaseClass<X> {
+        }
+        @SuppressWarnings("unused")
+        class Child<T> extends BaseClass<File>
+                implements InterfaceWithOneTypeParameter<Path>, InterfaceWithTwoTypeParameters<T, String> {
+        }
+
+        JavaClass child = new ClassFileImporter()
+                .importClasses(Child.class,
+                        InterfaceWithOneTypeParameter.class, InterfaceWithTwoTypeParameters.class, InterfaceWithThreeTypeParameters.class,
+                        Path.class, List.class, Map.class, String.class, Serializable.class, File.class)
+                .get(Child.class);
+
+        assertThatType(child.getSuperclass().get())
+                .hasErasure(BaseClass.class)
+                .hasActualTypeArguments(File.class);
+
+        assertThatType(getGenericInterface(child, InterfaceWithOneTypeParameter.class)).as("generic interface")
+                .hasActualTypeArguments(Path.class);
+
+        assertThatType(getGenericInterface(child, InterfaceWithTwoTypeParameters.class)).as("generic interface")
+                .hasActualTypeArguments(typeVariable("T"), concreteClass(String.class));
+    }
+
+    @Test
+    public void imports_nested_generic_interfaces() {
+        @SuppressWarnings("unused")
+        class Child<T> implements
+                SomeDeeplyNestedInterface<File, SomeNestedInterface<Path, Path>> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter()
+                        .importClasses(Child.class, SomeDeeplyNestedInterface.class, SomeNestedInterface.class, File.class, Path.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface")
+                .hasErasure(SomeDeeplyNestedInterface.class)
+                .hasActualTypeArguments(
+                        concreteClass(File.class),
+                        parameterizedType(SomeNestedInterface.class).withTypeArguments(Path.class, Path.class));
+    }
+
+    private JavaType getGenericInterface(JavaClass javaClass, Class<?> rawType) {
+        for (JavaType anInterface : javaClass.getInterfaces()) {
+            if (anInterface.toErasure().isEquivalentTo(rawType)) {
+                return anInterface;
+            }
+        }
+        throw new AssertionError(String.format("Class %s has no interface of raw type %s", javaClass.getName(), rawType.getName()));
+    }
+
+    private interface SomeInterface {
+    }
+
+    @SuppressWarnings("unused")
+    private interface InterfaceWithOneTypeParameter<T> {
+    }
+
+    @SuppressWarnings("unused")
+    private interface InterfaceWithTwoTypeParameters<A, B> {
+    }
+
+    @SuppressWarnings("unused")
+    private interface InterfaceWithThreeTypeParameters<A, B, C> {
+    }
+
+    @SuppressWarnings("unused")
+    static class Outer {
+        interface SomeNestedInterface<A, B> {
+            interface SomeDeeplyNestedInterface<C, D> extends SomeNestedInterface<C, String> {
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassParameterWithSingleTypeParameter<T> {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -421,15 +421,15 @@ public class ClassFileImporterTest {
         JavaClass someCollection = classes.get(SomeCollection.class);
         JavaClass collectionInterface = classes.get(CollectionInterface.class);
 
-        assertThat(baseClass.getInterfaces()).containsOnly(otherInterface);
-        assertThat(baseClass.getAllInterfaces()).containsOnly(otherInterface, grandParentInterface);
-        assertThat(subclass.getInterfaces()).containsOnly(subinterface);
-        assertThat(subclass.getAllInterfaces()).containsOnly(
+        assertThat(baseClass.getRawInterfaces()).containsOnly(otherInterface);
+        assertThat(baseClass.getAllRawInterfaces()).containsOnly(otherInterface, grandParentInterface);
+        assertThat(subclass.getRawInterfaces()).containsOnly(subinterface);
+        assertThat(subclass.getAllRawInterfaces()).containsOnly(
                 subinterface, otherInterface, parentInterface, grandParentInterface);
-        assertThat(otherSubclass.getInterfaces()).containsOnly(parentInterface);
-        assertThat(otherSubclass.getAllInterfaces()).containsOnly(parentInterface, grandParentInterface, otherInterface);
-        assertThat(someCollection.getInterfaces()).containsOnly(collectionInterface, otherInterface, subinterface);
-        assertThat(someCollection.getAllInterfaces()).extractingResultOf("reflect").containsOnly(
+        assertThat(otherSubclass.getRawInterfaces()).containsOnly(parentInterface);
+        assertThat(otherSubclass.getAllRawInterfaces()).containsOnly(parentInterface, grandParentInterface, otherInterface);
+        assertThat(someCollection.getRawInterfaces()).containsOnly(collectionInterface, otherInterface, subinterface);
+        assertThat(someCollection.getAllRawInterfaces()).extractingResultOf("reflect").containsOnly(
                 CollectionInterface.class, OtherInterface.class, Subinterface.class, ParentInterface.class,
                 GrandParentInterface.class, Collection.class, Iterable.class);
     }
@@ -442,12 +442,12 @@ public class ClassFileImporterTest {
         JavaClass grandParentInterface = classes.get(GrandParentInterface.class);
         JavaClass collectionInterface = classes.get(CollectionInterface.class);
 
-        assertThat(grandParentInterface.getAllInterfaces()).isEmpty();
-        assertThat(parentInterface.getInterfaces()).containsOnly(grandParentInterface);
-        assertThat(parentInterface.getAllInterfaces()).containsOnly(grandParentInterface);
-        assertThat(subinterface.getInterfaces()).containsOnly(parentInterface);
-        assertThat(subinterface.getAllInterfaces()).containsOnly(parentInterface, grandParentInterface);
-        assertThat(collectionInterface.getInterfaces()).extractingResultOf("reflect").containsOnly(Collection.class);
+        assertThat(grandParentInterface.getAllRawInterfaces()).isEmpty();
+        assertThat(parentInterface.getRawInterfaces()).containsOnly(grandParentInterface);
+        assertThat(parentInterface.getAllRawInterfaces()).containsOnly(grandParentInterface);
+        assertThat(subinterface.getRawInterfaces()).containsOnly(parentInterface);
+        assertThat(subinterface.getAllRawInterfaces()).containsOnly(parentInterface, grandParentInterface);
+        assertThat(collectionInterface.getRawInterfaces()).extractingResultOf("reflect").containsOnly(Collection.class);
     }
 
     @Test
@@ -474,7 +474,7 @@ public class ClassFileImporterTest {
         assertThat(parentInterface.getSubclasses()).containsOnly(subinterface, otherSubclass);
         assertThat(parentInterface.getAllSubclasses()).containsOnly(
                 subinterface, subclass, subSubclass, subSubSubclass, subSubSubSubclass, someCollection, otherSubclass);
-        JavaClass collection = getOnlyElement(collectionInterface.getInterfaces());
+        JavaClass collection = getOnlyElement(collectionInterface.getRawInterfaces());
         assertThat(collection.getAllSubclasses()).containsOnly(collectionInterface, someCollection);
     }
 
@@ -490,7 +490,7 @@ public class ClassFileImporterTest {
                         BaseClass.class.getName(),
                         Object.class.getName());
 
-        assertThat(javaClass.getAllInterfaces()).extracting("name")
+        assertThat(javaClass.getAllRawInterfaces()).extracting("name")
                 .containsOnly(
                         Subinterface.class.getName(),
                         YetAnotherInterface.class.getName(),

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -343,6 +343,11 @@ public class ImportTestUtils {
         }
 
         @Override
+        public Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner) {
+            return Optional.absent();
+        }
+
+        @Override
         public Set<JavaClass> createInterfaces(JavaClass owner) {
             return Collections.emptySet();
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
@@ -18,11 +18,11 @@ import com.tngtech.archunit.lang.FailureReport;
 import static java.util.regex.Pattern.quote;
 
 class ClassesShouldEvaluator {
-    private static String OPTIONAL_ARGS_REGEX = "(?:\\([^)]*\\))?";
-    private static String METHOD_OR_FIELD_REGEX = "\\.[\\w<>]+" + OPTIONAL_ARGS_REGEX;
-    private static String MEMBER_REFERENCE_REGEX = "<(.*)" + METHOD_OR_FIELD_REGEX + ">";
-    private static String SAME_CLASS_BACK_REFERENCE_REGEX = "<\\1" + METHOD_OR_FIELD_REGEX + ">";
-    private static String SELF_REFERENCE_REGEX = MEMBER_REFERENCE_REGEX + ".*" + SAME_CLASS_BACK_REFERENCE_REGEX;
+    private static final String OPTIONAL_ARGS_REGEX = "(?:\\([^)]*\\))?";
+    private static final String METHOD_OR_FIELD_REGEX = "\\.[\\w<>]+" + OPTIONAL_ARGS_REGEX;
+    private static final String MEMBER_REFERENCE_REGEX = "<(.*)" + METHOD_OR_FIELD_REGEX + ">";
+    private static final String SAME_CLASS_BACK_REFERENCE_REGEX = "<\\1" + METHOD_OR_FIELD_REGEX + ">";
+    private static final String SELF_REFERENCE_REGEX = MEMBER_REFERENCE_REGEX + ".*" + SAME_CLASS_BACK_REFERENCE_REGEX;
 
     private final ArchRule rule;
     private final ClassInReportLineMatcher reportLineMatcher;

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaClassAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaClassAssertion.java
@@ -53,17 +53,17 @@ public class JavaClassAssertion extends AbstractObjectAssert<JavaClassAssertion,
     }
 
     public JavaClassAssertion hasNoInterfaces() {
-        assertThat(actual.getInterfaces()).as(describeAssertion("interfaces")).isEmpty();
+        assertThat(actual.getRawInterfaces()).as(describeAssertion("interfaces")).isEmpty();
         return this;
     }
 
     public JavaClassAssertion hasInterfacesMatchingInAnyOrder(Class<?>... expectedInterfaces) {
-        assertThatTypes(actual.getInterfaces()).as(describeAssertion("interfaces")).matchInAnyOrder(expectedInterfaces);
+        assertThatTypes(actual.getRawInterfaces()).as(describeAssertion("interfaces")).matchInAnyOrder(expectedInterfaces);
         return this;
     }
 
     public JavaClassAssertion hasAllInterfacesMatchingInAnyOrder(Class<?>... expectedAllInterfaces) {
-        assertThatTypes(actual.getAllInterfaces()).as(describeAssertion("all interfaces")).matchInAnyOrder(expectedAllInterfaces);
+        assertThatTypes(actual.getAllRawInterfaces()).as(describeAssertion("all interfaces")).matchInAnyOrder(expectedAllInterfaces);
         return this;
     }
 


### PR DESCRIPTION
This next step to fully support generics within ArchUnit adds support for generic interfaces. In particular

* add `Set<JavaType> JavaClass.getInterfaces()`, which will return a set of `JavaParameterizedType` for a parameterized generic interface and the raw types otherwise
* add all type arguments of generic interfaces to `JavaClass.directDependencies{From/To}Self`

Example: ArchUnit would now detect `String` as a Dependency of `class Foo implements Set<List<? super String>>`

This PR contains a breaking change regarding `JavaClass.getInterfaces()`. The same method previously returned the raw interface types (now available through `JavaClass.getRawInterfaces()`). I was pondering about going some way through deprecation to get there, but figured that in the end that would also be tedious for users, if the API I introduce newly for generics will change in the future quickly again to become `JavaClass.getInterfaces()`. And I'm strongly convinced it should be `JavaClass.getInterfaces()` that returns the generic types, because that is consistent to other places like `JavaClass.getSuperclass()`.