### PR TITLE
Fix wrongly repackaged dependencies

### DIFF
--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -31,7 +31,7 @@ artifacts {
 
 dependencies {
     archJunitApi project(path: ':archunit', configuration: 'shadow')
-    implementation dependency.guava
+    dependency.addGuava { dependencyNotation, config -> implementation(dependencyNotation, config) }
     implementation dependency.slf4j
 
     testImplementation dependency.log4j_api

--- a/archunit-junit/junit4/build.gradle
+++ b/archunit-junit/junit4/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api project(path: ':archunit-junit', configuration: 'archJunitApi')
     api dependency.junit4
     implementation project(path: ':archunit-junit', configuration: 'shadow')
-    implementation dependency.guava
+    dependency.addGuava { dependencyNotation, config -> implementation(dependencyNotation, config) }
     implementation dependency.slf4j
 
     testImplementation dependency.log4j_api

--- a/archunit-junit/junit5/engine-api/build.gradle
+++ b/archunit-junit/junit5/engine-api/build.gradle
@@ -6,7 +6,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     api dependency.junitPlatformEngine
     implementation project(path: ':archunit')
-    implementation dependency.guava
+    dependency.addGuava { dependencyNotation, config -> implementation(dependencyNotation, config) }
     implementation dependency.slf4j
 
     testImplementation project(path: ':archunit-junit5-api')

--- a/archunit-junit/junit5/engine/build.gradle
+++ b/archunit-junit/junit5/engine/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(path: ':archunit-junit5-api')
     api project(path: ':archunit-junit5-engine-api')
     implementation project(path: ':archunit-junit')
-    implementation dependency.guava
+    dependency.addGuava { dependencyNotation, config -> implementation(dependencyNotation, config) }
     implementation dependency.slf4j
 
     testImplementation project(path: ':archunit', configuration: 'tests')

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -5,7 +5,7 @@ ext.moduleName = 'com.tngtech.archunit'
 dependencies {
     api dependency.slf4j
     implementation dependency.asm
-    implementation dependency.guava
+    dependency.addGuava { dependencyNotation, config -> implementation(dependencyNotation, config) }
 
     testImplementation dependency.log4j_api
     testImplementation dependency.log4j_core

--- a/build-steps/release/check-uploaded-artifacts.gradle
+++ b/build-steps/release/check-uploaded-artifacts.gradle
@@ -103,6 +103,18 @@ def checkJavadocExists = { String artifactId ->
     assert getUploadedFile(artifactId, 'jar', 'javadoc') != null
 }
 
+def checkArtifactContent = { Project project, JarFile jarFile ->
+    checkManifest(project.name, jarFile.manifest)
+    if (project.repackagesAsm) {
+        println "Artifact ${project.name} is configured to repackage 3rd party libs -> checking existence of 3rd party package..."
+        checkThirdParty(jarFile)
+    } else {
+        println "Artifact ${project.name} is configured to not repackage 3rd party libs -> checking absense of 3rd party package..."
+        checkNoThirdParty(jarFile)
+    }
+    checkNoIllegalJarEntries(jarFile)
+}
+
 task checkUploadedArtifacts {
     doLast {
         releaseProjects.each { Project project ->
@@ -111,15 +123,17 @@ task checkUploadedArtifacts {
             checkJavadocExists(project.name)
 
             JarFile jarFile = new JarFile(getUploadedFile(project.name, 'jar', ''))
-            checkManifest(project.name, jarFile.manifest)
-            if (project.repackagesAsm) {
-                println "Artifact ${project.name} is configured to repackage 3rd party libs -> checking existence of 3rd party package..."
-                checkThirdParty(jarFile)
-            } else {
-                println "Artifact ${project.name} is configured to not repackage 3rd party libs -> checking absense of 3rd party package..."
-                checkNoThirdParty(jarFile)
-            }
-            checkNoIllegalJarEntries(jarFile)
+            checkArtifactContent(project, jarFile)
         }
     }
+}
+
+releaseProjects.each { Project project ->
+    def task = project.task(['dependsOn': project.build],'checkArtifact') {
+        doLast {
+            def jarFile = new JarFile(project.jar.archiveFile.get().getAsFile())
+            checkArtifactContent(project, jarFile)
+        }
+    }
+    project.build.finalizedBy(task)
 }

--- a/build-steps/release/check-uploaded-artifacts.gradle
+++ b/build-steps/release/check-uploaded-artifacts.gradle
@@ -18,7 +18,8 @@ def createArtifactUrl = { String artifactId ->
 
 def getUploadedFile = { String artifactId, String ending, String suffix ->
     def fullEnding = (!suffix.isEmpty() ? "-${suffix}" : '') + ".${ending}"
-    File result = Files.createTempFile(artifactId, fullEnding).toFile()
+    def tempDir = Files.createTempDirectory('release-check').toFile()
+    File result = new File(tempDir, "${artifactId}${fullEnding}")
     result.bytes = new URL("${createArtifactUrl(artifactId)}${fullEnding}").bytes
     result
 }
@@ -82,6 +83,18 @@ def checkNoThirdParty = { JarFile jarFile ->
     assert jarFile.getEntry('com/tngtech/archunit/thirdparty') == null: 'There exists a third party folder'
 }
 
+def checkNoIllegalJarEntries = { JarFile jarFile ->
+    def illegalEntries = Collections.list(jarFile.entries()).findAll {
+        !it.name.startsWith('com/tngtech/archunit/') &&
+                it.name != 'com/' &&
+                it.name != 'com/tngtech/' &&
+                !it.name.startsWith('META-INF/')
+    }
+    assert illegalEntries.empty: """
+        |There are invalid entries contained inside of release artifact ${new File(jarFile.name).name}: 
+        |-> ${illegalEntries.join("${System.lineSeparator()}-> ")}""".stripMargin().trim()
+}
+
 def checkSourcesExist = { String artifactId ->
     assert getUploadedFile(artifactId, 'jar', 'sources') != null
 }
@@ -106,6 +119,7 @@ task checkUploadedArtifacts {
                 println "Artifact ${project.name} is configured to not repackage 3rd party libs -> checking absense of 3rd party package..."
                 checkNoThirdParty(jarFile)
             }
+            checkNoIllegalJarEntries(jarFile)
         }
     }
 }

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -33,12 +33,6 @@ releaseProjects*.with {
     tasks.withType(AbstractPublishToMaven) {
         it.dependsOn(build)
     }
-    tasks.withType(PublishToMavenRepository) {
-        it.doFirst {
-            assert !gradle.startParameter.isParallelProjectExecutionEnabled():
-                    'uploading archives with parallel execution seems to lead to broken uploads in Sonatype Nexus'
-        }
-    }
 
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ ext {
     dependency = [
             asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.1'],
             guava               : [group: 'com.google.guava', name: 'guava', version: '30.1-android'],  // -android is compatible with Java 7.
+            addGuava            : { dependencyHandler ->
+                                      dependencyHandler(dependency.guava) {
+                                          exclude module: 'listenablefuture'
+                                          exclude module: 'jsr305'
+                                          exclude module: 'checker-compat-qual'
+                                          exclude module: 'error_prone_annotations'
+                                          exclude module: 'j2objc-annotations'
+                                      }
+                                  },
             slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'],
             // log4j 2.13.0 requires Java 8.
             log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.12.1'],


### PR DESCRIPTION
When we upgraded Guava to version `guava:30.1-android` the dependency unfortunately contained some additional transitive dependencies that we overlooked to repackage. I have excluded all irrelevant transitive dependencies. We have sufficient test coverage to find any problems that could arise from excluding these dependencies (since they are also excluded from the Gradle build, not only the release artifacts).
I have also added an additional release artifact check that ensures we don't repackage any unexpected 3rd party libs in the future.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>