### PR TITLE
use latest ASM API version

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -36,12 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
-import static org.objectweb.asm.Opcodes.ASM8;
+import static org.objectweb.asm.Opcodes.ASM9;
 
 class ClassFileProcessor {
     private static final Logger LOG = LoggerFactory.getLogger(ClassFileProcessor.class);
 
-    static final int ASM_API_VERSION = ASM8;
+    static final int ASM_API_VERSION = ASM9;
 
     private final boolean md5InClassSourcesEnabled = ArchConfiguration.get().md5InClassSourcesEnabled();
     private final ClassResolver.Factory classResolverFactory = new ClassResolver.Factory();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileProcessorTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileProcessorTest.java
@@ -1,10 +1,18 @@
 package com.tngtech.archunit.core.importer;
 
+import java.lang.reflect.Field;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolverFromClasspath;
 import org.junit.Test;
+import org.objectweb.asm.Opcodes;
 
+import static com.google.common.collect.Iterables.getLast;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 
 public class ClassFileProcessorTest {
@@ -14,5 +22,22 @@ public class ClassFileProcessorTest {
                 .tryResolve("not.There");
 
         assertThat(resolved).isAbsent();
+    }
+
+    @Test
+    public void always_use_the_highest_ASM_API_version() throws IllegalAccessException {
+        Pattern asmApiFieldNamePattern = Pattern.compile("ASM(\\d+)");
+        SortedMap<Integer, Field> availableAsmApiFieldsBySortedVersion = new TreeMap<>();
+        for (Field field : Opcodes.class.getFields()) {
+            Matcher matcher = asmApiFieldNamePattern.matcher(field.getName());
+            if (matcher.matches()) {
+                availableAsmApiFieldsBySortedVersion.put(Integer.parseInt(matcher.group(1)), field);
+            }
+        }
+
+        Field maxAvailableAsmApiVersionField = getLast(availableAsmApiFieldsBySortedVersion.values());
+        int maxAvailableAsmApiVersion = (int) maxAvailableAsmApiVersionField.get(null);
+
+        assertThat(ClassFileProcessor.ASM_API_VERSION).as("used ASM API version").isEqualTo(maxAvailableAsmApiVersion);
     }
 }


### PR DESCRIPTION
I have added a test for now that we will always use the highest available ASM API version. So far we never had a problem by using a too high ASM API version, but we did have a problem by using a too low one (classes compiled with a new JDK could not be processed even though the code would have worked if only the API version would have been higher).

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>