### PR TITLE
add property `freeze.refreeze` to allow overwriting the current store

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
@@ -74,6 +74,8 @@ import static com.tngtech.archunit.library.freeze.ViolationStoreFactory.FREEZE_S
 public final class FreezingArchRule implements ArchRule {
     private static final Logger log = LoggerFactory.getLogger(FreezingArchRule.class);
 
+    private static final String FREEZE_REFREEZE_PROPERTY_NAME = "freeze.refreeze";
+
     private final ArchRule delegate;
     private final ViolationStoreLineBreakAdapter store;
     private final ViolationLineMatcher matcher;
@@ -112,11 +114,16 @@ public final class FreezingArchRule implements ArchRule {
         store.initialize(ArchConfiguration.get().getSubProperties(FREEZE_STORE_PROPERTY_NAME));
 
         EvaluationResultLineBreakAdapter result = new EvaluationResultLineBreakAdapter(delegate.evaluate(classes));
-        if (!store.contains(delegate)) {
+        if (!store.contains(delegate) || refreezeViolations()) {
             return storeViolationsAndReturnSuccess(result);
         } else {
             return removeObsoleteViolationsFromStoreAndReturnNewViolations(result);
         }
+    }
+
+    private boolean refreezeViolations() {
+        String configuredRefreeze = ArchConfiguration.get().getPropertyOrDefault(FREEZE_REFREEZE_PROPERTY_NAME, Boolean.FALSE.toString());
+        return Boolean.parseBoolean(configuredRefreeze);
     }
 
     private EvaluationResult storeViolationsAndReturnSuccess(EvaluationResultLineBreakAdapter result) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
@@ -70,6 +70,17 @@ public class TextFileBasedViolationStoreTest {
     }
 
     @Test
+    public void updates_stored_violations_of_single_rule() throws IOException {
+        store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
+        store.save(defaultRule(), ImmutableList.of("first overwritten violation", "second overwritten violation"));
+
+        Properties properties = readProperties(new File(configuredFolder, "stored.rules"));
+        String ruleViolationsFile = properties.getProperty(defaultRule().getDescription());
+        List<String> violationLines = Files.readLines(new File(configuredFolder, ruleViolationsFile), UTF_8);
+        assertThat(violationLines).containsOnly("first overwritten violation", "second overwritten violation");
+    }
+
+    @Test
     public void reads_violations_of_single_rule_from_configured_folder() {
         store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
 

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -386,6 +386,13 @@ For example to allow the creation of the violation store in a specific environme
 -Darchunit.freeze.store.default.allowStoreCreation=true
 ----
 
+It is also possible to allow all violations to be "refrozen", i.e. the store will just be updated
+with the current state, and the reported result will be success. Thus, it is effectively the same behavior
+as if all rules would never have been frozen.
+This can e.g. make sense, because current violations are consciously accepted and should be added to the store,
+or because the format of some violations has changed. The respective property to allow refreezing
+all current violations is `freeze.refreeze=true`, where the default is `false`.
+
 ==== Extension
 
 `FreezingArchRule` provides two extension points to adjust the behavior to custom needs.


### PR DESCRIPTION
From time to time it makes sense to simply refreeze violations reported by `FreezingArchRule`. This can be the case, because constraints force a team to temporarily accept some architecture violations, or because some violation format has changed.
This release of ArchUnit for example will change the format in which parameterized types are reported within rule violations. The new property `freeze.refreeze=true` nicely covers this by allowing to refreeze the current state when such changes happen on updating ArchUnit.

Resolves: #510

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>