### PR TITLE
Add generic method return types

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
@@ -11,4 +11,8 @@ import com.tngtech.archunit.example.layers.controller.one.SomeEnum;
 @SuppressWarnings("unused")
 public abstract class SpecialServiceHelper extends ServiceHelper<SomeUtility, HashMap<?, Set<? super SomeEnum>>> implements List<Set<? super SomeUtility>> {
     Map<?, Map<SomeEnum, ? extends SomeUtility>> fieldWithGenericTypeViolatingLayerRule;
+
+    Map<?, Map<SomeEnum, ? extends SomeUtility>> methodWithGenericReturnTypeViolatingLayerRule() {
+        return null;
+    }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -177,6 +177,7 @@ import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericFieldType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterfaceOf;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericMethodReturnType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclassOf;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
 import static com.tngtech.archunit.testutils.ExpectedDependency.method;
@@ -794,6 +795,10 @@ class ExamplesIntegrationTest {
                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
+                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                        .dependingOn(SomeEnum.class))
+                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                        .dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -862,6 +867,10 @@ class ExamplesIntegrationTest {
                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
+                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                        .dependingOn(SomeEnum.class))
+                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                        .dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -940,6 +949,10 @@ class ExamplesIntegrationTest {
                                 .by(genericInterfaceOf(SpecialServiceHelper.class).dependingOn(SomeUtility.class))
                                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeEnum.class))
                                 .by(genericFieldType(SpecialServiceHelper.class, "fieldWithGenericTypeViolatingLayerRule").dependingOn(SomeUtility.class))
+                                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                                        .dependingOn(SomeEnum.class))
+                                .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                                        .dependingOn(SomeUtility.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -325,6 +325,12 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
 
         @Override
         @PublicAPI(usage = ACCESS)
+        public JavaType getReturnType() {
+            return returnType;
+        }
+
+        @Override
+        @PublicAPI(usage = ACCESS)
         public JavaClass getRawReturnType() {
             return returnType;
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -156,6 +156,10 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         return tryCreateDependency(origin, genericDependencyType("type", origin.getType()), typeArgumentDependency);
     }
 
+    static Set<Dependency> tryCreateFromGenericMethodReturnTypeArgument(JavaMethod origin, JavaClass typeArgumentDependency) {
+        return tryCreateDependency(origin, genericDependencyType("return type", origin.getReturnType()), typeArgumentDependency);
+    }
+
     private static String genericDependencyType(String genericTypeDescription, JavaType genericType) {
         return "has generic " + genericTypeDescription + " " + bracketFormat(genericType.getName()) + " with type argument depending on";
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -140,6 +140,21 @@ class JavaClassDependencies {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
         for (JavaMethod method : javaClass.getMethods()) {
             result.addAll(Dependency.tryCreateFromReturnType(method));
+            result.addAll(genericReturnTypeArgumentDependencies(method));
+        }
+        return result.build();
+    }
+
+    private Set<Dependency> genericReturnTypeArgumentDependencies(JavaMethod method) {
+        if (!(method.getReturnType() instanceof JavaParameterizedType)) {
+            return emptySet();
+        }
+        JavaParameterizedType returnType = (JavaParameterizedType) method.getReturnType();
+
+        List<JavaType> actualTypeArguments = returnType.getActualTypeArguments();
+        ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
+        for (JavaClass returnTypeArgumentDependency : dependenciesOfTypes(actualTypeArguments)) {
+            result.addAll(Dependency.tryCreateFromGenericMethodReturnTypeArgument(method, returnTypeArgumentDependency));
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -51,7 +51,7 @@ public abstract class JavaCodeUnit
         extends JavaMember
         implements HasParameterTypes, HasReturnType, HasTypeParameters<JavaCodeUnit>, HasThrowsClause<JavaCodeUnit> {
 
-    private final JavaClass returnType;
+    private final JavaType returnType;
     private final JavaClassList parameters;
     private final String fullName;
     private final List<JavaTypeVariable<JavaCodeUnit>> typeParameters;
@@ -65,8 +65,8 @@ public abstract class JavaCodeUnit
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
         typeParameters = builder.getTypeParameters(this);
-        this.returnType = builder.getReturnType();
-        this.parameters = builder.getParameters();
+        returnType = builder.getReturnType(this);
+        parameters = builder.getParameters();
         fullName = formatMethod(getOwner().getName(), getName(), getRawParameterTypes());
         referencedClassObjects = ImmutableSet.copyOf(builder.getReferencedClassObjects(this));
         instanceofChecks = ImmutableSet.copyOf(builder.getInstanceofChecks(this));
@@ -101,8 +101,14 @@ public abstract class JavaCodeUnit
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public JavaClass getRawReturnType() {
+    public JavaType getReturnType() {
         return returnType;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getRawReturnType() {
+        return returnType.toErasure();
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
@@ -19,12 +19,16 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Functions.GET_RAW_RETURN_TYPE;
 
 public interface HasReturnType {
+
+    @PublicAPI(usage = ACCESS)
+    JavaType getReturnType();
 
     @PublicAPI(usage = ACCESS)
     JavaClass getRawReturnType();
@@ -53,6 +57,14 @@ public interface HasReturnType {
     final class Functions {
         private Functions() {
         }
+
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<HasReturnType, JavaType> GET_RETURN_TYPE = new ChainableFunction<HasReturnType, JavaType>() {
+            @Override
+            public JavaType apply(HasReturnType input) {
+                return input.getReturnType();
+            }
+        };
 
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<HasReturnType, JavaClass> GET_RAW_RETURN_TYPE = new ChainableFunction<HasReturnType, JavaClass>() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.NewJavaTypeCreationProcess;
+import com.tngtech.archunit.core.importer.SignatureTypeArgumentProcessor.ReferenceCreationProcess;
+import org.objectweb.asm.signature.SignatureVisitor;
+
+import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERSION;
+import static com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher.ARRAY_CREATOR;
+
+class GenericMemberTypeProcessor<T extends HasDescription> extends SignatureVisitor {
+    private JavaParameterizedTypeBuilder<T> parameterizedType;
+    private JavaTypeCreationProcess<T> typeCreationProcess;
+    private JavaTypeFinisher typeFinisher = JavaTypeFinisher.IDENTITY;
+
+    GenericMemberTypeProcessor() {
+        super(ASM_API_VERSION);
+    }
+
+    JavaTypeCreationProcess<T> getType() {
+        return typeCreationProcess;
+    }
+
+    @Override
+    public void visitClassType(String internalObjectName) {
+        updateType(new JavaParameterizedTypeBuilder<T>(JavaClassDescriptorImporter.createFromAsmObjectTypeName(internalObjectName)));
+    }
+
+    @Override
+    public void visitInnerClassType(String name) {
+        updateType(parameterizedType.forInnerClass(name));
+    }
+
+    @Override
+    public void visitTypeArgument() {
+        parameterizedType.addTypeArgument(new NewJavaTypeCreationProcess<>(new DomainBuilders.JavaWildcardTypeBuilder<T>()));
+    }
+
+    @Override
+    public SignatureVisitor visitTypeArgument(char wildcard) {
+        return SignatureTypeArgumentProcessor.create(wildcard, parameterizedType, JavaTypeFinisher.IDENTITY);
+    }
+
+    @Override
+    public SignatureVisitor visitArrayType() {
+        typeFinisher = typeFinisher.after(ARRAY_CREATOR);
+        return this;
+    }
+
+    @Override
+    public void visitTypeVariable(String name) {
+        typeCreationProcess = new ReferenceCreationProcess<>(name);
+    }
+
+    private void updateType(JavaParameterizedTypeBuilder<T> type) {
+        this.parameterizedType = type;
+        typeCreationProcess = new NewJavaTypeCreationProcess<>(this.parameterizedType, typeFinisher);
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -253,12 +253,13 @@ class JavaClassProcessor extends ClassVisitor {
 
         DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder = addCodeUnitBuilder(name);
         JavaCodeUnitSignature codeUnitSignature = JavaCodeUnitSignatureImporter.parseAsmMethodSignature(signature);
+        JavaClassDescriptor rawReturnType = JavaClassDescriptorImporter.importAsmMethodReturnType(desc);
         codeUnitBuilder
                 .withName(name)
                 .withModifiers(JavaModifier.getModifiersForMethod(access))
                 .withTypeParameters(codeUnitSignature.getTypeParameterBuilders())
                 .withParameters(parameters)
-                .withReturnType(JavaClassDescriptorImporter.importAsmMethodReturnType(desc))
+                .withReturnType(codeUnitSignature.getReturnType(), rawReturnType)
                 .withDescriptor(desc)
                 .withThrowsClause(typesFrom(exceptions));
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
@@ -2,10 +2,12 @@ package com.tngtech.archunit.core.domain.properties;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Functions.GET_RAW_RETURN_TYPE;
+import static com.tngtech.archunit.core.domain.properties.HasReturnType.Functions.GET_RETURN_TYPE;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
@@ -45,17 +47,43 @@ public class HasReturnTypeTest {
 
     @Test
     public void function_get_return_type() {
-        JavaClass expectedType = importClassWithContext(String.class);
-        assertThatType(GET_RAW_RETURN_TYPE.apply(newHasReturnType(expectedType)))
+        abstract class TestClass implements Iterable<String> {
+        }
+
+        JavaType expectedType = importClassWithContext(TestClass.class).getSuperclass().get();
+        JavaClass rawType = expectedType.toErasure();
+
+        assertThatType(GET_RETURN_TYPE.apply(newHasReturnType(expectedType, rawType)))
+                .as("result of GET_RETURN_TYPE").isEqualTo(expectedType);
+    }
+
+    @Test
+    public void function_get_raw_return_type() {
+        abstract class TestClass implements Iterable<String> {
+        }
+
+        JavaType genericType = importClassWithContext(TestClass.class).getSuperclass().get();
+        JavaClass expectedType = genericType.toErasure();
+
+        assertThatType(GET_RAW_RETURN_TYPE.apply(newHasReturnType(genericType, expectedType)))
                 .as("result of GET_RAW_RETURN_TYPE").isEqualTo(expectedType);
     }
 
-    private HasReturnType newHasReturnType(final JavaClass javaClass) {
+    private HasReturnType newHasReturnType(final JavaClass rawReturnType) {
+        return newHasReturnType(rawReturnType, rawReturnType);
+    }
+
+    private HasReturnType newHasReturnType(final JavaType genericReturnType, final JavaClass rawReturnType) {
         return new HasReturnType() {
 
             @Override
+            public JavaType getReturnType() {
+                return genericReturnType;
+            }
+
+            @Override
             public JavaClass getRawReturnType() {
-                return javaClass;
+                return rawReturnType;
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
@@ -1,0 +1,760 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.ref.Reference;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.testutil.ArchConfigurationRule;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.parameterizedTypeArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.typeVariableArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariable.typeVariable;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteWildcardType.wildcardType;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterGenericMethodReturnTypesTest {
+
+    @Rule
+    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
+
+    @Test
+    public void imports_non_generic_method_return_type() {
+        class NonGenericReturnType {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            NonGenericReturnType method() {
+                return null;
+            }
+        }
+
+        JavaType returnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(returnType).as("return type").matches(NonGenericReturnType.class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_one_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<String> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type")
+                .hasErasure(GenericReturnType.class)
+                .hasActualTypeArguments(String.class);
+    }
+
+    @Test
+    public void imports_raw_generic_method_return_type_as_JavaClass_instead_of_JavaParameterizedType() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings({"unused", "rawtypes"})
+        class SomeClass {
+            GenericReturnType method() {
+                return null;
+            }
+        }
+
+        JavaType rawGenericReturnType = new ClassFileImporter().importClasses(SomeClass.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(rawGenericReturnType).as("raw generic method return type").matches(GenericReturnType.class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<String[]> method() {
+                return null;
+            }
+        }
+
+        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericMethodReturnType).as("generic method return type")
+                .hasErasure(GenericReturnType.class)
+                .hasActualTypeArguments(String[].class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_primitive_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<int[]> method() {
+                return null;
+            }
+        }
+
+        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, int.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericMethodReturnType).as("generic method return type")
+                .hasErasure(GenericReturnType.class)
+                .hasActualTypeArguments(int[].class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_multiple_type_arguments() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<String, Serializable, File> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class, Serializable.class, File.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type")
+                .hasErasure(GenericReturnType.class)
+                .hasActualTypeArguments(String.class, Serializable.class, File.class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_single_actual_type_argument_parameterized_with_concrete_class() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<ClassParameterWithSingleTypeParameter<String>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_multiple_actual_type_arguments_parameterized_with_concrete_classes() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<
+                    ClassParameterWithSingleTypeParameter<File>,
+                    InterfaceParameterWithSingleTypeParameter<Serializable>,
+                    InterfaceParameterWithSingleTypeParameter<String>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(
+                        SomeClass.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
+                        File.class, Serializable.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(File.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(Serializable.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_single_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<?> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(wildcardType());
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_single_actual_type_argument_parameterized_with_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<ClassParameterWithSingleTypeParameter<?>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameter()
+        );
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_actual_type_arguments_parameterized_with_bounded_wildcards() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<
+                    ClassParameterWithSingleTypeParameter<? extends String>,
+                    ClassParameterWithSingleTypeParameter<? super File>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(String.class),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(File.class)
+        );
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_actual_type_arguments_with_multiple_wildcards_with_various_bounds() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<
+                    ClassParameterWithSingleTypeParameter<Map<? extends Serializable, ? super File>>,
+                    ClassParameterWithSingleTypeParameter<Reference<? super String>>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(
+                        SomeClass.class, ClassParameterWithSingleTypeParameter.class,
+                        Map.class, Serializable.class, File.class, Reference.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Map.class)
+                                .withWildcardTypeParameters(
+                                        wildcardType().withUpperBound(Serializable.class),
+                                        wildcardType().withLowerBound(File.class))),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Reference.class)
+                                .withWildcardTypeParameterWithLowerBound(String.class))
+        );
+    }
+
+    @Test
+    public void imports_type_variable_as_generic_method_return_type() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends String> {
+            T method() {
+                return null;
+            }
+        }
+
+        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericMethodReturnType).as("generic method return type")
+                .isInstanceOf(JavaTypeVariable.class)
+                .hasErasure(String.class);
+    }
+
+    @Test
+    public void imports_generic_method_return_type_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<OF_CLASS> {
+            GenericReturnType<OF_CLASS> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(typeVariable("OF_CLASS"));
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_actual_type_argument_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<OF_CLASS> {
+            GenericReturnType<ClassParameterWithSingleTypeParameter<OF_CLASS>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("OF_CLASS"))
+        );
+    }
+
+    @Test
+    public void references_type_variable_assigned_to_actual_type_argument_of_generic_method_return_type() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<T> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<OF_CLASS extends String> {
+            GenericReturnType<ClassParameterWithSingleTypeParameter<OF_CLASS>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("OF_CLASS").withUpperBounds(String.class))
+        );
+    }
+
+    @Test
+    public void references_outer_type_variable_assigned_to_actual_type_argument_of_generic_method_return_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                @SuppressWarnings("unused")
+                class GenericReturnType<T> {
+                }
+
+                class SomeClass {
+                    GenericReturnType<OUTER> method() {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        String.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                typeVariable("OUTER").withUpperBounds(String.class)
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_type_variables_of_enclosing_classes_that_are_out_of_context_for_generic_method_return_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class GenericReturnType<T> {
+                }
+
+                class SomeClass {
+                    GenericReturnType<OUTER> method() {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, String.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                typeVariable("OUTER").withoutUpperBounds()
+        );
+    }
+
+    @Test
+    public void considers_hierarchy_of_methods_and_classes_for_type_parameter_context() throws ClassNotFoundException {
+        @SuppressWarnings("unused")
+        class Level1<T1 extends String> {
+            <T2 extends T1> void level2() {
+                class Level3<T3 extends T2> {
+                    <T4 extends T3> T4 method() {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(innermostClass, Level1.class, String.class)
+                .get(innermostClass).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type")
+                .matches(
+                        typeVariable("T4").withUpperBounds(
+                                typeVariable("T3").withUpperBounds(
+                                        typeVariable("T2").withUpperBounds(
+                                                typeVariable("T1").withUpperBounds(String.class)))));
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_method_return_type_bound_by_type_variables() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<FIRST extends String, SECOND extends Serializable> {
+            GenericReturnType<
+                    ClassParameterWithSingleTypeParameter<? extends FIRST>,
+                    ClassParameterWithSingleTypeParameter<? super SECOND>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("FIRST").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("SECOND").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void imports_wildcards_of_generic_method_return_type_bound_by_type_variables_of_enclosing_classes() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class GenericReturnType<A, B> {
+                }
+
+                class SomeClass {
+                    GenericReturnType<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> method() {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @Test
+    public void creates_new_stub_type_variables_for_wildcards_bound_by_type_variables_of_enclosing_classes_that_are_out_of_context() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                @SuppressWarnings("unused")
+                class GenericReturnType<A, B> {
+                }
+
+                class SomeClass {
+                    GenericReturnType<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> method() {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(
+                        OuterWithTypeParameter.SomeInner.SomeClass.class,
+                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
+                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withoutUpperBounds()),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withoutUpperBounds())
+        );
+    }
+
+    @Test
+    public void imports_complex_generic_method_return_type_with_multiple_nested_actual_type_arguments_with_self_referencing_type_definitions() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            GenericReturnType<
+                    // assigned to GenericReturnType<A,_,_>
+                    List<? extends FIRST>,
+                    // assigned to GenericReturnType<_,B,_>
+                    Map<
+                            Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                            Map<? extends String,
+                                    Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                    // assigned to GenericReturnType<_,_,C>
+                    Comparable<SomeClass<FIRST, SECOND>>> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter()
+                .importClasses(SomeClass.class, String.class, Serializable.class, Cloneable.class,
+                        List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        // @formatter:off
+        assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
+            // assigned to GenericReturnType<A,_,_>
+            parameterizedType(List.class)
+                .withWildcardTypeParameterWithUpperBound(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class)),
+            // assigned to GenericReturnType<_,B,_>
+            parameterizedType(Map.class).withTypeArguments(
+                parameterizedType(Map.Entry.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    parameterizedType(Map.Entry.class).withTypeArguments(
+                        concreteClass(String.class),
+                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))),
+                parameterizedType(Map.class).withTypeArguments(
+                    wildcardType().withUpperBound(String.class),
+                    parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withUpperBound(Serializable.class),
+                        parameterizedType(List.class).withTypeArguments(
+                            parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(
+                                    parameterizedType(Set.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                            parameterizedType(Iterable.class).withTypeArguments(
+                                                wildcardType().withLowerBound(
+                                                    parameterizedType(Map.class).withTypeArguments(
+                                                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class),
+                                                        wildcardType()))))))))))),
+            // assigned to GenericReturnType<_,_,C>
+            parameterizedType(Comparable.class).withTypeArguments(
+                parameterizedType(SomeClass.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
+        // @formatter:on
+    }
+
+    @Test
+    public void imports_complex_generic_array_method_return_type() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] method() {
+                return null;
+            }
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).matches(
+                genericArray(
+                        GenericReturnType.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", "
+                                + Map.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", ?>, "
+                                + Serializable.class.getName() + ">>>[]"
+                ).withComponentType(
+                        parameterizedType(GenericReturnType.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String.class),
+                                        parameterizedType(Map.class).withTypeArguments(
+                                                parameterizedType(Map.class).withTypeArguments(
+                                                        wildcardType().withLowerBound(String.class),
+                                                        wildcardType()),
+                                                concreteClass(Serializable.class))))));
+    }
+
+    @Test
+    public void imports_complex_generic_method_return_type_with_multiple_nested_actual_type_arguments_with_concrete_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<
+                    List<Serializable[]>,
+                    List<? extends Serializable[][]>,
+                    Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> method() {
+                return null;
+            }
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(Serializable[].class),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(Serializable[][].class),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(String[].class),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String[][][].class),
+                                        wildcardType()),
+                                concreteClass(Serializable[][].class))));
+    }
+
+    @Test
+    public void imports_generic_method_return_type_with_parameterized_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+
+        @SuppressWarnings("unused")
+        class SomeClass {
+            GenericReturnType<List<String>[], List<String[]>[][], List<String[][]>[][][]> method() {
+                return null;
+            }
+        }
+
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, List.class, String.class)
+                .get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).hasActualTypeArguments(
+                genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
+                        parameterizedType(List.class).withTypeArguments(String.class)),
+                genericArray(parameterizedTypeArrayName(List.class, String[].class, 2)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[].class, 1)).withComponentType(
+                                parameterizedType(List.class).withTypeArguments(String[].class))),
+                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 3)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[][].class, 2)).withComponentType(
+                                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 1)).withComponentType(
+                                        parameterizedType(List.class).withTypeArguments(String[][].class)))));
+    }
+
+    @Test
+    public void imports_complex_generic_method_return_type_with_multiple_nested_actual_type_arguments_with_generic_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericReturnType<A, B, C> {
+        }
+        @SuppressWarnings("unused")
+        class SomeClass<X extends Serializable, Y extends String> {
+            GenericReturnType<
+                    List<X[]>,
+                    List<? extends X[][]>,
+                    Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> method() {
+                return null;
+            }
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
+                List.class, Serializable.class, Map.class, String.class);
+
+        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+
+        assertThatType(genericReturnType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(
+                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                typeVariable("X").withUpperBounds(Serializable.class))),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(
+                        genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                        typeVariable("X").withUpperBounds(Serializable.class)))),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(
+                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                        typeVariable("Y").withUpperBounds(String.class))),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                                genericArray(typeVariableArrayName("Y", 3)).withComponentType(
+                                                        genericArray(typeVariableArrayName("Y", 2)).withComponentType(
+                                                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                                                        typeVariable("Y").withUpperBounds(String.class))))),
+                                        wildcardType()),
+                                genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                                typeVariable("X").withUpperBounds(Serializable.class)))))
+        );
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassParameterWithSingleTypeParameter<T> {
+    }
+
+    @SuppressWarnings("unused")
+    public interface InterfaceParameterWithSingleTypeParameter<T> {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -76,7 +76,9 @@ public class ImportTestUtils {
         final Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaMethod>> methodBuilders = new HashSet<>();
         for (Method method : inputClass.getDeclaredMethods()) {
             methodBuilders.add(new DomainBuilders.JavaMethodBuilder()
-                    .withReturnType(JavaClassDescriptor.From.name(method.getReturnType().getName()))
+                    .withReturnType(
+                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent(),
+                            JavaClassDescriptor.From.name(method.getReturnType().getName()))
                     .withParameters(typesFrom(method.getParameterTypes()))
                     .withName(method.getName())
                     .withDescriptor(Type.getMethodDescriptor(method))
@@ -90,7 +92,9 @@ public class ImportTestUtils {
         final Set<DomainBuilders.BuilderWithBuildParameter<JavaClass, JavaConstructor>> constructorBuilders = new HashSet<>();
         for (Constructor<?> constructor : inputClass.getDeclaredConstructors()) {
             constructorBuilders.add(new DomainBuilders.JavaConstructorBuilder()
-                    .withReturnType(JavaClassDescriptor.From.name(void.class.getName()))
+                    .withReturnType(
+                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent(),
+                            JavaClassDescriptor.From.name(void.class.getName()))
                     .withParameters(typesFrom(constructor.getParameterTypes()))
                     .withName(CONSTRUCTOR_NAME)
                     .withDescriptor(Type.getConstructorDescriptor(constructor))

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypeAssertion.java
@@ -56,7 +56,7 @@ public class JavaTypeAssertion extends AbstractObjectAssert<JavaTypeAssertion, J
     }
 
     public void matches(ExpectedConcreteType type) {
-        type.assertMatchWith(actual, new DescriptionContext(actual.getName()));
+        type.assertMatchWith(actual, new DescriptionContext(""));
     }
 
     private String describeAssertion(String partialAssertionDescription) {


### PR DESCRIPTION
This next step to fully support Generics within ArchUnit adds support for generic method return types. In particular

* `JavaMethod.getReturnType()` now returns a `JavaParameterizedType` for a parameterized generic return type and the raw type otherwise
* all type arguments of generic method return types are added to `JavaClass.directDependencies{From/To}Self`

Example: ArchUnit would now detect `String` as a `Dependency` of a method declaration like

```
class SomeClass {
    Set<List<? super String>> someMethod() {
        return null;
    }
}
```