### PR TITLE
Enable CI release

### DIFF
--- a/build-steps/release/check-uploaded-artifacts.gradle
+++ b/build-steps/release/check-uploaded-artifacts.gradle
@@ -3,6 +3,9 @@ import java.time.LocalDateTime
 import java.util.jar.JarFile
 import java.util.jar.Manifest
 
+apply from: scriptRelativePath(this, 'vcs-utils.gradle')
+apply from: scriptRelativePath(this, 'archunit-examples-utils.gradle')
+
 File scriptRoot = currentScriptRootOf this
 def rootUrl =  {
     if (!project.hasProperty('tngRepoId')) {
@@ -129,11 +132,62 @@ task checkUploadedArtifacts {
 }
 
 releaseProjects.each { Project project ->
-    def task = project.task(['dependsOn': project.build],'checkArtifact') {
+    def task = project.task(['dependsOn': project.build], 'checkArtifact') {
         doLast {
             def jarFile = new JarFile(project.jar.archiveFile.get().getAsFile())
             checkArtifactContent(project, jarFile)
         }
     }
     project.build.finalizedBy(task)
+}
+
+task testRelease() {
+    File testReleaseDir = new File(project.buildDir, 'test-release')
+
+    def configureStagingRepository = {
+        new File(testReleaseDir, 'build.gradle').with {
+            text = text.replace('mavenCentral()', '''
+            mavenCentral()
+            maven {
+                url "https://oss.sonatype.org/content/repositories/staging/"
+                credentials {
+                    username project.getProperty('sonatypeUsername')
+                    password project.getProperty('sonatypePassword')
+                }
+            }''')
+        }
+    }
+
+    def testExampleProject = { String exampleProjectName ->
+        List<String> testClassNames = fileTree(new File(testReleaseDir, exampleProjectName)) {
+            include '**/*Test.java'
+        }.getFiles().collect { it.name.replaceAll(/\.java$/, '') }
+
+        def outputStream = new ByteArrayOutputStream()
+        exec {
+            workingDir testReleaseDir
+            commandLine './gradlew', ":${exampleProjectName}:build"
+            ignoreExitValue true
+            standardOutput = outputStream
+        }
+        String output = outputStream.toString()
+
+        assert output.contains("Task :${exampleProjectName}:test FAILED"): "The test task should have failed"
+        assert output.contains('java.lang.AssertionError'): "There should be AssertionErrors"
+        testClassNames.each { testClassName ->
+            assert output.contains(testClassName): "The failure output should contain the test class '${testClassName}'"
+        }
+    }
+
+    doFirst {
+        gitCheckOut(archunitExamplesGitRepo, testReleaseDir)
+
+        updateArchUnitExampleVersion(testReleaseDir)
+
+        configureStagingRepository()
+
+        testExampleProject('example-plain')
+        testExampleProject('example-junit4')
+        testExampleProject('example-junit5')
+    }
 }

--- a/build-steps/release/check-uploaded-artifacts.gradle
+++ b/build-steps/release/check-uploaded-artifacts.gradle
@@ -7,12 +7,13 @@ apply from: scriptRelativePath(this, 'vcs-utils.gradle')
 apply from: scriptRelativePath(this, 'archunit-examples-utils.gradle')
 
 File scriptRoot = currentScriptRootOf this
-def rootUrl =  {
-    if (!project.hasProperty('tngRepoId')) {
-        throw new IllegalArgumentException(
-                'You must pass the repo id (see Sonatype Repository Manager -> comtngtech-${repoId}) as parameter, e.g. -P tngRepoId=1162')
-    }
-    "https://oss.sonatype.org/service/local/repositories/comtngtech-${tngRepoId}/content/com/tngtech/archunit"
+
+ext {
+    tngRepoId = project.findProperty('tngRepoId')
+}
+
+def rootUrl = {
+    "https://oss.sonatype.org/service/local/repositories/${tngRepoId}/content/com/tngtech/archunit"
 }
 
 def createArtifactUrl = { String artifactId ->
@@ -119,6 +120,10 @@ def checkArtifactContent = { Project project, JarFile jarFile ->
 }
 
 task checkUploadedArtifacts {
+    doFirst {
+        tngRepoId = tngRepoId ?: closeSonatypeStagingRepository.stagingRepositoryId.get()
+    }
+
     doLast {
         releaseProjects.each { Project project ->
             checkPom(project.name)
@@ -130,6 +135,7 @@ task checkUploadedArtifacts {
         }
     }
 }
+closeSonatypeStagingRepository.finalizedBy(checkUploadedArtifacts)
 
 releaseProjects.each { Project project ->
     def task = project.task(['dependsOn': project.build], 'checkArtifact') {
@@ -191,3 +197,4 @@ task testRelease() {
         testExampleProject('example-junit5')
     }
 }
+closeSonatypeStagingRepository.finalizedBy(testRelease)

--- a/build-steps/release/create-release-news.gradle
+++ b/build-steps/release/create-release-news.gradle
@@ -26,3 +26,4 @@ task createReleaseNews {
         target.text = createArticleText(dateYYYYMMDDWithDash, version)
     }
 }
+prepareRelease.finalizedBy(createReleaseNews)

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -1,6 +1,3 @@
-apply from: scriptRelativePath(this, 'vcs-utils.gradle')
-apply from: scriptRelativePath(this, 'archunit-examples-utils.gradle')
-
 ext.isReleaseVersion = !project.version.endsWith("-SNAPSHOT")
 
 if (!hasProperty("sonatypeUsername")) {
@@ -96,56 +93,5 @@ releaseProjects*.with {
             isReleaseVersion && gradle.taskGraph.hasTask('publish') && project.hasProperty('sonatypeUsername')
         }
         sign publishing.publications.mavenJava
-    }
-}
-
-task testRelease() {
-    File testReleaseDir = new File(project.buildDir, 'test-release')
-
-    def configureStagingRepository = {
-        new File(testReleaseDir, 'build.gradle').with {
-            text = text.replace('mavenCentral()', '''
-            mavenCentral()
-            maven {
-                url "https://oss.sonatype.org/content/repositories/staging/"
-                credentials {
-                    username project.getProperty('sonatypeUsername')
-                    password project.getProperty('sonatypePassword')
-                }
-            }''')
-        }
-    }
-
-    def testExampleProject = { String exampleProjectName ->
-        List<String> testClassNames = fileTree(new File(testReleaseDir, exampleProjectName)) {
-            include '**/*Test.java'
-        }.getFiles().collect { it.name.replaceAll(/\.java$/, '') }
-
-        def outputStream = new ByteArrayOutputStream()
-        exec {
-            workingDir testReleaseDir
-            commandLine './gradlew', ":${exampleProjectName}:build"
-            ignoreExitValue true
-            standardOutput = outputStream
-        }
-        String output = outputStream.toString()
-
-        assert output.contains("Task :${exampleProjectName}:test FAILED"): "The test task should have failed"
-        assert output.contains('java.lang.AssertionError'): "There should be AssertionErrors"
-        testClassNames.each { testClassName ->
-            assert output.contains(testClassName): "The failure output should contain the test class '${testClassName}'"
-        }
-    }
-
-    doFirst {
-        gitCheckOut(archunitExamplesGitRepo, testReleaseDir)
-
-        updateArchUnitExampleVersion(testReleaseDir)
-
-        configureStagingRepository()
-
-        testExampleProject('example-plain')
-        testExampleProject('example-junit4')
-        testExampleProject('example-junit5')
     }
 }

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -95,3 +95,65 @@ releaseProjects*.with {
 
 task publishArchUnit(dependsOn: [closeSonatypeStagingRepository, releaseSonatypeStagingRepository])
 releaseProjects.each { publishArchUnit.dependsOn("${it.name}:publishToSonatype") }
+
+def getLastReleaseVersion() {
+    (new File(project.rootDir, 'README.md').text =~ /testImplementation 'com.tngtech.archunit:archunit:(\d+.\d+.\d+)'/).findAll().first()[1]
+}
+
+def gradleProperties = new File(project.rootDir, 'gradle.properties')
+
+def getCurrentVersion = {
+    (gradleProperties.text =~ /archunit\.version=(.*)/).findAll().first()[1]
+}
+
+def withCurrentVersion = { Closure<?> doWithCurrentVersion ->
+    List<String> versionParts = (getCurrentVersion() =~ /^(\d+)\.(\d+)\.(\d+)(.*)$/).findAll().first().tail()
+    assert versionParts.size() == 4: "Could not parse major.minor.patch(-suffix)? from supplied version string '$version'"
+
+    int majorVersion = Integer.parseInt(versionParts[0])
+    int minorVersion = Integer.parseInt(versionParts[1])
+    int patchVersion = Integer.parseInt(versionParts[2])
+    String suffix = versionParts[3]
+    return doWithCurrentVersion(majorVersion, minorVersion, patchVersion, suffix)
+}
+
+def updateVersion = { Closure<String> calculateNewVersion ->
+    def newVersion = withCurrentVersion(calculateNewVersion)
+    println "Setting ArchUnit version to ${newVersion}"
+    gradleProperties.text = gradleProperties.text.replaceAll(/archunit\.version=.*/, "archunit.version=${newVersion}")
+    rootProject.allprojects { it.version = newVersion }
+}
+
+def executeCommand = { String command ->
+    new StringBuilder().with { output ->
+        command.split(' ').execute().with { it.consumeProcessOutputStream(output); it }.waitFor()
+        output.toString().trim()
+    }
+}
+
+task prepareRelease() {
+    doFirst {
+        updateVersion { int oldMajor, int oldMinor, int oldPatch, String oldSuffix -> "$oldMajor.$oldMinor.$oldPatch" }
+
+        String currentVersion = getCurrentVersion()
+        def releaseBranch = "release-$currentVersion"
+        executeCommand("git checkout -b $releaseBranch")
+        String currentBranch = executeCommand('git rev-parse --abbrev-ref HEAD')
+        assert currentBranch == releaseBranch: "Mismatch: Should be on branch $releaseBranch but current branch is $currentBranch"
+
+        String lastReleaseVersion = getLastReleaseVersion()
+        ['README.md', 'docs/_data/navigation.yml', 'docs/_pages/getting-started.md'].each {
+            new File(project.rootDir, it).with { file ->
+                println "Replacing last release version $lastReleaseVersion by $currentVersion in file ${file.absolutePath}"
+                file.text = file.text.replaceAll(lastReleaseVersion, currentVersion)
+            }
+        }
+    }
+}
+prepareRelease.finalizedBy(':docs:renderUserGuide')
+
+task setNextSnapshotVersion() {
+    doFirst {
+        updateVersion { int oldMajor, int oldMinor, int oldPatch, String oldSuffix -> "$oldMajor.${oldMinor + 1}.0-SNAPSHOT" }
+    }
+}

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -92,3 +92,6 @@ releaseProjects*.with {
         sign publishing.publications.mavenJava
     }
 }
+
+task publishArchUnit(dependsOn: [closeSonatypeStagingRepository, releaseSonatypeStagingRepository])
+releaseProjects.each { publishArchUnit.dependsOn("${it.name}:publishToSonatype") }

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -88,10 +88,12 @@ releaseProjects*.with {
     }
 
     signing {
-        // requires gradle.properties, see http://www.gradle.org/docs/current/userguide/signing_plugin.html
         required {
             isReleaseVersion && gradle.taskGraph.hasTask('publish') && project.hasProperty('sonatypeUsername')
         }
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.mavenJava
     }
 }

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -1,16 +1,20 @@
 ext.isReleaseVersion = !project.version.endsWith("-SNAPSHOT")
 
-if (!hasProperty("sonatypeUsername")) {
-    ext.sonatypeUsername = ""
-}
-if (!hasProperty("sonatypePassword")) {
-    ext.sonatypePassword = ""
+apply plugin: "io.github.gradle-nexus.publish-plugin"
+
+nexusPublishing {
+    packageGroup = 'com.tngtech'
+    repositories {
+        sonatype {
+            username = findProperty("sonatypeUsername")
+            password = findProperty("sonatypePassword")
+        }
+    }
 }
 
 releaseProjects*.with {
     apply plugin: "maven-publish"
     apply plugin: "signing"
-    apply plugin: "de.marcphilipp.nexus-publish"
 
     tasks.withType(GenerateModuleMetadata) {
         enabled = false // the meta-data does not match the way the Maven artifacts are composed and thus is broken
@@ -76,20 +80,11 @@ releaseProjects*.with {
                 }
             }
         }
-
-        // respective username and password can be configured in ~/.gradle/gradle.properties
-        if (project.hasProperty('sonatypeUsername') && project.hasProperty('sonatypePassword')) {
-            nexusPublishing {
-                repositories {
-                    sonatype()
-                }
-            }
-        }
     }
 
     signing {
         required {
-            isReleaseVersion && gradle.taskGraph.hasTask('publish') && project.hasProperty('sonatypeUsername')
+            isReleaseVersion && gradle.taskGraph.hasTask('publish')
         }
         def signingKey = findProperty("signingKey")
         def signingPassword = findProperty("signingPassword")

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
     id 'com.github.spotbugs' version '4.7.3' apply false
-    id "de.marcphilipp.nexus-publish" version "0.4.0" apply false
+    id "io.github.gradle-nexus.publish-plugin" version "1.1.0" apply false
     id "com.diffplug.spotless" version "5.14.2" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ ext {
 
 allprojects {
     group = 'com.tngtech.archunit'
-    version = '0.21.0-SNAPSHOT'
+    version = getProperty('archunit.version')
 
     repositories {
         mavenCentral()

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -16,8 +16,7 @@ task cleanUserGuide(type: Delete) {
 
 asciidoctor {
     backends 'html'
-    attributes 'revnumber': project.version,
-            'source-highlighter': 'highlightjs',
+    attributes 'source-highlighter': 'highlightjs',
             'highlightjs-theme': 'mono-blue',
             'stylesheet': 'archunit.css'
     sourceDir file('userguide')
@@ -26,7 +25,10 @@ asciidoctor {
     }
     outputDir file('userguide')
     requires = ['asciidoctor-diagram']
-
+}
+asciidoctor.doFirst {
+    // make sure we get the current version in case it has changed during the run on release
+    asciidoctor.attributes('revnumber': project.version)
 }
 
 asciidoctorj {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.parallel=true
+archunit.version=0.21.0-SNAPSHOT

--- a/release/release.sh
+++ b/release/release.sh
@@ -66,6 +66,10 @@ if [ -n "$(git status --porcelain)" ]; then
     git commit -m "Update version to $VERSION"
 fi
 
+echo Tagging release "v$VERSION"
+git tag "v$VERSION"
+git push origin "v$VERSION"
+
 echo Publishing ArchUnit...
 ./gradlew clean publishArchUnit --no-parallel -PsonatypeUsername="$SONATYPE_USERNAME" -PsonatypePassword="$SONATYPE_PASSWORD" -PsigningKey="$GPG_SIGNING_KEY" -PsigningPassword="$GPG_SIGNING_PASSWORD"
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -5,12 +5,6 @@ set -e
 echo "Beginning"
 while [[ -n "${1-}" ]] ; do
   case "${1}" in
-    --old-version*)
-      OLD_VERSION=${1#*=}
-      ;;
-    --new-version*)
-      NEW_VERSION=${1#*=}
-      ;;
     --repository-username*)
       SONATYPE_USERNAME=${1#*=}
       ;;
@@ -31,40 +25,17 @@ while [[ -n "${1-}" ]] ; do
   shift
 done
 
-if [[ ! $OLD_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*(-[A-Z0-9]*)?$ ]]; then
-    echo "You have to provide the old version (without v-prefix, e.g. 0.14.0)"
-    exit 1
-fi
-
-if [[ ! $NEW_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*(-[A-Z0-9]*)?$ ]]; then
-    echo "You have to provide the new version (without v-prefix, e.g. 0.14.0)"
-    exit 1
-fi
-
-if [[ $(git rev-parse --abbrev-ref HEAD) != "release-$NEW_VERSION" ]]; then
-    echo "You are not on the release branch \"release-$NEW_VERSION\", aborting..."
-    exit 1
-fi
-
 if [ -n "$(git status --porcelain)" ]; then
     echo "There are local, uncommitted changes, aborting..."
     exit 1
 fi
 
-echo "Old version is $OLD_VERSION. Releasing version $NEW_VERSION..."
+./gradlew prepareRelease
+VERSION="$(grep -o -P '(?<=archunit\.version=).*' gradle.properties)"
 
-echo Updating version in build.gradle, README.md and docs...
-sed -i -e s/version\ =.*/version\ =\ \'$NEW_VERSION\'/ build.gradle
-sed -i -e s/$OLD_VERSION/$NEW_VERSION/ README.md ./docs/_data/navigation.yml ./docs/_pages/getting-started.md
-
-echo Create release news...
-./gradlew createReleaseNews
-
-if [ -n "$(git status --porcelain)" ]; then
-    echo Commiting version change
-    git add build.gradle README.md ./docs -- ':!docs/**.png'
-    git commit -m "Update version to $VERSION"
-fi
+echo Committing prepared release
+git add -A
+git commit -s -m "prepare release $VERSION"
 
 echo Tagging release "v$VERSION"
 git tag "v$VERSION"
@@ -78,6 +49,13 @@ echo Publishing website and examples...
 (cd build/docs-update && git add -A && git commit -s -m "release ArchUnit $VERSION" && git push)
 (cd build/example-update && git add -A && git commit -s -m "release ArchUnit $VERSION" && git push)
 
+./gradlew setNextSnapshotVersion
+
+echo Committing new SNAPSHOT version
+git add -A
+git commit -m "set next SNAPSHOT version"
+
+releaseBranch="$(git rev-parse --abbrev-ref HEAD)"
 git checkout main
-git merge release-"$NEW_VERSION"
+git merge "$releaseBranch"
 git push

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+echo "Beginning"
+while [[ -n "${1-}" ]] ; do
+  case "${1}" in
+    --old-version*)
+      OLD_VERSION=${1#*=}
+      ;;
+    --new-version*)
+      NEW_VERSION=${1#*=}
+      ;;
+    --repository-username*)
+      SONATYPE_USERNAME=${1#*=}
+      ;;
+    --repository-password*)
+      SONATYPE_PASSWORD=${1#*=}
+      ;;
+    --signing-key*)
+      GPG_SIGNING_KEY=${1#*=}
+      ;;
+    --signing-password*)
+      GPG_SIGNING_PASSWORD=${1#*=}
+      ;;
+    *)
+      echo "Unknown option '${1}'"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ ! $OLD_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*(-[A-Z0-9]*)?$ ]]; then
+    echo "You have to provide the old version (without v-prefix, e.g. 0.14.0)"
+    exit 1
+fi
+
+if [[ ! $NEW_VERSION =~ ^[0-9]*\.[0-9]*\.[0-9]*(-[A-Z0-9]*)?$ ]]; then
+    echo "You have to provide the new version (without v-prefix, e.g. 0.14.0)"
+    exit 1
+fi
+
+if [[ $(git rev-parse --abbrev-ref HEAD) != "release-$NEW_VERSION" ]]; then
+    echo "You are not on the release branch \"release-$NEW_VERSION\", aborting..."
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "There are local, uncommitted changes, aborting..."
+    exit 1
+fi
+
+echo "Old version is $OLD_VERSION. Releasing version $NEW_VERSION..."
+
+echo Updating version in build.gradle, README.md and docs...
+sed -i -e s/version\ =.*/version\ =\ \'$NEW_VERSION\'/ build.gradle
+sed -i -e s/$OLD_VERSION/$NEW_VERSION/ README.md ./docs/_data/navigation.yml ./docs/_pages/getting-started.md
+
+echo Create release news...
+./gradlew createReleaseNews
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo Commiting version change
+    git add build.gradle README.md ./docs -- ':!docs/**.png'
+    git commit -m "Update version to $VERSION"
+fi
+
+echo Publishing ArchUnit...
+./gradlew clean publishArchUnit --no-parallel -PsonatypeUsername="$SONATYPE_USERNAME" -PsonatypePassword="$SONATYPE_PASSWORD" -PsigningKey="$GPG_SIGNING_KEY" -PsigningPassword="$GPG_SIGNING_PASSWORD"
+
+git checkout main
+git merge release-"$NEW_VERSION"
+git push

--- a/release/release.sh
+++ b/release/release.sh
@@ -73,6 +73,11 @@ git push origin "v$VERSION"
 echo Publishing ArchUnit...
 ./gradlew clean publishArchUnit --no-parallel -PsonatypeUsername="$SONATYPE_USERNAME" -PsonatypePassword="$SONATYPE_PASSWORD" -PsigningKey="$GPG_SIGNING_KEY" -PsigningPassword="$GPG_SIGNING_PASSWORD"
 
+echo Publishing website and examples...
+./gradlew publishDocs
+(cd build/docs-update && git add -A && git commit -s -m "release ArchUnit $VERSION" && git push)
+(cd build/example-update && git add -A && git commit -s -m "release ArchUnit $VERSION" && git push)
+
 git checkout main
 git merge release-"$NEW_VERSION"
 git push


### PR DESCRIPTION
With this PR ArchUnit can be released via a GitHub Action.
In the release script release.sh all necessary Gradle commands are executed. This script is called by the CI pipeline.
Central change for the CI release process is the adaption of Gradle plugins to be able to obtain necessary credentials via Gradle properties. 
For releasing the artifacts, a new plugin is used that allows to reference the staging repository id in Sonatype.