### PR TITLE
correct same package being imported in the user guide example

### DIFF
--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -78,7 +78,7 @@ You can specify packages to import as strings:
 
 [source,java,options="nowrap"]
 ----
-@AnalyzeClasses(packages = {"com.myapp.subone", "com.myapp.subone"})
+@AnalyzeClasses(packages = {"com.myapp.subone", "com.myapp.subtwo"})
 ----
 
 To better support refactorings, packages can also be declared relative to classes, i.e. the


### PR DESCRIPTION
The example in section 9.1.2 is supposed to show that several different package can be imported with `@AnalyzeClasses`, but the same package was provided twice.

Signed-off-by: Luka Giorgadze <luka.giorgadze94@gmail.com>