### PR TITLE
pass annotations of rule fields and methods to JUnit test description

### DIFF
--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
@@ -47,7 +47,7 @@ class ArchRuleExecution extends ArchTestExecution {
 
     @Override
     Description describeSelf() {
-        return Description.createTestDescription(testClass, ruleField.getName());
+        return Description.createTestDescription(testClass, ruleField.getName(), ruleField.getAnnotations());
     }
 
     @Override

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -52,7 +52,7 @@ class ArchTestMethodExecution extends ArchTestExecution {
 
     @Override
     Description describeSelf() {
-        return Description.createTestDescription(testClass, testMethod.getName());
+        return Description.createTestDescription(testClass, testMethod.getName(), testMethod.getAnnotations());
     }
 
     @Override

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsMethodsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsMethodsTest.java
@@ -59,7 +59,6 @@ public class ArchUnitRunnerRunsMethodsTest {
     private JavaClasses cachedClasses = importClassesWithContext(ArchUnitRunnerRunsMethodsTest.class);
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() {
         when(cache.get()).thenReturn(classCache);
         when(classCache.getClassesToAnalyzeFor(any(Class.class), any(ClassAnalysisRequest.class))).thenReturn(cachedClasses);
@@ -126,6 +125,17 @@ public class ArchUnitRunnerRunsMethodsTest {
         runner.runChild(ArchUnitRunnerTestUtils.getRule(AbstractBaseClass.INSTANCE_METHOD_NAME, runner), runNotifier);
 
         verifyTestFinishedSuccessfully(AbstractBaseClass.INSTANCE_METHOD_NAME);
+    }
+
+    @Test
+    public void should_pass_annotations_of_test_method() {
+        ArchUnitRunner runner = newRunnerFor(ArchTestWithMethodWithAdditionalAnnotation.class, cache);
+
+        runner.runChild(ArchUnitRunnerTestUtils.getRule(ArchTestWithMethodWithAdditionalAnnotation.TEST_METHOD_NAME, runner), runNotifier);
+
+        verify(runNotifier).fireTestFinished(descriptionCaptor.capture());
+        Description description = descriptionCaptor.getValue();
+        assertThat(description.getAnnotation(Deprecated.class)).as("expected annotation").isNotNull();
     }
 
     private ArchUnitRunner newRunner(Class<ArchTestWithIllegalTestMethods> testClass) {
@@ -200,6 +210,16 @@ public class ArchUnitRunnerRunsMethodsTest {
         @ArchIgnore
         @ArchTest
         public static void toBeIgnored(JavaClasses classes) {
+        }
+    }
+
+    @AnalyzeClasses(packages = "some.pkg")
+    public static class ArchTestWithMethodWithAdditionalAnnotation {
+        static final String TEST_METHOD_NAME = "annotatedTestMethod";
+
+        @Deprecated
+        @ArchTest
+        public static void annotatedTestMethod(JavaClasses classes) {
         }
     }
 

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerRunsRuleFieldsTest.java
@@ -63,7 +63,6 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     private JavaClasses cachedClasses = importClassesWithContext(Object.class);
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() {
         when(cache.get()).thenReturn(classCache);
         when(classCache.getClassesToAnalyzeFor(any(Class.class), any(ClassAnalysisRequest.class))).thenReturn(cachedClasses);
@@ -157,6 +156,17 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
                 .contains(RULE_ONE_IN_IGNORED_TEST, RULE_TWO_IN_IGNORED_TEST);
     }
 
+    @Test
+    public void should_pass_annotations_of_rule_field() {
+        ArchUnitRunner runner = newRunnerFor(ArchTestWithFieldWithAdditionalAnnotation.class, cache);
+
+        runner.runChild(ArchUnitRunnerTestUtils.getRule(ArchTestWithFieldWithAdditionalAnnotation.TEST_FIELD_NAME, runner), runNotifier);
+
+        verify(runNotifier).fireTestFinished(descriptionCaptor.capture());
+        Description description = descriptionCaptor.getValue();
+        assertThat(description.getAnnotation(Deprecated.class)).as("expected annotation").isNotNull();
+    }
+
     private ArchTestExecution getRule(String name) {
         return ArchUnitRunnerTestUtils.getRule(name, runner);
     }
@@ -230,5 +240,14 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
 
         @ArchTest
         public static final ArchRule someRuleTwo = classes().should(NEVER_BE_SATISFIED);
+    }
+
+    @AnalyzeClasses(packages = "some.pkg")
+    public static class ArchTestWithFieldWithAdditionalAnnotation {
+        static final String TEST_FIELD_NAME = "annotatedTestField";
+
+        @Deprecated
+        @ArchTest
+        public static final ArchRule annotatedTestField = classes().should(NEVER_BE_SATISFIED);
     }
 }


### PR DESCRIPTION
To interact correctly with some other test frameworks it can be necessary to pass on the annotations of a certain rule method or field to the JUnit 4 `TestDescription` that the `ArchUnitRunner` creates.
One example framework mentioned in the respective GitHub issue was [Allure](https://docs.qameta.io/allure/).

Resolves: #552

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>