### PR TITLE
Add generic field types

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
@@ -2,10 +2,13 @@ package com.tngtech.archunit.example.layers.service;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.tngtech.archunit.example.layers.controller.SomeUtility;
 import com.tngtech.archunit.example.layers.controller.one.SomeEnum;
 
+@SuppressWarnings("unused")
 public abstract class SpecialServiceHelper extends ServiceHelper<SomeUtility, HashMap<?, Set<? super SomeEnum>>> implements List<Set<? super SomeUtility>> {
+    Map<?, Map<SomeEnum, ? extends SomeUtility>> fieldWithGenericTypeViolatingLayerRule;
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -175,8 +175,8 @@ import static com.tngtech.archunit.testutils.ExpectedAccess.callFromStaticInitia
 import static com.tngtech.archunit.testutils.ExpectedDependency.annotatedClass;
 import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
-import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterface;
-import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclass;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterfaceOf;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclassOf;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
 import static com.tngtech.archunit.testutils.ExpectedDependency.method;
 import static com.tngtech.archunit.testutils.ExpectedDependency.typeParameter;
@@ -784,9 +784,9 @@ class ExamplesIntegrationTest {
                         .inLine(25).asDependency())
                 .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
-                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
-                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
-                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
+                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
+                .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -846,9 +846,9 @@ class ExamplesIntegrationTest {
                         .inLine(25).asDependency())
                 .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
-                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
-                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
-                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
+                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
+                .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -918,9 +918,9 @@ class ExamplesIntegrationTest {
 
                                 .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
                                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))
-                                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeUtility.class))
-                                .by(genericSuperclass(SpecialServiceHelper.class, ServiceHelper.class).dependingOn(SomeEnum.class))
-                                .by(genericInterface(SpecialServiceHelper.class, List.class).dependingOn(SomeUtility.class))
+                                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                                .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
+                                .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -175,6 +175,7 @@ import static com.tngtech.archunit.testutils.ExpectedAccess.callFromStaticInitia
 import static com.tngtech.archunit.testutils.ExpectedDependency.annotatedClass;
 import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericFieldType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterfaceOf;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclassOf;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
@@ -787,6 +788,8 @@ class ExamplesIntegrationTest {
                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
+                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -849,6 +852,8 @@ class ExamplesIntegrationTest {
                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
+                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -921,6 +926,8 @@ class ExamplesIntegrationTest {
                                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                                 .by(genericSuperclassOf(SpecialServiceHelper.class).dependingOn(SomeEnum.class))
                                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
+                                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
+                                .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -47,6 +47,10 @@ public class ExpectedDependency implements ExpectedRelation {
         return new GenericSupertypeTypeArgumentCreator(clazz, "interface", getOnlyElement(interfaces));
     }
 
+    public static GenericFieldTypeArgumentCreator genericFieldType(Class<?> clazz, String fieldName) {
+        return new GenericFieldTypeArgumentCreator(clazz, fieldName);
+    }
+
     public static AnnotationDependencyCreator annotatedClass(Class<?> clazz) {
         return new AnnotationDependencyCreator(clazz);
     }
@@ -138,6 +142,30 @@ public class ExpectedDependency implements ExpectedRelation {
                     getDependencyPattern(childClass.getName(),
                             "has generic " + genericTypeDescription + " <" + quote(genericSupertype.getTypeName()) + "> with type argument depending on",
                             superclassTypeArgumentDependency.getName(),
+                            0));
+        }
+    }
+
+    public static class GenericFieldTypeArgumentCreator {
+        private final Class<?> owner;
+        private final String fieldName;
+        private final Type genericFieldType;
+
+        private GenericFieldTypeArgumentCreator(Class<?> owner, String fieldName) {
+            this.owner = owner;
+            this.fieldName = fieldName;
+            try {
+                this.genericFieldType = owner.getDeclaredField(fieldName).getGenericType();
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public ExpectedDependency dependingOn(Class<?> fieldTypeArgumentDependency) {
+            return new ExpectedDependency(owner, fieldTypeArgumentDependency,
+                    getDependencyPattern(owner.getName() + "." + fieldName,
+                            "has generic type <" + quote(genericFieldType.getTypeName()) + "> with type argument depending on",
+                            fieldTypeArgumentDependency.getName(),
                             0));
         }
     }

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/JavaParameterizedTypeTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/JavaParameterizedTypeTest.java
@@ -1,0 +1,67 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class JavaParameterizedTypeTest {
+
+    @DataProvider
+    @SuppressWarnings("unused")
+    public static Object[][] parameterized_types() {
+        class WithConcreteTypeName<TEST extends List<String>> {
+        }
+        class WithTypeVariable<X, TEST extends List<X>> {
+        }
+        class WithNestedType<TEST extends List<Map<String, File>>> {
+        }
+        class WithArrays<TEST extends List<Map<String[], int[][]>>> {
+        }
+        class WithTypeVariableArrays<X, Y, TEST extends List<Map<X[], Y[][]>>> {
+        }
+        class WithWildcards<TEST extends List<Map<Map<?, ? extends File>, ? super Map<? extends String[][], ? extends int[][]>>>> {
+        }
+        return Stream.of(
+                WithConcreteTypeName.class,
+                WithTypeVariable.class,
+                WithNestedType.class,
+                WithArrays.class,
+                WithTypeVariableArrays.class,
+                WithWildcards.class
+        ).map(JavaParameterizedTypeTest::createTestInput).toArray(Object[][]::new);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    private static Object[] createTestInput(Class<?> testClass) {
+        Type reflectionType = Arrays.stream(testClass.getTypeParameters())
+                .filter(v -> v.getName().equals("TEST"))
+                .map(v -> v.getBounds()[0])
+                .findFirst().get();
+        JavaType javaType = new ClassFileImporter().importClass(testClass).getTypeParameters().stream()
+                .filter(v -> v.getName().equals("TEST"))
+                .map(v -> v.getBounds().get(0))
+                .findFirst().get();
+
+        return $(javaType, reflectionType);
+    }
+
+    @Test
+    @UseDataProvider("parameterized_types")
+    public void name_of_parameterized_type_matches_Reflection_API(JavaType javaType, Type reflectionType) {
+        assertThat(javaType.getName()).isEqualTo(reflectionType.getTypeName());
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -145,16 +145,19 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
     }
 
     static Set<Dependency> tryCreateFromGenericSuperclassTypeArguments(JavaClass originClass, JavaType superclass, JavaClass typeArgumentDependency) {
-        return createGenericDependency(originClass, "superclass", superclass, typeArgumentDependency);
+        return tryCreateDependency(originClass, genericDependencyType("superclass", superclass), typeArgumentDependency);
     }
 
     static Set<Dependency> tryCreateFromGenericInterfaceTypeArgument(JavaClass originClass, JavaType genericInterface, JavaClass typeArgumentDependency) {
-        return createGenericDependency(originClass, "interface", genericInterface, typeArgumentDependency);
+        return tryCreateDependency(originClass, genericDependencyType("interface", genericInterface), typeArgumentDependency);
     }
 
-    private static Set<Dependency> createGenericDependency(JavaClass originClass, String genericTypeDescription, JavaType genericSuperType, JavaClass typeArgumentDependency) {
-        String dependencyType = "has generic " + genericTypeDescription + " " + bracketFormat(genericSuperType.getName()) + " with type argument depending on";
-        return tryCreateDependency(originClass, originClass.getDescription(), dependencyType, typeArgumentDependency, originClass.getSourceCodeLocation());
+    static Set<Dependency> tryCreateFromGenericFieldTypeArgument(JavaField origin, JavaClass typeArgumentDependency) {
+        return tryCreateDependency(origin, genericDependencyType("type", origin.getType()), typeArgumentDependency);
+    }
+
+    private static String genericDependencyType(String genericTypeDescription, JavaType genericType) {
+        return "has generic " + genericTypeDescription + " " + bracketFormat(genericType.getName()) + " with type argument depending on";
     }
 
     private static Origin findSuitableOrigin(Object dependencyCause, Object originCandidate) {
@@ -169,8 +172,13 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         throw new IllegalStateException("Could not find suitable dependency origin for " + dependencyCause);
     }
 
+    private static Set<Dependency> tryCreateDependency(JavaClass origin, String dependencyType, JavaClass targetClass) {
+        return tryCreateDependency(origin, origin.getDescription(), dependencyType, targetClass, origin.getSourceCodeLocation());
+    }
+
     private static <T extends HasOwner<JavaClass> & HasDescription> Set<Dependency> tryCreateDependency(
             T origin, String dependencyType, JavaClass targetClass) {
+
         return tryCreateDependency(origin, dependencyType, targetClass, origin.getOwner().getSourceCodeLocation());
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -171,8 +171,13 @@ public class DomainObjectCreationContext {
     }
 
     public static JavaGenericArrayType createGenericArrayType(JavaType componentType, JavaClass erasure) {
-        checkArgument(componentType instanceof JavaTypeVariable || componentType instanceof JavaGenericArrayType,
-                "Component type of a generic array type can only be a type variable or a generic array type. This is most likely a bug.");
+        checkArgument(
+                componentType instanceof JavaTypeVariable
+                        || componentType instanceof JavaGenericArrayType
+                        || componentType instanceof JavaParameterizedType,
+                "Component type of a generic array type can only be a type variable, a generic array type or a parameterized type, but was %s. "
+                        + "This is most likely a bug.", componentType);
+
         return new JavaGenericArrayType(componentType.getName() + "[]", componentType, erasure);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -117,6 +117,21 @@ class JavaClassDependencies {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
         for (JavaField field : javaClass.getFields()) {
             result.addAll(Dependency.tryCreateFromField(field));
+            result.addAll(genericFieldTypeArgumentDependencies(field));
+        }
+        return result.build();
+    }
+
+    private Set<Dependency> genericFieldTypeArgumentDependencies(JavaField field) {
+        if (!(field.getType() instanceof JavaParameterizedType)) {
+            return emptySet();
+        }
+        JavaParameterizedType fieldType = (JavaParameterizedType) field.getType();
+
+        List<JavaType> actualTypeArguments = fieldType.getActualTypeArguments();
+        ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
+        for (JavaClass fieldTypeArgumentDependency : dependenciesOfTypes(actualTypeArguments)) {
+            result.addAll(Dependency.tryCreateFromGenericFieldTypeArgument(field, fieldTypeArgumentDependency));
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -31,12 +31,12 @@ import com.tngtech.archunit.core.importer.DomainBuilders;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public class JavaField extends JavaMember implements HasType {
-    private final JavaClass type;
+    private final JavaType type;
     private final Supplier<Field> fieldSupplier;
 
     JavaField(DomainBuilders.JavaFieldBuilder builder) {
         super(builder);
-        type = builder.getType();
+        type = builder.getType(this);
         fieldSupplier = Suppliers.memoize(new ReflectFieldSupplier());
     }
 
@@ -62,7 +62,7 @@ public class JavaField extends JavaMember implements HasType {
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaClass getRawType() {
-        return type;
+        return type.toErasure();
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
@@ -25,8 +25,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * E.g. for {@code MyClass<A, T extends List<A[]>>} the upper bound {@code List<A[]>}
  * would have one {@link JavaGenericArrayType} {@code A[]} as its type parameter.<br>
  * Like its concrete counterpart a {@link JavaGenericArrayType} can be queried for its
- * {@link #getComponentType() component type}, which will by definition be a
- * {@link JavaTypeVariable} or a {@link JavaGenericArrayType} corresponding to a lower dimensional array.
+ * {@link #getComponentType() component type}, which can be a {@link JavaParameterizedType},
+ * a {@link JavaTypeVariable} or a {@link JavaGenericArrayType} corresponding to a lower dimensional array.
  */
 @PublicAPI(usage = ACCESS)
 public final class JavaGenericArrayType implements JavaType {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -16,17 +16,16 @@
 package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.properties.HasUpperBounds;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static com.tngtech.archunit.base.Guava.toGuava;
-import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
+import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 
 /**
  * Represents a wildcard type in a type signature (compare the JLS).
@@ -53,12 +52,14 @@ public class JavaWildcardType implements JavaType, HasUpperBounds {
     }
 
     /**
-     * @return The name of this {@link JavaWildcardType}, which is always "?"
+     * @return The name of this {@link JavaWildcardType}, which is always "{@code ?}",
+     *         followed by the respective bounds if any are present
+     *         (e.g. "{@code ? extends java.lang.String}")
      */
     @Override
     @PublicAPI(usage = ACCESS)
     public String getName() {
-        return WILDCARD_TYPE_NAME;
+        return WILDCARD_TYPE_NAME + boundsToString();
     }
 
     /**
@@ -96,8 +97,7 @@ public class JavaWildcardType implements JavaType, HasUpperBounds {
 
     @Override
     public String toString() {
-        String bounds = boundsToString();
-        return getClass().getSimpleName() + '{' + getName() + bounds + '}';
+        return getClass().getSimpleName() + '{' + getName() + '}';
     }
 
     private String boundsToString() {
@@ -107,6 +107,10 @@ public class JavaWildcardType implements JavaType, HasUpperBounds {
     }
 
     private String joinTypeNames(List<JavaType> types) {
-        return FluentIterable.from(types).transform(toGuava(GET_NAME)).join(Joiner.on(" & "));
+        List<String> formatted = new ArrayList<>();
+        for (JavaType type : types) {
+            formatted.add(ensureCanonicalArrayTypeName(type.getName()));
+        }
+        return Joiner.on(" & ").join(formatted);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -542,6 +542,41 @@ public final class DomainBuilders {
 
     interface JavaTypeCreationProcess<OWNER> {
         JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes);
+
+        abstract class JavaTypeFinisher {
+            JavaTypeFinisher() {
+            }
+
+            abstract JavaType finish(JavaType input, ClassesByTypeName classes);
+
+            abstract String getFinishedName(String name);
+
+            JavaTypeFinisher after(final JavaTypeFinisher other) {
+                return new JavaTypeFinisher() {
+                    @Override
+                    JavaType finish(JavaType input, ClassesByTypeName classes) {
+                        return JavaTypeFinisher.this.finish(other.finish(input, classes), classes);
+                    }
+
+                    @Override
+                    String getFinishedName(String name) {
+                        return JavaTypeFinisher.this.getFinishedName(other.getFinishedName(name));
+                    }
+                };
+            }
+
+            static JavaTypeFinisher IDENTITY = new JavaTypeFinisher() {
+                @Override
+                JavaType finish(JavaType input, ClassesByTypeName classes) {
+                    return input;
+                }
+
+                @Override
+                String getFinishedName(String name) {
+                    return name;
+                }
+            };
+        }
     }
 
     @Internal

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -74,6 +74,7 @@ import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.creat
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createThrowsClause;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createTypeVariable;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createWildcardType;
+import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 
 @Internal
@@ -958,7 +959,7 @@ public final class DomainBuilders {
 
         @Override
         public String getName() {
-            return type.getName();
+            return type.getName() + formatTypeArguments();
         }
 
         @Override
@@ -973,11 +974,15 @@ public final class DomainBuilders {
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + "{" + type.getName() + formatTypeArguments() + '}';
+            return getClass().getSimpleName() + "{" + getName() + '}';
         }
 
         private String formatTypeArguments() {
-            return "<" + Joiner.on(", ").join(typeArguments) + ">";
+            List<String> formatted = new ArrayList<>();
+            for (JavaType typeArgument : typeArguments) {
+                formatted.add(ensureCanonicalArrayTypeName(typeArgument.getName()));
+            }
+            return "<" + Joiner.on(", ").join(formatted) + ">";
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -63,6 +63,7 @@ import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.Source;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeVariable;
@@ -948,6 +949,9 @@ public final class DomainBuilders {
         private final List<JavaType> typeArguments;
 
         ImportedParameterizedType(JavaType type, List<JavaType> typeArguments) {
+            checkArgument(typeArguments.size() > 0,
+                    "Parameterized type cannot be created without type arguments. This is likely a bug.");
+
             this.type = type;
             this.typeArguments = typeArguments;
         }
@@ -973,7 +977,7 @@ public final class DomainBuilders {
         }
 
         private String formatTypeArguments() {
-            return typeArguments.isEmpty() ? "" : "<" + Joiner.on(", ").join(typeArguments) + ">";
+            return "<" + Joiner.on(", ").join(typeArguments) + ">";
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -67,6 +67,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeVariable;
+import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createGenericArrayType;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createInstanceofCheck;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createJavaClassList;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createReferencedClassObject;
@@ -196,26 +197,36 @@ public final class DomainBuilders {
 
     @Internal
     public static final class JavaFieldBuilder extends JavaMemberBuilder<JavaField, JavaFieldBuilder> {
-        private JavaClassDescriptor type;
+        private Optional<JavaTypeCreationProcess<JavaField>> genericType;
+        private JavaClassDescriptor rawType;
+        private ClassesByTypeName importedClasses;
 
         JavaFieldBuilder() {
         }
 
-        JavaFieldBuilder withType(JavaClassDescriptor type) {
-            this.type = type;
+        JavaFieldBuilder withType(Optional<JavaTypeCreationProcess<JavaField>> genericTypeBuilder, JavaClassDescriptor rawType) {
+            this.genericType = checkNotNull(genericTypeBuilder);
+            this.rawType = checkNotNull(rawType);
             return self();
         }
 
         String getTypeName() {
-            return type.getFullyQualifiedClassName();
+            return rawType.getFullyQualifiedClassName();
         }
 
-        public JavaClass getType() {
-            return get(type.getFullyQualifiedClassName());
+        public JavaType getType(JavaField field) {
+            return genericType.isPresent()
+                    ? genericType.get().finish(field, allTypeParametersInContextOf(field.getOwner()), importedClasses)
+                    : importedClasses.get(rawType.getFullyQualifiedClassName());
+        }
+
+        private static Set<JavaTypeVariable<?>> allTypeParametersInContextOf(JavaClass javaClass) {
+            return union(ImmutableSet.copyOf(javaClass.getTypeParameters()), allTypeParametersInEnclosingClassesOf(javaClass));
         }
 
         @Override
         JavaField construct(JavaFieldBuilder builder, ClassesByTypeName importedClasses) {
+            this.importedClasses = importedClasses;
             return DomainObjectCreationContext.createJavaField(builder);
         }
     }
@@ -544,7 +555,7 @@ public final class DomainBuilders {
         JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes);
 
         abstract class JavaTypeFinisher {
-            JavaTypeFinisher() {
+            private JavaTypeFinisher() {
             }
 
             abstract JavaType finish(JavaType input, ClassesByTypeName classes);
@@ -574,6 +585,24 @@ public final class DomainBuilders {
                 @Override
                 String getFinishedName(String name) {
                     return name;
+                }
+            };
+
+            static final JavaTypeFinisher ARRAY_CREATOR = new JavaTypeFinisher() {
+                @Override
+                public JavaType finish(JavaType componentType, ClassesByTypeName classes) {
+                    JavaClassDescriptor erasureType = JavaClassDescriptor.From.javaClass(componentType.toErasure()).toArrayDescriptor();
+                    if (componentType instanceof JavaClass) {
+                        return classes.get(erasureType.getFullyQualifiedClassName());
+                    }
+
+                    JavaClass erasure = classes.get(erasureType.getFullyQualifiedClassName());
+                    return createGenericArrayType(componentType, erasure);
+                }
+
+                @Override
+                String getFinishedName(String name) {
+                    return name + "[]";
                 }
             };
         }
@@ -626,22 +655,22 @@ public final class DomainBuilders {
             for (JavaTypeParameterBuilder<JavaClass> builder : typeParameterBuilders) {
                 typeArgumentsToBuilders.put(builder.build(owner, classesByTypeName), builder);
             }
-            Set<JavaTypeVariable<JavaClass>> allGenericParametersInContext = union(allTypeParametersInEnclosingClassesOf(owner), typeArgumentsToBuilders.keySet());
+            Set<JavaTypeVariable<?>> allGenericParametersInContext = union(allTypeParametersInEnclosingClassesOf(owner), typeArgumentsToBuilders.keySet());
             for (Map.Entry<JavaTypeVariable<JavaClass>, JavaTypeParameterBuilder<JavaClass>> typeParameterToBuilder : typeArgumentsToBuilders.entrySet()) {
                 List<JavaType> upperBounds = typeParameterToBuilder.getValue().getUpperBounds(allGenericParametersInContext);
                 completeTypeVariable(typeParameterToBuilder.getKey(), upperBounds);
             }
             return ImmutableList.copyOf(typeArgumentsToBuilders.keySet());
         }
+    }
 
-        private Set<JavaTypeVariable<JavaClass>> allTypeParametersInEnclosingClassesOf(JavaClass javaClass) {
-            Set<JavaTypeVariable<JavaClass>> result = new HashSet<>();
-            while (javaClass.getEnclosingClass().isPresent()) {
-                result.addAll(javaClass.getEnclosingClass().get().getTypeParameters());
-                javaClass = javaClass.getEnclosingClass().get();
-            }
-            return result;
+    private static Set<JavaTypeVariable<?>> allTypeParametersInEnclosingClassesOf(JavaClass javaClass) {
+        Set<JavaTypeVariable<?>> result = new HashSet<>();
+        while (javaClass.getEnclosingClass().isPresent()) {
+            result.addAll(javaClass.getEnclosingClass().get().getTypeParameters());
+            javaClass = javaClass.getEnclosingClass().get();
         }
+        return result;
     }
 
     interface JavaTypeBuilder<OWNER extends HasDescription> {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -469,10 +469,6 @@ public final class DomainBuilders {
             return this;
         }
 
-        JavaClassDescriptor getTypeDescriptor() {
-            return type;
-        }
-
         String getFullyQualifiedClassName() {
             return type.getFullyQualifiedClassName();
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -41,8 +41,10 @@ import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder.ValueBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
@@ -220,9 +222,11 @@ class JavaClassProcessor extends ClassVisitor {
             return super.visitField(access, name, desc, signature, value);
         }
 
+        JavaClassDescriptor rawType = JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc);
+        Optional<JavaTypeCreationProcess<JavaField>> genericType = JavaFieldTypeSignatureImporter.parseAsmFieldTypeSignature(signature);
         DomainBuilders.JavaFieldBuilder fieldBuilder = new DomainBuilders.JavaFieldBuilder()
                 .withName(name)
-                .withType(JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc))
+                .withType(genericType, rawType)
                 .withModifiers(JavaModifier.getModifiersForField(access))
                 .withDescriptor(desc);
         declarationHandler.onDeclaredField(fieldBuilder);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -149,7 +149,7 @@ class JavaClassSignatureImporter {
 
             @Override
             public SignatureVisitor visitTypeArgument(char wildcard) {
-                return TypeArgumentProcessor.create(wildcard, currentBound);
+                return SignatureTypeArgumentProcessor.create(wildcard, currentBound);
             }
         }
 
@@ -172,7 +172,7 @@ class JavaClassSignatureImporter {
 
             @Override
             public SignatureVisitor visitTypeArgument(char wildcard) {
-                return TypeArgumentProcessor.create(wildcard, superclass);
+                return SignatureTypeArgumentProcessor.create(wildcard, superclass);
             }
         }
 
@@ -192,7 +192,7 @@ class JavaClassSignatureImporter {
 
             @Override
             public SignatureVisitor visitTypeArgument(char wildcard) {
-                return TypeArgumentProcessor.create(wildcard, currentInterface);
+                return SignatureTypeArgumentProcessor.create(wildcard, currentInterface);
             }
         }
     }
@@ -242,7 +242,7 @@ class JavaClassSignatureImporter {
         }
     }
 
-    private static class TypeArgumentProcessor extends SignatureVisitor {
+    private static class SignatureTypeArgumentProcessor extends SignatureVisitor {
         private static final JavaTypeFinisher ARRAY_CREATOR = new JavaTypeFinisher() {
             @Override
             public JavaType finish(JavaType componentType, ClassesByTypeName classes) {
@@ -267,7 +267,7 @@ class JavaClassSignatureImporter {
 
         private JavaParameterizedTypeBuilder<JavaClass> currentTypeArgument;
 
-        TypeArgumentProcessor(
+        SignatureTypeArgumentProcessor(
                 TypeArgumentType typeArgumentType,
                 JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
                 JavaTypeFinisher typeFinisher) {
@@ -306,30 +306,30 @@ class JavaClassSignatureImporter {
 
         @Override
         public SignatureVisitor visitTypeArgument(char wildcard) {
-            return TypeArgumentProcessor.create(wildcard, currentTypeArgument, JavaTypeFinisher.IDENTITY);
+            return SignatureTypeArgumentProcessor.create(wildcard, currentTypeArgument, JavaTypeFinisher.IDENTITY);
         }
 
         @Override
         public SignatureVisitor visitArrayType() {
-            return new TypeArgumentProcessor(typeArgumentType, parameterizedType, typeFinisher.after(ARRAY_CREATOR));
+            return new SignatureTypeArgumentProcessor(typeArgumentType, parameterizedType, typeFinisher.after(ARRAY_CREATOR));
         }
 
-        static TypeArgumentProcessor create(char identifier, JavaParameterizedTypeBuilder<JavaClass> parameterizedType) {
+        static SignatureTypeArgumentProcessor create(char identifier, JavaParameterizedTypeBuilder<JavaClass> parameterizedType) {
             return create(identifier, parameterizedType, JavaTypeFinisher.IDENTITY);
         }
 
-        static TypeArgumentProcessor create(
+        static SignatureTypeArgumentProcessor create(
                 char identifier,
                 JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
                 JavaTypeFinisher typeFinisher) {
 
             switch (identifier) {
                 case INSTANCEOF:
-                    return new TypeArgumentProcessor(PARAMETERIZED_TYPE, parameterizedType, typeFinisher);
+                    return new SignatureTypeArgumentProcessor(PARAMETERIZED_TYPE, parameterizedType, typeFinisher);
                 case EXTENDS:
-                    return new TypeArgumentProcessor(WILDCARD_WITH_UPPER_BOUND, parameterizedType, typeFinisher);
+                    return new SignatureTypeArgumentProcessor(WILDCARD_WITH_UPPER_BOUND, parameterizedType, typeFinisher);
                 case SUPER:
-                    return new TypeArgumentProcessor(WILDCARD_WITH_LOWER_BOUND, parameterizedType, typeFinisher);
+                    return new SignatureTypeArgumentProcessor(WILDCARD_WITH_LOWER_BOUND, parameterizedType, typeFinisher);
                 default:
                     throw new IllegalStateException(String.format("Cannot handle asm type argument identifier '%s'", identifier));
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -20,26 +20,22 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
-import com.tngtech.archunit.core.domain.JavaType;
-import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.TypeParametersBuilder;
 import com.tngtech.archunit.core.importer.JavaClassProcessor.DeclarationHandler;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.NewJavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.ReferenceCreationProcess;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createGenericArrayType;
 import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERSION;
 
 class JavaClassSignatureImporter {
@@ -196,174 +192,4 @@ class JavaClassSignatureImporter {
             }
         }
     }
-
-    private static class NewJavaTypeCreationProcess<OWNER extends HasDescription> implements JavaTypeCreationProcess<OWNER> {
-        private final JavaTypeBuilder<OWNER> builder;
-        private final JavaTypeFinisher typeFinisher;
-
-        NewJavaTypeCreationProcess(JavaTypeBuilder<OWNER> builder) {
-            this(builder, JavaTypeFinisher.IDENTITY);
-        }
-
-        NewJavaTypeCreationProcess(JavaTypeBuilder<OWNER> builder, JavaTypeFinisher typeFinisher) {
-            this.builder = builder;
-            this.typeFinisher = typeFinisher;
-        }
-
-        @Override
-        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
-            JavaType type = builder.build(owner, allTypeParametersInContext, classes);
-            return typeFinisher.finish(type, classes);
-        }
-    }
-
-    private static class ReferenceCreationProcess<OWNER extends HasDescription> implements JavaTypeCreationProcess<OWNER> {
-        private final String typeVariableName;
-        private final JavaTypeFinisher finisher;
-
-        ReferenceCreationProcess(String typeVariableName, JavaTypeFinisher finisher) {
-            this.typeVariableName = typeVariableName;
-            this.finisher = finisher;
-        }
-
-        @Override
-        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
-            return finisher.finish(createTypeVariable(owner, allTypeParametersInContext, classes), classes);
-        }
-
-        private JavaType createTypeVariable(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
-            for (JavaTypeVariable<?> existingTypeVariable : allTypeParametersInContext) {
-                if (existingTypeVariable.getName().equals(typeVariableName)) {
-                    return existingTypeVariable;
-                }
-            }
-            // type variables can be missing from the import context -> create a simple unbound type variable since we have no more information
-            return new JavaTypeParameterBuilder<>(typeVariableName).build(owner, classes);
-        }
-    }
-
-    private static class SignatureTypeArgumentProcessor extends SignatureVisitor {
-        private static final JavaTypeFinisher ARRAY_CREATOR = new JavaTypeFinisher() {
-            @Override
-            public JavaType finish(JavaType componentType, ClassesByTypeName classes) {
-                JavaClassDescriptor erasureType = JavaClassDescriptor.From.javaClass(componentType.toErasure()).toArrayDescriptor();
-                if (componentType instanceof JavaClass) {
-                    return classes.get(erasureType.getFullyQualifiedClassName());
-                }
-
-                JavaClass erasure = classes.get(erasureType.getFullyQualifiedClassName());
-                return createGenericArrayType(componentType, erasure);
-            }
-
-            @Override
-            String getFinishedName(String name) {
-                return name + "[]";
-            }
-        };
-
-        private final TypeArgumentType typeArgumentType;
-        private final JavaParameterizedTypeBuilder<JavaClass> parameterizedType;
-        private final JavaTypeFinisher typeFinisher;
-
-        private JavaParameterizedTypeBuilder<JavaClass> currentTypeArgument;
-
-        SignatureTypeArgumentProcessor(
-                TypeArgumentType typeArgumentType,
-                JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
-                JavaTypeFinisher typeFinisher) {
-            super(ASM_API_VERSION);
-            this.typeArgumentType = typeArgumentType;
-            this.parameterizedType = parameterizedType;
-            this.typeFinisher = typeFinisher;
-        }
-
-        @Override
-        public void visitClassType(String internalObjectName) {
-            JavaClassDescriptor type = JavaClassDescriptorImporter.createFromAsmObjectTypeName(internalObjectName);
-            log.trace("Encountered {} for {}: Class type {}", typeArgumentType.description, parameterizedType.getTypeName(), type.getFullyQualifiedClassName());
-            currentTypeArgument = new JavaParameterizedTypeBuilder<>(type);
-            typeArgumentType.addTypeArgumentToBuilder(parameterizedType, new NewJavaTypeCreationProcess<>(this.currentTypeArgument, typeFinisher));
-        }
-
-        @Override
-        public void visitBaseType(char descriptor) {
-            visitClassType(String.valueOf(descriptor));
-        }
-
-        @Override
-        public void visitTypeArgument() {
-            log.trace("Encountered wildcard for {}", currentTypeArgument.getTypeName());
-            currentTypeArgument.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>(), JavaTypeFinisher.IDENTITY));
-        }
-
-        @Override
-        public void visitTypeVariable(String name) {
-            if (log.isTraceEnabled()) {
-                log.trace("Encountered {} for {}: Type variable {}", typeArgumentType.description, parameterizedType.getTypeName(), typeFinisher.getFinishedName(name));
-            }
-            typeArgumentType.addTypeArgumentToBuilder(parameterizedType, new ReferenceCreationProcess<JavaClass>(name, typeFinisher));
-        }
-
-        @Override
-        public SignatureVisitor visitTypeArgument(char wildcard) {
-            return SignatureTypeArgumentProcessor.create(wildcard, currentTypeArgument, JavaTypeFinisher.IDENTITY);
-        }
-
-        @Override
-        public SignatureVisitor visitArrayType() {
-            return new SignatureTypeArgumentProcessor(typeArgumentType, parameterizedType, typeFinisher.after(ARRAY_CREATOR));
-        }
-
-        static SignatureTypeArgumentProcessor create(char identifier, JavaParameterizedTypeBuilder<JavaClass> parameterizedType) {
-            return create(identifier, parameterizedType, JavaTypeFinisher.IDENTITY);
-        }
-
-        static SignatureTypeArgumentProcessor create(
-                char identifier,
-                JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
-                JavaTypeFinisher typeFinisher) {
-
-            switch (identifier) {
-                case INSTANCEOF:
-                    return new SignatureTypeArgumentProcessor(PARAMETERIZED_TYPE, parameterizedType, typeFinisher);
-                case EXTENDS:
-                    return new SignatureTypeArgumentProcessor(WILDCARD_WITH_UPPER_BOUND, parameterizedType, typeFinisher);
-                case SUPER:
-                    return new SignatureTypeArgumentProcessor(WILDCARD_WITH_LOWER_BOUND, parameterizedType, typeFinisher);
-                default:
-                    throw new IllegalStateException(String.format("Cannot handle asm type argument identifier '%s'", identifier));
-            }
-        }
-    }
-
-    private abstract static class TypeArgumentType {
-        private final String description;
-
-        TypeArgumentType(String description) {
-            this.description = description;
-        }
-
-        abstract void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> creationProcess);
-    }
-
-    private static final TypeArgumentType PARAMETERIZED_TYPE = new TypeArgumentType("type argument") {
-        @Override
-        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
-            parameterizedType.addTypeArgument(typeCreationProcess);
-        }
-    };
-
-    private static final TypeArgumentType WILDCARD_WITH_UPPER_BOUND = new TypeArgumentType("wildcard with upper bound") {
-        @Override
-        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
-            parameterizedType.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>().addUpperBound(typeCreationProcess)));
-        }
-    };
-
-    private static final TypeArgumentType WILDCARD_WITH_LOWER_BOUND = new TypeArgumentType("wildcard with lower bound") {
-        @Override
-        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
-            parameterizedType.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>().addLowerBound(typeCreationProcess)));
-        }
-    };
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -24,7 +24,6 @@ import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.TypeParametersBuilder;
@@ -140,7 +139,7 @@ class JavaClassSignatureImporter {
             @Override
             public void visitTypeVariable(String name) {
                 log.trace("Encountered upper bound for {}: Type variable {}", currentType.getName(), name);
-                currentType.addBound(new ReferenceCreationProcess<JavaClass>(name, JavaTypeFinisher.IDENTITY));
+                currentType.addBound(new ReferenceCreationProcess<JavaClass>(name));
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.NewJavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.ReferenceCreationProcess;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERSION;
+import static com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher.ARRAY_CREATOR;
+
+class JavaFieldTypeSignatureImporter {
+    private static final Logger log = LoggerFactory.getLogger(JavaFieldTypeSignatureImporter.class);
+
+    static Optional<JavaTypeCreationProcess<JavaField>> parseAsmFieldTypeSignature(String signature) {
+        if (signature == null) {
+            return Optional.absent();
+        }
+
+        log.trace("Analyzing field signature: {}", signature);
+
+        SignatureProcessor signatureProcessor = new SignatureProcessor();
+        new SignatureReader(signature).accept(signatureProcessor);
+        return Optional.of(signatureProcessor.getFieldType());
+    }
+
+    private static class SignatureProcessor extends SignatureVisitor {
+        private final GenericFieldTypeProcessor genericFieldTypeProcessor = new GenericFieldTypeProcessor();
+
+        SignatureProcessor() {
+            super(ASM_API_VERSION);
+        }
+
+        @Override
+        public SignatureVisitor visitSuperclass() {
+            return genericFieldTypeProcessor;
+        }
+
+        JavaTypeCreationProcess<JavaField> getFieldType() {
+            return genericFieldTypeProcessor.getFieldType();
+        }
+    }
+
+    private static class GenericFieldTypeProcessor extends SignatureVisitor {
+        private JavaParameterizedTypeBuilder<JavaField> parameterizedFieldType;
+        private JavaTypeCreationProcess<JavaField> fieldTypeCreationProcess;
+        private JavaTypeFinisher typeFinisher = JavaTypeFinisher.IDENTITY;
+
+        GenericFieldTypeProcessor() {
+            super(ASM_API_VERSION);
+        }
+
+        JavaTypeCreationProcess<JavaField> getFieldType() {
+            return fieldTypeCreationProcess;
+        }
+
+        @Override
+        public void visitClassType(String internalObjectName) {
+            updateFieldType(new JavaParameterizedTypeBuilder<JavaField>(JavaClassDescriptorImporter.createFromAsmObjectTypeName(internalObjectName)));
+        }
+
+        @Override
+        public void visitInnerClassType(String name) {
+            updateFieldType(parameterizedFieldType.forInnerClass(name));
+        }
+
+        @Override
+        public void visitTypeArgument() {
+            parameterizedFieldType.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaField>()));
+        }
+
+        @Override
+        public SignatureVisitor visitTypeArgument(char wildcard) {
+            return SignatureTypeArgumentProcessor.create(wildcard, parameterizedFieldType, JavaTypeFinisher.IDENTITY);
+        }
+
+        @Override
+        public SignatureVisitor visitArrayType() {
+            typeFinisher = typeFinisher.after(ARRAY_CREATOR);
+            return this;
+        }
+
+        @Override
+        public void visitTypeVariable(String name) {
+            fieldTypeCreationProcess = new ReferenceCreationProcess<>(name);
+        }
+
+        private void updateFieldType(JavaParameterizedTypeBuilder<JavaField> fieldType) {
+            this.parameterizedFieldType = fieldType;
+            fieldTypeCreationProcess = new NewJavaTypeCreationProcess<>(this.parameterizedFieldType, typeFinisher);
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeArgumentProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeArgumentProcessor.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClassDescriptor;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createGenericArrayType;
+import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERSION;
+
+class SignatureTypeArgumentProcessor extends SignatureVisitor {
+    private static final Logger log = LoggerFactory.getLogger(SignatureTypeArgumentProcessor.class);
+
+    private static final JavaTypeFinisher ARRAY_CREATOR = new JavaTypeFinisher() {
+        @Override
+        public JavaType finish(JavaType componentType, ClassesByTypeName classes) {
+            JavaClassDescriptor erasureType = JavaClassDescriptor.From.javaClass(componentType.toErasure()).toArrayDescriptor();
+            if (componentType instanceof JavaClass) {
+                return classes.get(erasureType.getFullyQualifiedClassName());
+            }
+
+            JavaClass erasure = classes.get(erasureType.getFullyQualifiedClassName());
+            return createGenericArrayType(componentType, erasure);
+        }
+
+        @Override
+        String getFinishedName(String name) {
+            return name + "[]";
+        }
+    };
+
+    private final TypeArgumentType typeArgumentType;
+    private final JavaParameterizedTypeBuilder<JavaClass> parameterizedType;
+    private final JavaTypeFinisher typeFinisher;
+
+    private JavaParameterizedTypeBuilder<JavaClass> currentTypeArgument;
+
+    SignatureTypeArgumentProcessor(
+            TypeArgumentType typeArgumentType,
+            JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
+            JavaTypeFinisher typeFinisher) {
+        super(ASM_API_VERSION);
+        this.typeArgumentType = typeArgumentType;
+        this.parameterizedType = parameterizedType;
+        this.typeFinisher = typeFinisher;
+    }
+
+    @Override
+    public void visitClassType(String internalObjectName) {
+        JavaClassDescriptor type = JavaClassDescriptorImporter.createFromAsmObjectTypeName(internalObjectName);
+        log.trace("Encountered {} for {}: Class type {}", typeArgumentType.description, parameterizedType.getTypeName(), type.getFullyQualifiedClassName());
+        currentTypeArgument = new JavaParameterizedTypeBuilder<>(type);
+        typeArgumentType.addTypeArgumentToBuilder(parameterizedType, new NewJavaTypeCreationProcess<>(this.currentTypeArgument, typeFinisher));
+    }
+
+    @Override
+    public void visitBaseType(char descriptor) {
+        visitClassType(String.valueOf(descriptor));
+    }
+
+    @Override
+    public void visitTypeArgument() {
+        log.trace("Encountered wildcard for {}", currentTypeArgument.getTypeName());
+        currentTypeArgument.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>(), JavaTypeFinisher.IDENTITY));
+    }
+
+    @Override
+    public void visitTypeVariable(String name) {
+        if (log.isTraceEnabled()) {
+            log.trace("Encountered {} for {}: Type variable {}", typeArgumentType.description, parameterizedType.getTypeName(), typeFinisher.getFinishedName(name));
+        }
+        typeArgumentType.addTypeArgumentToBuilder(parameterizedType, new ReferenceCreationProcess<JavaClass>(name, typeFinisher));
+    }
+
+    @Override
+    public SignatureVisitor visitTypeArgument(char wildcard) {
+        return SignatureTypeArgumentProcessor.create(wildcard, currentTypeArgument, JavaTypeFinisher.IDENTITY);
+    }
+
+    @Override
+    public SignatureVisitor visitArrayType() {
+        return new SignatureTypeArgumentProcessor(typeArgumentType, parameterizedType, typeFinisher.after(ARRAY_CREATOR));
+    }
+
+    static SignatureTypeArgumentProcessor create(char identifier, JavaParameterizedTypeBuilder<JavaClass> parameterizedType) {
+        return create(identifier, parameterizedType, JavaTypeFinisher.IDENTITY);
+    }
+
+    static SignatureTypeArgumentProcessor create(
+            char identifier,
+            JavaParameterizedTypeBuilder<JavaClass> parameterizedType,
+            JavaTypeFinisher typeFinisher) {
+
+        switch (identifier) {
+            case INSTANCEOF:
+                return new SignatureTypeArgumentProcessor(PARAMETERIZED_TYPE, parameterizedType, typeFinisher);
+            case EXTENDS:
+                return new SignatureTypeArgumentProcessor(WILDCARD_WITH_UPPER_BOUND, parameterizedType, typeFinisher);
+            case SUPER:
+                return new SignatureTypeArgumentProcessor(WILDCARD_WITH_LOWER_BOUND, parameterizedType, typeFinisher);
+            default:
+                throw new IllegalStateException(String.format("Cannot handle asm type argument identifier '%s'", identifier));
+        }
+    }
+
+    private abstract static class TypeArgumentType {
+        private final String description;
+
+        TypeArgumentType(String description) {
+            this.description = description;
+        }
+
+        abstract void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> creationProcess);
+    }
+
+    private static final TypeArgumentType PARAMETERIZED_TYPE = new TypeArgumentType("type argument") {
+        @Override
+        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
+            parameterizedType.addTypeArgument(typeCreationProcess);
+        }
+    };
+
+    private static final TypeArgumentType WILDCARD_WITH_UPPER_BOUND = new TypeArgumentType("wildcard with upper bound") {
+        @Override
+        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
+            parameterizedType.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>().addUpperBound(typeCreationProcess)));
+        }
+    };
+
+    private static final TypeArgumentType WILDCARD_WITH_LOWER_BOUND = new TypeArgumentType("wildcard with lower bound") {
+        @Override
+        void addTypeArgumentToBuilder(JavaParameterizedTypeBuilder<JavaClass> parameterizedType, JavaTypeCreationProcess<JavaClass> typeCreationProcess) {
+            parameterizedType.addTypeArgument(new NewJavaTypeCreationProcess<>(new JavaWildcardTypeBuilder<JavaClass>().addLowerBound(typeCreationProcess)));
+        }
+    };
+
+    static class NewJavaTypeCreationProcess<OWNER extends HasDescription> implements JavaTypeCreationProcess<OWNER> {
+        private final JavaTypeBuilder<OWNER> builder;
+        private final JavaTypeFinisher typeFinisher;
+
+        NewJavaTypeCreationProcess(JavaTypeBuilder<OWNER> builder) {
+            this(builder, JavaTypeFinisher.IDENTITY);
+        }
+
+        NewJavaTypeCreationProcess(JavaTypeBuilder<OWNER> builder, JavaTypeFinisher typeFinisher) {
+            this.builder = builder;
+            this.typeFinisher = typeFinisher;
+        }
+
+        @Override
+        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
+            JavaType type = builder.build(owner, allTypeParametersInContext, classes);
+            return typeFinisher.finish(type, classes);
+        }
+    }
+
+    static class ReferenceCreationProcess<OWNER extends HasDescription> implements JavaTypeCreationProcess<OWNER> {
+        private final String typeVariableName;
+        private final JavaTypeFinisher finisher;
+
+        ReferenceCreationProcess(String typeVariableName, JavaTypeFinisher finisher) {
+            this.typeVariableName = typeVariableName;
+            this.finisher = finisher;
+        }
+
+        @Override
+        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
+            return finisher.finish(createTypeVariable(owner, allTypeParametersInContext, classes), classes);
+        }
+
+        private JavaType createTypeVariable(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ClassesByTypeName classes) {
+            for (JavaTypeVariable<?> existingTypeVariable : allTypeParametersInContext) {
+                if (existingTypeVariable.getName().equals(typeVariableName)) {
+                    return existingTypeVariable;
+                }
+            }
+            // type variables can be missing from the import context -> create a simple unbound type variable since we have no more information
+            return new JavaTypeParameterBuilder<>(typeVariableName).build(owner, classes);
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/ArchUnitTestStructureTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/ArchUnitTestStructureTest.java
@@ -21,7 +21,7 @@ public class ArchUnitTestStructureTest {
                 .should(onlyBeAccessedByClassesThat(
                         have(nameMatching(TestUtils.class.getName() + ".*"))
                                 .or(have(nameMatching(ImportTestUtils.class.getName() + ".*")))))
-                .because("we wan't one central TestUtils for all tests")
+                .because("we want one central TestUtils for all tests")
                 .check(archUnitClasses);
     }
 
@@ -29,7 +29,7 @@ public class ArchUnitTestStructureTest {
     public void ImportTestUtils_doesnt_access_TestUtils() {
         noClasses().that().haveNameMatching(ImportTestUtils.class.getName() + ".*")
                 .should().accessClassesThat().haveNameMatching(TestUtils.class.getName() + ".*")
-                .because("we wan't one central TestUtils for all tests")
+                .because("we want one central TestUtils for all tests")
                 .check(archUnitClasses);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -289,8 +289,11 @@ public class DependencyTest {
         assertThatType(dependency.getOriginClass()).matches(ClassWithGenericSuperclass.class);
         assertThatType(dependency.getTargetClass()).matches(String.class);
         assertThat(dependency.getDescription()).as("description").contains(String.format(
-                "Class <%s> has generic superclass <%s> with type argument depending on <%s> in (%s.java:0)",
-                ClassWithGenericSuperclass.class.getName(), Base.class.getName(), String.class.getName(), getClass().getSimpleName()));
+                "Class <%s> has generic superclass <%s<%s>> with type argument depending on <%s> in (%s.java:0)",
+                ClassWithGenericSuperclass.class.getName(),
+                Base.class.getName(), String.class.getName(),
+                String.class.getName(),
+                getClass().getSimpleName()));
     }
 
     @SuppressWarnings("unused")
@@ -311,8 +314,11 @@ public class DependencyTest {
         assertThatType(dependency.getOriginClass()).matches(ClassWithGenericInterface.class);
         assertThatType(dependency.getTargetClass()).matches(String.class);
         assertThat(dependency.getDescription()).as("description").contains(String.format(
-                "Class <%s> has generic interface <%s> with type argument depending on <%s> in (%s.java:0)",
-                ClassWithGenericInterface.class.getName(), InterfaceWithTypeParameter.class.getName(), String.class.getName(), getClass().getSimpleName()));
+                "Class <%s> has generic interface <%s<%s>> with type argument depending on <%s> in (%s.java:0)",
+                ClassWithGenericInterface.class.getName(),
+                InterfaceWithTypeParameter.class.getName(), String.class.getName(),
+                String.class.getName(),
+                getClass().getSimpleName()));
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -282,9 +282,9 @@ public class DependencyTest {
         }
 
         JavaClass javaClass = importClassesWithContext(ClassWithGenericSuperclass.class, String.class).get(ClassWithGenericSuperclass.class);
-        JavaParameterizedType genericSuperClass = (JavaParameterizedType) javaClass.getSuperclass().get();
+        JavaParameterizedType genericSuperclass = (JavaParameterizedType) javaClass.getSuperclass().get();
 
-        Dependency dependency = getOnlyElement(Dependency.tryCreateFromGenericSuperclassTypeArguments(javaClass, genericSuperClass, (JavaClass) genericSuperClass.getActualTypeArguments().get(0)));
+        Dependency dependency = getOnlyElement(Dependency.tryCreateFromGenericSuperclassTypeArguments(javaClass, genericSuperclass, (JavaClass) genericSuperclass.getActualTypeArguments().get(0)));
 
         assertThatType(dependency.getOriginClass()).matches(ClassWithGenericSuperclass.class);
         assertThatType(dependency.getTargetClass()).matches(String.class);

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
@@ -1,5 +1,13 @@
 package com.tngtech.archunit.core.domain;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -8,9 +16,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.google.common.collect.Sets.union;
+import static com.google.common.primitives.Primitives.allPrimitiveTypes;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static java.util.Collections.singleton;
 
 @RunWith(DataProviderRunner.class)
 public class FormattersTest {
@@ -18,6 +29,7 @@ public class FormattersTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void ensureSimpleName_withNullString() {
         thrown.expect(NullPointerException.class);
 
@@ -47,5 +59,42 @@ public class FormattersTest {
     @UseDataProvider("simple_name_test_cases")
     public void ensureSimpleName(String input, String expected) {
         assertThat(Formatters.ensureSimpleName(input)).isEqualTo(expected);
+    }
+
+    @DataProvider
+    public static List<List<String>> canonical_array_name_test_cases() {
+        class SomeClass {
+        }
+
+        List<List<String>> testCases = new ArrayList<>();
+        testCases.add(ImmutableList.of("", ""));
+        testCases.add(ImmutableList.of(SomeClass.class.getSimpleName(), SomeClass.class.getSimpleName()));
+        testCases.addAll(generateCanonicalNameTestCases(union(ImmutableSet.of(String.class, SomeClass.class), allRelevantPrimitiveTypes())));
+        testCases.add(ImmutableList.of("[[Lorg.example.Some$Inner;", "org.example.Some$Inner[][]"));
+        return testCases;
+    }
+
+    private static Set<Class<?>> allRelevantPrimitiveTypes() {
+        return Sets.difference(allPrimitiveTypes(), singleton(void.class));
+    }
+
+    private static List<List<String>> generateCanonicalNameTestCases(Iterable<Class<?>> classes) {
+        List<List<String>> result = new ArrayList<>();
+        for (Class<?> componentType : classes) {
+            result.add(ImmutableList.of(componentType.getName(), componentType.getName()));
+
+            Class<?> oneDim = Array.newInstance(componentType, 0).getClass();
+            result.add(ImmutableList.of(oneDim.getName(), componentType.getName() + "[]"));
+
+            Class<?> twoDim = Array.newInstance(oneDim, 0).getClass();
+            result.add(ImmutableList.of(twoDim.getName(), componentType.getName() + "[][]"));
+        }
+        return result;
+    }
+
+    @Test
+    @UseDataProvider("canonical_array_name_test_cases")
+    public void ensureCanonicalArrayTypeName(String input, String expected) {
+        assertThat(Formatters.ensureCanonicalArrayTypeName(input)).as("Canonical name of '%s'", input).isEqualTo(expected);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -104,6 +104,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(DataProviderRunner.class)
+@SuppressWarnings("SameParameterValue")
 public class JavaClassTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -524,7 +525,9 @@ public class JavaClassTest {
                         .withDescriptionContaining("extends")
 
                         .from(Child.class)
-                        .withExpectedDescriptionTemplate("has generic superclass <" + Base.class.getName() + "> with type argument depending on <#target>")
+                        .withExpectedDescriptionPatternTemplate(
+                                ".*has generic superclass <" + quote(Base.class.getName()) +
+                                        ".+> with type argument depending on <#target>.*")
                         .to(Comparable.class, Map.class, Map.Entry.class, String.class, BufferedInputStream[][].class, Serializable.class, List.class, Set.class, Iterable.class, File.class)
 
                         .from(Child.class).to(BufferedInputStream.class).inLocation(getClass(), 0)
@@ -549,7 +552,9 @@ public class JavaClassTest {
                         .withDescriptionContaining("implements")
 
                         .from(Child.class)
-                        .withExpectedDescriptionTemplate("has generic interface <" + InterfaceWithTwoTypeParameters.class.getName() + "> with type argument depending on <#target>")
+                        .withExpectedDescriptionPatternTemplate(
+                                ".*has generic interface <" + quote(InterfaceWithTwoTypeParameters.class.getName()) +
+                                        ".+> with type argument depending on <#target>.*")
                         .to(Comparable.class, Map.class, Map.Entry.class, String.class, BufferedInputStream[][].class, Serializable.class, List.class, Set.class, Iterable.class, File.class)
 
                         .from(Child.class).to(BufferedInputStream.class).inLocation(getClass(), 0)
@@ -788,11 +793,11 @@ public class JavaClassTest {
 
         assertThatDependencies(javaClasses.get(File.class).getDirectDependenciesToSelf())
                 .contain(from(FirstChild.class).to(File.class).inLocation(getClass(), 0)
-                        .withDescriptionContaining("Class <%s> has generic superclass <%s> with type argument depending on <%s>",
+                        .withDescriptionMatching("Class <%s> has generic superclass <%s.+> with type argument depending on <%s>.*",
                                 FirstChild.class.getName(), FirstBase.class.getName(), File.class.getName())
 
                         .from(SecondChild.class).to(File.class).inLocation(getClass(), 0)
-                        .withDescriptionContaining("Class <%s> has generic superclass <%s> with type argument depending on <%s>",
+                        .withDescriptionMatching("Class <%s> has generic superclass <%s.+> with type argument depending on <%s>.*",
                                 SecondChild.class.getName(), SecondBase.class.getName(), File.class.getName())
                 );
 
@@ -818,11 +823,11 @@ public class JavaClassTest {
 
         assertThatDependencies(javaClasses.get(File.class).getDirectDependenciesToSelf())
                 .contain(from(FirstChild.class).to(File.class).inLocation(getClass(), 0)
-                        .withDescriptionContaining("Class <%s> has generic interface <%s> with type argument depending on <%s>",
+                        .withDescriptionMatching("Class <%s> has generic interface <%s.+> with type argument depending on <%s>.*",
                                 FirstChild.class.getName(), InterfaceWithTwoTypeParameters.class.getName(), File.class.getName())
 
                         .from(SecondChild.class).to(File.class).inLocation(getClass(), 0)
-                        .withDescriptionContaining("Class <%s> has generic interface <%s> with type argument depending on <%s>",
+                        .withDescriptionMatching("Class <%s> has generic interface <%s.+> with type argument depending on <%s>.*",
                                 SecondChild.class.getName(), InterfaceWithTypeParameter.class.getName(), File.class.getName())
                 );
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaWildcardTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaWildcardTypeTest.java
@@ -13,7 +13,7 @@ import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 public class JavaWildcardTypeTest {
 
     @Test
-    public void wildcard_name() {
+    public void wildcard_name_unbounded() {
         @SuppressWarnings("unused")
         class ClassWithUnboundTypeParameter<T extends List<?>> {
         }
@@ -21,6 +21,50 @@ public class JavaWildcardTypeTest {
         JavaWildcardType type = importWildcardTypeOf(ClassWithUnboundTypeParameter.class);
 
         assertThat(type.getName()).isEqualTo("?");
+    }
+
+    @Test
+    public void wildcard_name_upper_bounded() {
+        @SuppressWarnings("unused")
+        class UpperBounded<T extends List<? extends String>> {
+        }
+
+        JavaWildcardType wildcardType = importWildcardTypeOf(UpperBounded.class);
+
+        assertThat(wildcardType.getName()).isEqualTo("? extends java.lang.String");
+    }
+
+    @Test
+    public void wildcard_name_upper_bounded_by_array() {
+        @SuppressWarnings("unused")
+        class UpperBounded<T extends List<? extends String[][]>> {
+        }
+
+        JavaWildcardType wildcardType = importWildcardTypeOf(UpperBounded.class);
+
+        assertThat(wildcardType.getName()).isEqualTo("? extends java.lang.String[][]");
+    }
+
+    @Test
+    public void wildcard_name_lower_bounded() {
+        @SuppressWarnings("unused")
+        class LowerBounded<T extends List<? super String>> {
+        }
+
+        JavaWildcardType wildcardType = importWildcardTypeOf(LowerBounded.class);
+
+        assertThat(wildcardType.getName()).isEqualTo("? super java.lang.String");
+    }
+
+    @Test
+    public void wildcard_name_lower_bounded_by_array() {
+        @SuppressWarnings("unused")
+        class LowerBounded<T extends List<? super String[][]>> {
+        }
+
+        JavaWildcardType wildcardType = importWildcardTypeOf(LowerBounded.class);
+
+        assertThat(wildcardType.getName()).isEqualTo("? super java.lang.String[][]");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
@@ -322,15 +322,15 @@ public class ClassFileImporterAccessesTest {
     @Test
     public void imports_shadowed_and_superclass_field_access() {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/hierarchicalfieldaccess"));
-        JavaClass classThatAccessesFieldOfSuperClass = classes.get(AccessToSuperAndSubclassField.class);
-        JavaClass superClassWithAccessedField = classes.get(SuperclassWithAccessedField.class);
+        JavaClass classThatAccessesFieldOfSuperclass = classes.get(AccessToSuperAndSubclassField.class);
+        JavaClass superclassWithAccessedField = classes.get(SuperclassWithAccessedField.class);
         JavaClass subClassWithAccessedField = classes.get(SubclassWithAccessedField.class);
 
-        Set<JavaFieldAccess> accesses = classThatAccessesFieldOfSuperClass.getFieldAccessesFromSelf();
+        Set<JavaFieldAccess> accesses = classThatAccessesFieldOfSuperclass.getFieldAccessesFromSelf();
 
         assertThat(accesses).hasSize(2);
-        JavaField field = superClassWithAccessedField.getField("field");
-        AccessTarget.FieldAccessTarget expectedSuperClassFieldAccess = new DomainBuilders.FieldAccessTargetBuilder()
+        JavaField field = superclassWithAccessedField.getField("field");
+        AccessTarget.FieldAccessTarget expectedSuperclassFieldAccess = new DomainBuilders.FieldAccessTargetBuilder()
                 .withOwner(subClassWithAccessedField)
                 .withName(field.getName())
                 .withType(field.getRawType())
@@ -338,7 +338,7 @@ public class ClassFileImporterAccessesTest {
                 .build();
         assertThatAccess(getOnly(accesses, "field", GET))
                 .isFrom("accessSuperclassField")
-                .isTo(expectedSuperClassFieldAccess)
+                .isTo(expectedSuperclassFieldAccess)
                 .inLineNumber(5);
         assertThatAccess(getOnly(accesses, "maskedField", GET))
                 .isFrom("accessSubclassField")
@@ -368,30 +368,30 @@ public class ClassFileImporterAccessesTest {
     @Test
     public void imports_shadowed_and_superclass_method_calls() {
         JavaClasses classes = new ClassFileImporter().importUrl(getClass().getResource("testexamples/hierarchicalmethodcall"));
-        JavaClass classThatCallsMethodOfSuperClass = classes.get(CallOfSuperAndSubclassMethod.class);
-        JavaClass superClassWithCalledMethod = classes.get(SuperclassWithCalledMethod.class);
+        JavaClass classThatCallsMethodOfSuperclass = classes.get(CallOfSuperAndSubclassMethod.class);
+        JavaClass superclassWithCalledMethod = classes.get(SuperclassWithCalledMethod.class);
         JavaClass subClassWithCalledMethod = classes.get(SubclassWithCalledMethod.class);
 
-        Set<JavaMethodCall> calls = classThatCallsMethodOfSuperClass.getMethodCallsFromSelf();
+        Set<JavaMethodCall> calls = classThatCallsMethodOfSuperclass.getMethodCallsFromSelf();
 
         assertThat(calls).hasSize(2);
 
-        JavaCodeUnit callSuperclassMethod = classThatCallsMethodOfSuperClass
+        JavaCodeUnit callSuperclassMethod = classThatCallsMethodOfSuperclass
                 .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSuperclassMethod);
-        JavaMethod expectedSuperClassMethod = superClassWithCalledMethod.getMethod(SuperclassWithCalledMethod.method);
-        AccessTarget.MethodCallTarget expectedSuperClassCall = new DomainBuilders.MethodCallTargetBuilder()
+        JavaMethod expectedSuperclassMethod = superclassWithCalledMethod.getMethod(SuperclassWithCalledMethod.method);
+        AccessTarget.MethodCallTarget expectedSuperclassCall = new DomainBuilders.MethodCallTargetBuilder()
                 .withOwner(subClassWithCalledMethod)
-                .withName(expectedSuperClassMethod.getName())
-                .withParameters(expectedSuperClassMethod.getRawParameterTypes())
-                .withReturnType(expectedSuperClassMethod.getRawReturnType())
-                .withMethods(Suppliers.ofInstance(Collections.singleton(expectedSuperClassMethod)))
+                .withName(expectedSuperclassMethod.getName())
+                .withParameters(expectedSuperclassMethod.getRawParameterTypes())
+                .withReturnType(expectedSuperclassMethod.getRawReturnType())
+                .withMethods(Suppliers.ofInstance(Collections.singleton(expectedSuperclassMethod)))
                 .build();
         assertThatCall(getOnlyByCaller(calls, callSuperclassMethod))
                 .isFrom(callSuperclassMethod)
-                .isTo(expectedSuperClassCall)
+                .isTo(expectedSuperclassCall)
                 .inLineNumber(CallOfSuperAndSubclassMethod.callSuperclassLineNumber);
 
-        JavaCodeUnit callSubclassMethod = classThatCallsMethodOfSuperClass
+        JavaCodeUnit callSubclassMethod = classThatCallsMethodOfSuperclass
                 .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSubclassMethod);
         assertThatCall(getOnlyByCaller(calls, callSubclassMethod))
                 .isFrom(callSubclassMethod)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
@@ -1,0 +1,666 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.ref.Reference;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.testutil.ArchConfigurationRule;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.parameterizedTypeArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.typeVariableArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariable.typeVariable;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteWildcardType.wildcardType;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterGenericFieldTypesTest {
+
+    @Rule
+    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
+
+    @Test
+    public void imports_non_generic_field_type() {
+        class NonGenericFieldType {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            NonGenericFieldType field;
+        }
+
+        JavaType fieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+
+        assertThatType(fieldType).as("generic field type").matches(NonGenericFieldType.class);
+    }
+
+    @Test
+    public void imports_generic_field_type_with_one_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<String> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type")
+                .hasErasure(GenericFieldType.class)
+                .hasActualTypeArguments(String.class);
+    }
+
+    @Test
+    public void imports_raw_generic_field_type_as_JavaClass_instead_of_JavaParameterizedType() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings({"unused", "rawtypes"})
+        class SomeClass {
+            GenericFieldType field;
+        }
+
+        JavaType rawGenericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(rawGenericFieldType).as("raw generic field type").matches(GenericFieldType.class);
+    }
+
+    @Test
+    public void imports_generic_field_type_with_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<String[]> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type")
+                .hasErasure(GenericFieldType.class)
+                .hasActualTypeArguments(String[].class);
+    }
+
+    @Test
+    public void imports_generic_field_type_with_primitive_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<int[]> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, int.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type")
+                .hasErasure(GenericFieldType.class)
+                .hasActualTypeArguments(int[].class);
+    }
+
+    @Test
+    public void imports_generic_field_type_with_multiple_type_arguments() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<String, Serializable, File> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class, Serializable.class, File.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type")
+                .hasErasure(GenericFieldType.class)
+                .hasActualTypeArguments(String.class, Serializable.class, File.class);
+    }
+
+    @Test
+    public void imports_generic_field_type_with_single_actual_type_argument_parameterized_with_concrete_class() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<ClassParameterWithSingleTypeParameter<String>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_field_type_with_multiple_actual_type_arguments_parameterized_with_concrete_classes() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<
+                    ClassParameterWithSingleTypeParameter<File>,
+                    InterfaceParameterWithSingleTypeParameter<Serializable>,
+                    InterfaceParameterWithSingleTypeParameter<String>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(
+                        SomeClass.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
+                        File.class, Serializable.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(File.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(Serializable.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_field_type_with_single_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<?> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(wildcardType());
+    }
+
+    @Test
+    public void imports_generic_field_type_with_single_actual_type_argument_parameterized_with_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<ClassParameterWithSingleTypeParameter<?>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameter()
+        );
+    }
+
+    @Test
+    public void imports_generic_field_type_with_actual_type_arguments_parameterized_with_bounded_wildcards() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<
+                    ClassParameterWithSingleTypeParameter<? extends String>,
+                    ClassParameterWithSingleTypeParameter<? super File>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(String.class),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(File.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_field_type_with_actual_type_arguments_with_multiple_wildcards_with_various_bounds() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<
+                    ClassParameterWithSingleTypeParameter<Map<? extends Serializable, ? super File>>,
+                    ClassParameterWithSingleTypeParameter<Reference<? super String>>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(
+                        SomeClass.class, ClassParameterWithSingleTypeParameter.class,
+                        Map.class, Serializable.class, File.class, Reference.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Map.class)
+                                .withWildcardTypeParameters(
+                                        wildcardType().withUpperBound(Serializable.class),
+                                        wildcardType().withLowerBound(File.class))),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Reference.class)
+                                .withWildcardTypeParameterWithLowerBound(String.class))
+        );
+    }
+
+    @Test
+    public void imports_generic_field_type_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<SUPER> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<SUB> {
+            GenericFieldType<SUB> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(typeVariable("SUB"));
+    }
+
+    @Test
+    public void imports_generic_field_type_with_actual_type_argument_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<SUPER> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<SUB> {
+            GenericFieldType<ClassParameterWithSingleTypeParameter<SUB>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("SUB"))
+        );
+    }
+
+    @Test
+    public void references_type_variable_assigned_to_actual_type_argument_of_generic_field_type() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<SUPER> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<SUB extends String> {
+            GenericFieldType<ClassParameterWithSingleTypeParameter<SUB>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("SUB").withUpperBounds(String.class))
+        );
+    }
+
+    @Test
+    public void references_outer_type_variable_assigned_to_actual_type_argument_of_generic_field_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                @SuppressWarnings("unused")
+                class GenericFieldType<T> {
+                }
+
+                class SomeClass {
+                    GenericFieldType<OUTER> field;
+                }
+            }
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        String.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                typeVariable("OUTER").withUpperBounds(String.class)
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_type_variables_of_enclosing_classes_that_are_out_of_context_for_generic_field_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class GenericFieldType<T> {
+                }
+
+                class SomeClass {
+                    GenericFieldType<OUTER> field;
+                }
+            }
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, String.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                typeVariable("OUTER").withoutUpperBounds()
+        );
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_field_type_bound_by_type_variables() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<FIRST extends String, SECOND extends Serializable> {
+            GenericFieldType<
+                    ClassParameterWithSingleTypeParameter<? extends FIRST>,
+                    ClassParameterWithSingleTypeParameter<? super SECOND>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("FIRST").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("SECOND").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_field_type_bound_by_type_variables_of_enclosing_classes() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class GenericFieldType<A, B> {
+                }
+
+                class SomeClass {
+                    GenericFieldType<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> field;
+                }
+            }
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_wildcards_bound_by_type_variables_of_enclosing_classes_that_are_out_of_context() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                @SuppressWarnings("unused")
+                class GenericFieldType<A, B> {
+                }
+
+                class SomeClass {
+                    GenericFieldType<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> field;
+                }
+            }
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withoutUpperBounds()),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withoutUpperBounds())
+        );
+    }
+
+    @Test
+    public void imports_complex_generic_field_type_with_multiple_nested_actual_type_arguments_with_self_referencing_type_definitions() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            GenericFieldType<
+                    // assigned to GenericFieldType<A,_,_>
+                    List<? extends FIRST>,
+                    // assigned to GenericFieldType<_,B,_>
+                    Map<
+                            Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                            Map<? extends String,
+                                    Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                    // assigned to GenericFieldType<_,_,C>
+                    Comparable<SomeClass<FIRST, SECOND>>> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter()
+                .importClasses(SomeClass.class, String.class, Serializable.class, Cloneable.class,
+                        List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        // @formatter:off
+        assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
+            // assigned to GenericFieldType<A,_,_>
+            parameterizedType(List.class)
+                .withWildcardTypeParameterWithUpperBound(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class)),
+            // assigned to GenericFieldType<_,B,_>
+            parameterizedType(Map.class).withTypeArguments(
+                parameterizedType(Map.Entry.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    parameterizedType(Map.Entry.class).withTypeArguments(
+                        concreteClass(String.class),
+                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))),
+                parameterizedType(Map.class).withTypeArguments(
+                    wildcardType().withUpperBound(String.class),
+                    parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withUpperBound(Serializable.class),
+                        parameterizedType(List.class).withTypeArguments(
+                            parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(
+                                    parameterizedType(Set.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                            parameterizedType(Iterable.class).withTypeArguments(
+                                                wildcardType().withLowerBound(
+                                                    parameterizedType(Map.class).withTypeArguments(
+                                                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class),
+                                                        wildcardType()))))))))))),
+            // assigned to GenericFieldType<_,_,C>
+            parameterizedType(Comparable.class).withTypeArguments(
+                parameterizedType(SomeClass.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
+        // @formatter:on
+    }
+
+    @Test
+    public void imports_complex_generic_array_field_type() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] field;
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).matches(
+                genericArray(
+                        GenericFieldType.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", "
+                                + Map.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", ?>, "
+                                + Serializable.class.getName() + ">>>[]"
+                ).withComponentType(
+                        parameterizedType(GenericFieldType.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String.class),
+                                        parameterizedType(Map.class).withTypeArguments(
+                                                parameterizedType(Map.class).withTypeArguments(
+                                                        wildcardType().withLowerBound(String.class),
+                                                        wildcardType()),
+                                                concreteClass(Serializable.class))))));
+    }
+
+    @Test
+    public void imports_complex_generic_field_type_with_multiple_nested_actual_type_arguments_with_concrete_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<
+                    List<Serializable[]>,
+                    List<? extends Serializable[][]>,
+                    Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> field;
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(Serializable[].class),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(Serializable[][].class),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(String[].class),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String[][][].class),
+                                        wildcardType()),
+                                concreteClass(Serializable[][].class))));
+    }
+
+    @Test
+    public void imports_generic_field_type_with_parameterized_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericFieldType<List<String>[], List<String[]>[][], List<String[][]>[][][]> field;
+        }
+
+        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, List.class, String.class)
+                .get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).hasActualTypeArguments(
+                genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
+                        parameterizedType(List.class).withTypeArguments(String.class)),
+                genericArray(parameterizedTypeArrayName(List.class, String[].class, 2)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[].class, 1)).withComponentType(
+                                parameterizedType(List.class).withTypeArguments(String[].class))),
+                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 3)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[][].class, 2)).withComponentType(
+                                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 1)).withComponentType(
+                                        parameterizedType(List.class).withTypeArguments(String[][].class)))));
+    }
+
+    @Test
+    public void imports_complex_generic_field_type_with_multiple_nested_actual_type_arguments_with_generic_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericFieldType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<X extends Serializable, Y extends String> {
+            GenericFieldType<
+                    List<X[]>,
+                    List<? extends X[][]>,
+                    Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> field;
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+
+        assertThatType(genericFieldType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(
+                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                typeVariable("X").withUpperBounds(Serializable.class))),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(
+                        genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                        typeVariable("X").withUpperBounds(Serializable.class)))),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(
+                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                        typeVariable("Y").withUpperBounds(String.class))),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                                genericArray(typeVariableArrayName("Y", 3)).withComponentType(
+                                                        genericArray(typeVariableArrayName("Y", 2)).withComponentType(
+                                                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                                                        typeVariable("Y").withUpperBounds(String.class))))),
+                                        wildcardType()),
+                                genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                                typeVariable("X").withUpperBounds(Serializable.class)))))
+        );
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassParameterWithSingleTypeParameter<T> {
+    }
+
+    @SuppressWarnings("unused")
+    public interface InterfaceParameterWithSingleTypeParameter<T> {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -62,6 +62,19 @@ public class ClassFileImporterGenericInterfacesTest {
     }
 
     @Test
+    public void imports_raw_generic_superclass_as_JavaClass_instead_of_JavaParameterizedType() {
+        @SuppressWarnings("rawtypes")
+        class Child implements InterfaceWithOneTypeParameter {
+        }
+
+        JavaType rawGenericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(Child.class, InterfaceWithOneTypeParameter.class)
+                        .get(Child.class).getInterfaces());
+
+        assertThatType(rawGenericInterface).as("raw generic interface").matches(InterfaceWithOneTypeParameter.class);
+    }
+
+    @Test
     public void imports_generic_interface_with_array_type_argument() {
         class Child implements InterfaceWithOneTypeParameter<String[]> {
         }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -26,6 +26,7 @@ import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariable.typeVariable;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariableArray.typeVariableArray;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteWildcardType.wildcardType;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
@@ -441,6 +442,101 @@ public class ClassFileImporterGenericInterfacesTest {
                     typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
                     typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
         // @formatter:on
+    }
+
+    private static class Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds {
+        static class ClassChild implements InterfaceWithThreeTypeParameters<
+                List<Serializable[]>,
+                List<? extends Serializable[][]>,
+                Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> {
+        }
+
+        interface InterfaceChild extends InterfaceWithThreeTypeParameters<
+                List<Serializable[]>,
+                List<? extends Serializable[][]>,
+                Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> {
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds() {
+        return testForEach(
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds.ClassChild.class,
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds.InterfaceChild.class
+        );
+    }
+
+    @Test
+    @UseDataProvider("data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds")
+    public void imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds(Class<?> testInput) {
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(testInput, List.class, Serializable.class, Map.class, String.class)
+                        .get(testInput).getInterfaces());
+
+        assertThatType(genericInterface).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(Serializable[].class),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(Serializable[][].class),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(String[].class),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String[][][].class),
+                                        wildcardType()),
+                                concreteClass(Serializable[][].class))));
+    }
+
+    private static class Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds {
+        static class ClassChild<X extends Serializable, Y extends String> implements InterfaceWithThreeTypeParameters<
+                List<X[]>,
+                List<? extends X[][]>,
+                Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> {
+        }
+
+        interface InterfaceChild<X extends Serializable, Y extends String> extends InterfaceWithThreeTypeParameters<
+                List<X[]>,
+                List<? extends X[][]>,
+                Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> {
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds() {
+        return testForEach(
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds.ClassChild.class,
+                Data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds.InterfaceChild.class
+        );
+    }
+
+    @Test
+    @UseDataProvider("data_of_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds")
+    public void imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds(Class<?> testInput) {
+        JavaType genericInterface = getOnlyElement(
+                new ClassFileImporter().importClasses(testInput, List.class, Serializable.class, Map.class, String.class)
+                        .get(testInput).getInterfaces());
+
+        assertThatType(genericInterface).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(
+                        typeVariableArray("X[]").withComponentType(typeVariable("X").withUpperBounds(Serializable.class))),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(
+                        typeVariableArray("X[][]").withComponentType(
+                                typeVariableArray("X[]").withComponentType(
+                                        typeVariable("X").withUpperBounds(Serializable.class)))),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(
+                                typeVariableArray("Y[]").withComponentType(
+                                        typeVariable("Y").withUpperBounds(String.class))),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                                typeVariableArray("Y[][][]").withComponentType(
+                                                        typeVariableArray("Y[][]").withComponentType(
+                                                                typeVariableArray("Y[]").withComponentType(
+                                                                        typeVariable("Y").withUpperBounds(String.class))))),
+                                        wildcardType()),
+                                typeVariableArray("X[][]").withComponentType(
+                                        typeVariableArray("X[]").withComponentType(
+                                                typeVariable("X").withUpperBounds(Serializable.class)))))
+        );
     }
 
     private static class Data_of_imports_multiple_generic_interfaces {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -221,6 +221,17 @@ public class ClassFileImporterGenericInterfacesTest {
     }
 
     @Test
+    public void imports_generic_interface_parameterized_with_type_variable() {
+        class Child<SUB> implements InterfaceWithOneTypeParameter<SUB> {
+        }
+
+        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClasses(Child.class, InterfaceWithOneTypeParameter.class)
+                .get(Child.class).getInterfaces());
+
+        assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(typeVariable("SUB"));
+    }
+
+    @Test
     public void imports_generic_interface_with_actual_type_argument_parameterized_with_type_variable() {
         class Child<SUB> implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<SUB>> {
         }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -56,6 +56,21 @@ public class ClassFileImporterGenericSuperclassTest {
     }
 
     @Test
+    public void imports_raw_generic_superclass_as_JavaClass_instead_of_JavaParameterizedType() {
+        @SuppressWarnings("unused")
+        class BaseClass<T> {
+        }
+        @SuppressWarnings("rawtypes")
+        class Child extends BaseClass {
+        }
+
+        JavaType rawGenericSuperclass = new ClassFileImporter().importClasses(Child.class, BaseClass.class)
+                .get(Child.class).getSuperclass().get();
+
+        assertThatType(rawGenericSuperclass).as("raw generic superclass").matches(BaseClass.class);
+    }
+
+    @Test
     public void imports_generic_superclass_with_array_type_argument() {
         @SuppressWarnings("unused")
         class BaseClass<T> {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -230,6 +230,20 @@ public class ClassFileImporterGenericSuperclassTest {
     }
 
     @Test
+    public void imports_generic_superclass_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class BaseClass<SUPER> {
+        }
+        class Child<SUB> extends BaseClass<SUB> {
+        }
+
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, BaseClass.class)
+                .get(Child.class).getSuperclass().get();
+
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(typeVariable("SUB"));
+    }
+
+    @Test
     public void imports_generic_superclass_with_actual_type_argument_parameterized_with_type_variable() {
         @SuppressWarnings("unused")
         class BaseClass<SUPER> {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -33,9 +33,9 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").matches(BaseClass.class);
+        assertThatType(genericSuperclass).as("generic superclass").matches(BaseClass.class);
     }
 
     @Test
@@ -46,9 +46,9 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, String.class).get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, String.class).get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass")
+        assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
                 .hasActualTypeArguments(String.class);
     }
@@ -94,10 +94,10 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String, Serializable, File> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, String.class, Serializable.class, File.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, String.class, Serializable.class, File.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass")
+        assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
                 .hasActualTypeArguments(String.class, Serializable.class, File.class);
     }
@@ -110,10 +110,10 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withTypeArguments(String.class)
         );
@@ -130,13 +130,13 @@ public class ClassFileImporterGenericSuperclassTest {
                 InterfaceParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(
                         Child.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
                         File.class, Serializable.class, String.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withTypeArguments(File.class),
                 parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
@@ -154,10 +154,10 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<?>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withWildcardTypeParameter()
         );
@@ -173,10 +173,10 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super File>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withWildcardTypeParameterWithUpperBound(String.class),
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -194,13 +194,13 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<Reference<? super String>>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(
                         Child.class, ClassParameterWithSingleTypeParameter.class,
                         Map.class, Serializable.class, File.class, Reference.class, String.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withTypeArguments(parameterizedType(Map.class)
                                 .withWildcardTypeParameters(
@@ -220,10 +220,10 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withTypeArguments(typeVariable("SUB"))
         );
@@ -237,10 +237,10 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB extends String> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
+        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withTypeArguments(typeVariable("SUB").withUpperBounds(String.class))
         );
@@ -260,7 +260,7 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(
                         OuterWithTypeParameter.class,
                         OuterWithTypeParameter.SomeInner.class,
@@ -268,7 +268,7 @@ public class ClassFileImporterGenericSuperclassTest {
                         String.class)
                 .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
         );
     }
@@ -287,11 +287,11 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(OuterWithTypeParameter.SomeInner.Child.class, String.class)
                 .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 typeVariable("OUTER").withoutUpperBounds()
         );
     }
@@ -307,11 +307,11 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super SECOND>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
                 .get(Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withWildcardTypeParameterWithUpperBound(
                                 typeVariable("FIRST").withUpperBounds(String.class)),
@@ -337,7 +337,7 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(
                         OuterWithTypeParameter.class,
                         OuterWithTypeParameter.SomeInner.class,
@@ -345,7 +345,7 @@ public class ClassFileImporterGenericSuperclassTest {
                         ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
                 .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withWildcardTypeParameterWithUpperBound(
                                 typeVariable("OUTER_ONE").withUpperBounds(String.class)),
@@ -371,13 +371,13 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(
                         OuterWithTypeParameter.SomeInner.Child.class,
                         ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
                 .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
                         .withWildcardTypeParameterWithUpperBound(
                                 typeVariable("OUTER_ONE").withoutUpperBounds()),
@@ -405,13 +405,13 @@ public class ClassFileImporterGenericSuperclassTest {
                 Comparable<Child<FIRST, SECOND>>> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter()
+        JavaType genericSuperclass = new ClassFileImporter()
                 .importClasses(Child.class, String.class, Serializable.class, Cloneable.class,
                         List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
                 .get(Child.class).getSuperclass().get();
 
         // @formatter:off
-        assertThatType(genericSuperClass).as("generic superclass").hasActualTypeArguments(
+        assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
             // assigned to BaseClass<A,_,_>
             parameterizedType(List.class)
                 .withWildcardTypeParameterWithUpperBound(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -41,6 +41,7 @@ import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import org.objectweb.asm.Type;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
@@ -66,7 +67,7 @@ public class ImportTestUtils {
                     .withName(field.getName())
                     .withDescriptor(Type.getDescriptor(field.getType()))
                     .withModifiers(JavaModifier.getModifiersForField(field.getModifiers()))
-                    .withType(JavaClassDescriptor.From.name(field.getType().getName())));
+                    .withType(Optional.<JavaTypeCreationProcess<JavaField>>absent(), JavaClassDescriptor.From.name(field.getType().getName())));
         }
         return fieldBuilders;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
@@ -245,7 +245,7 @@ public interface ExpectedConcreteType {
         public void assertMatchWith(JavaType actual, DescriptionContext context) {
             assertThat(actual).as(context.step("JavaType").toString()).isInstanceOf(JavaGenericArrayType.class);
             JavaGenericArrayType actualArrayType = (JavaGenericArrayType) actual;
-            assertThat(actualArrayType.getName()).as(context.step("type variable name").toString()).isEqualTo(name);
+            assertThat(actualArrayType.getName()).as(context.step("array type name").toString()).isEqualTo(name);
 
             if (componentType != null) {
                 DescriptionContext newContext = context.describe(actual.getName()).step("component type").metaInfo();

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
@@ -3,8 +3,10 @@ package com.tngtech.archunit.testutil.assertion;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaGenericArrayType;
@@ -14,6 +16,7 @@ import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.JavaWildcardType;
 import org.junit.Assert;
 
+import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 import static com.tngtech.archunit.core.domain.Formatters.ensureSimpleName;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
@@ -223,15 +226,17 @@ public interface ExpectedConcreteType {
         }
     }
 
-    class ExpectedConcreteTypeVariableArray implements ExpectedConcreteType {
+    class ExpectedConcreteGenericArray implements ExpectedConcreteType {
+        private static final Pattern ARRAY_PATTERN = Pattern.compile("(\\[+)(.*)");
+
         private final String name;
         private ExpectedConcreteType componentType;
 
-        private ExpectedConcreteTypeVariableArray(String name) {
+        private ExpectedConcreteGenericArray(String name) {
             this.name = name;
         }
 
-        public ExpectedConcreteTypeVariableArray withComponentType(ExpectedConcreteType componentType) {
+        public ExpectedConcreteGenericArray withComponentType(ExpectedConcreteType componentType) {
             this.componentType = componentType;
             return this;
         }
@@ -248,8 +253,16 @@ public interface ExpectedConcreteType {
             }
         }
 
-        public static ExpectedConcreteTypeVariableArray typeVariableArray(String typeVariableArrayString) {
-            return new ExpectedConcreteTypeVariableArray(typeVariableArrayString);
+        public static ExpectedConcreteGenericArray genericArray(String genericArrayName) {
+            return new ExpectedConcreteGenericArray(genericArrayName);
+        }
+
+        public static String parameterizedTypeArrayName(Class<?> rawType, Class<?> typeParameter, int dimensions) {
+            return rawType.getName() + "<" + ensureCanonicalArrayTypeName(typeParameter.getName()) + ">" + Strings.repeat("[]", dimensions);
+        }
+
+        public static String typeVariableArrayName(String typeVariableName, int dimensions) {
+            return typeVariableName + Strings.repeat("[]", dimensions);
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedConcreteType.java
@@ -135,7 +135,7 @@ public interface ExpectedConcreteType {
 
             assertThat(actual).as(context.toString()).isInstanceOf(JavaWildcardType.class);
             JavaWildcardType wildcardType = (JavaWildcardType) actual;
-            assertThat(wildcardType.getName()).as(context.toString()).isEqualTo("?");
+            assertThat(wildcardType.getName()).as(context.toString()).startsWith("?");
 
             assertUpperBoundsMatch(wildcardType, context);
             assertLowerBoundMatch(wildcardType, context);

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
@@ -1,11 +1,8 @@
 package com.tngtech.archunit.testutil.assertion;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -14,11 +11,11 @@ import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass;
 import org.assertj.core.api.AbstractObjectAssert;
-import org.objectweb.asm.Type;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.tngtech.archunit.base.Guava.toGuava;
+import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypeVariable;
 import static com.tngtech.archunit.testutil.TestUtils.namesOf;
@@ -28,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.api.Assertions.assertThat;
 
 public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, JavaType> {
-    private static final Pattern ARRAY_PATTERN = Pattern.compile("(\\[+)(.*)");
 
     public JavaTypeAssertion(JavaType javaType) {
         super(javaType, JavaTypeAssertion.class);
@@ -45,7 +41,7 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
         assertThat(javaClass.getName()).as(describeAssertion("Name of " + javaClass))
                 .isEqualTo(clazz.getName());
         assertThat(javaClass.getSimpleName()).as(describeAssertion("Simple name of " + javaClass))
-                .isEqualTo(ensureArrayName(clazz.getSimpleName()));
+                .isEqualTo(ensureCanonicalArrayTypeName(clazz.getSimpleName()));
         assertThat(javaClass.getPackage().getName()).as(describeAssertion("Package of " + javaClass))
                 .isEqualTo(getExpectedPackageName(clazz));
         assertThat(javaClass.getPackageName()).as(describeAssertion("Package name of " + javaClass))
@@ -113,16 +109,6 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
     private JavaClass actualClass() {
         assertThat(actual).as(describeAssertion(actual.getName())).isInstanceOf(JavaClass.class);
         return (JavaClass) actual;
-    }
-
-    private String ensureArrayName(String name) {
-        String suffix = "";
-        Matcher matcher = ARRAY_PATTERN.matcher(name);
-        if (matcher.matches()) {
-            name = Type.getType(matcher.group(2)).getClassName();
-            suffix = Strings.repeat("[]", matcher.group(1).length());
-        }
-        return name + suffix;
     }
 
     public static String getExpectedPackageName(Class<?> clazz) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
@@ -59,6 +59,10 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
         }
     }
 
+    public void matches(ExpectedConcreteType type) {
+        type.assertMatchWith(actual, new DescriptionContext(actual.getName()));
+    }
+
     private String describeAssertion(String partialAssertionDescription) {
         return isNullOrEmpty(descriptionText())
                 ? partialAssertionDescription

--- a/build-steps/codequality/spotbugs-excludes.xml
+++ b/build-steps/codequality/spotbugs-excludes.xml
@@ -34,7 +34,7 @@
     </Match>
     <Match>
         <!-- Null is not used as a value (return or input) in any method, so we don't need @Nullable and co. -->
-        <Class name="com.tngtech.archunit.core.importer.JavaClassSignatureImporter$TypeArgumentProcessor"/>
+        <Class name="com.tngtech.archunit.core.importer.JavaClassSignatureImporter$SignatureTypeArgumentProcessor"/>
         <Method name="visitClassType"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>

--- a/build-steps/codequality/spotbugs-excludes.xml
+++ b/build-steps/codequality/spotbugs-excludes.xml
@@ -34,7 +34,7 @@
     </Match>
     <Match>
         <!-- Null is not used as a value (return or input) in any method, so we don't need @Nullable and co. -->
-        <Class name="com.tngtech.archunit.core.importer.JavaClassSignatureImporter$SignatureTypeArgumentProcessor"/>
+        <Class name="com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor"/>
         <Method name="visitClassType"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>


### PR DESCRIPTION
This next step to fully support Generics within ArchUnit adds support for generic field types. In particular

* `JavaField.getType()` now returns a `JavaParameterizedType` for a parameterized generic field type and the raw types otherwise
* all type arguments of generic field types are added to `JavaClass.directDependencies{From/To}Self`

Example: ArchUnit would now detect `String` as a `Dependency` of a field declaration like

```
class SomeClass {
    Set<List<? super String>> someField;
}
```