### PR TITLE
add `containAny{Members,Fields,Methods,...}That(..)` to rule syntax

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -21,7 +21,13 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -446,5 +452,35 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
 
     private CONJUNCTION givenWith(DescribedPredicate<? super JavaClass> predicate) {
         return addPredicate.apply(predicate);
+    }
+
+    @Override
+    public CONJUNCTION containAnyMembersThat(DescribedPredicate<? super JavaMember> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyMembersThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyFieldsThat(DescribedPredicate<? super JavaField> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyFieldsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyCodeUnitsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyMethodsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyConstructorsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyStaticInitializersThat(DescribedPredicate<? super JavaStaticInitializer> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyStaticInitializersThat(predicate));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -21,8 +21,13 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
 import com.tngtech.archunit.lang.syntax.elements.GivenMembersConjunction;
 
@@ -445,6 +450,36 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
     @Override
     public CONJUNCTION doNotBelongToAnyOf(Class<?>... classes) {
         return givenWith(doNot(JavaClass.Predicates.belongToAnyOf(classes)));
+    }
+
+    @Override
+    public CONJUNCTION containAnyMembersThat(DescribedPredicate<? super JavaMember> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyMembersThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyFieldsThat(DescribedPredicate<? super JavaField> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyFieldsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyCodeUnitsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyMethodsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyConstructorsThat(predicate));
+    }
+
+    @Override
+    public CONJUNCTION containAnyStaticInitializersThat(DescribedPredicate<? super JavaStaticInitializer> predicate) {
+        return givenWith(JavaClass.Predicates.containAnyStaticInitializersThat(predicate));
     }
 
     private CONJUNCTION givenWith(DescribedPredicate<? super JavaClass> predicate) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -22,7 +22,13 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.PackageMatcher;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.properties.HasName.Predicates;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -710,4 +716,59 @@ public interface ClassesThat<CONJUNCTION> {
      */
     @PublicAPI(usage = ACCESS)
     CONJUNCTION doNotBelongToAnyOf(Class<?>... classes);
+
+    /**
+     * Matches classes that contain any {@link JavaMember member} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaMember JavaMembers}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyMembersThat(DescribedPredicate<? super JavaMember> predicate);
+
+    /**
+     * Matches classes that contain any {@link JavaField field} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaField JavaFields}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyFieldsThat(DescribedPredicate<? super JavaField> predicate);
+
+    /**
+     * Matches classes that contain any {@link JavaCodeUnit code unit} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaCodeUnit JavaCodeUnits}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate);
+
+    /**
+     * Matches classes that contain any {@link JavaMethod method} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaMethod JavaMethods}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyMethodsThat(DescribedPredicate<? super JavaMethod> predicate);
+
+    /**
+     * Matches classes that contain any {@link JavaConstructor constructor} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaConstructor JavaConstructors}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate);
+
+    /**
+     * Matches classes that contain a {@link JavaStaticInitializer static initializer} matching the supplied predicate.
+     *
+     * @param predicate A predicate defining matching {@link JavaStaticInitializer JavaStaticInitializers}
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containAnyStaticInitializersThat(DescribedPredicate<? super JavaStaticInitializer> predicate);
+
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesThatTestsExistTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesThatTestsExistTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ClassesThatTestsExistTest {
     private static final Set<Class<?>> CLASSES_SHOULD_THAT_CONTEXT = ImmutableSet.of(
-            GivenClassesThatTest.class, ShouldClassesThatTest.class, ShouldOnlyByClassesThatTest.class
+            GivenClassesThatTest.class, ShouldClassesThatTest.class, ShouldOnlyByClassesThatTest.class, GivenMembersDeclaredInClassesThatTest.class
     );
 
     @Test


### PR DESCRIPTION
Signed-off-by: Nils Christian Ehmke <nils@rhocas.de>