### PR TITLE
Add generic method parameter types

### DIFF
--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/service/SpecialServiceHelper.java
@@ -15,4 +15,7 @@ public abstract class SpecialServiceHelper extends ServiceHelper<SomeUtility, Ha
     Map<?, Map<SomeEnum, ? extends SomeUtility>> methodWithGenericReturnTypeViolatingLayerRule() {
         return null;
     }
+
+    void methodWithGenericParameterTypeViolatingLayerRule(Map<?, Map<SomeEnum, ? extends SomeUtility>> param) {
+    }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
@@ -15,6 +15,7 @@ import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.Location;
+import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchTests;
@@ -54,7 +55,13 @@ public class ArchUnitArchitectureTest {
             .whereLayer("Library").mayOnlyBeAccessedByLayers("JUnit")
             .whereLayer("Lang").mayOnlyBeAccessedByLayers("Library", "JUnit")
             .whereLayer("Core").mayOnlyBeAccessedByLayers("Lang", "Library", "JUnit")
-            .whereLayer("Base").mayOnlyBeAccessedByLayers("Root", "Core", "Lang", "Library", "JUnit");
+            .whereLayer("Base").mayOnlyBeAccessedByLayers("Root", "Core", "Lang", "Library", "JUnit")
+
+            // This is a conscious exception, to allow a more concise API. Otherwise the configuration of the
+            // ClassResolver would need to be moved to `importer` making it harder to use,
+            // or we would need to remove the bound from Class<? extends ClassResolver>, which also makes the
+            // API harder to use
+            .ignoreDependency(ArchConfiguration.class, ClassResolver.class);
 
     @ArchTest
     public static final ArchTests importer_rules = ArchTests.in(ImporterRules.class);

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
@@ -177,6 +178,7 @@ import static com.tngtech.archunit.testutils.ExpectedDependency.constructor;
 import static com.tngtech.archunit.testutils.ExpectedDependency.field;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericFieldType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericInterfaceOf;
+import static com.tngtech.archunit.testutils.ExpectedDependency.genericMethodParameterType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericMethodReturnType;
 import static com.tngtech.archunit.testutils.ExpectedDependency.genericSuperclassOf;
 import static com.tngtech.archunit.testutils.ExpectedDependency.inheritanceFrom;
@@ -799,6 +801,10 @@ class ExamplesIntegrationTest {
                         .dependingOn(SomeEnum.class))
                 .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
                         .dependingOn(SomeUtility.class))
+                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
+                        .dependingOn(SomeEnum.class))
+                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
+                        .dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentOnComponentTypeMethod).withParameter(UseCaseTwoController[].class))
@@ -870,6 +876,10 @@ class ExamplesIntegrationTest {
                 .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
                         .dependingOn(SomeEnum.class))
                 .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                        .dependingOn(SomeUtility.class))
+                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
+                        .dependingOn(SomeEnum.class))
+                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
                         .dependingOn(SomeUtility.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))
@@ -952,6 +962,10 @@ class ExamplesIntegrationTest {
                                 .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
                                         .dependingOn(SomeEnum.class))
                                 .by(genericMethodReturnType(SpecialServiceHelper.class, "methodWithGenericReturnTypeViolatingLayerRule")
+                                        .dependingOn(SomeUtility.class))
+                                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
+                                        .dependingOn(SomeEnum.class))
+                                .by(genericMethodParameterType(SpecialServiceHelper.class, "methodWithGenericParameterTypeViolatingLayerRule", Map.class)
                                         .dependingOn(SomeUtility.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withParameter(UseCaseTwoController.class))
                                 .by(method(ServiceViolatingLayerRules.class, dependentMethod).withReturnType(SomeGuiController.class))

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -3,6 +3,7 @@ package com.tngtech.archunit.testutils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collection;
 
 import com.google.common.collect.ImmutableList;
@@ -63,6 +64,18 @@ public class ExpectedDependency implements ExpectedRelation {
                 methodName,
                 "return type",
                 getMethod(clazz, methodName, parameterTypes).getGenericReturnType());
+    }
+
+    public static GenericMemberTypeArgumentCreator genericMethodParameterType(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
+        Type[] genericParameterTypes = getMethod(clazz, methodName, parameterTypes).getGenericParameterTypes();
+        checkArgument(genericParameterTypes.length == 1,
+                "Currently only exactly one generic method parameter type is supported, but %s.%s(..) has the following generic parameter types: %s. "
+                        + "Feel free to extend this method to cover multiple parameter types.", clazz.getName(), methodName, Arrays.toString(genericParameterTypes));
+        return new GenericMemberTypeArgumentCreator(
+                clazz,
+                methodName,
+                "parameter type",
+                genericParameterTypes[0]);
     }
 
     public static AnnotationDependencyCreator annotatedClass(Class<?> clazz) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -318,6 +318,12 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         }
 
         @Override
+        @SuppressWarnings({"unchecked", "rawtypes"}) // cast is okay, since this list can only be used in a covariant way (immutable)
+        public List<JavaType> getParameterTypes() {
+            return (List) parameters;
+        }
+
+        @Override
         @PublicAPI(usage = ACCESS)
         public List<JavaClass> getRawParameterTypes() {
             return parameters;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -160,6 +160,10 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         return tryCreateDependency(origin, genericDependencyType("return type", origin.getReturnType()), typeArgumentDependency);
     }
 
+    static Set<Dependency> tryCreateFromGenericCodeUnitParameterTypeArgument(JavaCodeUnit origin, JavaType parameterType, JavaClass typeArgumentDependency) {
+        return tryCreateDependency(origin, genericDependencyType("parameter type", parameterType), typeArgumentDependency);
+    }
+
     private static String genericDependencyType(String genericTypeDescription, JavaType genericType) {
         return "has generic " + genericTypeDescription + " " + bracketFormat(genericType.getName()) + " with type argument depending on";
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -54,6 +54,7 @@ public abstract class JavaCodeUnit
 
     private final JavaType returnType;
     private final List<JavaClass> rawParameterTypes;
+    private final List<JavaType> parameterTypes;
     private final String fullName;
     private final List<JavaTypeVariable<JavaCodeUnit>> typeParameters;
     private final Set<ReferencedClassObject> referencedClassObjects;
@@ -68,9 +69,16 @@ public abstract class JavaCodeUnit
         typeParameters = builder.getTypeParameters(this);
         returnType = builder.getReturnType(this);
         rawParameterTypes = builder.getRawParameterTypes();
+        parameterTypes = getParameterTypes(builder);
         fullName = formatMethod(getOwner().getName(), getName(), namesOf(getRawParameterTypes()));
         referencedClassObjects = ImmutableSet.copyOf(builder.getReferencedClassObjects(this));
         instanceofChecks = ImmutableSet.copyOf(builder.getInstanceofChecks(this));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"}) // the cast is safe because the list is immutable, thus used in a covariant way
+    private List<JavaType> getParameterTypes(JavaCodeUnitBuilder<?, ?> builder) {
+        List<JavaType> genericParameterTypes = builder.getGenericParameterTypes(this);
+        return genericParameterTypes.isEmpty() ? (List) rawParameterTypes : genericParameterTypes;
     }
 
     /**
@@ -86,6 +94,12 @@ public abstract class JavaCodeUnit
     @PublicAPI(usage = ACCESS)
     public List<JavaClass> getRawParameterTypes() {
         return rawParameterTypes;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public List<JavaType> getParameterTypes() {
+        return parameterTypes;
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.domain.JavaTypeVariable;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
@@ -30,6 +32,30 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
 
 public interface HasParameterTypes {
 
+    /**
+     * @return the raw parameter types of this object, e.g.<br>
+     *         for a method
+     *         <pre><code>void someMethod(String first, int second) {..}</code></pre>
+     *         this would be the {@link JavaClass JavaClasses} equivalent to {@code [String.class, int.class]},<br>
+     *         for a method
+     *         <pre><code>&lt;T&gt; void someMethod(T generic) {..}</code></pre>
+     *         this would be the {@link JavaTypeVariable JavaTypeVariable} {@code T}.<br>
+     *         Note that for non-generic cases this returns the same as {@link #getRawParameterTypes()}.
+     */
+    @PublicAPI(usage = ACCESS)
+    List<JavaType> getParameterTypes();
+
+    /**
+     * @return the raw parameter types of this object, e.g.<br>
+     *         for a method
+     *         <pre><code>void someMethod(String first, int second) {..}</code></pre>
+     *         this would be the {@link JavaClass JavaClasses} equivalent to {@code [String.class, int.class]},<br>
+     *         for a method
+     *         <pre><code>&lt;T&gt; void someMethod(T generic) {..}</code></pre>
+     *         this would be the erasure of the generic type variable {@code T},
+     *         i.e. the {@link JavaClass} equivalent to {@code Object.class}.<br>
+     *         Note that for non-generic cases this returns the same as {@link #getParameterTypes()}.
+     */
     @PublicAPI(usage = ACCESS)
     List<JavaClass> getRawParameterTypes();
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasTypeParameters.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasTypeParameters.java
@@ -25,6 +25,13 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 @PublicAPI(usage = ACCESS)
 public interface HasTypeParameters<OWNER extends HasDescription> {
+    /**
+     * @return the type parameters of this object, e.g. for any generic method
+     *         <pre><code>&lt;A, B&gt; B someMethod(A a) {..}</code></pre> this would return
+     *         the {@link JavaTypeVariable JavaTypeVariables} {@code [A, B]}.<br>
+     *         If this object is non-generic, e.g. a method <pre><code>void someMethod() {..}</code></pre>
+     *         an empty list will be returned.
+     */
     @PublicAPI(usage = ACCESS)
     List<? extends JavaTypeVariable<? extends OWNER>> getTypeParameters();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
@@ -16,6 +16,7 @@
 package com.tngtech.archunit.core.importer;
 
 import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher;
@@ -35,8 +36,8 @@ class GenericMemberTypeProcessor<T extends HasDescription> extends SignatureVisi
         super(ASM_API_VERSION);
     }
 
-    JavaTypeCreationProcess<T> getType() {
-        return typeCreationProcess;
+    Optional<JavaTypeCreationProcess<T>> getType() {
+        return Optional.ofNullable(typeCreationProcess);
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -248,8 +248,8 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         LOG.trace("Analyzing method {}.{}:{}", className, name, desc);
-        List<JavaClassDescriptor> parameters = JavaClassDescriptorImporter.importAsmMethodArgumentTypes(desc);
-        accessHandler.setContext(new CodeUnit(name, namesOf(parameters), className));
+        List<JavaClassDescriptor> rawParameterTypes = JavaClassDescriptorImporter.importAsmMethodArgumentTypes(desc);
+        accessHandler.setContext(new CodeUnit(name, namesOf(rawParameterTypes), className));
 
         DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder = addCodeUnitBuilder(name);
         JavaCodeUnitSignature codeUnitSignature = JavaCodeUnitSignatureImporter.parseAsmMethodSignature(signature);
@@ -258,7 +258,7 @@ class JavaClassProcessor extends ClassVisitor {
                 .withName(name)
                 .withModifiers(JavaModifier.getModifiersForMethod(access))
                 .withTypeParameters(codeUnitSignature.getTypeParameterBuilders())
-                .withParameterTypes(parameters)
+                .withParameterTypes(codeUnitSignature.getParameterTypes(), rawParameterTypes)
                 .withReturnType(codeUnitSignature.getReturnType(), rawReturnType)
                 .withDescriptor(desc)
                 .withThrowsClause(typesFrom(exceptions));

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaCodeUnitSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaCodeUnitSignatureImporter.java
@@ -15,6 +15,7 @@
  */
 package com.tngtech.archunit.core.importer;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,6 +48,7 @@ class JavaCodeUnitSignatureImporter {
 
     private static class SignatureProcessor extends SignatureVisitor {
         private final SignatureTypeParameterProcessor<JavaCodeUnit> typeParameterProcessor = new SignatureTypeParameterProcessor<>();
+        private final List<GenericMemberTypeProcessor<JavaCodeUnit>> genericMethodParameterTypeProcessors = new ArrayList<>();
         private final GenericMemberTypeProcessor<JavaCodeUnit> genericMethodReturnTypeProcessor = new GenericMemberTypeProcessor<>();
 
         SignatureProcessor() {
@@ -70,36 +72,59 @@ class JavaCodeUnitSignatureImporter {
         }
 
         @Override
+        public SignatureVisitor visitParameterType() {
+            GenericMemberTypeProcessor<JavaCodeUnit> parameterTypeProcessor = new GenericMemberTypeProcessor<>();
+            genericMethodParameterTypeProcessors.add(parameterTypeProcessor);
+            return parameterTypeProcessor;
+        }
+
+        @Override
         public SignatureVisitor visitReturnType() {
             return genericMethodReturnTypeProcessor;
         }
 
         public JavaCodeUnitSignature getParsedSignature() {
+            List<JavaTypeCreationProcess<JavaCodeUnit>> parameterTypes = new ArrayList<>();
+            for (GenericMemberTypeProcessor<JavaCodeUnit> parameterTypeProcessor : genericMethodParameterTypeProcessors) {
+                if (parameterTypeProcessor.getType().isPresent()) {
+                    parameterTypes.add(parameterTypeProcessor.getType().get());
+                }
+            }
+
             return new JavaCodeUnitSignature(
                     typeParameterProcessor.getTypeParameterBuilders(),
-                    Optional.ofNullable(genericMethodReturnTypeProcessor.getType()));
+                    parameterTypes,
+                    genericMethodReturnTypeProcessor.getType());
         }
     }
 
     static class JavaCodeUnitSignature {
         static final JavaCodeUnitSignature ABSENT = new JavaCodeUnitSignature(
                 Collections.<JavaTypeParameterBuilder<JavaCodeUnit>>emptyList(),
+                Collections.<JavaTypeCreationProcess<JavaCodeUnit>>emptyList(),
                 Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty()
         );
 
         private final List<JavaTypeParameterBuilder<JavaCodeUnit>> typeParameterBuilders;
+        private final List<JavaTypeCreationProcess<JavaCodeUnit>> parameterTypes;
         private final Optional<JavaTypeCreationProcess<JavaCodeUnit>> returnType;
 
         private JavaCodeUnitSignature(
                 List<JavaTypeParameterBuilder<JavaCodeUnit>> typeParameterBuilders,
+                List<JavaTypeCreationProcess<JavaCodeUnit>> parameterTypes,
                 Optional<JavaTypeCreationProcess<JavaCodeUnit>> returnType
         ) {
             this.typeParameterBuilders = checkNotNull(typeParameterBuilders);
+            this.parameterTypes = parameterTypes;
             this.returnType = checkNotNull(returnType);
         }
 
         List<JavaTypeParameterBuilder<JavaCodeUnit>> getTypeParameterBuilders() {
             return typeParameterBuilders;
+        }
+
+        List<JavaTypeCreationProcess<JavaCodeUnit>> getParameterTypes() {
+            return parameterTypes;
         }
 
         Optional<JavaTypeCreationProcess<JavaCodeUnit>> getReturnType() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
@@ -37,7 +37,7 @@ class JavaFieldTypeSignatureImporter {
 
         SignatureProcessor signatureProcessor = new SignatureProcessor();
         new SignatureReader(signature).accept(signatureProcessor);
-        return Optional.of(signatureProcessor.getFieldType());
+        return signatureProcessor.getFieldType();
     }
 
     private static class SignatureProcessor extends SignatureVisitor {
@@ -52,7 +52,7 @@ class JavaFieldTypeSignatureImporter {
             return genericFieldTypeProcessor;
         }
 
-        JavaTypeCreationProcess<JavaField> getFieldType() {
+        Optional<JavaTypeCreationProcess<JavaField>> getFieldType() {
             return genericFieldTypeProcessor.getType();
         }
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.DescribedPredicate;
@@ -89,8 +88,8 @@ import static com.tngtech.archunit.core.domain.TestUtils.importPackagesOf;
 import static com.tngtech.archunit.core.domain.TestUtils.simulateCall;
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
-import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatCodeUnit;
 import static com.tngtech.archunit.testutil.Assertions.assertThatDependencies;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
@@ -441,44 +440,33 @@ public class JavaClassTest {
             }
         });
 
-        assertThat(clazz.getCodeUnitWithParameterTypes("childMethod", String.class))
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, "childMethod", String.class));
-        assertThat(clazz.getCodeUnitWithParameterTypeNames("childMethod", String.class.getName()))
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, "childMethod", String.class));
-        assertThat(clazz.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME, Object.class))
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, CONSTRUCTOR_NAME, Object.class));
-        assertThat(clazz.getCodeUnitWithParameterTypeNames(CONSTRUCTOR_NAME, Object.class.getName()))
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, CONSTRUCTOR_NAME, Object.class));
+        assertThatCodeUnit(clazz.getCodeUnitWithParameterTypes("childMethod", String.class))
+                .matchesMethod(ChildWithFieldAndMethod.class, "childMethod", String.class);
+        assertThatCodeUnit(clazz.getCodeUnitWithParameterTypeNames("childMethod", String.class.getName()))
+                .matchesMethod(ChildWithFieldAndMethod.class, "childMethod", String.class);
+        assertThatCodeUnit(clazz.getCodeUnitWithParameterTypes(CONSTRUCTOR_NAME, Object.class))
+                .matchesConstructor(ChildWithFieldAndMethod.class, Object.class);
+        assertThatCodeUnit(clazz.getCodeUnitWithParameterTypeNames(CONSTRUCTOR_NAME, Object.class.getName()))
+                .matchesConstructor(ChildWithFieldAndMethod.class, Object.class);
     }
 
     @Test
     public void tryGetCodeUnitWithParameterTypes() {
         final JavaClass clazz = importClasses(ChildWithFieldAndMethod.class).get(ChildWithFieldAndMethod.class);
 
-        assertThat(clazz.tryGetCodeUnitWithParameterTypes("childMethod", Collections.<Class<?>>singletonList(String.class)).get())
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, "childMethod", String.class));
-        assertThat(clazz.tryGetCodeUnitWithParameterTypeNames("childMethod", singletonList(String.class.getName())).get())
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, "childMethod", String.class));
-        assertThat(clazz.tryGetCodeUnitWithParameterTypes(CONSTRUCTOR_NAME, Collections.<Class<?>>singletonList(Object.class)).get())
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, CONSTRUCTOR_NAME, Object.class));
-        assertThat(clazz.tryGetCodeUnitWithParameterTypeNames(CONSTRUCTOR_NAME, singletonList(Object.class.getName())).get())
-                .is(equivalentCodeUnit(ChildWithFieldAndMethod.class, CONSTRUCTOR_NAME, Object.class));
+        assertThatCodeUnit(clazz.tryGetCodeUnitWithParameterTypes("childMethod", Collections.<Class<?>>singletonList(String.class)).get())
+                .matchesMethod(ChildWithFieldAndMethod.class, "childMethod", String.class);
+        assertThatCodeUnit(clazz.tryGetCodeUnitWithParameterTypeNames("childMethod", singletonList(String.class.getName())).get())
+                .matchesMethod(ChildWithFieldAndMethod.class, "childMethod", String.class);
+        assertThatCodeUnit(clazz.tryGetCodeUnitWithParameterTypes(CONSTRUCTOR_NAME, Collections.<Class<?>>singletonList(Object.class)).get())
+                .matchesConstructor(ChildWithFieldAndMethod.class, Object.class);
+        assertThatCodeUnit(clazz.tryGetCodeUnitWithParameterTypeNames(CONSTRUCTOR_NAME, singletonList(Object.class.getName())).get())
+                .matchesConstructor(ChildWithFieldAndMethod.class, Object.class);
 
         assertThat(clazz.tryGetCodeUnitWithParameterTypes("childMethod", Collections.<Class<?>>emptyList())).isAbsent();
         assertThat(clazz.tryGetCodeUnitWithParameterTypeNames("childMethod", Collections.<String>emptyList())).isAbsent();
         assertThat(clazz.tryGetCodeUnitWithParameterTypes(CONSTRUCTOR_NAME, Collections.<Class<?>>emptyList())).isAbsent();
         assertThat(clazz.tryGetCodeUnitWithParameterTypeNames(CONSTRUCTOR_NAME, Collections.<String>emptyList())).isAbsent();
-    }
-
-    private Condition<JavaCodeUnit> equivalentCodeUnit(final Class<?> owner, final String methodName, final Class<?> paramType) {
-        return new Condition<JavaCodeUnit>() {
-            @Override
-            public boolean matches(JavaCodeUnit value) {
-                return value.getOwner().isEquivalentTo(owner) &&
-                        value.getName().equals(methodName) &&
-                        namesOf(value.getRawParameterTypes()).equals(ImmutableList.of(paramType.getName()));
-            }
-        };
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaType;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
@@ -50,6 +51,12 @@ public class HasParameterTypesTest {
 
     private HasParameterTypes newHasParameterTypes(final Class<?>... parameters) {
         return new HasParameterTypes() {
+
+            @Override
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            public List<JavaType> getParameterTypes() {
+                return (List) getRawParameterTypes();
+            }
 
             @Override
             public List<JavaClass> getRawParameterTypes() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
@@ -1,0 +1,1152 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.ref.Reference;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.FluentIterable;
+import com.tngtech.archunit.ArchConfiguration;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.testutil.ArchConfigurationRule;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.parameterizedTypeArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.typeVariableArrayName;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteTypeVariable.typeVariable;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteWildcardType.wildcardType;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterGenericCodeUnitParameterTypesTest {
+
+    @Rule
+    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
+
+    @DataProvider
+    public static Object[][] data_imports_non_generic_code_unit_parameter_type() {
+        class NonGenericParameterType {
+        }
+        @SuppressWarnings("unused")
+        class NoGenericSignatureOnConstructor {
+            NoGenericSignatureOnConstructor(NonGenericParameterType param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class NoGenericSignatureOnMethod {
+            void method(NonGenericParameterType param) {
+            }
+        }
+        Object[][] testCases = testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                NoGenericSignatureOnConstructor.class,
+                NoGenericSignatureOnMethod.class,
+                NonGenericParameterType.class);
+        return $$(
+                $(testCases[0][0], NonGenericParameterType.class),
+                $(testCases[1][0], NonGenericParameterType.class)
+        );
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_non_generic_code_unit_parameter_type(JavaCodeUnit codeUnit, Class<?> expectedParameterType) {
+        JavaType parameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(parameterType).as("parameter type").matches(expectedParameterType);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_one_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<String> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<String> param) {
+            }
+        }
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_one_type_argument(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type")
+                .hasErasure(ClassParameterWithSingleTypeParameter.class)
+                .hasActualTypeArguments(String.class);
+    }
+
+    @Test
+    public void imports_raw_parameter_types_and_generic_parameter_types_of_inner_class_constructor_like_Reflection_API() {
+        @SuppressWarnings("unused")
+        class LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter {
+            public LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter(ClassParameterWithSingleTypeParameter<String> param) {
+            }
+        }
+
+        JavaConstructor constructor = new ClassFileImporter()
+                .importClasses(
+                        LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter.class,
+                        getClass(), ClassParameterWithSingleTypeParameter.class, String.class)
+                .get(LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter.class)
+                .getConstructor(getClass(), ClassParameterWithSingleTypeParameter.class);
+
+        assertThatTypes(constructor.getRawParameterTypes()).matchExactly(getClass(), ClassParameterWithSingleTypeParameter.class);
+
+        assertThat(constructor.getParameterTypes()).hasSize(1);
+        assertThatType(constructor.getParameterTypes().get(0)).matches(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String.class));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_raw_generic_code_unit_parameter_type_as_JavaClass_instead_of_JavaParameterizedType() {
+        @SuppressWarnings({"unused", "rawtypes"})
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter param) {
+            }
+        }
+        @SuppressWarnings({"unused", "rawtypes"})
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_raw_generic_code_unit_parameter_type_as_JavaClass_instead_of_JavaParameterizedType(JavaCodeUnit codeUnit) {
+        JavaType rawGenericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(rawGenericParameterType).as("raw generic parameter type").matches(ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<String[]> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<String[]> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_array_type_argument(JavaCodeUnit codeUnit) {
+        JavaType genericMethodParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericMethodParameterType).as("generic parameter type")
+                .hasErasure(ClassParameterWithSingleTypeParameter.class)
+                .hasActualTypeArguments(String[].class);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_primitive_array_type_argument() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<int[]> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<int[]> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_primitive_array_type_argument(JavaCodeUnit codeUnit) {
+        JavaType genericMethodParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericMethodParameterType).as("generic parameter type")
+                .hasErasure(ClassParameterWithSingleTypeParameter.class)
+                .hasActualTypeArguments(int[].class);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_multiple_type_arguments() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<String, Serializable, File> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithThreeTypeParameters<String, Serializable, File> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, Serializable.class, File.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_multiple_type_arguments(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type")
+                .hasErasure(ClassParameterWithThreeTypeParameters.class)
+                .hasActualTypeArguments(String.class, Serializable.class, File.class);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_single_actual_type_argument_parameterized_with_concrete_class() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<String>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<String>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_single_actual_type_argument_parameterized_with_concrete_class(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_multiple_actual_type_arguments_parameterized_with_concrete_classes() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<
+                    ClassParameterWithSingleTypeParameter<File>,
+                    InterfaceParameterWithSingleTypeParameter<Serializable>,
+                    InterfaceParameterWithSingleTypeParameter<String>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithThreeTypeParameters<
+                    ClassParameterWithSingleTypeParameter<File>,
+                    InterfaceParameterWithSingleTypeParameter<Serializable>,
+                    InterfaceParameterWithSingleTypeParameter<String>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
+                File.class, Serializable.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_multiple_actual_type_arguments_parameterized_with_concrete_classes(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(File.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(Serializable.class),
+                parameterizedType(InterfaceParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(String.class)
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_single_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<?> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<?> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_single_unbound_wildcard(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(wildcardType());
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_single_actual_type_argument_parameterized_with_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<?>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<?>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_single_actual_type_argument_parameterized_with_unbound_wildcard(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameter()
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_actual_type_arguments_parameterized_with_bounded_wildcards() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<? extends String>,
+                    ClassParameterWithSingleTypeParameter<? super File>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<? extends String>,
+                    ClassParameterWithSingleTypeParameter<? super File>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_actual_type_arguments_parameterized_with_bounded_wildcards(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(String.class),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(File.class)
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_actual_type_arguments_with_multiple_wildcards_with_various_bounds() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<Map<? extends Serializable, ? super File>>,
+                    ClassParameterWithSingleTypeParameter<Reference<? super String>>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<Map<? extends Serializable, ? super File>>,
+                    ClassParameterWithSingleTypeParameter<Reference<? super String>>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, Map.class, Serializable.class, File.class, Reference.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_actual_type_arguments_with_multiple_wildcards_with_various_bounds(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Map.class)
+                                .withWildcardTypeParameters(
+                                        wildcardType().withUpperBound(Serializable.class),
+                                        wildcardType().withLowerBound(File.class))),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(parameterizedType(Reference.class)
+                                .withWildcardTypeParameterWithLowerBound(String.class))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_type_variable_as_generic_code_unit_parameter_type() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<T extends String> {
+            GenericSignatureOnConstructor(T param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<T extends String> {
+            void method(T param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_type_variable_as_generic_code_unit_parameter_type(JavaCodeUnit codeUnit) {
+        JavaType genericMethodParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericMethodParameterType).as("generic parameter type")
+                .isInstanceOf(JavaTypeVariable.class)
+                .hasErasure(String.class);
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<OF_CLASS> {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<OF_CLASS> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<OF_CLASS> {
+            void method(ClassParameterWithSingleTypeParameter<OF_CLASS> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_parameterized_with_type_variable(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(typeVariable("OF_CLASS"));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_actual_type_argument_parameterized_with_type_variable() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<OF_CLASS> {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<OF_CLASS>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<OF_CLASS> {
+            void method(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<OF_CLASS>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_actual_type_argument_parameterized_with_type_variable(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("OF_CLASS"))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_references_type_variable_assigned_to_actual_type_argument_of_generic_code_unit_parameter_type() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<OF_CLASS extends String> {
+            GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<OF_CLASS>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<OF_CLASS extends String> {
+            void method(ClassParameterWithSingleTypeParameter<ClassParameterWithSingleTypeParameter<OF_CLASS>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_references_type_variable_assigned_to_actual_type_argument_of_generic_code_unit_parameter_type(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withTypeArguments(typeVariable("OF_CLASS").withUpperBounds(String.class))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_references_outer_type_variable_assigned_to_actual_type_argument_of_generic_code_unit_parameter_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class GenericSignatureOnConstructor {
+                    GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<OUTER> param) {
+                    }
+                }
+
+                class GenericSignatureOnMethod {
+                    void method(ClassParameterWithSingleTypeParameter<OUTER> param) {
+                    }
+                }
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                OuterWithTypeParameter.class, OuterWithTypeParameter.SomeInner.class, ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_references_outer_type_variable_assigned_to_actual_type_argument_of_generic_code_unit_parameter_type_of_inner_class(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                typeVariable("OUTER").withUpperBounds(String.class)
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_creates_new_stub_type_variables_for_type_variables_of_enclosing_classes_that_are_out_of_context_for_generic_code_unit_parameter_type_of_inner_class() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER extends String> {
+            class SomeInner {
+                class GenericSignatureOnConstructor {
+                    GenericSignatureOnConstructor(ClassParameterWithSingleTypeParameter<OUTER> param) {
+                    }
+                }
+
+                class GenericSignatureOnMethod {
+                    void method(ClassParameterWithSingleTypeParameter<OUTER> param) {
+                    }
+                }
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_creates_new_stub_type_variables_for_type_variables_of_enclosing_classes_that_are_out_of_context_for_generic_code_unit_parameter_type_of_inner_class(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                typeVariable("OUTER").withoutUpperBounds()
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_considers_hierarchy_of_methods_and_classes_for_type_parameter_context() throws ClassNotFoundException {
+        @SuppressWarnings("unused")
+        class Level1<T1 extends String> {
+            <T2 extends T1> void level2() {
+                class GenericSignatureOnConstructor<T3 extends T2> {
+                    <T4 extends T3> GenericSignatureOnConstructor(T4 param) {
+                    }
+                }
+                class GenericSignatureOnMethod<T3 extends T2> {
+                    <T4 extends T3> void method(T4 param) {
+                    }
+                }
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                Class.forName(Level1.class.getName() + "$1GenericSignatureOnConstructor"),
+                Class.forName(Level1.class.getName() + "$1GenericSignatureOnMethod"),
+                Level1.class, ClassParameterWithSingleTypeParameter.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_considers_hierarchy_of_methods_and_classes_for_type_parameter_context(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type")
+                .matches(
+                        typeVariable("T4").withUpperBounds(
+                                typeVariable("T3").withUpperBounds(
+                                        typeVariable("T2").withUpperBounds(
+                                                typeVariable("T1").withUpperBounds(String.class)))));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_wildcards_of_generic_code_unit_parameter_type_bound_by_type_variables() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<FIRST extends String, SECOND extends Serializable> {
+            GenericSignatureOnConstructor(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<? extends FIRST>,
+                    ClassParameterWithSingleTypeParameter<? super SECOND>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<FIRST extends String, SECOND extends Serializable> {
+            void method(ClassParameterWithTwoTypeParameters<
+                    ClassParameterWithSingleTypeParameter<? extends FIRST>,
+                    ClassParameterWithSingleTypeParameter<? super SECOND>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_wildcards_of_generic_code_unit_parameter_type_bound_by_type_variables(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("FIRST").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("SECOND").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_wildcards_of_generic_code_unit_parameter_type_bound_by_type_variables_of_enclosing_classes() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class GenericSignatureOnConstructor {
+                    GenericSignatureOnConstructor(ClassParameterWithTwoTypeParameters<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> param) {
+                    }
+                }
+
+                class GenericSignatureOnMethod {
+                    void method(ClassParameterWithTwoTypeParameters<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> param) {
+                    }
+                }
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                OuterWithTypeParameter.class, OuterWithTypeParameter.SomeInner.class, ClassParameterWithTwoTypeParameters.class,
+                ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_wildcards_of_generic_code_unit_parameter_type_bound_by_type_variables_of_enclosing_classes(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withUpperBounds(String.class)),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withUpperBounds(Serializable.class))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_creates_new_stub_type_variables_for_wildcards_bound_by_type_variables_of_enclosing_classes_that_are_out_of_context() {
+        @SuppressWarnings("unused")
+        class OuterWithTypeParameter<OUTER_ONE extends String, OUTER_TWO extends Serializable> {
+            class SomeInner {
+                class GenericSignatureOnConstructor {
+                    GenericSignatureOnConstructor(ClassParameterWithTwoTypeParameters<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> param) {
+                    }
+                }
+
+                class GenericSignatureOnMethod {
+                    void method(ClassParameterWithTwoTypeParameters<
+                            ClassParameterWithSingleTypeParameter<? extends OUTER_ONE>,
+                            ClassParameterWithSingleTypeParameter<? super OUTER_TWO>> param) {
+                    }
+                }
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_creates_new_stub_type_variables_for_wildcards_bound_by_type_variables_of_enclosing_classes_that_are_out_of_context(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithUpperBound(
+                                typeVariable("OUTER_ONE").withoutUpperBounds()),
+                parameterizedType(ClassParameterWithSingleTypeParameter.class)
+                        .withWildcardTypeParameterWithLowerBound(
+                                typeVariable("OUTER_TWO").withoutUpperBounds())
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_self_referencing_type_definitions() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<
+                    // assigned to ClassParameterWithThreeTypeParameters<A,_,_>
+                    List<? extends FIRST>,
+                    // assigned to ClassParameterWithThreeTypeParameters<_,B,_>
+                    Map<
+                            Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                            Map<? extends String,
+                                    Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                    // assigned to ClassParameterWithThreeTypeParameters<_,_,C>
+                    Comparable<GenericSignatureOnConstructor<FIRST, SECOND>>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            void method(ClassParameterWithThreeTypeParameters<
+                    // assigned to ClassParameterWithThreeTypeParameters<A,_,_>
+                    List<? extends FIRST>,
+                    // assigned to ClassParameterWithThreeTypeParameters<_,B,_>
+                    Map<
+                            Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                            Map<? extends String,
+                                    Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>>,
+                    // assigned to ClassParameterWithThreeTypeParameters<_,_,C>
+                    Comparable<GenericSignatureOnMethod<FIRST, SECOND>>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, String.class, Serializable.class, Cloneable.class, List.class,
+                Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_self_referencing_type_definitions(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        // @formatter:off
+        assertThatType(genericParameterType).as("generic parameter type").hasActualTypeArguments(
+            // assigned to ClassParameterWithThreeTypeParameters<A,_,_>
+            parameterizedType(List.class)
+                .withWildcardTypeParameterWithUpperBound(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class)),
+            // assigned to ClassParameterWithThreeTypeParameters<_,B,_>
+            parameterizedType(Map.class).withTypeArguments(
+                parameterizedType(Map.Entry.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    parameterizedType(Map.Entry.class).withTypeArguments(
+                        concreteClass(String.class),
+                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))),
+                parameterizedType(Map.class).withTypeArguments(
+                    wildcardType().withUpperBound(String.class),
+                    parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withUpperBound(Serializable.class),
+                        parameterizedType(List.class).withTypeArguments(
+                            parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(
+                                    parameterizedType(Set.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                            parameterizedType(Iterable.class).withTypeArguments(
+                                                wildcardType().withLowerBound(
+                                                    parameterizedType(Map.class).withTypeArguments(
+                                                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class),
+                                                        wildcardType()))))))))))),
+            // assigned to ClassParameterWithThreeTypeParameters<_,_,C>
+            parameterizedType(Comparable.class).withTypeArguments(
+                parameterizedType(codeUnit.getOwner().reflect()).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
+        // @formatter:on
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_complex_generic_array_code_unit_parameter_type() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(List<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(List<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                List.class, Serializable.class, Map.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_complex_generic_array_code_unit_parameter_type(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).matches(
+                genericArray(
+                        List.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", "
+                                + Map.class.getName() + "<" + Map.class.getName() + "<? super " + String.class.getName() + ", ?>, "
+                                + Serializable.class.getName() + ">>>[]"
+                ).withComponentType(
+                        parameterizedType(List.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String.class),
+                                        parameterizedType(Map.class).withTypeArguments(
+                                                parameterizedType(Map.class).withTypeArguments(
+                                                        wildcardType().withLowerBound(String.class),
+                                                        wildcardType()),
+                                                concreteClass(Serializable.class))))));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_concrete_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<
+                    List<Serializable[]>,
+                    List<? extends Serializable[][]>,
+                    Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithThreeTypeParameters<
+                    List<Serializable[]>,
+                    List<? extends Serializable[][]>,
+                    Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, List.class, Serializable.class, Map.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_concrete_array_bounds(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(Serializable[].class),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(Serializable[][].class),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(String[].class),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(String[][][].class),
+                                        wildcardType()),
+                                concreteClass(Serializable[][].class))));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_generic_code_unit_parameter_type_with_parameterized_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<List<String>[], List<String[]>[][], List<String[][]>[][][]> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod {
+            void method(ClassParameterWithThreeTypeParameters<List<String>[], List<String[]>[][], List<String[][]>[][][]> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, List.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_generic_code_unit_parameter_type_with_parameterized_array_bounds(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).hasActualTypeArguments(
+                genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
+                        parameterizedType(List.class).withTypeArguments(String.class)),
+                genericArray(parameterizedTypeArrayName(List.class, String[].class, 2)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[].class, 1)).withComponentType(
+                                parameterizedType(List.class).withTypeArguments(String[].class))),
+                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 3)).withComponentType(
+                        genericArray(parameterizedTypeArrayName(List.class, String[][].class, 2)).withComponentType(
+                                genericArray(parameterizedTypeArrayName(List.class, String[][].class, 1)).withComponentType(
+                                        parameterizedType(List.class).withTypeArguments(String[][].class)))));
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_generic_array_bounds() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<X extends Serializable, Y extends String> {
+            GenericSignatureOnConstructor(ClassParameterWithThreeTypeParameters<
+                    List<X[]>,
+                    List<? extends X[][]>,
+                    Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> param) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<X extends Serializable, Y extends String> {
+            void method(ClassParameterWithThreeTypeParameters<
+                    List<X[]>,
+                    List<? extends X[][]>,
+                    Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> param) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithThreeTypeParameters.class, List.class, Serializable.class, Map.class, String.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_complex_generic_code_unit_parameter_type_with_multiple_nested_actual_type_arguments_with_generic_array_bounds(JavaCodeUnit codeUnit) {
+        JavaType genericParameterType = codeUnit.getParameterTypes().get(0);
+
+        assertThatType(genericParameterType).hasActualTypeArguments(
+                parameterizedType(List.class).withTypeArguments(
+                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                typeVariable("X").withUpperBounds(Serializable.class))),
+                parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(
+                        genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                        typeVariable("X").withUpperBounds(Serializable.class)))),
+                parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withLowerBound(
+                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                        typeVariable("Y").withUpperBounds(String.class))),
+                        parameterizedType(Map.class).withTypeArguments(
+                                parameterizedType(Map.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                                genericArray(typeVariableArrayName("Y", 3)).withComponentType(
+                                                        genericArray(typeVariableArrayName("Y", 2)).withComponentType(
+                                                                genericArray(typeVariableArrayName("Y", 1)).withComponentType(
+                                                                        typeVariable("Y").withUpperBounds(String.class))))),
+                                        wildcardType()),
+                                genericArray(typeVariableArrayName("X", 2)).withComponentType(
+                                        genericArray(typeVariableArrayName("X", 1)).withComponentType(
+                                                typeVariable("X").withUpperBounds(Serializable.class)))))
+        );
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_multiple_generic_code_unit_parameter_types() {
+        @SuppressWarnings("unused")
+        class GenericSignatureOnConstructor<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            GenericSignatureOnConstructor(
+                    ClassParameterWithSingleTypeParameter<List<? extends FIRST>> first,
+                    ClassParameterWithSingleTypeParameter<
+                            Map<
+                                    Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                                    Map<? extends String,
+                                            Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>
+                                    >
+                            > second,
+                    ClassParameterWithSingleTypeParameter<Comparable<GenericSignatureOnConstructor<FIRST, SECOND>>> third) {
+            }
+        }
+        @SuppressWarnings("unused")
+        class GenericSignatureOnMethod<FIRST extends String & Serializable, SECOND extends Serializable & Cloneable> {
+            void method(
+                    ClassParameterWithSingleTypeParameter<List<? extends FIRST>> first,
+                    ClassParameterWithSingleTypeParameter<
+                            Map<
+                                    Map.Entry<FIRST, Map.Entry<String, SECOND>>,
+                                    Map<? extends String,
+                                            Map<? extends Serializable, List<List<? extends Set<? super Iterable<? super Map<SECOND, ?>>>>>>>
+                                    >
+                            > second,
+                    ClassParameterWithSingleTypeParameter<Comparable<GenericSignatureOnMethod<FIRST, SECOND>>> third) {
+            }
+        }
+
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
+                GenericSignatureOnConstructor.class,
+                GenericSignatureOnMethod.class,
+                ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class, Cloneable.class,
+                List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_multiple_generic_code_unit_parameter_types(JavaCodeUnit codeUnit) {
+        List<JavaType> genericParameterTypes = codeUnit.getParameterTypes();
+
+        // @formatter:off
+        assertThatType(genericParameterTypes.get(0)).as("first generic parameter type").hasActualTypeArguments(
+            parameterizedType(List.class)
+                .withWildcardTypeParameterWithUpperBound(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class)));
+
+        assertThatType(genericParameterTypes.get(1)).as("second generic parameter type").hasActualTypeArguments(
+            parameterizedType(Map.class).withTypeArguments(
+                parameterizedType(Map.Entry.class).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    parameterizedType(Map.Entry.class).withTypeArguments(
+                        concreteClass(String.class),
+                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))),
+                parameterizedType(Map.class).withTypeArguments(
+                    wildcardType().withUpperBound(String.class),
+                    parameterizedType(Map.class).withTypeArguments(
+                        wildcardType().withUpperBound(Serializable.class),
+                        parameterizedType(List.class).withTypeArguments(
+                            parameterizedType(List.class).withTypeArguments(
+                                wildcardType().withUpperBound(
+                                    parameterizedType(Set.class).withTypeArguments(
+                                        wildcardType().withLowerBound(
+                                            parameterizedType(Iterable.class).withTypeArguments(
+                                                wildcardType().withLowerBound(
+                                                    parameterizedType(Map.class).withTypeArguments(
+                                                        typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class),
+                                                        wildcardType()))))))))))));
+
+        assertThatType(genericParameterTypes.get(2)).as("third generic parameter type").hasActualTypeArguments(
+            parameterizedType(Comparable.class).withTypeArguments(
+                parameterizedType(codeUnit.getOwner().reflect()).withTypeArguments(
+                    typeVariable("FIRST").withUpperBounds(String.class, Serializable.class),
+                    typeVariable("SECOND").withUpperBounds(Serializable.class, Cloneable.class))));
+        // @formatter:on
+    }
+
+    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(
+            Class<?> genericSignatureOnConstructor,
+            Class<?> genericSignatureOnMethod,
+            Class<?>... additionalImports) {
+        final List<Class<?>> toImport = FluentIterable.from(additionalImports).append(genericSignatureOnConstructor).append(genericSignatureOnMethod).toList();
+        JavaClasses classes = ArchConfigurationRule.resetConfigurationAround(new Callable<JavaClasses>() {
+            @Override
+            public JavaClasses call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(toImport);
+            }
+        });
+
+        return testForEach(
+                getOnlyElement(classes.get(genericSignatureOnConstructor).getConstructors()),
+                getOnlyElement(classes.get(genericSignatureOnMethod).getMethods())
+        );
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassParameterWithSingleTypeParameter<T> {
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassParameterWithTwoTypeParameters<A, B> {
+    }
+
+    @SuppressWarnings("unused")
+    public static class ClassParameterWithThreeTypeParameters<A, B, C> {
+    }
+
+    @SuppressWarnings("unused")
+    public interface InterfaceParameterWithSingleTypeParameter<T> {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
@@ -209,7 +209,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class)
                 .get(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(wildcardType());
@@ -624,7 +624,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
         }
 
         JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
+                Serializable.class, Map.class, String.class);
 
         JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -79,7 +79,7 @@ public class ImportTestUtils {
                     .withReturnType(
                             Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty(),
                             JavaClassDescriptor.From.name(method.getReturnType().getName()))
-                    .withParameterTypes(typesFrom(method.getParameterTypes()))
+                    .withParameterTypes(Collections.<JavaTypeCreationProcess<JavaCodeUnit>>emptyList(), typesFrom(method.getParameterTypes()))
                     .withName(method.getName())
                     .withDescriptor(Type.getMethodDescriptor(method))
                     .withModifiers(JavaModifier.getModifiersForMethod(method.getModifiers()))
@@ -95,7 +95,7 @@ public class ImportTestUtils {
                     .withReturnType(
                             Optional.<JavaTypeCreationProcess<JavaCodeUnit>>empty(),
                             JavaClassDescriptor.From.name(void.class.getName()))
-                    .withParameterTypes(typesFrom(constructor.getParameterTypes()))
+                    .withParameterTypes(Collections.<JavaTypeCreationProcess<JavaCodeUnit>>emptyList(), typesFrom(constructor.getParameterTypes()))
                     .withName(CONSTRUCTOR_NAME)
                     .withDescriptor(Type.getConstructorDescriptor(constructor))
                     .withModifiers(JavaModifier.getModifiersForMethod(constructor.getModifiers()))

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaCodeUnitAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaCodeUnitAssertion.java
@@ -12,6 +12,8 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypeVariable;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.constructor;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 import static com.tngtech.archunit.testutil.assertion.JavaTypeVariableAssertion.getTypeVariableWithName;
 
 public class JavaCodeUnitAssertion<T extends JavaCodeUnit, SELF extends JavaCodeUnitAssertion<T, SELF>>
@@ -46,6 +48,14 @@ public class JavaCodeUnitAssertion<T extends JavaCodeUnit, SELF extends JavaCode
     public JavaTypeVariableOfCodeUnitAssertion hasOnlyTypeParameter(String name) {
         assertThat(actual.getTypeParameters()).as("Type parameters").hasSize(1);
         return hasTypeParameter(name);
+    }
+
+    public void matchesConstructor(Class<?> owner, Class<?>... parameterTypes) {
+        isEquivalentTo(constructor(owner, parameterTypes));
+    }
+
+    public void matchesMethod(Class<?> owner, String methodName, Class<?>... parameterTypes) {
+        isEquivalentTo(method(owner, methodName, parameterTypes));
     }
 
     public class JavaTypeVariableOfCodeUnitAssertion extends AbstractObjectAssert<JavaTypeVariableOfCodeUnitAssertion, JavaTypeVariable<JavaCodeUnit>> {


### PR DESCRIPTION
As last step to fully support Generics within ArchUnit this adds support for generic method/constructor parameter types. In particular

* `JavaMethod.getParameterTypes()` now returns a `List` of `JavaParameterizedType` for parameterized generic method/constructor parameter types and the raw types otherwise
* all type arguments of generic method parameter types are added to `JavaClass.directDependencies{From/To}Self`

Example: ArchUnit would now detect `String` and `File` as `Dependency` of a method declaration like

```
class SomeClass {
    void someMethod(Set<List<? super String>> first, Map<?, ? extends File> second) {
    }
}
```

Note that analogously to the Java Reflection API `JavaConstructor.getParameterTypes()` and `JavaConstructor.getRawParameterTypes()` do not behave exactly the same for inner classes. While `JavaConstructor.getRawParameterTypes()` contains the enclosing class as first parameter type, `JavaConstructor.getParameterTypes()` does not contain it if the constructor has generic parameters. On the other hand it just returns the same list of raw parameter types if the constructor is non-generic. This might surprise some users, but I decided to stick to the same behavior as the Reflection API, because this has always been the strategy and the solution can never truly satisfy all assumptions a user might have.

Resolves: #115
Resolves: #144
Resolves: #440