### PR TITLE
Evaluate DisplayNameGenerator.ReplaceUnderscores

### DIFF
--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchRuleExecution.java
@@ -21,6 +21,8 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.Description;
 
+import static com.tngtech.archunit.junit.DisplayNameResolver.determineDisplayName;
+
 class ArchRuleExecution extends ArchTestExecution {
     private final Field ruleField;
 
@@ -47,7 +49,7 @@ class ArchRuleExecution extends ArchTestExecution {
 
     @Override
     Description describeSelf() {
-        return Description.createTestDescription(testClass, ruleField.getName(), ruleField.getAnnotations());
+        return Description.createTestDescription(testClass, determineDisplayName(ruleField.getName()), ruleField.getAnnotations());
     }
 
     @Override

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchTestMethodExecution.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.runner.Description;
 
+import static com.tngtech.archunit.junit.DisplayNameResolver.determineDisplayName;
 import static com.tngtech.archunit.junit.ReflectionUtils.invokeMethod;
 
 class ArchTestMethodExecution extends ArchTestExecution {
@@ -52,7 +53,7 @@ class ArchTestMethodExecution extends ArchTestExecution {
 
     @Override
     Description describeSelf() {
-        return Description.createTestDescription(testClass, testMethod.getName(), testMethod.getAnnotations());
+        return Description.createTestDescription(testClass, determineDisplayName(testMethod.getName()), testMethod.getAnnotations());
     }
 
     @Override

--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Suppliers.memoize;
 import static com.tngtech.archunit.junit.ArchTestInitializationException.WRAP_CAUSE;
+import static com.tngtech.archunit.junit.DisplayNameResolver.determineDisplayName;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllFields;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllMethods;
 import static com.tngtech.archunit.junit.ReflectionUtils.getValueOrThrowException;
@@ -145,7 +146,7 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
         private final Supplier<JavaClasses> classes;
 
         ArchUnitRuleDescriptor(UniqueId uniqueId, ArchRule rule, Supplier<JavaClasses> classes, Field field) {
-            super(uniqueId, field.getName(), FieldSource.from(field), field);
+            super(uniqueId, determineDisplayName(field.getName()), FieldSource.from(field), field);
             this.rule = rule;
             this.classes = classes;
         }
@@ -167,7 +168,8 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
         private final Supplier<JavaClasses> classes;
 
         ArchUnitMethodDescriptor(UniqueId uniqueId, Method method, Supplier<JavaClasses> classes) {
-            super(uniqueId.append("method", method.getName()), method.getName(), MethodSource.from(method), method);
+            super(uniqueId.append("method", method.getName()),
+                    determineDisplayName(method.getName()), MethodSource.from(method), method);
             validate(method);
 
             this.method = method;

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/DisplayNameResolver.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/DisplayNameResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.junit;
+
+import com.tngtech.archunit.ArchConfiguration;
+
+final class DisplayNameResolver {
+
+    static final String JUNIT_DISPLAYNAME_REPLACE_UNDERSCORES_BY_SPACES_PROPERTY_NAME = "junit.displayName.replaceUnderscoresBySpaces";
+
+    static String determineDisplayName(String elementName) {
+        return replaceUnderscoresBySpaces() ? underscoresReplacedBySpaces(elementName) : elementName;
+    }
+
+    private static String underscoresReplacedBySpaces(String elementName) {
+        return elementName.replace('_', ' ');
+    }
+
+    private static boolean replaceUnderscoresBySpaces() {
+        String replaceUnderscoresBySpaces = ArchConfiguration.get()
+                .getPropertyOrDefault(JUNIT_DISPLAYNAME_REPLACE_UNDERSCORES_BY_SPACES_PROPERTY_NAME, Boolean.FALSE.toString());
+        return Boolean.parseBoolean(replaceUnderscoresBySpaces);
+    }
+}

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/DisplayNameResolverTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/DisplayNameResolverTest.java
@@ -1,0 +1,54 @@
+package com.tngtech.archunit.junit;
+
+import com.tngtech.archunit.ArchConfiguration;
+import com.tngtech.archunit.testutil.ArchConfigurationRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.tngtech.archunit.junit.DisplayNameResolver.JUNIT_DISPLAYNAME_REPLACE_UNDERSCORES_BY_SPACES_PROPERTY_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DisplayNameResolverTest {
+
+    @Rule
+    public final ArchConfigurationRule archConfigurationRule = new ArchConfigurationRule();
+
+    @Test
+    public void replaces_underscores_with_blanks_if_property_is_set_to_true() {
+        // Given
+        String elementName = "some_element_Name";
+        ArchConfiguration.get().setProperty(JUNIT_DISPLAYNAME_REPLACE_UNDERSCORES_BY_SPACES_PROPERTY_NAME, "true");
+
+        // When
+        String displayName = DisplayNameResolver.determineDisplayName(elementName);
+
+        // Then
+        assertThat(displayName).isEqualTo("some element Name");
+    }
+
+    @Test
+    public void returns_original_name_if_property_is_set_to_false() {
+        // Given
+        String elementName = "some_element_Name";
+        ArchConfiguration.get().setProperty(JUNIT_DISPLAYNAME_REPLACE_UNDERSCORES_BY_SPACES_PROPERTY_NAME, "false");
+
+        // When
+        String displayName = DisplayNameResolver.determineDisplayName(elementName);
+
+        // Then
+        assertThat(displayName).isEqualTo("some_element_Name");
+    }
+
+    @Test
+    public void returns_original_name_if_property_is_unset() {
+        // Given
+        String elementName = "some_element_Name";
+        ArchConfiguration.get().reset();
+
+        // When
+        String displayName = DisplayNameResolver.determineDisplayName(elementName);
+
+        // Then
+        assertThat(displayName).isEqualTo("some_element_Name");
+    }
+}

--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -197,3 +197,34 @@ public class ArchitectureTest {
 The runner will include all `@ArchTest` annotated members within `ServiceRules` and `PersistenceRules` and evaluate
 them against the classes declared within `@AnalyzeClasses` on `ArchitectureTest`.
 This also allows an easy reuse of a rule library in different projects or modules.
+
+==== Generating Display Names
+
+ArchUnit offers the possibility to generate more readable names in the test report by replacing underscores in the
+original rule names by spaces. For example, if a method or field is named
+
+[source,options="nowrap"]
+----
+some_Field_or_Method_rule
+----
+
+this will appear as
+
+[source,options="nowrap"]
+----
+some Field or Method rule
+----
+
+in the test report.
+
+This is similar to JUnit 5's `@DisplayNameGeneration` annotation, but because this display name generation does not
+fit well with ArchUnit's rule execution and because we'd like to offer this feature for JUnit 4 as well, you can enable
+display name generation in ArchUnit with a configuration property (see <<Advanced Configuration>>):
+
+[source,options="nowrap"]
+.archunit.properties
+----
+junit.displayName.replaceUnderscoresBySpaces=true
+----
+
+If you omit the property (or set it to `false`) the original rule names are used as display names.


### PR DESCRIPTION
I like to use JUnit 5's feature for automatic display name generation, especially the strategy for replacing underscores in test method names by spaces. This way, I can phrase the test names like a human readable sentence – without having to use ```@DisplayName``` all the time.

Unfortunately, this doesn't work with ArchUnit yet. On the one hand, ArchUnitTestDescriptor isn't derived (or does not use) the specialised Jupiter descriptor classes. But refactoring this might be too much of a change. And on the other hand, JUnit's DisplayNameGenerator API isn't really suited for ArchUnit's way of dealing with tests, especially the field based tests.

So I tried a really simple approach: Evaluating only the one DisplayNameGenerator strategy that makes sense most IMHO for ArchUnit (ReplaceUnderscores) with an implementation not (syntactically) derived from JUnit's implementation of the DisplayNameGenerator API.

With the changes in this PR it's possible to write

```java
@AnalyzeClasses(packages = "some.dummy.package")
@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
public class SomeTestClass { ... }
```

for field and method based ArchUnit tests.

Feel free to reject this PR if it is too little benefit for too much change. Or if you think this is crude use of a public API. But I tried to be as little invasive as possible, while still solving my main use case.