### PR TITLE
add fluent API for transitive dependencies

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1602,6 +1602,15 @@ public class JavaClass implements JavaType, HasName.AndFullName, HasAnnotations<
                 };
 
         @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<Dependency>> GET_TRANSITIVE_DEPENDENCIES_FROM_SELF =
+                new ChainableFunction<JavaClass, Set<Dependency>>() {
+                    @Override
+                    public Set<Dependency> apply(JavaClass input) {
+                        return input.getTransitiveDependenciesFromSelf();
+                    }
+                };
+
+        @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaAccess<?>>> GET_ACCESSES_TO_SELF =
                 new ChainableFunction<JavaClass, Set<JavaAccess<?>>>() {
                     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -82,6 +82,7 @@ import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELDS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELD_ACCESSES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_METHOD_CALLS_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
+import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_TRANSITIVE_DEPENDENCIES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
@@ -294,6 +295,14 @@ public final class ArchConditions {
                 "depend on classes that " + predicate.getDescription(),
                 GET_TARGET_CLASS.is(predicate),
                 GET_DIRECT_DEPENDENCIES_FROM_SELF);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> transitivelyDependOnClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+        return new AnyDependencyCondition(
+                "transitively depend on classes that " + predicate.getDescription(),
+                GET_TARGET_CLASS.is(predicate),
+                GET_TRANSITIVE_DEPENDENCIES_FROM_SELF);
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -545,6 +545,21 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
+    public ClassesThat<ClassesShouldConjunction> transitivelyDependOnClassesThat() {
+        return new ClassesThatInternal<>(new Function<DescribedPredicate<? super JavaClass>, ClassesShouldConjunction>() {
+            @Override
+            public ClassesShouldConjunction apply(DescribedPredicate<? super JavaClass> predicate) {
+                return addCondition(ArchConditions.transitivelyDependOnClassesThat(predicate));
+            }
+        });
+    }
+
+    @Override
+    public ClassesShouldConjunction transitivelyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
+        return addCondition(ArchConditions.transitivelyDependOnClassesThat(predicate));
+    }
+
+    @Override
     public OnlyBeAccessedSpecification<ClassesShouldConjunction> onlyBeAccessed() {
         return new OnlyBeAccessedSpecificationInternal(this);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -992,6 +992,37 @@ public interface ClassesShould {
     ClassesShouldConjunction onlyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate);
 
     /**
+     * Asserts that all classes selected by this rule transitively depend on certain classes.<br>
+     * NOTE: This usually makes more sense the negated way, e.g.
+     * <p>
+     * <pre><code>
+     * {@link ArchRuleDefinition#noClasses() noClasses()}.{@link GivenClasses#should() should()}.{@link #transitivelyDependOnClassesThat()}.{@link ClassesThat#haveFullyQualifiedName(String) haveFullyQualifiedName(String)}
+     * </code></pre>
+     *
+     * NOTE: 'dependOn' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
+     *
+     * @return A syntax element that allows choosing to which classes a transitive dependency should exist
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesThat<ClassesShouldConjunction> transitivelyDependOnClassesThat();
+
+    /**
+     * Asserts that all classes selected by this rule transitively depend on certain classes.<br>
+     * NOTE: This usually makes more sense the negated way, e.g.
+     * <p>
+     * <pre><code>
+     * {@link ArchRuleDefinition#noClasses() noClasses()}.{@link GivenClasses#should() should()}.{@link #transitivelyDependOnClassesThat(DescribedPredicate) transitivelyDependOnClassesThat(myPredicate)}
+     * </code></pre>
+     *
+     * NOTE: 'dependOn' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
+     *
+     * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency target
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesShouldConjunction transitivelyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
+    /**
      * Asserts that only certain classes access the classes selected by this rule.<br>
      * <br>E.g.
      * <pre><code>


### PR DESCRIPTION
This allows to write `ArchRule`s such as
```java
noClasses()
    // .that()//...
    .should().transitivelyDependOnClassesThat()//...
```