### PR TITLE
fix bug where some JDK 7 compiled classes cannot be imported anymore

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -294,14 +294,16 @@ class ClassFileImportRecord {
         private final Map<String, CodeUnit> innerClassNameToEnclosingCodeUnit = new HashMap<>();
 
         void registerEnclosingClass(String innerName, String outerName) {
-            checkArgument(!innerClassNameToEnclosingClassName.containsKey(innerName),
+            checkArgument(!innerClassNameToEnclosingClassName.containsKey(innerName)
+                            || innerClassNameToEnclosingClassName.get(innerName).equals(outerName),
                     "Can't register multiple enclosing classes, this is likely a bug!");
 
             innerClassNameToEnclosingClassName.put(innerName, outerName);
         }
 
         void registerEnclosingCodeUnit(String innerName, CodeUnit codeUnit) {
-            checkArgument(!innerClassNameToEnclosingCodeUnit.containsKey(innerName),
+            checkArgument(!innerClassNameToEnclosingCodeUnit.containsKey(innerName)
+                            || innerClassNameToEnclosingCodeUnit.get(innerName).equals(codeUnit),
                     "Can't register multiple enclosing code units, this is likely a bug!");
 
             innerClassNameToEnclosingCodeUnit.put(innerName, codeUnit);


### PR DESCRIPTION
It turns out that JDK 7 compiled certain synthetic anonymous classes in a different way from later JDKs (and this does not show if you compile with a newer JDK and target compatibility 7).
According to the [JLS](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6) the `outer_class_info_index` should be 0 for non-member, local or anonymous classes. However JDK 7 compiles the synthetic class `Foo$1` differently in a scenario like

```
class Foo {
    private Foo(Builder builder) {
    }

    public static Builder builder() {
        return new Builder();
    }

    public static class  Builder {
        private Builder() {}

        public Foo build() {
            return new Foo(this);
        }
    }
}
```

With JDK 7 the class `Foo$1` in this scenario will have an outer class set, leading to an exception in `com.tngtech.archunit.core.importer.ClassFileImportRecord.EnclosingDeclarationsByInnerClasses.registerEnclosingClass`, since then both `visitOuterClass` and `visitInnerClass` are called in a way that sets the enclosing class.

To fix this regression, and support such classes compiled by JDK 7 again, I decided to make the checks more lenient again and accepting the same outer class or outer method being registered several times.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>