### PR TITLE
support primitve array as generic type argument

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -353,11 +353,11 @@ class JavaClassSignatureImporter {
                 ReferenceCreationProcess.JavaTypeVariableFinisher typeVariableFinisher) {
 
             switch (identifier) {
-                case '=':
+                case INSTANCEOF:
                     return new TypeArgumentProcessor(PARAMETERIZED_TYPE, parameterizedType, typeMapping, typeVariableFinisher);
-                case '+':
+                case EXTENDS:
                     return new TypeArgumentProcessor(WILDCARD_WITH_UPPER_BOUND, parameterizedType, typeMapping, typeVariableFinisher);
-                case '-':
+                case SUPER:
                     return new TypeArgumentProcessor(WILDCARD_WITH_LOWER_BOUND, parameterizedType, typeMapping, typeVariableFinisher);
                 default:
                     throw new IllegalStateException(String.format("Cannot handle asm type argument identifier '%s'", identifier));

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -319,6 +319,11 @@ class JavaClassSignatureImporter {
         }
 
         @Override
+        public void visitBaseType(char descriptor) {
+            visitClassType(String.valueOf(descriptor));
+        }
+
+        @Override
         public void visitTypeArgument() {
             log.trace("Encountered wildcard for {}", currentTypeArgument.getTypeName());
             currentTypeArgument.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>()));

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
@@ -159,6 +159,36 @@ public class ClassFileImporterGenericClassesTest {
     }
 
     @Test
+    public void imports_single_class_bound_with_single_type_parameter_assigned_to_array_type_argument() {
+        @SuppressWarnings("unused")
+        class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<String[]>> {
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class,
+                ClassParameterWithSingleTypeParameter.class, String.class);
+
+        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+
+        assertThatType(javaClass).hasOnlyTypeParameter("T")
+                .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String[].class));
+    }
+
+    @Test
+    public void imports_single_class_bound_with_single_type_parameter_assigned_to_primitive_array_type_argument() {
+        @SuppressWarnings("unused")
+        class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<int[]>> {
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class,
+                ClassParameterWithSingleTypeParameter.class, String.class);
+
+        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+
+        assertThatType(javaClass).hasOnlyTypeParameter("T")
+                .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(int[].class));
+    }
+
+    @Test
     public void imports_multiple_class_bounds_with_single_type_parameters_assigned_to_concrete_types() {
         @SuppressWarnings("unused")
         class ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes<

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -61,6 +61,34 @@ public class ClassFileImporterGenericInterfacesTest {
     }
 
     @Test
+    public void imports_generic_interface_with_array_type_argument() {
+        class Child implements InterfaceWithOneTypeParameter<String[]> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(Child.class, InterfaceWithOneTypeParameter.class, String.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface")
+                .hasErasure(InterfaceWithOneTypeParameter.class)
+                .hasActualTypeArguments(String[].class);
+    }
+
+    @Test
+    public void imports_generic_interface_with_primitive_array_type_argument() {
+        class Child implements InterfaceWithOneTypeParameter<int[]> {
+        }
+
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(Child.class, InterfaceWithOneTypeParameter.class, int.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface")
+                .hasErasure(InterfaceWithOneTypeParameter.class)
+                .hasActualTypeArguments(int[].class);
+    }
+
+    @Test
     public void imports_generic_interface_with_multiple_type_arguments() {
         @SuppressWarnings("unused")
         class Child implements InterfaceWithThreeTypeParameters<String, Serializable, File> {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -54,6 +54,38 @@ public class ClassFileImporterGenericSuperclassTest {
     }
 
     @Test
+    public void imports_generic_superclass_with_array_type_argument() {
+        @SuppressWarnings("unused")
+        class BaseClass<T> {
+        }
+        class Child extends BaseClass<String[]> {
+        }
+
+        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, String.class)
+                .get(Child.class).getSuperclass().get();
+
+        assertThatType(genericSuperClass).as("generic superclass")
+                .hasErasure(BaseClass.class)
+                .hasActualTypeArguments(String[].class);
+    }
+
+    @Test
+    public void imports_generic_superclass_with_primitive_array_type_argument() {
+        @SuppressWarnings("unused")
+        class BaseClass<T> {
+        }
+        class Child extends BaseClass<int[]> {
+        }
+
+        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, int.class)
+                .get(Child.class).getSuperclass().get();
+
+        assertThatType(genericSuperClass).as("generic superclass")
+                .hasErasure(BaseClass.class)
+                .hasActualTypeArguments(int[].class);
+    }
+
+    @Test
     public void imports_generic_superclass_with_multiple_type_arguments() {
         @SuppressWarnings("unused")
         class BaseClass<A, B, C> {


### PR DESCRIPTION
With this change, the supertypes of a class such as 
```java
class Child extends ArrayList<int[]> implements List<int[]> {
}
```
are properly recognized as `JavaParameterizedType`s.