### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Java
         uses: actions/setup-java@v1
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Build JDK
         uses: actions/setup-java@v1
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
       - name: Set up Build JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           java-version: ${{ matrix.test_java_version }}
       - name: Provide installed JDKs
-        uses: actions/github-script@v3
+        uses: actions/github-script@v4.0.2
         with:
           script: |
             for ( let envVarName in process.env ) {
@@ -105,7 +105,7 @@ jobs:
         with:
           java-version: ${{ matrix.java_version }}
       - name: Provide installed JDKs
-        uses: actions/github-script@v3
+        uses: actions/github-script@v4.0.2
         id: provideJdkPaths
         with:
           script: |

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@v1.0.3

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -12,5 +12,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -17,6 +17,6 @@ jobs:
           java-version: 14
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v1
+        uses: gradle-update/update-gradle-wrapper-action@v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
 
       - name: Install Gradle JDK
         uses: actions/setup-java@v1


### PR DESCRIPTION
Contains

* Bump `gradle/wrapper-validation-action` from 1 to 1.0.3
* Bump `gradle-update/update-gradle-wrapper-action` from 1 to 1.0.13
* Bump `actions/checkout` from 2 to 2.3.4
* Bump `actions/github-script` from 3 to 4.0.2