### PR TITLE
upgrade JUnit 5 dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,12 @@ ext {
             log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.12.1'],
 
             junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.7.1'],
-            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.1'],
-            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.1'],
-            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.7.1'],
-            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.7.1'],
-            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.7.1'],
+            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.7.2'],
+            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.2'],
+            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.7.2'],
+            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.7.2'],
+            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.7.2'],
+            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.7.2'],
             hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'],
             junit_dataprovider  : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
             mockito             : [group: 'org.mockito', name: 'mockito-core', version: '2.28.2'],  // version 3 requires Java 8.


### PR DESCRIPTION
In particular JUnit Platform `1.7.1` to `1.7.2` and JUnit Jupiter `5.7.1` to `5.7.2`

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>