### PR TITLE
Some preparation for java 8

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
@@ -30,6 +30,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
 import static com.tngtech.archunit.base.DescribedPredicate.doNot;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
@@ -186,7 +187,7 @@ public class PublicAPIRules {
 
             private boolean equivalentMethod(JavaMethod method, String name, Class<?>... paramTypes) {
                 return method.getName().equals(name) &&
-                        namesOf(method.getRawParameterTypes()).equals(JavaClass.namesOf(paramTypes));
+                        namesOf(method.getRawParameterTypes()).equals(formatNamesOf(paramTypes));
             }
 
             private boolean enumMethod(JavaMethod methodToCheck, String name, Class<?>... paramTypes) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -156,7 +156,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import static com.google.common.base.Predicates.containsPattern;
 import static com.google.common.collect.Collections2.filter;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.example.layers.OtherClassViolatingSessionBeanRules.init;
 import static com.tngtech.archunit.example.layers.SomeMediator.violateLayerRulesIndirectly;
 import static com.tngtech.archunit.example.layers.controller.one.UseCaseOneTwoController.doSomethingOne;
@@ -1210,7 +1210,7 @@ class ExamplesIntegrationTest {
     }
 
     private static MessageAssertionChain.Link classesContaining(final Class<?>... classes) {
-        final String expectedLine = String.format("there is/are %d element(s) in classes %s", classes.length, namesOf(classes));
+        final String expectedLine = String.format("there is/are %d element(s) in classes %s", classes.length, formatNamesOf(classes));
         return new MessageAssertionChain.Link() {
             @Override
             public Result filterMatching(List<String> lines) {
@@ -1226,7 +1226,7 @@ class ExamplesIntegrationTest {
 
             @Override
             public String getDescription() {
-                return "classes containing " + namesOf(classes);
+                return "classes containing " + formatNamesOf(classes);
             }
         };
     }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedConstructor.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedConstructor.java
@@ -2,10 +2,9 @@ package com.tngtech.archunit.testutils;
 
 import java.lang.annotation.Annotation;
 
-import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaConstructor;
-
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 
 public class ExpectedConstructor {
     public static ExpectedConstructor.Creator of(Class<?> owner, Class<?>... params) {
@@ -29,7 +28,7 @@ public class ExpectedConstructor {
 
         public ExpectedMessage beingAnnotatedWith(Class<? extends Annotation> annotationType) {
             return new ExpectedMessage(String.format("Constructor <%s> is annotated with @%s in (%s.java:%d)",
-                    formatMethod(clazz.getName(), JavaConstructor.CONSTRUCTOR_NAME, JavaClass.namesOf(params)),
+                    formatMethod(clazz.getName(), CONSTRUCTOR_NAME, formatNamesOf(params)),
                     annotationType.getSimpleName(),
                     clazz.getSimpleName(), lineNumber));
         }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedMethod.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedMethod.java
@@ -2,10 +2,9 @@ package com.tngtech.archunit.testutils;
 
 import java.lang.annotation.Annotation;
 
-import com.tngtech.archunit.core.domain.JavaClass;
-
-import static java.lang.String.format;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+import static java.lang.String.format;
 
 public class ExpectedMethod {
     public static ExpectedMethod.Creator of(Class<?> owner, String methodName, Class<?>... params) {
@@ -42,7 +41,7 @@ public class ExpectedMethod {
         }
 
         private ExpectedMessage method(String message) {
-            String methodDescription = format("Method <%s>", formatMethod(clazz.getName(), methodName, JavaClass.namesOf(params)));
+            String methodDescription = format("Method <%s>", formatMethod(clazz.getName(), methodName, formatNamesOf(params)));
             String sourceCodeLocation = format("(%s.java:%d)", clazz.getSimpleName(), lineNumber);
             return new ExpectedMessage(format("%s %s in %s", methodDescription, message, sourceCodeLocation));
         }

--- a/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
@@ -122,7 +122,7 @@ public final class ArchConfiguration {
 
     @PublicAPI(usage = ACCESS)
     public Optional<String> getClassResolver() {
-        return Optional.fromNullable(properties.getProperty(CLASS_RESOLVER));
+        return Optional.ofNullable(properties.getProperty(CLASS_RESOLVER));
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/Optional.java
@@ -36,14 +36,32 @@ public abstract class Optional<T> {
         return new Present<>(object);
     }
 
+    /**
+     * @deprecated use {@link #ofNullable(Object)} instead
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static <T> Optional<T> fromNullable(T object) {
-        return object == null ? new Absent<T>() : new Present<>(object);
+        return ofNullable(object);
     }
 
     @PublicAPI(usage = ACCESS)
+    public static <T> Optional<T> ofNullable(T object) {
+        return object == null ? Optional.<T>empty() : new Present<>(object);
+    }
+
+    /**
+     * @deprecated use {@link #empty()} instead
+     */
+    @Deprecated
+    @PublicAPI(usage = ACCESS)
     public static <T> Optional<T> absent() {
-        return Absent.getInstance();
+        return empty();
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static <T> Optional<T> empty() {
+        return Empty.getInstance();
     }
 
     @PublicAPI(usage = ACCESS)
@@ -59,30 +77,69 @@ public abstract class Optional<T> {
     @PublicAPI(usage = ACCESS)
     public abstract T getOrThrow(RuntimeException e);
 
+    /**
+     * @deprecated Use {@link #orElseThrow(Supplier)} instead
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
-    public abstract T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier);
+    public T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
+        return orElseThrow(exceptionSupplier);
+    }
 
     @PublicAPI(usage = ACCESS)
-    public abstract <U> Optional<U> transform(Function<? super T, U> function);
+    public abstract <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X;
+
+    /**
+     * @deprecated Use {@link #map(Function)} instead.
+     */
+    @Deprecated
+    @PublicAPI(usage = ACCESS)
+    public <U> Optional<U> transform(Function<? super T, U> function) {
+        return map(function);
+    }
 
     @PublicAPI(usage = ACCESS)
-    public abstract T orNull();
+    public abstract <U> Optional<U> map(Function<? super T, ? extends U> mapper);
+
+    /**
+     * @deprecated Use {@link #orElse(Object) orElse(null)} instead.
+     */
+    @PublicAPI(usage = ACCESS)
+    public T orNull() {
+        return orElse(null);
+    }
+
+    /**
+     * @deprecated Use {@link #orElse(Object)} instead.
+     */
+    @Deprecated
+    @PublicAPI(usage = ACCESS)
+    public T or(T value) {
+        return orElse(value);
+    }
 
     @PublicAPI(usage = ACCESS)
-    public abstract T or(T value);
+    public abstract T orElse(T other);
 
+    @PublicAPI(usage = ACCESS)
+    public abstract T orElseGet(Supplier<? extends T> supplier);
+
+    /**
+     * @deprecated This method will be removed in the future, use {@link #orElseGet(Supplier)} instead.
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public abstract Optional<T> or(Optional<? extends T> value);
 
     @PublicAPI(usage = ACCESS)
     public abstract Set<T> asSet();
 
-    private static class Absent<T> extends Optional<T> {
-        private static final Absent<Object> INSTANCE = new Absent<>();
+    private static class Empty<T> extends Optional<T> {
+        private static final Empty<Object> INSTANCE = new Empty<>();
 
         @SuppressWarnings("unchecked")
-        private static <T> Absent<T> getInstance() {
-            return (Absent<T>) INSTANCE;
+        private static <T> Empty<T> getInstance() {
+            return (Empty<T>) INSTANCE;
         }
 
         @Override
@@ -96,13 +153,13 @@ public abstract class Optional<T> {
         }
 
         @Override
-        public T orNull() {
-            return null;
+        public T orElse(T value) {
+            return value;
         }
 
         @Override
-        public T or(T value) {
-            return value;
+        public T orElseGet(Supplier<? extends T> supplier) {
+            return supplier.get();
         }
 
         @Override
@@ -122,13 +179,13 @@ public abstract class Optional<T> {
         }
 
         @Override
-        public T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
+        public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
             throw exceptionSupplier.get();
         }
 
         @Override
-        public <U> Optional<U> transform(Function<? super T, U> function) {
-            return absent();
+        public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+            return empty();
         }
 
         @Override
@@ -138,12 +195,12 @@ public abstract class Optional<T> {
 
         @Override
         public boolean equals(Object obj) {
-            return obj instanceof Absent;
+            return obj instanceof Optional.Empty;
         }
 
         @Override
         public String toString() {
-            return Optional.class.getSimpleName() + ".absent()";
+            return Optional.class.getSimpleName() + ".empty()";
         }
     }
 
@@ -165,12 +222,12 @@ public abstract class Optional<T> {
         }
 
         @Override
-        public T orNull() {
+        public T orElse(T value) {
             return object;
         }
 
         @Override
-        public T or(T value) {
+        public T orElseGet(Supplier<? extends T> supplier) {
             return object;
         }
 
@@ -190,13 +247,13 @@ public abstract class Optional<T> {
         }
 
         @Override
-        public T getOrThrow(Supplier<? extends RuntimeException> exceptionSupplier) {
+        public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) {
             return object;
         }
 
         @Override
-        public <U> Optional<U> transform(Function<? super T, U> function) {
-            return Optional.of(function.apply(object));
+        public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+            return Optional.of(mapper.apply(object));
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/base/PackageMatcher.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/PackageMatcher.java
@@ -133,7 +133,7 @@ public final class PackageMatcher {
     @PublicAPI(usage = ACCESS)
     public Optional<Result> match(String aPackage) {
         Matcher matcher = packagePattern.matcher(aPackage);
-        return matcher.matches() ? Optional.of(new Result(matcher)) : Optional.<Result>absent();
+        return matcher.matches() ? Optional.of(new Result(matcher)) : Optional.<Result>empty();
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AnnotationProxy.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AnnotationProxy.java
@@ -100,7 +100,7 @@ class AnnotationProxy {
                 return handlersByMethod.get(key).handle(proxy, method, args);
             }
 
-            Object result = toProxy.get(method.getName()).or(method.getDefaultValue());
+            Object result = toProxy.get(method.getName()).orElse(method.getDefaultValue());
             return conversions.convertIfNecessary(result, method.getReturnType());
         }
     }
@@ -315,7 +315,7 @@ class AnnotationProxy {
             if (returnType.isInstance(result)) {
                 return result;
             }
-            return tryFindConversionFor(returnType).or(new NoOpConversion<>()).convert(result, returnType);
+            return tryFindConversionFor(returnType).orElse(new NoOpConversion<>()).convert(result, returnType);
         }
 
         private static class NoOpConversion<T> implements Conversion<T> {
@@ -337,7 +337,7 @@ class AnnotationProxy {
                     return Optional.of((Conversion<F>) conversion);
                 }
             }
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -221,7 +221,7 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
 
     private static Optional<Dependency> tryCreateDependency(JavaClass originClass, JavaClass targetClass, String description, int lineNumber) {
         if (originClass.equals(targetClass) || targetClass.isPrimitive()) {
-            return Optional.absent();
+            return Optional.empty();
         }
         return Optional.of(new Dependency(originClass, targetClass, lineNumber, description));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
@@ -19,9 +19,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
 
 import static com.google.common.base.Strings.repeat;
+import static com.google.common.collect.ImmutableList.copyOf;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public final class Formatters {
@@ -75,6 +77,27 @@ public final class Formatters {
     @PublicAPI(usage = ACCESS)
     public static String formatThrowsDeclarationTypeNames(List<String> typeNames) {
         return Joiner.on(", ").join(typeNames);
+    }
+
+    /**
+     * @see #formatNamesOf(Iterable)
+     */
+    @PublicAPI(usage = ACCESS)
+    public static List<String> formatNamesOf(Class<?>... paramTypes) {
+        return formatNamesOf(copyOf(paramTypes));
+    }
+
+    /**
+     * @param paramTypes an iterable of {@link Class} objects
+     * @return A {@link List} of fully qualified class names of the passed {@link Class} objects
+     */
+    @PublicAPI(usage = ACCESS)
+    public static List<String> formatNamesOf(Iterable<Class<?>> paramTypes) {
+        ImmutableList.Builder<String> result = ImmutableList.builder();
+        for (Class<?> paramType : paramTypes) {
+            result.add(paramType.getName());
+        }
+        return result.build();
     }
 
     // Excluding the '$' character might be incorrect, but since '$' is a valid character of a class name

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAnnotation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAnnotation.java
@@ -208,7 +208,7 @@ public final class JavaAnnotation<OWNER extends HasDescription> implements HasTy
         Optional<JavaMethod> method = type.tryGetMethod(property);
         return method.isPresent()
                 ? method.get().getDefaultValue()
-                : Optional.absent();
+                : Optional.empty();
     }
 
     /**
@@ -259,7 +259,7 @@ public final class JavaAnnotation<OWNER extends HasDescription> implements HasTy
      */
     @PublicAPI(usage = ACCESS)
     public Optional<Object> tryGetExplicitlyDeclaredProperty(String propertyName) {
-        return Optional.fromNullable(values.get(propertyName));
+        return Optional.ofNullable(values.get(propertyName));
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -134,7 +134,7 @@ public class JavaClass
         }
     });
     private EnclosingDeclaration enclosingDeclaration = EnclosingDeclaration.ABSENT;
-    private Optional<JavaClass> componentType = Optional.absent();
+    private Optional<JavaClass> componentType = Optional.empty();
     private Map<String, JavaAnnotation<JavaClass>> annotations = emptyMap();
     private JavaClassDependencies javaClassDependencies = new JavaClassDependencies(this);  // just for stubs; will be overwritten for imported classes
     private ReverseDependencies reverseDependencies = ReverseDependencies.EMPTY;  // just for stubs; will be overwritten for imported classes
@@ -250,7 +250,7 @@ public class JavaClass
     public Optional<JavaEnumConstant> tryGetEnumConstant(String name) {
         Optional<JavaField> field = tryGetField(name);
         if (!field.isPresent() || !field.get().getModifiers().contains(ENUM)) {
-            return Optional.absent();
+            return Optional.empty();
         }
         return Optional.of(new JavaEnumConstant(this, field.get().getName()));
     }
@@ -632,7 +632,7 @@ public class JavaClass
     @Override
     @PublicAPI(usage = ACCESS)
     public <A extends Annotation> Optional<A> tryGetAnnotationOfType(Class<A> type) {
-        return tryGetAnnotationOfType(type.getName()).transform(toAnnotationOfType(type));
+        return tryGetAnnotationOfType(type.getName()).map(toAnnotationOfType(type));
     }
 
     /**
@@ -641,7 +641,7 @@ public class JavaClass
     @Override
     @PublicAPI(usage = ACCESS)
     public Optional<JavaAnnotation<JavaClass>> tryGetAnnotationOfType(String typeName) {
-        return Optional.fromNullable(annotations.get(typeName));
+        return Optional.ofNullable(annotations.get(typeName));
     }
 
     @Override
@@ -1419,7 +1419,7 @@ public class JavaClass
     }
 
     private static class Superclass {
-        private static final Superclass ABSENT = new Superclass(Optional.<JavaType>absent());
+        private static final Superclass ABSENT = new Superclass(Optional.<JavaType>empty());
 
         private final Optional<JavaClass> rawType;
         private final Optional<JavaType> type;
@@ -1429,7 +1429,7 @@ public class JavaClass
         }
 
         private Superclass(Optional<JavaType> type) {
-            this.rawType = type.transform(TO_ERASURE);
+            this.rawType = type.map(TO_ERASURE);
             this.type = type;
         }
 
@@ -1485,7 +1485,7 @@ public class JavaClass
     }
 
     private static class EnclosingDeclaration {
-        static final EnclosingDeclaration ABSENT = new EnclosingDeclaration(Optional.<JavaCodeUnit>absent(), Optional.<JavaClass>absent());
+        static final EnclosingDeclaration ABSENT = new EnclosingDeclaration(Optional.<JavaCodeUnit>empty(), Optional.<JavaClass>empty());
 
         private final Optional<JavaCodeUnit> enclosingCodeUnit;
         private final Optional<JavaClass> enclosingClass;
@@ -1512,7 +1512,7 @@ public class JavaClass
         }
 
         static EnclosingDeclaration ofClass(Optional<JavaClass> clazz) {
-            return new EnclosingDeclaration(Optional.<JavaCodeUnit>absent(), clazz);
+            return new EnclosingDeclaration(Optional.<JavaCodeUnit>empty(), clazz);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -16,7 +16,6 @@
 package com.tngtech.archunit.core.domain;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -54,6 +53,7 @@ import static com.tngtech.archunit.base.ClassLoaders.getCurrentClassLoader;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.base.Guava.toGuava;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CODE_UNITS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CONSTRUCTORS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELDS;
@@ -882,7 +882,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public JavaCodeUnit getCodeUnitWithParameterTypes(String name, List<Class<?>> parameters) {
-        return getCodeUnitWithParameterTypeNames(name, namesOf(parameters));
+        return getCodeUnitWithParameterTypeNames(name, formatNamesOf(parameters));
     }
 
     /**
@@ -891,7 +891,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaCodeUnit> tryGetCodeUnitWithParameterTypes(String name, List<Class<?>> parameters) {
-        return tryGetCodeUnitWithParameterTypeNames(name, namesOf(parameters));
+        return tryGetCodeUnitWithParameterTypeNames(name, formatNamesOf(parameters));
     }
 
     /**
@@ -926,7 +926,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public JavaMethod getMethod(String name, Class<?>... parameters) {
-        return members.getMethod(name, namesOf(parameters));
+        return members.getMethod(name, formatNamesOf(parameters));
     }
 
     /**
@@ -952,7 +952,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaMethod> tryGetMethod(String name, Class<?>... parameters) {
-        return members.tryGetMethod(name, namesOf(parameters));
+        return members.tryGetMethod(name, formatNamesOf(parameters));
     }
 
     /**
@@ -988,7 +988,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public JavaConstructor getConstructor(Class<?>... parameters) {
-        return members.getConstructor(namesOf(parameters));
+        return members.getConstructor(formatNamesOf(parameters));
     }
 
     /**
@@ -1014,7 +1014,7 @@ public class JavaClass
      */
     @PublicAPI(usage = ACCESS)
     public Optional<JavaConstructor> tryGetConstructor(Class<?>... parameters) {
-        return members.tryGetConstructor(namesOf(parameters));
+        return members.tryGetConstructor(formatNamesOf(parameters));
     }
 
     /**
@@ -1391,18 +1391,22 @@ public class JavaClass
         return "JavaClass{name='" + descriptor.getFullyQualifiedClassName() + "'}";
     }
 
+    /**
+     * @deprecated use {@link Formatters#formatNamesOf(Class[])} instead
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static List<String> namesOf(Class<?>... paramTypes) {
-        return namesOf(ImmutableList.copyOf(paramTypes));
+        return formatNamesOf(paramTypes);
     }
 
+    /**
+     * @deprecated use {@link Formatters#formatNamesOf(Iterable)} instead
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static List<String> namesOf(Iterable<Class<?>> paramTypes) {
-        ArrayList<String> result = new ArrayList<>();
-        for (Class<?> paramType : paramTypes) {
-            result.add(paramType.getName());
-        }
-        return result;
+        return formatNamesOf(paramTypes);
     }
 
     /**
@@ -2117,7 +2121,7 @@ public class JavaClass
             private final Class<?>[] classes;
 
             BelongToAnyOfPredicate(Class<?>... classes) {
-                super("belong to any of " + JavaClass.namesOf(classes));
+                super("belong to any of " + formatNamesOf(classes));
                 this.classes = classes;
             }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDescriptor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDescriptor.java
@@ -185,7 +185,7 @@ public interface JavaClassDescriptor {
 
             @Override
             public Optional<JavaClassDescriptor> tryGetComponentType() {
-                return Optional.absent();
+                return Optional.empty();
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -128,7 +128,7 @@ class JavaClassMembers {
                 return Optional.of(field);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     Set<JavaCodeUnit> getCodeUnits() {
@@ -261,7 +261,7 @@ class JavaClassMembers {
                 return Optional.of(codeUnit);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     void completeAnnotations(ImportContext context) {
@@ -288,7 +288,7 @@ class JavaClassMembers {
                 Collections.<JavaField>emptySet(),
                 Collections.<JavaMethod>emptySet(),
                 Collections.<JavaConstructor>emptySet(),
-                Optional.<JavaStaticInitializer>absent());
+                Optional.<JavaStaticInitializer>empty());
     }
 
     static JavaClassMembers create(JavaClass owner, ImportContext context) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -92,13 +92,13 @@ public abstract class JavaMember implements
     @Override
     @PublicAPI(usage = ACCESS)
     public <A extends Annotation> Optional<A> tryGetAnnotationOfType(Class<A> type) {
-        return tryGetAnnotationOfType(type.getName()).transform(toAnnotationOfType(type));
+        return tryGetAnnotationOfType(type.getName()).map(toAnnotationOfType(type));
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public Optional<? extends JavaAnnotation<? extends JavaMember>> tryGetAnnotationOfType(String typeName) {
-        return Optional.fromNullable(annotations.get(typeName));
+        return Optional.ofNullable(annotations.get(typeName));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -57,7 +57,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     private final Set<JavaClass> classes;
     private final Optional<JavaClass> packageInfo;
     private final Map<String, JavaPackage> subpackages;
-    private Optional<JavaPackage> parent = Optional.absent();
+    private Optional<JavaPackage> parent = Optional.empty();
 
     private JavaPackage(String name, Set<JavaClass> classes, Map<String, JavaPackage> subpackages) {
         this.name = checkNotNull(name);
@@ -129,16 +129,16 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
         if (packageInfo.isPresent()) {
             return packageInfo.get().tryGetAnnotationOfType(type);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public Optional<JavaAnnotation<JavaPackage>> tryGetAnnotationOfType(String typeName) {
         if (packageInfo.isPresent()) {
-            return packageInfo.get().tryGetAnnotationOfType(typeName).transform(withSelfAsOwner);
+            return packageInfo.get().tryGetAnnotationOfType(typeName).map(withSelfAsOwner);
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     @Override
@@ -360,7 +360,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
     private Optional<JavaClass> tryGetClassWith(DescribedPredicate<? super JavaClass> predicate) {
         Set<JavaClass> matching = getClassesWith(predicate);
-        return matching.size() == 1 ? Optional.of(getOnlyElement(matching)) : Optional.<JavaClass>absent();
+        return matching.size() == 1 ? Optional.of(getOnlyElement(matching)) : Optional.<JavaClass>empty();
     }
 
     private Set<JavaClass> getClassesWith(Predicate<? super JavaClass> predicate) {
@@ -405,7 +405,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
 
         String next = packageParts.poll();
         if (!subpackages.containsKey(next)) {
-            return Optional.absent();
+            return Optional.empty();
         }
         JavaPackage child = subpackages.get(next);
         return child.tryGetPackage(child, packageParts);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
@@ -180,7 +180,7 @@ public class Source {
             try (InputStream in = uri.toURL().openStream()) {
                 return Optional.of(ByteStreams.toByteArray(in));
             } catch (IOException | RuntimeException e) {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/SourceCodeLocation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/SourceCodeLocation.java
@@ -54,7 +54,7 @@ public final class SourceCodeLocation {
     private static String formatLocation(JavaClass sourceClass, int lineNumber) {
         Optional<String> recordedSourceFileName = sourceClass.getSource().isPresent()
                 ? sourceClass.getSource().get().getFileName()
-                : Optional.<String>absent();
+                : Optional.<String>empty();
         String sourceFileName = recordedSourceFileName.isPresent() ? recordedSourceFileName.get() : guessSourceFileName(sourceClass);
         return "(" + sourceFileName + ":" + lineNumber + ")";
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -25,7 +25,7 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethodParameterTypeNames;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAMES;
 
 public interface HasParameterTypes {
@@ -39,7 +39,7 @@ public interface HasParameterTypes {
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final Class<?>... types) {
-            return rawParameterTypes(namesOf(types));
+            return rawParameterTypes(formatNamesOf(types));
         }
 
         @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
@@ -27,8 +27,8 @@ import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.Formatters.formatThrowsDeclarationTypeNames;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAMES;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
@@ -44,7 +44,7 @@ public interface HasThrowsClause<LOCATION extends HasParameterTypes & HasReturnT
         @PublicAPI(usage = ACCESS)
         @SafeVarargs
         public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(final Class<? extends Throwable>... types) {
-            return throwsClauseWithTypes(namesOf(types));
+            return throwsClauseWithTypes(formatNamesOf(types));
         }
 
         @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -147,7 +147,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
                             return Optional.of(constructor);
                         }
                     }
-                    return Optional.absent();
+                    return Optional.empty();
                 }
             }
         }
@@ -334,7 +334,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
         };
 
         private static <T> Optional<T> uniqueTargetIn(Collection<T> collection) {
-            return collection.size() == 1 ? Optional.of(getOnlyElement(collection)) : Optional.<T>absent();
+            return collection.size() == 1 ? Optional.of(getOnlyElement(collection)) : Optional.<T>empty();
         }
 
         private static List<JavaClass> getArgumentTypesFrom(String descriptor, ImportedClasses classes) {
@@ -359,7 +359,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
                         return Optional.of(subclass);
                     }
                 }
-                return Optional.absent();
+                return Optional.empty();
             }
 
             private List<JavaClass> createPath(JavaClass parent, JavaClass child) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -124,7 +124,7 @@ class ClassFileImportRecord {
     }
 
     Optional<String> getSuperclassFor(String name) {
-        return Optional.fromNullable(superclassNamesByOwner.get(name));
+        return Optional.ofNullable(superclassNamesByOwner.get(name));
     }
 
     Set<String> getInterfaceNamesFor(String ownerName) {
@@ -139,11 +139,11 @@ class ClassFileImportRecord {
     }
 
     Optional<JavaParameterizedTypeBuilder<JavaClass>> getGenericSuperclassFor(JavaClass owner) {
-        return Optional.fromNullable(genericSuperclassBuilderByOwner.get(owner.getName()));
+        return Optional.ofNullable(genericSuperclassBuilderByOwner.get(owner.getName()));
     }
 
     Optional<Set<JavaParameterizedTypeBuilder<JavaClass>>> getGenericInterfacesFor(JavaClass owner) {
-        return Optional.fromNullable(genericInterfaceBuildersByOwner.get(owner.getName()));
+        return Optional.ofNullable(genericInterfaceBuildersByOwner.get(owner.getName()));
     }
 
     Set<String> getMemberSignatureTypeNames() {
@@ -178,7 +178,7 @@ class ClassFileImportRecord {
     }
 
     Optional<DomainBuilders.JavaStaticInitializerBuilder> getStaticInitializerBuilderFor(String ownerName) {
-        return Optional.fromNullable(staticInitializerBuildersByOwner.get(ownerName));
+        return Optional.ofNullable(staticInitializerBuildersByOwner.get(ownerName));
     }
 
     Set<String> getAnnotationTypeNamesFor(JavaClass owner) {
@@ -220,7 +220,7 @@ class ClassFileImportRecord {
     }
 
     Optional<DomainBuilders.JavaAnnotationBuilder.ValueBuilder> getAnnotationDefaultValueBuilderFor(JavaMethod method) {
-        return Optional.fromNullable(annotationDefaultValuesByOwner.get(getMemberKey(method)));
+        return Optional.ofNullable(annotationDefaultValuesByOwner.get(getMemberKey(method)));
     }
 
     Optional<String> getEnclosingClassFor(String ownerName) {
@@ -310,11 +310,11 @@ class ClassFileImportRecord {
         }
 
         Optional<String> getEnclosingClassName(String ownerName) {
-            return Optional.fromNullable(innerClassNameToEnclosingClassName.get(ownerName));
+            return Optional.ofNullable(innerClassNameToEnclosingClassName.get(ownerName));
         }
 
         Optional<CodeUnit> getEnclosingCodeUnit(String ownerName) {
-            return Optional.fromNullable(innerClassNameToEnclosingCodeUnit.get(ownerName));
+            return Optional.ofNullable(innerClassNameToEnclosingCodeUnit.get(ownerName));
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -220,7 +220,7 @@ class ClassFileProcessor {
                 return classProcessor.createJavaClass();
             } catch (Exception e) {
                 LOG.warn(String.format("Error during import from %s, falling back to simple import", uri), e);
-                return Optional.absent();
+                return Optional.empty();
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -239,7 +239,7 @@ class ClassGraphCreator implements ImportContext {
         Optional<String> superclassName = importRecord.getSuperclassFor(owner.getName());
         return superclassName.isPresent() ?
                 Optional.of(classes.getOrResolve(superclassName.get())) :
-                Optional.<JavaClass>absent();
+                Optional.<JavaClass>empty();
     }
 
     @Override
@@ -247,14 +247,14 @@ class ClassGraphCreator implements ImportContext {
         Optional<JavaParameterizedTypeBuilder<JavaClass>> genericSuperclassBuilder = importRecord.getGenericSuperclassFor(owner);
         return genericSuperclassBuilder.isPresent()
                 ? Optional.of(genericSuperclassBuilder.get().build(owner, getTypeParametersInContextOf(owner), classes.byTypeName()))
-                : Optional.<JavaType>absent();
+                : Optional.<JavaType>empty();
     }
 
     @Override
     public Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner) {
         Optional<Set<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuilders = importRecord.getGenericInterfacesFor(owner);
         if (!genericInterfaceBuilders.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         ImmutableSet.Builder<JavaType> result = ImmutableSet.builder();
@@ -302,7 +302,7 @@ class ClassGraphCreator implements ImportContext {
                     @Override
                     public Optional<Object> apply(JavaMethod method) {
                         Optional<ValueBuilder> defaultValueBuilder = importRecord.getAnnotationDefaultValueBuilderFor(method);
-                        return defaultValueBuilder.isPresent() ? defaultValueBuilder.get().build(method, ClassGraphCreator.this) : Optional.absent();
+                        return defaultValueBuilder.isPresent() ? defaultValueBuilder.get().build(method, ClassGraphCreator.this) : Optional.empty();
                     }
                 });
             }
@@ -319,7 +319,7 @@ class ClassGraphCreator implements ImportContext {
     public Optional<JavaStaticInitializer> createStaticInitializer(JavaClass owner) {
         Optional<DomainBuilders.JavaStaticInitializerBuilder> builder = importRecord.getStaticInitializerBuilderFor(owner.getName());
         if (!builder.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
         JavaStaticInitializer staticInitializer = builder.get().build(owner, classes.byTypeName());
         return Optional.of(staticInitializer);
@@ -344,14 +344,14 @@ class ClassGraphCreator implements ImportContext {
         Optional<String> enclosingClassName = importRecord.getEnclosingClassFor(owner.getName());
         return enclosingClassName.isPresent() ?
                 Optional.of(classes.getOrResolve(enclosingClassName.get())) :
-                Optional.<JavaClass>absent();
+                Optional.<JavaClass>empty();
     }
 
     @Override
     public Optional<JavaCodeUnit> createEnclosingCodeUnit(JavaClass owner) {
         Optional<CodeUnit> enclosingCodeUnit = importRecord.getEnclosingCodeUnitFor(owner.getName());
         if (!enclosingCodeUnit.isPresent()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         CodeUnit codeUnit = enclosingCodeUnit.get();
@@ -371,6 +371,6 @@ class ClassGraphCreator implements ImportContext {
                 return Optional.of(classes.getOrResolve(methodBuilder.getReturnTypeName()));
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -342,7 +342,7 @@ public final class DomainBuilders {
         private static final Function<JavaMethod, Optional<Object>> NO_ANNOTATION_DEFAULT_VALUE = new Function<JavaMethod, Optional<Object>>() {
             @Override
             public Optional<Object> apply(JavaMethod input) {
-                return Optional.absent();
+                return Optional.empty();
             }
         };
         private Function<JavaMethod, Optional<Object>> createAnnotationDefaultValue = NO_ANNOTATION_DEFAULT_VALUE;
@@ -373,8 +373,8 @@ public final class DomainBuilders {
 
     @Internal
     public static final class JavaClassBuilder {
-        private Optional<SourceDescriptor> sourceDescriptor = Optional.absent();
-        private Optional<String> sourceFileName = Optional.absent();
+        private Optional<SourceDescriptor> sourceDescriptor = Optional.empty();
+        private Optional<String> sourceFileName = Optional.empty();
         private JavaClassDescriptor descriptor;
         private boolean isInterface;
         private boolean isEnum;
@@ -449,7 +449,7 @@ public final class DomainBuilders {
         public Optional<Source> getSource() {
             return sourceDescriptor.isPresent()
                     ? Optional.of(createSource(sourceDescriptor.get().getUri(), sourceFileName, sourceDescriptor.get().isMd5InClassSourcesEnabled()))
-                    : Optional.<Source>absent();
+                    : Optional.<Source>empty();
         }
 
         public JavaClassDescriptor getDescriptor() {
@@ -554,7 +554,7 @@ public final class DomainBuilders {
     @Internal
     public static final class JavaStaticInitializerBuilder extends JavaCodeUnitBuilder<JavaStaticInitializer, JavaStaticInitializerBuilder> {
         JavaStaticInitializerBuilder() {
-            withReturnType(Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent(), JavaClassDescriptor.From.name(void.class.getName()));
+            withReturnType(Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty(), JavaClassDescriptor.From.name(void.class.getName()));
             withParameterTypes(Collections.<JavaClassDescriptor>emptyList());
             withName(JavaStaticInitializer.STATIC_INITIALIZER_NAME);
             withDescriptor("()V");

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -89,7 +89,7 @@ class JavaClassProcessor extends ClassVisitor {
     }
 
     Optional<JavaClass> createJavaClass() {
-        return javaClassBuilder != null ? Optional.of(javaClassBuilder.build()) : Optional.<JavaClass>absent();
+        return javaClassBuilder != null ? Optional.of(javaClassBuilder.build()) : Optional.<JavaClass>empty();
     }
 
     @Override
@@ -106,7 +106,7 @@ class JavaClassProcessor extends ClassVisitor {
         boolean opCodeForEnumIsPresent = (access & Opcodes.ACC_ENUM) != 0;
         boolean opCodeForAnnotationIsPresent = (access & Opcodes.ACC_ANNOTATION) != 0;
         Optional<String> superclassName = getSuperclassName(superName, opCodeForInterfaceIsPresent);
-        LOG.trace("Found superclass {} on class '{}'", superclassName.orNull(), name);
+        LOG.trace("Found superclass {} on class '{}'", superclassName.orElse(null), name);
 
         javaClassBuilder = new DomainBuilders.JavaClassBuilder()
                 .withSourceDescriptor(sourceDescriptor)
@@ -130,7 +130,7 @@ class JavaClassProcessor extends ClassVisitor {
     private Optional<String> getSuperclassName(String superName, boolean isInterface) {
         return superName != null && !isInterface ?
                 Optional.of(createTypeName(superName)) :
-                Optional.<String>absent();
+                Optional.<String>empty();
     }
 
     private boolean importAborted() {
@@ -677,7 +677,7 @@ class JavaClassProcessor extends ClassVisitor {
             public <T extends HasDescription> Optional<Object> build(T owner, ImportContext importContext) {
                 Optional<Class<?>> componentType = determineComponentType(importContext);
                 if (!componentType.isPresent()) {
-                    return Optional.absent();
+                    return Optional.empty();
                 }
 
                 return Optional.of(toArray(componentType.get(), buildValues(owner, importContext)));
@@ -724,7 +724,7 @@ class JavaClassProcessor extends ClassVisitor {
 
                 return returnType.isPresent() ?
                         determineComponentTypeFromReturnValue(returnType.get()) :
-                        Optional.<Class<?>>absent();
+                        Optional.<Class<?>>empty();
             }
 
             private Optional<Class<?>> determineComponentTypeFromReturnValue(JavaClass returnType) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -68,7 +68,7 @@ class JavaClassSignatureImporter {
         }
 
         Optional<JavaParameterizedTypeBuilder<JavaClass>> getGenericSuperclass() {
-            return Optional.fromNullable(superclassProcessor.superclass);
+            return Optional.ofNullable(superclassProcessor.superclass);
         }
 
         Set<JavaParameterizedTypeBuilder<JavaClass>> getGenericInterfaces() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaCodeUnitSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaCodeUnitSignatureImporter.java
@@ -77,14 +77,14 @@ class JavaCodeUnitSignatureImporter {
         public JavaCodeUnitSignature getParsedSignature() {
             return new JavaCodeUnitSignature(
                     typeParameterProcessor.getTypeParameterBuilders(),
-                    Optional.fromNullable(genericMethodReturnTypeProcessor.getType()));
+                    Optional.ofNullable(genericMethodReturnTypeProcessor.getType()));
         }
     }
 
     static class JavaCodeUnitSignature {
         static final JavaCodeUnitSignature ABSENT = new JavaCodeUnitSignature(
                 Collections.<JavaTypeParameterBuilder<JavaCodeUnit>>emptyList(),
-                Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent()
+                Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty()
         );
 
         private final List<JavaTypeParameterBuilder<JavaCodeUnit>> typeParameterBuilders;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
@@ -30,7 +30,7 @@ class JavaFieldTypeSignatureImporter {
 
     static Optional<JavaTypeCreationProcess<JavaField>> parseAsmFieldTypeSignature(String signature) {
         if (signature == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         log.trace("Analyzing field signature: {}", signature);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
@@ -119,10 +119,10 @@ interface UrlSource extends Iterable<URL> {
 
         private static Optional<Path> findParentPathOf(URI uri) {
             try {
-                return Optional.fromNullable(Paths.get(ensureFileUrl(uri).toURI()).getParent());
+                return Optional.ofNullable(Paths.get(ensureFileUrl(uri).toURI()).getParent());
             } catch (Exception e) {
                 LOG.warn("Could not find parent folder for " + uri, e);
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 
@@ -156,7 +156,7 @@ interface UrlSource extends Iterable<URL> {
                 return Optional.of(convertToJarUrlIfNecessary(parent.toUri().resolve(URI.create(classpathUrlEntry).getRawSchemeSpecificPart())));
             } catch (Exception e) {
                 LOG.warn("Cannot parse URL classpath entry " + classpathUrlEntry, e);
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 
@@ -169,7 +169,7 @@ interface UrlSource extends Iterable<URL> {
                 return Optional.of(convertToJarUrlIfNecessary(path.toUri()));
             } catch (Exception e) {
                 LOG.warn("Cannot parse file path classpath entry " + classpathFilePathEntry, e);
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 
@@ -200,7 +200,7 @@ interface UrlSource extends Iterable<URL> {
                 return Optional.of(Paths.get(path).toUri().toURL());
             } catch (MalformedURLException e) {
                 LOG.warn("Cannot parse URL from path " + path, e);
-                return Optional.absent();
+                return Optional.empty();
             } catch (InvalidPathException e) {
                 Optional<URL> fallback = tryResolvePathFromUrl(path);
                 if (!fallback.isPresent()) {
@@ -220,7 +220,7 @@ interface UrlSource extends Iterable<URL> {
             try {
                 return Optional.of(Paths.get(new URL("file:" + path).toURI()).toUri().toURL());
             } catch (MalformedURLException | URISyntaxException | InvalidPathException e) {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 
@@ -228,10 +228,10 @@ interface UrlSource extends Iterable<URL> {
             Optional<URL> fileUri = newFileUri(path);
 
             try {
-                return fileUri.isPresent() ? Optional.of(new URL("jar:" + fileUri.get() + "!/")) : Optional.<URL>absent();
+                return fileUri.isPresent() ? Optional.of(new URL("jar:" + fileUri.get() + "!/")) : Optional.<URL>empty();
             } catch (MalformedURLException e) {
                 LOG.warn("Cannot parse URL from path " + path, e);
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
@@ -103,7 +103,7 @@ public interface ClassResolver {
         private Optional<ClassResolver> getExplicitlyConfiguredClassResolver() {
             Optional<String> resolverClassName = ArchConfiguration.get().getClassResolver();
             if (!resolverClassName.isPresent()) {
-                return Optional.absent();
+                return Optional.empty();
             }
 
             Class<?> resolverClass = classForName(resolverClassName);
@@ -152,7 +152,7 @@ public interface ClassResolver {
             try {
                 return Optional.<Constructor<?>>of(resolverClass.getConstructor(List.class));
             } catch (NoSuchMethodException e) {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 
@@ -179,7 +179,7 @@ public interface ClassResolver {
 
             @Override
             public Optional<JavaClass> tryResolve(String typeName) {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFromClasspath.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFromClasspath.java
@@ -48,13 +48,13 @@ public final class ClassResolverFromClasspath implements ClassResolver {
 
         Optional<URI> uri = tryGetUriOf(typeFile);
 
-        return uri.isPresent() ? classUriImporter.tryImport(uri.get()) : Optional.<JavaClass>absent();
+        return uri.isPresent() ? classUriImporter.tryImport(uri.get()) : Optional.<JavaClass>empty();
     }
 
     private Optional<URI> tryGetUriOf(String typeFile) {
         URL resource = getCurrentClassLoader(getClass()).getResource(typeFile);
         if (resource == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
         try {
             return Optional.of(resource.toURI());

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspath.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspath.java
@@ -55,6 +55,6 @@ public final class SelectedClassResolverFromClasspath implements ClassResolver {
                 return classResolverFromClasspath.tryResolve(typeName);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
@@ -163,7 +163,7 @@ public interface ArchRule extends CanBeEvaluated, CanOverrideDescription<ArchRul
     @Internal
     class Factory {
         public static <T> ArchRule create(final ClassesTransformer<T> classesTransformer, final ArchCondition<T> condition, final Priority priority) {
-            return new SimpleArchRule<>(priority, classesTransformer, condition, Optional.<String>absent());
+            return new SimpleArchRule<>(priority, classesTransformer, condition, Optional.<String>empty());
         }
 
         public static ArchRule withBecause(ArchRule rule, String reason) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
@@ -40,7 +40,7 @@ public final class ConditionEvents implements Iterable<ConditionEvent> {
     }
 
     private final Multimap<Type, ConditionEvent> eventsByViolation = ArrayListMultimap.create();
-    private Optional<String> informationAboutNumberOfViolations = Optional.absent();
+    private Optional<String> informationAboutNumberOfViolations = Optional.empty();
 
     @PublicAPI(usage = ACCESS)
     public void add(ConditionEvent event) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/FailureMessages.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/FailureMessages.java
@@ -41,7 +41,7 @@ public class FailureMessages extends ForwardingList<String> {
      */
     @PublicAPI(usage = ACCESS)
     public String getInformationAboutNumberOfViolations() {
-        return informationAboutNumberOfViolations.or(failures.size() + " times");
+        return informationAboutNumberOfViolations.orElse(failures.size() + " times");
     }
 
     FailureMessages filter(Predicate<String> predicate) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -71,6 +71,7 @@ import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_TARGET_C
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyTarget;
 import static com.tngtech.archunit.core.domain.Formatters.ensureSimpleName;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_ACCESSES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_ACCESSES_TO_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CALLS_FROM_SELF;
@@ -91,7 +92,6 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameCo
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameEndingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameStartingWith;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.JavaMember.Predicates.declaredIn;
 import static com.tngtech.archunit.core.domain.JavaModifier.FINAL;
@@ -185,7 +185,7 @@ public final class ArchConditions {
                 .and(JavaCall.Predicates.target(name(methodName)))
                 .and(JavaCall.Predicates.target(rawParameterTypes(parameterTypes))))
                 .as("call method %s", Formatters.formatMethodSimple(
-                        owner.getSimpleName(), methodName, namesOf(parameterTypes)));
+                        owner.getSimpleName(), methodName, formatNamesOf(parameterTypes)));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -218,7 +218,7 @@ public final class ArchConditions {
                 .and(JavaCall.Predicates.target(name(CONSTRUCTOR_NAME)))
                 .and(JavaCall.Predicates.target(rawParameterTypes(parameterTypes))))
                 .as("call constructor %s", Formatters.formatMethodSimple(
-                        owner.getSimpleName(), CONSTRUCTOR_NAME, namesOf(parameterTypes)));
+                        owner.getSimpleName(), CONSTRUCTOR_NAME, formatNamesOf(parameterTypes)));
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractGivenCodeUnitsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractGivenCodeUnitsInternal.java
@@ -72,7 +72,7 @@ abstract class AbstractGivenCodeUnitsInternal<MEMBER extends JavaCodeUnit, SELF 
                     classesTransformer,
                     prepareCondition,
                     new PredicateAggregator<JavaCodeUnit>(),
-                    Optional.<String>absent());
+                    Optional.<String>empty());
         }
 
         private GivenCodeUnitsInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractGivenMembersInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractGivenMembersInternal.java
@@ -74,7 +74,7 @@ abstract class AbstractGivenMembersInternal<MEMBER extends JavaMember, SELF exte
                     classesTransformer,
                     prepareCondition,
                     new PredicateAggregator<JavaMember>(),
-                    Optional.<String>absent());
+                    Optional.<String>empty());
         }
 
         private GivenMembersInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenClassesInternal.java
@@ -38,7 +38,7 @@ class GivenClassesInternal extends AbstractGivenObjects<JavaClass, GivenClassesI
 
     GivenClassesInternal(Priority priority, ClassesTransformer<JavaClass> classesTransformer,
             Function<ArchCondition<JavaClass>, ArchCondition<JavaClass>> prepareCondition) {
-        this(priority, classesTransformer, prepareCondition, new PredicateAggregator<JavaClass>(), Optional.<String>absent());
+        this(priority, classesTransformer, prepareCondition, new PredicateAggregator<JavaClass>(), Optional.<String>empty());
     }
 
     private GivenClassesInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenConstructorsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenConstructorsInternal.java
@@ -42,7 +42,7 @@ class GivenConstructorsInternal extends AbstractGivenCodeUnitsInternal<JavaConst
                 classesTransformer,
                 prepareCondition,
                 new PredicateAggregator<JavaConstructor>(),
-                Optional.<String>absent());
+                Optional.<String>empty());
     }
 
     private GivenConstructorsInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenFieldsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenFieldsInternal.java
@@ -43,7 +43,7 @@ class GivenFieldsInternal
                 classesTransformer,
                 prepareCondition,
                 new PredicateAggregator<JavaField>(),
-                Optional.<String>absent());
+                Optional.<String>empty());
     }
 
     private GivenFieldsInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenMethodsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenMethodsInternal.java
@@ -43,7 +43,7 @@ class GivenMethodsInternal
                 classesTransformer,
                 prepareCondition,
                 new PredicateAggregator<JavaMethod>(),
-                Optional.<String>absent());
+                Optional.<String>empty());
     }
 
     private GivenMethodsInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenObjectsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/GivenObjectsInternal.java
@@ -33,7 +33,7 @@ class GivenObjectsInternal<T> extends AbstractGivenObjects<T, GivenObjectsIntern
     GivenObjectsInternal(Priority priority,
             ClassesTransformer<T> classesTransformer,
             Function<ArchCondition<T>, ArchCondition<T>> prepareCondition) {
-        this(priority, classesTransformer, prepareCondition, new PredicateAggregator<T>(), Optional.<String>absent());
+        this(priority, classesTransformer, prepareCondition, new PredicateAggregator<T>(), Optional.<String>empty());
     }
 
     private GivenObjectsInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ObjectsShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ObjectsShouldInternal.java
@@ -112,7 +112,7 @@ class ObjectsShouldInternal<T> implements ArchRule {
         private final AddMode<T> addMode;
 
         ConditionAggregator() {
-            this(Optional.<ArchCondition<T>>absent(), AddMode.<T>and());
+            this(Optional.<ArchCondition<T>>empty(), AddMode.<T>and());
         }
 
         ConditionAggregator(ArchCondition<T> condition) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/PredicateAggregator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/PredicateAggregator.java
@@ -25,7 +25,7 @@ public final class PredicateAggregator<T> {
     private final Optional<DescribedPredicate<T>> predicate;
 
     public PredicateAggregator() {
-        this(AddMode.<T>and(), Optional.<DescribedPredicate<T>>absent());
+        this(AddMode.<T>and(), Optional.<DescribedPredicate<T>>empty());
     }
 
     private PredicateAggregator(AddMode<T> addMode, Optional<DescribedPredicate<T>> predicate) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -114,7 +114,7 @@ public final class Architectures {
             this(new LayerDefinitions(),
                     new LinkedHashSet<LayerDependencySpecification>(),
                     new PredicateAggregator<Dependency>().thatORs(),
-                    Optional.<String>absent(),
+                    Optional.<String>empty(),
                     false);
         }
 
@@ -472,7 +472,7 @@ public final class Architectures {
         private List<IgnoredDependency> ignoredDependencies = new ArrayList<>();
 
         private OnionArchitecture() {
-            overriddenDescription = Optional.absent();
+            overriddenDescription = Optional.empty();
         }
 
         private OnionArchitecture(String[] domainModelPackageIdentifiers,

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
@@ -174,7 +174,7 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
         }
 
         private Transformer(SliceAssignment sliceAssignment, String description, SlicesPredicateAggregator predicate) {
-            this(sliceAssignment, description, Optional.<String>absent(), predicate);
+            this(sliceAssignment, description, Optional.<String>empty(), predicate);
         }
 
         private Transformer(SliceAssignment sliceAssignment,
@@ -331,8 +331,8 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
         @Override
         public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
             PackageMatcher matcher = PackageMatcher.of(packageIdentifier);
-            Optional<List<String>> result = matcher.match(javaClass.getPackageName()).transform(TO_GROUPS);
-            List<String> parts = result.or(Collections.<String>emptyList());
+            Optional<List<String>> result = matcher.match(javaClass.getPackageName()).map(TO_GROUPS);
+            List<String> parts = result.orElse(Collections.<String>emptyList());
             return parts.isEmpty() ? SliceIdentifier.ignore() : SliceIdentifier.of(parts);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
@@ -59,7 +59,7 @@ public final class MetricsComponents<T> extends ForwardingCollection<MetricsComp
      */
     @PublicAPI(usage = ACCESS)
     public Optional<MetricsComponent<T>> tryGetComponent(String identifier) {
-        return Optional.fromNullable(componentsByIdentifier.get(identifier));
+        return Optional.ofNullable(componentsByIdentifier.get(identifier));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/ComponentIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/ComponentIdentifier.java
@@ -24,7 +24,7 @@ class ComponentIdentifier {
     private final Optional<Alias> alias;
 
     ComponentIdentifier(ComponentName componentName) {
-        this(componentName, Optional.<Alias>absent());
+        this(componentName, Optional.<Alias>empty());
     }
 
     ComponentIdentifier(ComponentName componentName, Alias alias) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlParser.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlParser.java
@@ -97,7 +97,7 @@ class PlantUmlParser {
 
         ComponentName componentName = new ComponentName(matcher.matchComponentName());
         ImmutableSet<Stereotype> immutableStereotypes = identifyStereotypes(matcher, componentName);
-        Optional<Alias> alias = Optional.fromNullable(matcher.matchAlias().transform(TO_ALIAS).orNull());
+        Optional<Alias> alias = Optional.ofNullable(matcher.matchAlias().transform(TO_ALIAS).orNull());
 
         return new PlantUmlComponent.Builder()
                 .withComponentName(componentName)

--- a/archunit/src/test/java/com/tngtech/archunit/base/PackageMatcherTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/PackageMatcherTest.java
@@ -127,7 +127,7 @@ public class PackageMatcherTest {
         Optional<Result> result = PackageMatcher.of("com.(*)..service.(**)")
                 .match("com.mycompany.some.service.special.name");
 
-        assertThat(result.transform(TO_GROUPS).get()).contains("mycompany", "special.name");
+        assertThat(result.map(TO_GROUPS).get()).contains("mycompany", "special.name");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
@@ -2,6 +2,7 @@ package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -16,6 +17,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Sets.union;
 import static com.google.common.primitives.Primitives.allPrimitiveTypes;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
@@ -27,6 +29,19 @@ import static java.util.Collections.singleton;
 public class FormattersTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void formatNamesOf() {
+        assertThat(Formatters.formatNamesOf()).isEmpty();
+
+        assertThat(Formatters.formatNamesOf(List.class, Iterable.class, String.class))
+                .containsExactly(List.class.getName(), Iterable.class.getName(), String.class.getName());
+
+        assertThat(Formatters.formatNamesOf(Collections.<Class<?>>emptyList())).isEmpty();
+
+        assertThat(Formatters.formatNamesOf(of(List.class, Iterable.class, String.class)))
+                .containsExactly(List.class.getName(), Iterable.class.getName(), String.class.getName());
+    }
 
     @Test
     @SuppressWarnings("ConstantConditions")

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/SourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/SourceTest.java
@@ -42,7 +42,7 @@ public class SourceTest {
         Source source = new Source(urlOf(Object.class).toURI(), Optional.of("SomeClass.java"), false);
         assertThat(source.getFileName()).as("source file name").contains("SomeClass.java");
 
-        source = new Source(urlOf(Object.class).toURI(), Optional.<String>absent(), false);
+        source = new Source(urlOf(Object.class).toURI(), Optional.<String>empty(), false);
         assertThat(source.getFileName()).as("source file name").isAbsent();
     }
 
@@ -162,7 +162,7 @@ public class SourceTest {
     }
 
     private Source newSource(URI uri) {
-        return new Source(uri, Optional.<String>absent(), true);
+        return new Source(uri, Optional.<String>empty(), true);
     }
 
     private static Md5sum md5sumOf(String data) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -24,6 +24,7 @@ import com.tngtech.archunit.core.importer.ImportTestUtils;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 import static com.tngtech.archunit.core.importer.ImportTestUtils.newFieldAccess;
@@ -87,7 +88,7 @@ public class TestUtils {
 
     public static JavaClasses importClassesWithContext(Class<?>... classes) {
         JavaClasses importedHierarchy = importHierarchies(classes);
-        final List<String> classNames = JavaClass.namesOf(classes);
+        final List<String> classNames = formatNamesOf(classes);
         return importedHierarchy.that(new DescribedPredicate<JavaClass>("") {
             @Override
             public boolean apply(JavaClass input) {
@@ -240,7 +241,7 @@ public class TestUtils {
                 String methodName,
                 Class<?>[] paramTypes) {
 
-            List<String> paramNames = JavaClass.namesOf(paramTypes);
+            List<String> paramNames = formatNamesOf(paramTypes);
             for (T call : callsFromSelf) {
                 if (call.getTargetOwner().isEquivalentTo(targetOwner) &&
                         call.getTarget().getName().equals(methodName) &&

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -76,7 +76,7 @@ public class TestUtils {
         File file = newTemporaryFile();
         try {
             Files.write(bytes, file);
-            return new Source(file.toURI(), Optional.<String>absent(), true).getMd5sum();
+            return new Source(file.toURI(), Optional.<String>empty(), true).getMd5sum();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
@@ -10,8 +10,8 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.TestUtils.throwsClause;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
@@ -82,7 +82,7 @@ public class HasThrowsClauseTest {
 
             @Override
             public String toString() {
-                return HasThrowsClause.class.getSimpleName() + "{ throws " + namesOf(throwsDeclarations) + "}";
+                return HasThrowsClause.class.getSimpleName() + "{ throws " + formatNamesOf(throwsDeclarations) + "}";
             }
         };
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
@@ -131,7 +131,7 @@ public class ClassFileImporterMembersTest {
     @Test
     public void imports_simple_methods_with_correct_parameters() throws Exception {
         Set<JavaMethod> methods = getMethods(new ClassFileImporter().importUrl(getClass().getResource("testexamples/methodimport")));
-        assertThat(methods).extractingResultOf("getDefaultValue").containsOnly(Optional.absent());
+        assertThat(methods).extractingResultOf("getDefaultValue").containsOnly(Optional.empty());
 
         assertThat(findAnyByName(methods, "createString")).isEquivalentTo(
                 ClassWithStringStringMethod.class.getDeclaredMethod("createString", String.class));

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -67,7 +67,7 @@ public class ImportTestUtils {
                     .withName(field.getName())
                     .withDescriptor(Type.getDescriptor(field.getType()))
                     .withModifiers(JavaModifier.getModifiersForField(field.getModifiers()))
-                    .withType(Optional.<JavaTypeCreationProcess<JavaField>>absent(), JavaClassDescriptor.From.name(field.getType().getName())));
+                    .withType(Optional.<JavaTypeCreationProcess<JavaField>>empty(), JavaClassDescriptor.From.name(field.getType().getName())));
         }
         return fieldBuilders;
     }
@@ -77,7 +77,7 @@ public class ImportTestUtils {
         for (Method method : inputClass.getDeclaredMethods()) {
             methodBuilders.add(new DomainBuilders.JavaMethodBuilder()
                     .withReturnType(
-                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent(),
+                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty(),
                             JavaClassDescriptor.From.name(method.getReturnType().getName()))
                     .withParameterTypes(typesFrom(method.getParameterTypes()))
                     .withName(method.getName())
@@ -93,7 +93,7 @@ public class ImportTestUtils {
         for (Constructor<?> constructor : inputClass.getDeclaredConstructors()) {
             constructorBuilders.add(new DomainBuilders.JavaConstructorBuilder()
                     .withReturnType(
-                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>absent(),
+                            Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty(),
                             JavaClassDescriptor.From.name(void.class.getName()))
                     .withParameterTypes(typesFrom(constructor.getParameterTypes()))
                     .withName(CONSTRUCTOR_NAME)
@@ -339,17 +339,17 @@ public class ImportTestUtils {
 
         @Override
         public Optional<JavaClass> createSuperclass(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
         public Optional<JavaType> createGenericSuperclass(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
         public Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
@@ -379,7 +379,7 @@ public class ImportTestUtils {
 
         @Override
         public Optional<JavaStaticInitializer> createStaticInitializer(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
@@ -394,12 +394,12 @@ public class ImportTestUtils {
 
         @Override
         public Optional<JavaClass> createEnclosingClass(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
         public Optional<JavaCodeUnit> createEnclosingCodeUnit(JavaClass owner) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         @Override
@@ -424,7 +424,7 @@ public class ImportTestUtils {
 
         @Override
         public Optional<JavaClass> getMethodReturnType(String declaringClassName, String methodName) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
@@ -142,7 +142,7 @@ public class ClassResolverFactoryTest {
 
         @Override
         public Optional<JavaClass> tryResolve(String typeName) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -157,7 +157,7 @@ public class ClassResolverFactoryTest {
 
         @Override
         public Optional<JavaClass> tryResolve(String typeName) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -171,7 +171,7 @@ public class ClassResolverFactoryTest {
 
         @Override
         public Optional<JavaClass> tryResolve(String typeName) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 
@@ -185,7 +185,7 @@ public class ClassResolverFactoryTest {
 
         @Override
         public Optional<JavaClass> tryResolve(String typeName) {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/FailureDisplayFormatFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/FailureDisplayFormatFactoryTest.java
@@ -25,7 +25,7 @@ public class FailureDisplayFormatFactoryTest {
         assertThat(failureDisplayFormat).isInstanceOf(TestFailureDisplayFormat.class);
 
         String message = failureDisplayFormat.formatFailure(hasDescription("some-rule"),
-                new FailureMessages(ImmutableList.of("some-failure"), Optional.<String>absent()),
+                new FailureMessages(ImmutableList.of("some-failure"), Optional.<String>empty()),
                 Priority.LOW);
 
         assertThat(message).isEqualTo("test-format: some-rule has [some-failure] with priority LOW");

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -19,7 +19,6 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaCall;
-import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotatedTest.ClassRetentionAnnotation;
@@ -47,6 +46,7 @@ import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
 import static com.tngtech.archunit.base.DescribedPredicate.lessThan;
 import static com.tngtech.archunit.base.DescribedPredicate.lessThanOrEqualTo;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.core.domain.JavaClassTest.expectInvalidSyntaxUsageForClassInsteadOfInterface;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
@@ -1889,7 +1889,7 @@ public class ClassesShouldTest {
     }
 
     private Pattern callRegex(Class<?> origin, Class<?> targetClass, String targetType, String methodName, Class<?>... paramTypes) {
-        String params = Joiner.on(", ").join(JavaClass.namesOf(paramTypes));
+        String params = Joiner.on(", ").join(formatNamesOf(paramTypes));
         String originCalls = String.format("%s[^%s]* calls", quote(origin.getName()), FAILURE_REPORT_NEWLINE_MARKER);
         String target = String.format("[^%s]*%s\\.%s\\(%s\\)",
                 FAILURE_REPORT_NEWLINE_MARKER, quote(targetClass.getName()), methodName, quote(params));

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -27,8 +27,8 @@ import org.junit.runner.RunWith;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.JavaModifier.PRIVATE;
 import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
@@ -663,7 +663,7 @@ public class MembersShouldTest {
 
     static Set<String> parseMembers(List<Class<?>> possibleOwners, List<String> details) {
         List<String> classNamePatterns = new ArrayList<>();
-        for (String className : namesOf(possibleOwners)) {
+        for (String className : formatNamesOf(possibleOwners)) {
             classNamePatterns.add(quote(className));
         }
         String classesWithMembersRegex = String.format("(?:%s)", Joiner.on("|").join(classNamePatterns));

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
@@ -119,7 +119,7 @@ public class SlicesTest {
                 }
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private SliceAssignment assignmentOfJavaLangAndUtil(final String description) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -88,7 +88,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
     }
 
     public static <T> org.assertj.guava.api.OptionalAssert<T> assertThat(Optional<T> optional) {
-        return org.assertj.guava.api.Assertions.assertThat(com.google.common.base.Optional.fromNullable(optional.orNull()));
+        return org.assertj.guava.api.Assertions.assertThat(com.google.common.base.Optional.fromNullable(optional.orElse(null)));
     }
 
     public static <T> DescribedPredicateAssertion<T> assertThat(DescribedPredicate<T> predicate) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -69,7 +69,7 @@ import org.assertj.core.api.ObjectAssertFactory;
 
 import static com.google.common.base.Strings.emptyToNull;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethodSimple;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.TestUtils.resolvedTargetFrom;
 import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
@@ -246,7 +246,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
             }
 
             public Condition<JavaAccess<?>> toConstructor(final Class<?> targetClass, final Class<?>... paramTypes) {
-                final List<String> paramTypeNames = namesOf(paramTypes);
+                final List<String> paramTypeNames = formatNamesOf(paramTypes);
                 return new Condition<JavaAccess<?>>(
                         String.format("%s from %s.%s to %s",
                                 JavaAccess.class.getSimpleName(),
@@ -452,11 +452,11 @@ public class Assertions extends org.assertj.core.api.Assertions {
         }
 
         public MethodCallAssertion isTo(final String methodName, final Class<?>... parameterTypes) {
-            return isTo(new Condition<MethodCallTarget>("method " + methodName + "(" + namesOf(parameterTypes) + ")") {
+            return isTo(new Condition<MethodCallTarget>("method " + methodName + "(" + formatNamesOf(parameterTypes) + ")") {
                 @Override
                 public boolean matches(MethodCallTarget methodCallTarget) {
                     return methodCallTarget.getName().equals(methodName)
-                            && HasName.Utils.namesOf(methodCallTarget.getRawParameterTypes()).equals(namesOf(parameterTypes));
+                            && HasName.Utils.namesOf(methodCallTarget.getRawParameterTypes()).equals(formatNamesOf(parameterTypes));
                 }
             });
         }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Conditions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Conditions.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import org.assertj.core.api.Condition;
 
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 
 public final class Conditions {
     private Conditions() {
@@ -27,8 +27,8 @@ public final class Conditions {
         return new Condition<JavaCodeUnit>() {
             @Override
             public boolean matches(JavaCodeUnit value) {
-                return name.equals(value.getName()) && namesOf(parameters).equals(HasName.Utils.namesOf(value.getRawParameterTypes()));
+                return name.equals(value.getName()) && formatNamesOf(parameters).equals(HasName.Utils.namesOf(value.getRawParameterTypes()));
             }
-        }.as("matches signature <" + name + ", " + namesOf(parameters) + ">");
+        }.as("matches signature <" + name + ", " + formatNamesOf(parameters) + ">");
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaMemberAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaMemberAssertion.java
@@ -9,7 +9,7 @@ import com.tngtech.archunit.core.domain.JavaMember;
 import org.assertj.core.api.AbstractObjectAssert;
 
 import static com.tngtech.archunit.core.domain.Formatters.formatMethodParameterTypeNames;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.testutil.assertion.JavaMembersAssertion.assertEquivalent;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +54,6 @@ public class JavaMemberAssertion<T extends JavaMember, SELF extends JavaMemberAs
     }
 
     private static String expectedParametersOf(Class<?>[] parameterTypes) {
-        return String.format("(%s)", formatMethodParameterTypeNames(namesOf(parameterTypes)));
+        return String.format("(%s)", formatMethodParameterTypeNames(formatNamesOf(parameterTypes)));
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaMethodsAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaMethodsAssertion.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import org.assertj.core.api.AbstractIterableAssert;
 
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Predicates.rawParameterTypes;
 
 public class JavaMethodsAssertion
@@ -22,7 +22,7 @@ public class JavaMethodsAssertion
     public JavaMethodsAssertion contain(Class<?> owner, String name, Class<?>... parameterTypes) {
         if (!contains(owner, name, parameterTypes)) {
             throw new AssertionError(String.format("There is no method %s contained in %s",
-                    formatMethod(owner.getName(), name, namesOf(parameterTypes)), actual));
+                    formatMethod(owner.getName(), name, formatNamesOf(parameterTypes)), actual));
         }
         return this;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypesAssertion.java
@@ -8,13 +8,13 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import org.assertj.core.api.AbstractObjectAssert;
 
 import static com.google.common.collect.Iterables.toArray;
-import static com.tngtech.archunit.core.domain.JavaClass.namesOf;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.TestUtils.sortByName;
 import static java.util.Arrays.sort;
@@ -34,7 +34,7 @@ public class JavaTypesAssertion extends AbstractObjectAssert<JavaTypesAssertion,
     }
 
     public void matchInAnyOrder(Iterable<Class<?>> classes) {
-        assertThat(HasName.Utils.namesOf(actual)).as(descriptionText()).containsOnlyElementsOf(namesOf(classes));
+        assertThat(HasName.Utils.namesOf(actual)).as(descriptionText()).containsOnlyElementsOf(formatNamesOf(classes));
 
         JavaType[] actualSorted = sortedJavaTypes(actual);
         Class<?>[] expectedSorted = sortedClasses(classes);
@@ -60,7 +60,7 @@ public class JavaTypesAssertion extends AbstractObjectAssert<JavaTypesAssertion,
     }
 
     public void matchExactly(Class<?>... classes) {
-        assertThat(HasName.Utils.namesOf(actual)).as(descriptionText()).containsExactlyElementsOf(namesOf(classes));
+        assertThat(HasName.Utils.namesOf(actual)).as(descriptionText()).containsExactlyElementsOf(formatNamesOf(classes));
         matchInAnyOrder(classes);
     }
 
@@ -70,11 +70,11 @@ public class JavaTypesAssertion extends AbstractObjectAssert<JavaTypesAssertion,
     }
 
     public void doNotContain(Class<?>... classes) {
-        assertThat(actualNames()).doesNotContainAnyElementsOf(namesOf(classes));
+        assertThat(actualNames()).doesNotContainAnyElementsOf(formatNamesOf(classes));
     }
 
     public void contain(Iterable<Class<?>> classes) {
-        List<String> expectedNames = namesOf(Lists.newArrayList(classes));
+        List<String> expectedNames = formatNamesOf(newArrayList(classes));
         assertThat(actualNames()).as(descriptionText()).containsAll(expectedNames);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
@@ -51,7 +51,7 @@ public class MethodChoiceStrategy {
     Optional<Method> choose(PropagatedType type, boolean tryToTerminate) {
         List<Method> methods = getPossibleMethodCandidates(type.getRawType());
         if (methods.isEmpty()) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         return tryToTerminate
@@ -65,7 +65,7 @@ public class MethodChoiceStrategy {
                 return Optional.of(method);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private List<Method> getPossibleMethodCandidates(Class<?> clazz) {


### PR DESCRIPTION
Once we drop support for Java 7 we can also drop ArchUnit's own `Optional` type and use the standard `java.util.Optional` instead. To make that transition easier it makes sense to already adjust the ArchUnit `Optional` to the Java 8 `Optional` as much as possible (originally it was modelled close to the Guava `Optional`).
