### PR TITLE
Improve documentation of rules library

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -60,7 +60,11 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 
 /**
- * Offers convenience to assert typical architectures, like a {@link #layeredArchitecture()}.
+ * Offers convenience to assert typical architectures:
+ * <ul>
+ * <li>{@link #layeredArchitecture()}</li>
+ * <li>{@link #onionArchitecture()}</li>
+ * </ul>
  */
 public final class Architectures {
     private Architectures() {

--- a/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
@@ -22,20 +22,96 @@ import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.library.dependencies.Slices;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+/**
+ * DependencyRules provides a set of general {@link ArchCondition ArchConditions}
+ * and {@link ArchRule ArchRules} for checking dependencies between classes.
+ *
+ * <p>
+ * For checking dependencies between classes that belong to different
+ * architectural concepts, see also {@link Architectures} and {@link Slices}.
+ * </p>
+ */
 @PublicAPI(usage = ACCESS)
 public final class DependencyRules {
     private DependencyRules() {
     }
 
+    /**
+     * A rule that checks that none of the given classes directly depends on
+     * classes from upper packages. For an description what "directly depends"
+     * means, see {@link JavaClass#getDirectDependenciesFromSelf()}.
+     *
+     * <p>
+     * This rule is good practice, because otherwise that might prevent
+     * packages on that level from being split into separate artifacts
+     * in a clean way in the future.
+     * </p>
+     *
+     * <p>
+     * Example that satisfies the rule:
+     * <pre>{@code
+     * mycomponent
+     *   |-- api
+     *   |       |-- interface MyPublicInterface
+     *   |-- subComponentOne
+     *   |       |-- class MyPublicInterfaceImplOne implements MyPublicInterface
+     *   |-- subComponentTwo
+     *           |-- class MyPublicInterfaceImplTwo implements MyPublicInterface
+     * }</pre>
+     * </p>
+     *
+     * <p>
+     * Example that violates the rule:
+     * <pre>{@code
+     * mycomponent
+     *   |-- interface MyPublicInterface
+     *   |-- subComponentOne
+     *   |       |-- class MyPublicInterfaceImplOne implements MyPublicInterface // violation
+     *   |-- subComponentTwo
+     *           |-- class MyPublicInterfaceImplTwo implements MyPublicInterface // violation
+     * }</pre>
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_DEPEND_UPPER_PACKAGES =
             noClasses().should(dependOnUpperPackages())
                     .because("that might prevent packages on that level from being split into separate artifacts in a clean way");
 
+    /**
+     * Returns a condition that matches classes that directly depend on classes
+     * from upper packages. For an description what "directly depend" means,
+     * see {@link JavaClass#getDirectDependenciesFromSelf()}.
+     *
+     * <p>
+     * Example that satisfies the rule:
+     * <pre>{@code
+     * mycomponent
+     *   |-- api
+     *   |       |-- interface MyPublicInterface
+     *   |-- subComponentOne
+     *   |       |-- class MyPublicInterfaceImplOne implements MyPublicInterface
+     *   |-- subComponentTwo
+     *           |-- class MyPublicInterfaceImplTwo implements MyPublicInterface
+     * }</pre>
+     * </p>
+     *
+     * <p>
+     * Example that violates the rule:
+     * <pre>{@code
+     * mycomponent
+     *   |-- interface MyPublicInterface
+     *   |-- subComponentOne
+     *   |       |-- class MyPublicInterfaceImplOne implements MyPublicInterface // violation
+     *   |-- subComponentTwo
+     *           |-- class MyPublicInterfaceImplTwo implements MyPublicInterface // violation
+     * }</pre>
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> dependOnUpperPackages() {
         return new DependOnUpperPackagesCondition();

--- a/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
@@ -48,6 +48,10 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
 
 /**
+ * GeneralCodingRules provides a set of very general {@link ArchCondition ArchConditions}
+ * and {@link ArchRule ArchRules} for coding that might be useful in various projects.
+ *
+ * <p>
  * When checking these rules, it is always important to remember that all necessary classes need to be
  * imported. E.g. if {@link #ACCESS_STANDARD_STREAMS} is checked, which looks for calls on classes
  * assignable to {@link Throwable}, it is important to ensure that {@link Exception} and {@link RuntimeException}
@@ -55,13 +59,37 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
  * and thus will not consider a call of {@link RuntimeException} a violation, since it does not know that
  * {@link RuntimeException} extends {@link Throwable}.
  * For further information refer to {@link ClassFileImporter}.
+ * </p>
  */
 public final class GeneralCodingRules {
     private GeneralCodingRules() {
     }
 
     /**
+     * A condition that matches classes that access {@code System.out} or {@code System.err}.
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * System.out.println("foo"); // matches
+     * System.err.println("bar"); // matches
+     *
+     * OutputStream out = System.out; // matches
+     * out.write(bytes);
+     *
+     * try {
+     *     // ...
+     * } catch (Exception e) {
+     *     e.printStackTrace(); // matches
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this condition, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchCondition<JavaClass> ACCESS_STANDARD_STREAMS = accessStandardStreams();
@@ -78,20 +106,73 @@ public final class GeneralCodingRules {
     }
 
     /**
+     * A rule that checks that none of the given classes access the standard streams
+     * {@code System.out} and {@code System.err}.
+     *
+     * <p>
      * It is generally good practice to use correct logging instead of writing to the console.
      * <ul>
      * <li>Writing to the console cannot be configured in production</li>
      * <li>Writing to the console is synchronized and can lead to bottle necks</li>
      * </ul>
+     * </p>
      *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * System.out.println("foo"); // violation
+     * System.err.println("bar"); // violation
+     *
+     * OutputStream out = System.out; // violation
+     * out.write(bytes);
+     *
+     * try {
+     *     // ...
+     * } catch (Exception e) {
+     *     e.printStackTrace(); // violation
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this rule, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #ACCESS_STANDARD_STREAMS
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS =
             noClasses().should(ACCESS_STANDARD_STREAMS);
 
     /**
+     * A condition that matches classes that throw generic exceptions like
+     * {@code Exception}, {@code RuntimeException}, or {@code Throwable}.
+     * More precisely, the condition matches when a constructor of the
+     * mentioned classes is called.
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * throw new Exception(); // matches
+     * throw new RuntimeException("error"); // matches
+     * throw new Throwable("error"); // matches
+     *
+     * class CustomException extends Throwable { // matches
+     * }
+     *
+     * class CustomException extends Exception {
+     *     CustomException() {
+     *         super("error"); // does not match
+     *     }
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this condition, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchCondition<JavaClass> THROW_GENERIC_EXCEPTIONS = throwGenericExceptions();
@@ -110,17 +191,61 @@ public final class GeneralCodingRules {
     }
 
     /**
+     * A rule that checks that none of the given classes throw generic exceptions like
+     * {@code Exception}, {@code RuntimeException}, or {@code Throwable}.
+     * More precisely, the rule reports a violation when a constructor of the
+     * mentioned classes is called.
+     *
+     * <p>
      * It is generally good practice to throw specific exceptions like {@link java.lang.IllegalArgumentException}
      * or custom exceptions, instead of throwing generic exceptions like {@link java.lang.RuntimeException}.
-     * <br>
+     * </p>
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * throw new Exception(); // violation
+     * throw new RuntimeException("error"); // violation
+     * throw new Throwable("error"); // violation
+     *
+     * class CustomException extends Throwable { // violation
+     * }
+     *
+     * class CustomException extends Exception {
+     *     CustomException() {
+     *         super("error"); // no violation
+     *     }
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this rule, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #THROW_GENERIC_EXCEPTIONS
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS =
             noClasses().should(THROW_GENERIC_EXCEPTIONS);
 
     /**
+     * A condition that matches classes that access Java Util Logging.
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * import java.util.logging.Logger;
+     *
+     * Logger logger = Logger.getLogger("Example"); // matches
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this condition, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchCondition<JavaClass> USE_JAVA_UTIL_LOGGING =
@@ -129,17 +254,49 @@ public final class GeneralCodingRules {
                     .as("use java.util.logging");
 
     /**
+     * A rule that checks that none of the given classes access Java Util Logging.
+     *
+     * <p>
      * Most projects use the more powerful LOG4J or Logback instead of java.util.logging, often hidden behind
      * SLF4J. In this case it's important to ensure consistent use of the agreed logging framework.
-     * <br>
+     * </p>
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * import java.util.logging.Logger;
+     *
+     * Logger logger = Logger.getLogger("Example"); // violation
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this rule, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #USE_JAVA_UTIL_LOGGING
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING =
             noClasses().should(USE_JAVA_UTIL_LOGGING);
 
     /**
+     * A condition that matches classes that access JodaTime.
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * import org.joda.time.DateTime;
+     *
+     * DateTime now = DateTime.now(); // matches
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this condition, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #NO_CLASSES_SHOULD_USE_JODATIME
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchCondition<JavaClass> USE_JODATIME =
@@ -147,16 +304,56 @@ public final class GeneralCodingRules {
                     .as("use JodaTime");
 
     /**
-     * Modern Java projects use the [java.time] API instead of the JodaTime library
-     * <br>
+     * A rule that checks that none of the given classes access JodaTime.
+     *
+     * <p>
+     * Modern Java projects use the [java.time] API instead of the JodaTime library.
+     * </p>
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * import org.joda.time.DateTime;
+     *
+     * DateTime now = DateTime.now(); // violation
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this rule, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #USE_JODATIME
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_USE_JODATIME =
             noClasses().should(USE_JODATIME).because("modern Java projects use the [java.time] API instead");
 
     /**
+     * A condition that matches fields that have an annotation for injection.
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * class Example {
+     *
+     *     @Resource
+     *     DataSource dataSource; // matches
+     *
+     *     @Inject
+     *     File configFile; // matches
+     *
+     *     @Autowired
+     *     CustomerService customerService; // matches
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this condition, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #NO_CLASSES_SHOULD_USE_FIELD_INJECTION
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchCondition<JavaField> BE_ANNOTATED_WITH_AN_INJECTION_ANNOTATION = beAnnotatedWithAnInjectionAnnotation();
@@ -174,10 +371,35 @@ public final class GeneralCodingRules {
     }
 
     /**
+     * A rule that checks that none of the given classes uses field injection.
+     *
+     * <p>
      * Field injection is seen as an anti-pattern.
      * It is a good practice to use constructor injection for mandatory dependencies and setter injection for optional dependencies.
-     * <br>
+     * </p>
+     *
+     * <p>
+     * Example:
+     * <pre>{@code
+     * class Example {
+     *
+     *     @Resource
+     *     DataSource dataSource; // violation
+     *
+     *     @Inject
+     *     File configFile; // violation
+     *
+     *     @Autowired
+     *     CustomerService customerService; // violation
+     * }
+     * }</pre>
+     * </p>
+     *
+     * <p>
      * For information about checking this rule, refer to {@link GeneralCodingRules}.
+     * </p>
+     *
+     * @see #BE_ANNOTATED_WITH_AN_INJECTION_ANNOTATION
      */
     @PublicAPI(usage = ACCESS)
     public static final ArchRule NO_CLASSES_SHOULD_USE_FIELD_INJECTION =

--- a/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
@@ -32,27 +32,135 @@ import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predica
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+/**
+ * ProxyRules provides a set of general {@link ArchCondition ArchConditions}
+ * and {@link ArchRule ArchRules} for checking the usage of proxies.
+ */
 @PublicAPI(usage = ACCESS)
 public final class ProxyRules {
     private ProxyRules() {
     }
 
+    /**
+     * Returns a rule that checks that none of the given classes directly calls
+     * other methods declared in the same class that are annotated with the
+     * given annotation.
+     *
+     * <p>
+     * As an example, the Spring Framework handles transactions by creating a proxy.
+     * This proxy does the actual transaction management every time a method
+     * annotated with {@code @Transactional} is invoked.
+     * <pre>{@code
+     * class FooEndpoint {
+     *     void updateFooName(String name) {
+     *         // ...
+     *         fooService.update(foo); // Spring proxies this method call to do the actual transaction management
+     *     }
+     * }
+     *
+     * class FooService {
+     *     @Transactional
+     *     void update(Foo foo) {
+     *         // ... does something
+     *     }
+     * }
+     * }</pre>
+     * However, this does not work if the method call comes from the same class.
+     * <pre>{@code
+     * class FooService {
+     *     void updateFooName(String name) {
+     *         // ...
+     *         update(foo); // Spring does not proxy this method call and does not start a transaction
+     *     }
+     *
+     *     @Transactional
+     *     void update(Foo foo) {
+     *         // ... does something
+     *     }
+     * }
+     * }</pre>
+     * This case could be checked with
+     * <pre>{@code
+     * no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Transactional.class)
+     * }</pre>
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchRule no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class<? extends Annotation> annotationType) {
         return no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(are(annotatedWith(annotationType)));
     }
 
+    /**
+     * Returns a rule that checks that none of the given classes directly calls
+     * other methods declared in the same class that matches the given predicate.
+     *
+     * <p>
+     * For an example, see {@link #no_classes_should_directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class)}
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchRule no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(DescribedPredicate<? super MethodCallTarget> predicate) {
         return noClasses().should(directly_call_other_methods_declared_in_the_same_class_that(predicate))
                 .because("it bypasses the proxy mechanism");
     }
 
+    /**
+     * Returns a condition that matches classes that directly calls other methods
+     * declared in the same class that are annotated with the given annotation.
+     *
+     * <p>
+     * As an example, the Spring Framework handles transactions by creating a proxy.
+     * This proxy does the actual transaction management every time a method
+     * annotated with {@code @Transactional} is invoked.
+     * <pre>{@code
+     * class FooEndpoint {
+     *     void updateFooName(String name) {
+     *         // ...
+     *         fooService.update(foo); // Spring proxies this method call to do the actual transaction management
+     *     }
+     * }
+     *
+     * class FooService {
+     *     @Transactional
+     *     void update(Foo foo) {
+     *         // ... does something
+     *     }
+     * }
+     * }</pre>
+     * However, this does not work if the method call comes from the same class.
+     * <pre>{@code
+     * class FooService {
+     *     void updateFooName(String name) {
+     *         // ...
+     *         update(foo); // Spring does not proxy this method call and does not start a transaction
+     *     }
+     *
+     *     @Transactional
+     *     void update(Foo foo) {
+     *         // ... does something
+     *     }
+     * }
+     * }</pre>
+     * The condition
+     * <pre>{@code
+     * directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Transactional.class)
+     * }</pre>
+     * matches the second example.
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class<? extends Annotation> annotationType) {
         return directly_call_other_methods_declared_in_the_same_class_that(are(annotatedWith(annotationType)));
     }
 
+    /**
+     * Returns a condition that matches classes that directly calls other methods
+     * declared in the same class that matches the given predicate.
+     *
+     * <p>
+     * For an example, see {@link #directly_call_other_methods_declared_in_the_same_class_that_are_annotated_with(Class)}
+     * </p>
+     */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that(final DescribedPredicate<? super MethodCallTarget> predicate) {
         return new ArchCondition<JavaClass>("directly call other methods declared in the same class that " + predicate.getDescription()) {

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -204,11 +204,33 @@ Those can be found within
 
 [source,java,options="nowrap"]
 ----
-com.tngtech.archunit.library.GeneralCodingRules
+com.tngtech.archunit.library
 ----
 
-These for example contain rules not to use `java.util.logging`, not to write to `System.out`
-(but use logging instead) or not to throw generic exceptions.
+==== GeneralCodingRules
+
+The class `GeneralCodingRules` contains a set of very general rules and conditions for coding.
+For example:
+
+* To check that classes do not access `System.out` or `System.err`, but use logging instead.
+* To check that classes do not throw generic exceptions, but use specific exceptions instead.
+* To check that classes do not use `java.util.logging`, but use other libraries like Log4j, Logback, or SLF4J instead
+* To check that classes do not use JodaTime, but use `java.time` instead.
+* To check that classes do not use field injection, but constructor injection instead.
+
+==== DependencyRules
+
+The class `DependencyRules` contains a set of rules and conditions for checking dependencies between classes.
+For example:
+
+* To check that classes do not depend on classes from upper packages.
+
+==== ProxyRules
+
+The class `ProxyRules` contains a set of rules and conditions for checking the usage of proxy objects.
+For example:
+
+* To check that methods that matches a predicate are not called directly from within the same class.
 
 === PlantUML Component Diagrams as rules
 


### PR DESCRIPTION
I noticed that the Library API now contains more classes besides `GeneralCodingRules`. Currently, those neither have Javadoc nor are mentioned in the user guide. For users it may be difficult to discover the already available rules.

This is my attempt the improve both aspects of the documentation.