### PR TITLE
Support method and constructor references

### DIFF
--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/AccessTargetNewerJavaVersionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/AccessTargetNewerJavaVersionTest.java
@@ -1,0 +1,95 @@
+package com.tngtech.archunit.core.domain;
+
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitAccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorReferenceTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+
+public class AccessTargetNewerJavaVersionTest {
+
+    private static class Data_function_resolve_member {
+        static class Target {
+            String field;
+
+            void method() {
+            }
+        }
+    }
+
+    @Test
+    public void function_resolve_member() {
+        @SuppressWarnings("unused")
+        class Origin {
+            String access() {
+                Data_function_resolve_member.Target target = new Data_function_resolve_member.Target();
+                Supplier<Data_function_resolve_member.Target> supplier = Data_function_resolve_member.Target::new;
+                Consumer<Data_function_resolve_member.Target> consumer = Data_function_resolve_member.Target::method;
+                target.method();
+                return target.field;
+            }
+        }
+        JavaClass targetClass = new ClassFileImporter().importClasses(Origin.class, Data_function_resolve_member.Target.class).get(Data_function_resolve_member.Target.class);
+        MethodCallTarget methodCallTarget = findTargetWithType(targetClass.getAccessesToSelf(), MethodCallTarget.class);
+
+        assertThat(AccessTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(AccessTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        assertThat(CodeUnitAccessTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(CodeUnitAccessTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        assertThat(MethodCallTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(MethodCallTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        MethodReferenceTarget methodReferenceTarget = findTargetWithType(targetClass.getAccessesToSelf(), MethodReferenceTarget.class);
+
+        assertThat(MethodReferenceTarget.Functions.RESOLVE_MEMBER.apply(methodReferenceTarget))
+                .contains(methodReferenceTarget.resolveMember().get());
+
+        ConstructorCallTarget constructorCallTarget = findTargetWithType(targetClass.getAccessesToSelf(), ConstructorCallTarget.class);
+
+        assertThat(ConstructorCallTarget.Functions.RESOLVE_MEMBER.apply(constructorCallTarget))
+                .contains(constructorCallTarget.resolveMember().get());
+        assertThat(ConstructorCallTarget.Functions.RESOLVE.apply(constructorCallTarget))
+                .isEqualTo(ImmutableSet.of(constructorCallTarget.resolveMember().get()));
+
+        ConstructorReferenceTarget constructorReferenceTarget = findTargetWithType(targetClass.getAccessesToSelf(), ConstructorReferenceTarget.class);
+
+        assertThat(ConstructorReferenceTarget.Functions.RESOLVE_MEMBER.apply(constructorReferenceTarget))
+                .contains(constructorReferenceTarget.resolveMember().get());
+
+        FieldAccessTarget fieldAccessTarget = findTargetWithType(targetClass.getAccessesToSelf(), FieldAccessTarget.class);
+
+        assertThat(FieldAccessTarget.Functions.RESOLVE_MEMBER.apply(fieldAccessTarget))
+                .contains(fieldAccessTarget.resolveMember().get());
+        assertThat(FieldAccessTarget.Functions.RESOLVE.apply(fieldAccessTarget))
+                .isEqualTo(ImmutableSet.of(fieldAccessTarget.resolveMember().get()));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AccessTarget> T findTargetWithType(Set<JavaAccess<?>> set, Class<T> type) {
+        for (JavaAccess<?> access : set) {
+            if (type.isInstance(access.getTarget())) {
+                return (T) access.getTarget();
+            }
+        }
+        throw new AssertionError(String.format("Set %s does not contain element of type %s", set, type.getName()));
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/DependencyReferencesTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/DependencyReferencesTest.java
@@ -1,0 +1,71 @@
+package com.tngtech.archunit.core.domain;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class DependencyReferencesTest {
+
+    static class Data_dependency_from_access {
+        static class Target {
+            String field;
+
+            void callMe() {
+            }
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_dependency_from_access() {
+        @SuppressWarnings("unused")
+        class Origin {
+            String fieldAccess(Data_dependency_from_access.Target target) {
+                return target.field;
+            }
+
+            void constructorCall() {
+                new Data_dependency_from_access.Target();
+            }
+
+            void methodCall(Data_dependency_from_access.Target target) {
+                target.callMe();
+            }
+
+            Supplier<Data_dependency_from_access.Target> constructorReference() {
+                return Data_dependency_from_access.Target::new;
+            }
+
+            Consumer<Data_dependency_from_access.Target> methodReference() {
+                return Data_dependency_from_access.Target::callMe;
+            }
+        }
+        JavaClass origin = new ClassFileImporter().importClasses(Origin.class, Data_dependency_from_access.Target.class).get(Origin.class);
+        return testForEach(
+                getOnlyElement(origin.getMethod("fieldAccess", Data_dependency_from_access.Target.class).getFieldAccesses()),
+                getOnlyElement(origin.getMethod("constructorCall").getConstructorCallsFromSelf()),
+                getOnlyElement(origin.getMethod("methodCall", Data_dependency_from_access.Target.class).getMethodCallsFromSelf()),
+                getOnlyElement(origin.getMethod("constructorReference").getConstructorReferencesFromSelf()),
+                getOnlyElement(origin.getMethod("methodReference").getMethodReferencesFromSelf())
+        );
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_dependency_from_access(JavaAccess<?> access) {
+        Dependency dependency = getOnlyElement(Dependency.tryCreateFromAccess(access));
+        assertThatType(dependency.getTargetClass()).as("target class").isEqualTo(access.getTargetOwner());
+        assertThat(dependency.getDescription()).as("description").isEqualTo(access.getDescription());
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/JavaClassReferencesTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/JavaClassReferencesTest.java
@@ -1,0 +1,102 @@
+package com.tngtech.archunit.core.domain;
+
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.tngtech.archunit.core.domain.JavaClassTest.DependencyConditionCreation;
+import com.tngtech.archunit.core.domain.testexamples.AReferencingB;
+import com.tngtech.archunit.core.domain.testexamples.BReferencedByA;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaClassReferencesTest {
+
+    @Test
+    public void direct_dependencies_from_self_by_references() {
+        JavaClass javaClass = importClasses(AReferencingB.class, BReferencedByA.class).get(AReferencingB.class);
+
+        assertReferencesFromAToB(javaClass.getDirectDependenciesFromSelf());
+    }
+
+    @Test
+    public void direct_dependencies_to_self_by_references() {
+        JavaClass javaClass = importClasses(AReferencingB.class, BReferencedByA.class).get(BReferencedByA.class);
+
+        assertReferencesFromAToB(javaClass.getDirectDependenciesToSelf());
+    }
+
+    @Test
+    public void function_get_code_unit_references_from_self() {
+        class Target {
+            void target() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class Origin {
+            Consumer<Target> origin() {
+                Supplier<Target> supplier = Target::new;
+                return Target::target;
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClasses(Origin.class, Target.class).get(Origin.class);
+
+        assertThat(JavaClass.Functions.GET_CODE_UNIT_REFERENCES_FROM_SELF.apply(javaClass)).isEqualTo(javaClass.getCodeUnitReferencesFromSelf());
+        assertThat(JavaClass.Functions.GET_METHOD_REFERENCES_FROM_SELF.apply(javaClass)).isEqualTo(javaClass.getMethodReferencesFromSelf());
+        assertThat(JavaClass.Functions.GET_CONSTRUCTOR_REFERENCES_FROM_SELF.apply(javaClass)).isEqualTo(javaClass.getConstructorReferencesFromSelf());
+    }
+
+    @Test
+    public void function_get_code_unit_references_to_self() {
+        class Target {
+            void target() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class Origin {
+            Consumer<Target> origin() {
+                Supplier<Target> supplier = Target::new;
+                return Target::target;
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClasses(Origin.class, Target.class).get(Target.class);
+
+        assertThat(JavaClass.Functions.GET_CODE_UNIT_REFERENCES_TO_SELF.apply(javaClass)).isEqualTo(javaClass.getCodeUnitReferencesToSelf());
+        assertThat(JavaClass.Functions.GET_METHOD_REFERENCES_TO_SELF.apply(javaClass)).isEqualTo(javaClass.getMethodReferencesToSelf());
+        assertThat(JavaClass.Functions.GET_CONSTRUCTOR_REFERENCES_TO_SELF.apply(javaClass)).isEqualTo(javaClass.getConstructorReferencesToSelf());
+    }
+
+    private void assertReferencesFromAToB(Set<Dependency> dependencies) {
+        assertThat(dependencies)
+                .areAtLeastOne(referenceDependency()
+                        .from(AReferencingB.class)
+                        .to(BReferencedByA.class, CONSTRUCTOR_NAME)
+                        .inLineNumber(9))
+                .areAtLeastOne(referenceDependency()
+                        .from(AReferencingB.class)
+                        .to(BReferencedByA.class, CONSTRUCTOR_NAME)
+                        .inLineNumber(10))
+                .areAtLeastOne(referenceDependency()
+                        .from(AReferencingB.class)
+                        .to(BReferencedByA.class, "getSomeField")
+                        .inLineNumber(14))
+                .areAtLeastOne(referenceDependency()
+                        .from(AReferencingB.class)
+                        .to(BReferencedByA.class, "getSomeField")
+                        .inLineNumber(15))
+                .areAtLeastOne(referenceDependency()
+                        .from(AReferencingB.class)
+                        .to(BReferencedByA.class, "getNothing")
+                        .inLineNumber(16));
+    }
+
+    private DependencyConditionCreation referenceDependency() {
+        return new DependencyConditionCreation("references");
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/testexamples/AReferencingB.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/testexamples/AReferencingB.java
@@ -1,0 +1,18 @@
+package com.tngtech.archunit.core.domain.testexamples;
+
+import com.tngtech.archunit.base.Function;
+import com.tngtech.archunit.base.Supplier;
+
+@SuppressWarnings("unused")
+public class AReferencingB {
+    void referenceConstructors() {
+        Supplier<BReferencedByA> noArgs = BReferencedByA::new;
+        Function<String, BReferencedByA> oneArg = BReferencedByA::new;
+    }
+
+    void referenceMethods(BReferencedByA b) {
+        Supplier<String> getSomeField = b::getSomeField;
+        Function<BReferencedByA, String> getSomeFieldStatically = BReferencedByA::getSomeField;
+        Runnable runnable = b::getNothing;
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/testexamples/BReferencedByA.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/domain/testexamples/BReferencedByA.java
@@ -1,0 +1,19 @@
+package com.tngtech.archunit.core.domain.testexamples;
+
+public class BReferencedByA {
+    String someField;
+
+    public BReferencedByA() {
+    }
+
+    public BReferencedByA(String someField) {
+        this.someField = someField;
+    }
+
+    String getSomeField() {
+        return someField;
+    }
+
+    void getNothing() {
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterCodeUnitReferencesTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterCodeUnitReferencesTest.java
@@ -1,0 +1,374 @@
+package com.tngtech.archunit.core.importer;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorReference;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
+import com.tngtech.archunit.core.importer.testexamples.codeunitreferences.Origin;
+import com.tngtech.archunit.core.importer.testexamples.codeunitreferences.Target;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterCodeUnitReferencesTest {
+
+    @SuppressWarnings({"unused", "InnerClassMayBeStatic"})
+    private static class Data_imports_static_method_references {
+        interface ReferencedInterfaceTarget {
+            static void staticMethodToReference() {
+            }
+        }
+
+        static class ReferencedClassTarget {
+            static void staticMethodToReference() {
+            }
+        }
+
+        class OriginReferencingInterface {
+            void accessesStaticMethodReference() {
+                Runnable b = ReferencedInterfaceTarget::staticMethodToReference;
+            }
+        }
+
+        class OriginReferencingClass {
+            void accessesStaticMethodReference() {
+                Runnable b = ReferencedClassTarget::staticMethodToReference;
+            }
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_static_method_references() {
+        return $$(
+                $(
+                        Data_imports_static_method_references.OriginReferencingInterface.class,
+                        Data_imports_static_method_references.ReferencedInterfaceTarget.class
+                ),
+                $(
+                        Data_imports_static_method_references.OriginReferencingClass.class,
+                        Data_imports_static_method_references.ReferencedClassTarget.class
+                ));
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_static_method_references(Class<?> originClassInput, Class<?> targetClassInput) {
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(originClassInput, targetClassInput);
+        JavaClass originClass = javaClasses.get(originClassInput);
+        JavaClass targetClass = javaClasses.get(targetClassInput);
+
+        assertThatAccess(getOnlyElement(originClass.getMethod("accessesStaticMethodReference").getMethodReferencesFromSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("accessesStaticMethodReference"))
+                .isTo(targetClass.getMethod("staticMethodToReference"));
+
+        assertThatAccess(getOnlyElement(targetClass.getMethod("staticMethodToReference").getReferencesToSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("accessesStaticMethodReference"))
+                .isTo(targetClass.getMethod("staticMethodToReference"));
+    }
+
+    @SuppressWarnings({"unused", "InnerClassMayBeStatic"})
+    private static class Data_imports_instance_method_references_bound_to_instance {
+        interface ReferencedInterfaceTarget {
+            void instanceMethodToReference();
+        }
+
+        class ReferencedClassTarget {
+            void instanceMethodToReference() {
+            }
+        }
+
+        class OriginReferencingInterface {
+            private ReferencedInterfaceTarget target;
+
+            void referencesInstanceMethodBoundToInstance() {
+                Runnable c = target::instanceMethodToReference;
+            }
+        }
+
+        class OriginReferencingClass {
+            private ReferencedClassTarget target;
+
+            void referencesInstanceMethodBoundToInstance() {
+                Runnable c = target::instanceMethodToReference;
+            }
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_instance_method_references_bound_to_instance() {
+        return $$(
+                $(
+                        Data_imports_instance_method_references_bound_to_instance.OriginReferencingInterface.class,
+                        Data_imports_instance_method_references_bound_to_instance.ReferencedInterfaceTarget.class
+                ),
+                $(
+                        Data_imports_instance_method_references_bound_to_instance.OriginReferencingClass.class,
+                        Data_imports_instance_method_references_bound_to_instance.ReferencedClassTarget.class
+                ));
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_instance_method_references_bound_to_instance(Class<?> originClassInput, Class<?> targetClassInput) {
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(originClassInput, targetClassInput);
+        JavaClass originClass = javaClasses.get(originClassInput);
+        JavaClass targetClass = javaClasses.get(targetClassInput);
+
+        assertThatAccess(getOnlyElement(originClass.getMethod("referencesInstanceMethodBoundToInstance").getMethodReferencesFromSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesInstanceMethodBoundToInstance"))
+                .isTo(targetClass.getMethod("instanceMethodToReference"));
+
+        assertThatAccess(getOnlyElement(targetClass.getMethod("instanceMethodToReference").getReferencesToSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesInstanceMethodBoundToInstance"))
+                .isTo(targetClass.getMethod("instanceMethodToReference"));
+    }
+
+    @SuppressWarnings({"unused", "InnerClassMayBeStatic"})
+    private static class Data_imports_instance_method_references_not_bound_to_instance {
+        interface ReferencedInterfaceTarget {
+            void instanceMethodToReference();
+        }
+
+        class ReferencedClassTarget {
+            void instanceMethodToReference() {
+            }
+        }
+
+        class OriginReferencingInterface {
+            void referencesInstanceMethodNotBoundToInstance() {
+                Consumer<ReferencedInterfaceTarget> d = ReferencedInterfaceTarget::instanceMethodToReference;
+            }
+        }
+
+        class OriginReferencingClass {
+            void referencesInstanceMethodNotBoundToInstance() {
+                Consumer<ReferencedClassTarget> d = ReferencedClassTarget::instanceMethodToReference;
+            }
+        }
+    }
+
+    @DataProvider
+    public static Object[][] data_imports_instance_method_references_not_bound_to_instance() {
+        return $$(
+                $(
+                        Data_imports_instance_method_references_not_bound_to_instance.OriginReferencingInterface.class,
+                        Data_imports_instance_method_references_not_bound_to_instance.ReferencedInterfaceTarget.class
+                ),
+                $(
+                        Data_imports_instance_method_references_not_bound_to_instance.OriginReferencingClass.class,
+                        Data_imports_instance_method_references_not_bound_to_instance.ReferencedClassTarget.class
+                ));
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imports_instance_method_references_not_bound_to_instance(Class<?> originClassInput, Class<?> targetClassInput) {
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(originClassInput, targetClassInput);
+        JavaClass originClass = javaClasses.get(originClassInput);
+        JavaClass targetClass = javaClasses.get(targetClassInput);
+
+        assertThatAccess(getOnlyElement(originClass.getMethod("referencesInstanceMethodNotBoundToInstance").getMethodReferencesFromSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesInstanceMethodNotBoundToInstance"))
+                .isTo(targetClass.getMethod("instanceMethodToReference"));
+
+        assertThatAccess(getOnlyElement(targetClass.getMethod("instanceMethodToReference").getReferencesToSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesInstanceMethodNotBoundToInstance"))
+                .isTo(targetClass.getMethod("instanceMethodToReference"));
+    }
+
+    private static class Data_imports_constructor_references {
+        @SuppressWarnings("unused")
+        static class ReferencedTarget {
+            ReferencedTarget() {
+            }
+        }
+
+        @SuppressWarnings("unused")
+        static class Origin {
+            void referencesConstructor() {
+                Supplier<ReferencedTarget> a = ReferencedTarget::new;
+            }
+        }
+    }
+
+    @Test
+    public void imports_constructor_references() {
+        JavaClasses javaClasses = new ClassFileImporter()
+                .importClasses(Data_imports_constructor_references.Origin.class, Data_imports_constructor_references.ReferencedTarget.class);
+        JavaClass originClass = javaClasses.get(Data_imports_constructor_references.Origin.class);
+        JavaClass targetClass = javaClasses.get(Data_imports_constructor_references.ReferencedTarget.class);
+
+        assertThatAccess(getOnlyElement(originClass.getMethod("referencesConstructor").getConstructorReferencesFromSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesConstructor"))
+                .isTo(targetClass.getConstructor());
+
+        assertThatAccess(getOnlyElement(targetClass.getConstructor().getReferencesToSelf()))
+                .isFrom(originClass.getCodeUnitWithParameterTypeNames("referencesConstructor"))
+                .isTo(targetClass.getConstructor());
+    }
+
+    /**
+     * A local class constructor obtains extra parameters from the outer scope that the compiler transparently adds
+     * to the byte code. A reference to this local constructor will then always be translated to a lambda call.
+     * Thus, in this case we do not expect a constructor reference.
+     */
+    @Test
+    public void does_not_import_local_constructor_references() {
+        @SuppressWarnings("unused")
+        class ReferencedTarget {
+            ReferencedTarget() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class Origin {
+            void referencesConstructor() {
+                Supplier<ReferencedTarget> a = ReferencedTarget::new;
+            }
+        }
+
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(Origin.class, ReferencedTarget.class);
+
+        assertThat(javaClasses.get(Origin.class).getMethod("referencesConstructor").getConstructorReferencesFromSelf()).isEmpty();
+        assertThat(javaClasses.get(ReferencedTarget.class).getConstructor(ClassFileImporterCodeUnitReferencesTest.class).getReferencesToSelf()).isEmpty();
+    }
+
+    @Test
+    public void does_not_import_lambdas_as_method_or_constructor_references() {
+        @SuppressWarnings("unused")
+        class ReferencedTarget {
+            void call() {
+            }
+        }
+        @SuppressWarnings({"unused", "Convert2MethodRef"})
+        class Origin {
+            void referencesConstructor(ReferencedTarget target) {
+                Runnable r = () -> target.call();
+            }
+        }
+
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(Origin.class, ReferencedTarget.class);
+
+        assertThat(javaClasses.get(Origin.class).getCodeUnitReferencesFromSelf()).isEmpty();
+        assertThat(javaClasses.get(ReferencedTarget.class).getCodeUnitReferencesToSelf()).isEmpty();
+    }
+
+    private static class Data_imports_method_and_constructor_references_as_accesses {
+        @SuppressWarnings("unused")
+        static class ReferencedTarget {
+            ReferencedTarget() {
+            }
+
+            void call() {
+            }
+        }
+
+        @SuppressWarnings("unused")
+        static class Origin {
+            void referencesConstructorsAndMethods1() {
+                Supplier<ReferencedTarget> a = ReferencedTarget::new;
+                Consumer<ReferencedTarget> b = ReferencedTarget::call;
+                Supplier<ReferencedTarget> c = ReferencedTarget::new;
+                Consumer<ReferencedTarget> d = ReferencedTarget::call;
+            }
+
+            void referencesConstructorsAndMethods2() {
+                Supplier<ReferencedTarget> a = ReferencedTarget::new;
+                Consumer<ReferencedTarget> b = ReferencedTarget::call;
+                Supplier<ReferencedTarget> c = ReferencedTarget::new;
+                Consumer<ReferencedTarget> d = ReferencedTarget::call;
+            }
+        }
+    }
+
+    @Test
+    public void imports_method_and_constructor_references_from_self_as_accesses() {
+        JavaClasses javaClasses = new ClassFileImporter()
+                .importClasses(Data_imports_method_and_constructor_references_as_accesses.Origin.class, Data_imports_method_and_constructor_references_as_accesses.ReferencedTarget.class);
+        JavaClass originClass = javaClasses.get(Data_imports_method_and_constructor_references_as_accesses.Origin.class);
+
+        assertThat(originClass.getAccessesFromSelf()).containsAll(originClass.getCodeUnitAccessesFromSelf());
+
+        assertThat(originClass.getCodeUnitAccessesFromSelf()).containsAll(originClass.getCodeUnitReferencesFromSelf());
+
+        assertThat(originClass.getCodeUnitReferencesFromSelf())
+                .hasSize(8)
+                .containsAll(originClass.getMethodReferencesFromSelf())
+                .containsAll(originClass.getConstructorReferencesFromSelf())
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods1").getCodeUnitReferencesFromSelf())
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods2").getCodeUnitReferencesFromSelf());
+
+        assertThat(originClass.getConstructorReferencesFromSelf())
+                .hasSize(4)
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods1").getConstructorReferencesFromSelf())
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods2").getConstructorReferencesFromSelf());
+
+        assertThat(originClass.getMethodReferencesFromSelf())
+                .hasSize(4)
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods1").getMethodReferencesFromSelf())
+                .containsAll(originClass.getMethod("referencesConstructorsAndMethods2").getMethodReferencesFromSelf());
+    }
+
+    @Test
+    public void imports_method_and_constructor_references_to_self_as_accesses() {
+        JavaClasses javaClasses = new ClassFileImporter()
+                .importClasses(Data_imports_method_and_constructor_references_as_accesses.Origin.class, Data_imports_method_and_constructor_references_as_accesses.ReferencedTarget.class);
+        JavaClass targetClass = javaClasses.get(Data_imports_method_and_constructor_references_as_accesses.ReferencedTarget.class);
+
+        assertThat(targetClass.getAccessesToSelf()).containsAll(targetClass.getCodeUnitAccessesToSelf());
+
+        assertThat(targetClass.getCodeUnitAccessesToSelf()).containsAll(targetClass.getCodeUnitReferencesToSelf());
+
+        assertThat(targetClass.getCodeUnitReferencesToSelf())
+                .hasSize(8)
+                .containsAll(targetClass.getMethodReferencesToSelf())
+                .containsAll(targetClass.getConstructorReferencesToSelf())
+                .containsAll(targetClass.getMethod("call").getReferencesToSelf())
+                .containsAll(targetClass.getConstructor().getReferencesToSelf());
+
+        assertThat(targetClass.getConstructorReferencesToSelf())
+                .hasSize(4)
+                .containsAll(targetClass.getConstructor().getReferencesToSelf());
+
+        assertThat(targetClass.getMethodReferencesToSelf())
+                .hasSize(4)
+                .containsAll(targetClass.getMethod("call").getReferencesToSelf());
+    }
+
+    @Test
+    public void creates_correct_description_for_references() {
+        JavaClasses javaClasses = new ClassFileImporter().importClasses(Origin.class, Target.class);
+        JavaClass originClass = javaClasses.get(Origin.class);
+        JavaClass targetClass = javaClasses.get(Target.class);
+
+        JavaMethod constructorReferenceOrigin = originClass.getMethod("referencesConstructor");
+        JavaConstructor targetConstructor = targetClass.getConstructor();
+        JavaMethod methodReferenceOrigin = originClass.getMethod("referencesMethod");
+        JavaMethod targetMethod = targetClass.getMethod("call");
+
+        JavaConstructorReference constructorReference = getOnlyElement(constructorReferenceOrigin.getConstructorReferencesFromSelf());
+        assertThat(constructorReference.getDescription()).isEqualTo(String.format(
+                "Method <%s> references constructor <%s> in (%s.java:%d)",
+                constructorReferenceOrigin.getFullName(), targetConstructor.getFullName(), Origin.class.getSimpleName(), 9
+        ));
+
+        JavaMethodReference methodReference = getOnlyElement(originClass.getMethod("referencesMethod").getMethodReferencesFromSelf());
+        assertThat(methodReference.getDescription()).isEqualTo(String.format(
+                "Method <%s> references method <%s> in (%s.java:%d)",
+                methodReferenceOrigin.getFullName(), targetMethod.getFullName(), Origin.class.getSimpleName(), 13
+        ));
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/codeunitreferences/Origin.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/codeunitreferences/Origin.java
@@ -1,0 +1,15 @@
+package com.tngtech.archunit.core.importer.testexamples.codeunitreferences;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+@SuppressWarnings("unused")
+public class Origin {
+    void referencesConstructor() {
+        Supplier<Target> a = Target::new;
+    }
+
+    void referencesMethod() {
+        Consumer<Target> b = Target::call;
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/codeunitreferences/Target.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/codeunitreferences/Target.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.core.importer.testexamples.codeunitreferences;
+
+@SuppressWarnings("unused")
+public class Target {
+    Target() {
+    }
+
+    void call() {
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -353,13 +353,25 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             }
 
             @PublicAPI(usage = ACCESS)
-            public static final ChainableFunction<FieldAccessTarget, Optional<JavaField>> RESOLVE =
+            public static final ChainableFunction<FieldAccessTarget, Optional<JavaField>> RESOLVE_MEMBER =
                     new ChainableFunction<FieldAccessTarget, Optional<JavaField>>() {
                         @Override
                         public Optional<JavaField> apply(FieldAccessTarget input) {
                             return input.resolveMember();
                         }
                     };
+
+            /**
+             * @deprecated Use {@link #RESOLVE_MEMBER} instead
+             */
+            @Deprecated
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<FieldAccessTarget, Set<JavaField>> RESOLVE = RESOLVE_MEMBER.then(new Function<Optional<JavaField>, Set<JavaField>>() {
+                @Override
+                public Set<JavaField> apply(Optional<JavaField> input) {
+                    return input.asSet();
+                }
+            });
         }
     }
 
@@ -438,7 +450,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             }
 
             @PublicAPI(usage = ACCESS)
-            public static final ChainableFunction<CodeUnitCallTarget, Optional<JavaCodeUnit>> RESOLVE =
+            public static final ChainableFunction<CodeUnitCallTarget, Optional<JavaCodeUnit>> RESOLVE_MEMBER =
                     new ChainableFunction<CodeUnitCallTarget, Optional<JavaCodeUnit>>() {
                         @SuppressWarnings("unchecked") // Optional is covariant
                         @Override
@@ -446,6 +458,18 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
                             return (Optional<JavaCodeUnit>) input.resolveMember();
                         }
                     };
+
+            /**
+             * @deprecated Use {@link #RESOLVE_MEMBER} instead
+             */
+            @Deprecated
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<CodeUnitCallTarget, Set<JavaCodeUnit>> RESOLVE = RESOLVE_MEMBER.then(new Function<Optional<JavaCodeUnit>, Set<JavaCodeUnit>>() {
+                @Override
+                public Set<JavaCodeUnit> apply(Optional<JavaCodeUnit> input) {
+                    return input.asSet();
+                }
+            });
         }
     }
 
@@ -497,13 +521,25 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             }
 
             @PublicAPI(usage = ACCESS)
-            public static final ChainableFunction<ConstructorCallTarget, Optional<JavaConstructor>> RESOLVE =
+            public static final ChainableFunction<ConstructorCallTarget, Optional<JavaConstructor>> RESOLVE_MEMBER =
                     new ChainableFunction<ConstructorCallTarget, Optional<JavaConstructor>>() {
                         @Override
                         public Optional<JavaConstructor> apply(ConstructorCallTarget input) {
                             return input.resolveMember();
                         }
                     };
+
+            /**
+             * @deprecated Use {@link #RESOLVE_MEMBER} instead
+             */
+            @Deprecated
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<ConstructorCallTarget, Set<JavaConstructor>> RESOLVE = RESOLVE_MEMBER.then(new Function<Optional<JavaConstructor>, Set<JavaConstructor>>() {
+                @Override
+                public Set<JavaConstructor> apply(Optional<JavaConstructor> input) {
+                    return input.asSet();
+                }
+            });
         }
     }
 
@@ -575,13 +611,25 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             }
 
             @PublicAPI(usage = ACCESS)
-            public static final ChainableFunction<MethodCallTarget, Optional<JavaMethod>> RESOLVE =
+            public static final ChainableFunction<MethodCallTarget, Optional<JavaMethod>> RESOLVE_MEMBER =
                     new ChainableFunction<MethodCallTarget, Optional<JavaMethod>>() {
                         @Override
                         public Optional<JavaMethod> apply(MethodCallTarget input) {
                             return input.resolveMember();
                         }
                     };
+
+            /**
+             * @deprecated Use {@link #RESOLVE_MEMBER} instead
+             */
+            @Deprecated
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<MethodCallTarget, Set<JavaMethod>> RESOLVE = RESOLVE_MEMBER.then(new Function<Optional<JavaMethod>, Set<JavaMethod>>() {
+                @Override
+                public Set<JavaMethod> apply(Optional<JavaMethod> input) {
+                    return input.asSet();
+                }
+            });
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -25,19 +25,23 @@ import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorReferenceTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders;
-import com.tngtech.archunit.core.importer.DomainBuilders.CodeUnitCallTargetBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.CodeUnitAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorCallBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorReferenceBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaEnumConstantBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaFieldAccessBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaFieldBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodReferenceBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
 
@@ -119,8 +123,16 @@ public class DomainObjectCreationContext {
         return new JavaConstructorCall(builder);
     }
 
-    public static ConstructorCallTarget createConstructorCallTarget(CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget> builder) {
+    public static JavaConstructorReference createJavaConstructorReference(JavaConstructorReferenceBuilder builder) {
+        return new JavaConstructorReference(builder);
+    }
+
+    public static ConstructorCallTarget createConstructorCallTarget(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget> builder) {
         return new ConstructorCallTarget(builder);
+    }
+
+    public static ConstructorReferenceTarget createConstructorReferenceTarget(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget> builder) {
+        return new ConstructorReferenceTarget(builder);
     }
 
     public static JavaMethod createJavaMethod(JavaMethodBuilder builder, Function<JavaMethod, Optional<Object>> createAnnotationDefaultValue) {
@@ -131,8 +143,16 @@ public class DomainObjectCreationContext {
         return new JavaMethodCall(builder);
     }
 
-    public static MethodCallTarget createMethodCallTarget(CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget> builder) {
+    public static JavaMethodReference createJavaMethodReference(JavaMethodReferenceBuilder builder) {
+        return new JavaMethodReference(builder);
+    }
+
+    public static MethodCallTarget createMethodCallTarget(CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget> builder) {
         return new MethodCallTarget(builder);
+    }
+
+    public static MethodReferenceTarget createMethodReferenceTarget(CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget> builder) {
+        return new MethodReferenceTarget(builder);
     }
 
     public static JavaStaticInitializer createJavaStaticInitializer(JavaStaticInitializerBuilder builder) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -24,8 +24,10 @@ import com.tngtech.archunit.Internal;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders;
-import com.tngtech.archunit.core.importer.DomainBuilders.ConstructorCallTargetBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.CodeUnitCallTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassBuilder;
@@ -38,7 +40,6 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.MethodCallTargetBuilder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -118,8 +119,8 @@ public class DomainObjectCreationContext {
         return new JavaConstructorCall(builder);
     }
 
-    public static AccessTarget.ConstructorCallTarget createConstructorCallTarget(ConstructorCallTargetBuilder builder) {
-        return new AccessTarget.ConstructorCallTarget(builder);
+    public static ConstructorCallTarget createConstructorCallTarget(CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget> builder) {
+        return new ConstructorCallTarget(builder);
     }
 
     public static JavaMethod createJavaMethod(JavaMethodBuilder builder, Function<JavaMethod, Optional<Object>> createAnnotationDefaultValue) {
@@ -130,8 +131,8 @@ public class DomainObjectCreationContext {
         return new JavaMethodCall(builder);
     }
 
-    public static AccessTarget.MethodCallTarget createMethodCallTarget(MethodCallTargetBuilder builder) {
-        return new AccessTarget.MethodCallTarget(builder);
+    public static MethodCallTarget createMethodCallTarget(CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget> builder) {
+        return new MethodCallTarget(builder);
     }
 
     public static JavaStaticInitializer createJavaStaticInitializer(JavaStaticInitializerBuilder builder) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -56,5 +56,9 @@ public interface ImportContext {
 
     Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit);
 
+    Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit);
+
+    Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit);
+
     JavaClass resolveClass(String fullyQualifiedClassName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -154,7 +154,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaAccess<?>> target(final DescribedPredicate<? super AccessTarget> predicate) {
-            return new TargetPredicate(predicate);
+            return new TargetPredicate<>(predicate);
         }
 
         private static class OriginOwnerEqualsTargetOwnerPredicate extends DescribedPredicate<JavaAccess<?>> {
@@ -168,16 +168,16 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
             }
         }
 
-        private static class TargetPredicate extends DescribedPredicate<JavaAccess<?>> {
-            private final DescribedPredicate<? super AccessTarget> predicate;
+        static class TargetPredicate<ACCESS extends JavaAccess<? extends TARGET>, TARGET extends AccessTarget> extends DescribedPredicate<ACCESS> {
+            private final DescribedPredicate<? super TARGET> predicate;
 
-            TargetPredicate(DescribedPredicate<? super AccessTarget> predicate) {
+            TargetPredicate(DescribedPredicate<? super TARGET> predicate) {
                 super("target " + predicate.getDescription());
                 this.predicate = predicate;
             }
 
             @Override
-            public boolean apply(JavaAccess<?> input) {
+            public boolean apply(ACCESS input) {
                 return predicate.apply(input.getTarget());
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1043,13 +1043,25 @@ public class JavaClass
         return members.getStaticInitializer();
     }
 
+    /**
+     * @return All accesses of this class to any members (fields/methods/constructors)
+     *
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaAccess<?>> getAccessesFromSelf() {
-        return union(getFieldAccessesFromSelf(), getCodeUnitCallsFromSelf());
+        return union(getFieldAccessesFromSelf(), getCodeUnitAccessesFromSelf());
     }
 
     /**
-     * @return Set of all {@link JavaAccess} in the class hierarchy, as opposed to the accesses this class directly performs.
+     * @return {@link #getAccessesFromSelf()} but for every class in the class hierarchy (i.e. all superclasses)
      */
     @PublicAPI(usage = ACCESS)
     public Set<JavaAccess<?>> getAllAccessesFromSelf() {
@@ -1060,9 +1072,41 @@ public class JavaClass
         return result.build();
     }
 
+    /**
+     * @return All accesses of this class to fields. These can be {@link JavaFieldAccess.AccessType#GET read} accesses
+     *         (e.g. {@code return this.example}) or {@link JavaFieldAccess.AccessType#SET write} accesses
+     *         (e.g. {@code this.example = example})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaFieldAccess> getFieldAccessesFromSelf() {
         return members.getFieldAccessesFromSelf();
+    }
+
+    /**
+     * @return All access of this class to other code units. This can be calls to methods/constructors (e.g. {@code someExample.call()})
+     *         or references of methods/constructors (e.g. {@code SomeExample::call})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCodeUnitAccess<?>> getCodeUnitAccessesFromSelf() {
+        return union(getCodeUnitCallsFromSelf(), getCodeUnitReferencesFromSelf());
     }
 
     /**
@@ -1077,22 +1121,103 @@ public class JavaClass
     /**
      * Returns all calls of this class to methods or constructors.
      *
-     * @see #getMethodCallsFromSelf()
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
      * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
      */
     @PublicAPI(usage = ACCESS)
     public Set<JavaCall<?>> getCodeUnitCallsFromSelf() {
         return union(getMethodCallsFromSelf(), getConstructorCallsFromSelf());
     }
 
+    /**
+     * @return All method calls (e.g. a call to {@code SomeExample.someMethod()})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getMethodCallsFromSelf() {
         return members.getMethodCallsFromSelf();
     }
 
+    /**
+     * @return All constructor calls (e.g. a call to {@code SomeExample()})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaConstructorCall> getConstructorCallsFromSelf() {
         return members.getConstructorCallsFromSelf();
+    }
+
+    /**
+     * @return All references of this class to {@link #getMethodReferencesFromSelf() method} or {@link #getConstructorReferencesFromSelf() constructor references}.
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCodeUnitReference<?>> getCodeUnitReferencesFromSelf() {
+        return union(getMethodReferencesFromSelf(), getConstructorReferencesFromSelf());
+    }
+
+    /**
+     * @return All method references (e.g. {@code SomeExample::someMethod})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getConstructorReferencesFromSelf()
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaMethodReference> getMethodReferencesFromSelf() {
+        return members.getMethodReferencesFromSelf();
+    }
+
+    /**
+     * @return All constructor references (e.g. {@code SomeExample::new})
+     *
+     * @see #getAccessesFromSelf()
+     * @see #getFieldAccessesFromSelf()
+     * @see #getCodeUnitAccessesFromSelf()
+     * @see #getCodeUnitCallsFromSelf()
+     * @see #getConstructorCallsFromSelf()
+     * @see #getMethodCallsFromSelf()
+     * @see #getCodeUnitReferencesFromSelf()
+     * @see #getMethodReferencesFromSelf()
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaConstructorReference> getConstructorReferencesFromSelf() {
+        return members.getConstructorReferencesFromSelf();
     }
 
     /**
@@ -1141,23 +1266,68 @@ public class JavaClass
         return members.getFieldAccessesToSelf();
     }
 
+    /**
+     * Like {@link #getCodeUnitAccessesFromSelf()} but this class is target instead of origin.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCodeUnitAccess<?>> getCodeUnitAccessesToSelf() {
+        return union(getCodeUnitCallsToSelf(), getCodeUnitReferencesToSelf());
+    }
+
+    /**
+     * Like {@link #getCodeUnitCallsFromSelf()} but this class is target instead of origin.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCall<?>> getCodeUnitCallsToSelf() {
+        return union(getMethodCallsToSelf(), getConstructorCallsToSelf());
+    }
+
+    /**
+     * Like {@link #getCodeUnitReferencesFromSelf()} but this class is target instead of origin.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCodeUnitReference<?>> getCodeUnitReferencesToSelf() {
+        return union(getMethodReferencesToSelf(), getConstructorReferencesToSelf());
+    }
+
+    /**
+     * Like {@link #getMethodCallsFromSelf()} but this class is target instead of origin.
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getMethodCallsToSelf() {
         return members.getMethodCallsToSelf();
     }
 
+    /**
+     * Like {@link #getMethodReferencesFromSelf()} but this class is target instead of origin.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaMethodReference> getMethodReferencesToSelf() {
+        return members.getMethodReferencesToSelf();
+    }
+
+    /**
+     * Like {@link #getConstructorCallsFromSelf()} but this class is target instead of origin.
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaConstructorCall> getConstructorCallsToSelf() {
         return members.getConstructorCallsToSelf();
     }
 
+    /**
+     * Like {@link #getConstructorReferencesFromSelf()} but this class is target instead of origin.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaConstructorReference> getConstructorReferencesToSelf() {
+        return members.getConstructorReferencesToSelf();
+    }
+
+    /**
+     * Like {@link #getAccessesFromSelf()} but this class is target instead of origin.
+     */
     @PublicAPI(usage = ACCESS)
     public Set<JavaAccess<?>> getAccessesToSelf() {
-        return ImmutableSet.<JavaAccess<?>>builder()
-                .addAll(getFieldAccessesToSelf())
-                .addAll(getMethodCallsToSelf())
-                .addAll(getConstructorCallsToSelf())
-                .build();
+        return union(getFieldAccessesToSelf(), getCodeUnitAccessesToSelf());
     }
 
     /**
@@ -1596,6 +1766,9 @@ public class JavaClass
         private Functions() {
         }
 
+        /**
+         * @see #getSimpleName()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, String> GET_SIMPLE_NAME = new ChainableFunction<JavaClass, String>() {
             @Override
@@ -1604,6 +1777,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getPackageName()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, String> GET_PACKAGE_NAME = new ChainableFunction<JavaClass, String>() {
             @Override
@@ -1612,6 +1788,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getPackage()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, JavaPackage> GET_PACKAGE = new ChainableFunction<JavaClass, JavaPackage>() {
             @Override
@@ -1620,6 +1799,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getMembers()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaMember>> GET_MEMBERS = new ChainableFunction<JavaClass, Set<JavaMember>>() {
             @Override
@@ -1628,6 +1810,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getFields()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaField>> GET_FIELDS = new ChainableFunction<JavaClass, Set<JavaField>>() {
             @Override
@@ -1636,6 +1821,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getCodeUnits()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaCodeUnit>> GET_CODE_UNITS =
                 new ChainableFunction<JavaClass, Set<JavaCodeUnit>>() {
@@ -1645,6 +1833,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getMethods()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaMethod>> GET_METHODS = new ChainableFunction<JavaClass, Set<JavaMethod>>() {
             @Override
@@ -1653,6 +1844,9 @@ public class JavaClass
             }
         };
 
+        /**
+         * @see #getConstructors()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaConstructor>> GET_CONSTRUCTORS =
                 new ChainableFunction<JavaClass, Set<JavaConstructor>>() {
@@ -1662,6 +1856,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getStaticInitializer()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Optional<JavaStaticInitializer>> GET_STATIC_INITIALIZER =
                 new ChainableFunction<JavaClass, Optional<JavaStaticInitializer>>() {
@@ -1671,6 +1868,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getFieldAccessesFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaFieldAccess>> GET_FIELD_ACCESSES_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaFieldAccess>>() {
@@ -1680,6 +1880,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getMethodCallsFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaMethodCall>> GET_METHOD_CALLS_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaMethodCall>>() {
@@ -1689,6 +1892,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getConstructorCallsFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaConstructorCall>> GET_CONSTRUCTOR_CALLS_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaConstructorCall>>() {
@@ -1698,6 +1904,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getCodeUnitCallsFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaCall<?>>> GET_CODE_UNIT_CALLS_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaCall<?>>>() {
@@ -1714,6 +1923,81 @@ public class JavaClass
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaCall<?>>> GET_CALLS_FROM_SELF = GET_CODE_UNIT_CALLS_FROM_SELF;
 
+        /**
+         * @see #getMethodReferencesFromSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaMethodReference>> GET_METHOD_REFERENCES_FROM_SELF =
+                new ChainableFunction<JavaClass, Set<JavaMethodReference>>() {
+                    @Override
+                    public Set<JavaMethodReference> apply(JavaClass input) {
+                        return input.getMethodReferencesFromSelf();
+                    }
+                };
+
+        /**
+         * @see #getConstructorReferencesFromSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaConstructorReference>> GET_CONSTRUCTOR_REFERENCES_FROM_SELF =
+                new ChainableFunction<JavaClass, Set<JavaConstructorReference>>() {
+                    @Override
+                    public Set<JavaConstructorReference> apply(JavaClass input) {
+                        return input.getConstructorReferencesFromSelf();
+                    }
+                };
+
+        /**
+         * @see #getCodeUnitReferencesFromSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaCodeUnitReference<?>>> GET_CODE_UNIT_REFERENCES_FROM_SELF =
+                new ChainableFunction<JavaClass, Set<JavaCodeUnitReference<?>>>() {
+                    @Override
+                    public Set<JavaCodeUnitReference<?>> apply(JavaClass input) {
+                        return input.getCodeUnitReferencesFromSelf();
+                    }
+                };
+
+        /**
+         * @see #getMethodReferencesToSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaMethodReference>> GET_METHOD_REFERENCES_TO_SELF =
+                new ChainableFunction<JavaClass, Set<JavaMethodReference>>() {
+                    @Override
+                    public Set<JavaMethodReference> apply(JavaClass input) {
+                        return input.getMethodReferencesToSelf();
+                    }
+                };
+
+        /**
+         * @see #getConstructorReferencesToSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaConstructorReference>> GET_CONSTRUCTOR_REFERENCES_TO_SELF =
+                new ChainableFunction<JavaClass, Set<JavaConstructorReference>>() {
+                    @Override
+                    public Set<JavaConstructorReference> apply(JavaClass input) {
+                        return input.getConstructorReferencesToSelf();
+                    }
+                };
+
+        /**
+         * @see #getCodeUnitReferencesToSelf()
+         */
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaCodeUnitReference<?>>> GET_CODE_UNIT_REFERENCES_TO_SELF =
+                new ChainableFunction<JavaClass, Set<JavaCodeUnitReference<?>>>() {
+                    @Override
+                    public Set<JavaCodeUnitReference<?>> apply(JavaClass input) {
+                        return input.getCodeUnitReferencesToSelf();
+                    }
+                };
+
+        /**
+         * @see #getAccessesFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaAccess<?>>> GET_ACCESSES_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaAccess<?>>>() {
@@ -1723,6 +2007,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getDirectDependenciesFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<Dependency>> GET_DIRECT_DEPENDENCIES_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<Dependency>>() {
@@ -1732,6 +2019,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getTransitiveDependenciesFromSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<Dependency>> GET_TRANSITIVE_DEPENDENCIES_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<Dependency>>() {
@@ -1741,6 +2031,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getAccessesToSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaAccess<?>>> GET_ACCESSES_TO_SELF =
                 new ChainableFunction<JavaClass, Set<JavaAccess<?>>>() {
@@ -1750,6 +2043,9 @@ public class JavaClass
                     }
                 };
 
+        /**
+         * @see #getDirectDependenciesToSelf()
+         */
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<Dependency>> GET_DIRECT_DEPENDENCIES_TO_SELF =
                 new ChainableFunction<JavaClass, Set<Dependency>>() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1045,7 +1045,7 @@ public class JavaClass
 
     @PublicAPI(usage = ACCESS)
     public Set<JavaAccess<?>> getAccessesFromSelf() {
-        return union(getFieldAccessesFromSelf(), getCallsFromSelf());
+        return union(getFieldAccessesFromSelf(), getCodeUnitCallsFromSelf());
     }
 
     /**
@@ -1066,13 +1066,22 @@ public class JavaClass
     }
 
     /**
+     * @deprecated Use {@link #getCodeUnitCallsFromSelf()} instead
+     */
+    @Deprecated
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCall<?>> getCallsFromSelf() {
+        return getCodeUnitCallsFromSelf();
+    }
+
+    /**
      * Returns all calls of this class to methods or constructors.
      *
      * @see #getMethodCallsFromSelf()
      * @see #getConstructorCallsFromSelf()
      */
     @PublicAPI(usage = ACCESS)
-    public Set<JavaCall<?>> getCallsFromSelf() {
+    public Set<JavaCall<?>> getCodeUnitCallsFromSelf() {
         return union(getMethodCallsFromSelf(), getConstructorCallsFromSelf());
     }
 
@@ -1690,13 +1699,20 @@ public class JavaClass
                 };
 
         @PublicAPI(usage = ACCESS)
-        public static final ChainableFunction<JavaClass, Set<JavaCall<?>>> GET_CALLS_FROM_SELF =
+        public static final ChainableFunction<JavaClass, Set<JavaCall<?>>> GET_CODE_UNIT_CALLS_FROM_SELF =
                 new ChainableFunction<JavaClass, Set<JavaCall<?>>>() {
                     @Override
                     public Set<JavaCall<?>> apply(JavaClass input) {
-                        return input.getCallsFromSelf();
+                        return input.getCodeUnitCallsFromSelf();
                     }
                 };
+
+        /**
+         * @deprecated Use {@link #GET_CODE_UNIT_CALLS_FROM_SELF} instead
+         */
+        @Deprecated
+        @PublicAPI(usage = ACCESS)
+        public static final ChainableFunction<JavaClass, Set<JavaCall<?>>> GET_CALLS_FROM_SELF = GET_CODE_UNIT_CALLS_FROM_SELF;
 
         @PublicAPI(usage = ACCESS)
         public static final ChainableFunction<JavaClass, Set<JavaAccess<?>>> GET_ACCESSES_FROM_SELF =

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -228,6 +228,22 @@ class JavaClassMembers {
         return result.build();
     }
 
+    Set<JavaMethodReference> getMethodReferencesFromSelf() {
+        ImmutableSet.Builder<JavaMethodReference> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getMethodReferencesFromSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaConstructorReference> getConstructorReferencesFromSelf() {
+        ImmutableSet.Builder<JavaConstructorReference> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getConstructorReferencesFromSelf());
+        }
+        return result.build();
+    }
+
     Set<JavaFieldAccess> getFieldAccessesToSelf() {
         ImmutableSet.Builder<JavaFieldAccess> result = ImmutableSet.builder();
         for (JavaField field : fields) {
@@ -244,10 +260,26 @@ class JavaClassMembers {
         return result.build();
     }
 
+    Set<JavaMethodReference> getMethodReferencesToSelf() {
+        ImmutableSet.Builder<JavaMethodReference> result = ImmutableSet.builder();
+        for (JavaMethod method : methods) {
+            result.addAll(method.getReferencesToSelf());
+        }
+        return result.build();
+    }
+
     Set<JavaConstructorCall> getConstructorCallsToSelf() {
         ImmutableSet.Builder<JavaConstructorCall> result = ImmutableSet.builder();
         for (JavaConstructor constructor : constructors) {
             result.addAll(constructor.getCallsOfSelf());
+        }
+        return result.build();
+    }
+
+    Set<JavaConstructorReference> getConstructorReferencesToSelf() {
+        ImmutableSet.Builder<JavaConstructorReference> result = ImmutableSet.builder();
+        for (JavaConstructor constructor : constructors) {
+            result.addAll(constructor.getReferencesToSelf());
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -36,6 +36,7 @@ import com.tngtech.archunit.core.domain.properties.HasThrowsClause;
 import com.tngtech.archunit.core.domain.properties.HasTypeParameters;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaCodeUnitBuilder;
 
+import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
@@ -64,6 +65,8 @@ public abstract class JavaCodeUnit
     private Set<JavaFieldAccess> fieldAccesses = Collections.emptySet();
     private Set<JavaMethodCall> methodCalls = Collections.emptySet();
     private Set<JavaConstructorCall> constructorCalls = Collections.emptySet();
+    private Set<JavaMethodReference> methodReferences = Collections.emptySet();
+    private Set<JavaConstructorReference> constructorReferences = Collections.emptySet();
 
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
@@ -179,6 +182,16 @@ public abstract class JavaCodeUnit
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<JavaMethodReference> getMethodReferencesFromSelf() {
+        return methodReferences;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaConstructorReference> getConstructorReferencesFromSelf() {
+        return constructorReferences;
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<ReferencedClassObject> getReferencedClassObjects() {
         return referencedClassObjects;
     }
@@ -190,10 +203,12 @@ public abstract class JavaCodeUnit
 
     @PublicAPI(usage = ACCESS)
     public Set<JavaCall<?>> getCallsFromSelf() {
-        return ImmutableSet.<JavaCall<?>>builder()
-                .addAll(getMethodCallsFromSelf())
-                .addAll(getConstructorCallsFromSelf())
-                .build();
+        return union(getMethodCallsFromSelf(), getConstructorCallsFromSelf());
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaCodeUnitReference<?>> getCodeUnitReferencesFromSelf() {
+        return union(getMethodReferencesFromSelf(), getConstructorReferencesFromSelf());
     }
 
     @PublicAPI(usage = ACCESS)
@@ -201,6 +216,7 @@ public abstract class JavaCodeUnit
         return ImmutableSet.<JavaAccess<?>>builder()
                 .addAll(getCallsFromSelf())
                 .addAll(getFieldAccesses())
+                .addAll(getCodeUnitReferencesFromSelf())
                 .build();
     }
 
@@ -241,6 +257,8 @@ public abstract class JavaCodeUnit
         fieldAccesses = context.createFieldAccessesFor(this);
         methodCalls = context.createMethodCallsFor(this);
         constructorCalls = context.createConstructorCallsFor(this);
+        methodReferences = context.createMethodReferencesFor(this);
+        constructorReferences = context.createConstructorReferencesFor(this);
     }
 
     @ResolvesTypesViaReflection

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
@@ -17,14 +17,14 @@ package com.tngtech.archunit.core.domain;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitAccessTarget;
 import com.tngtech.archunit.core.domain.JavaAccess.Predicates.TargetPredicate;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUnitAccess<T> {
-    JavaCall(JavaAccessBuilder<T, ?> builder) {
+public abstract class JavaCodeUnitAccess<T extends CodeUnitAccessTarget> extends JavaAccess<T> {
+    JavaCodeUnitAccess(JavaAccessBuilder<T, ?> builder) {
         super(builder);
     }
 
@@ -33,7 +33,7 @@ public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUni
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaCall<?>> target(final DescribedPredicate<? super CodeUnitCallTarget> predicate) {
+        public static DescribedPredicate<JavaCodeUnitAccess<?>> target(final DescribedPredicate<? super CodeUnitAccessTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
@@ -17,14 +17,14 @@ package com.tngtech.archunit.core.domain;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitReferenceTarget;
 import com.tngtech.archunit.core.domain.JavaAccess.Predicates.TargetPredicate;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUnitAccess<T> {
-    JavaCall(JavaAccessBuilder<T, ?> builder) {
+public abstract class JavaCodeUnitReference<T extends CodeUnitReferenceTarget> extends JavaCodeUnitAccess<T> {
+    JavaCodeUnitReference(JavaAccessBuilder<T, ?> builder) {
         super(builder);
     }
 
@@ -33,7 +33,7 @@ public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUni
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaCall<?>> target(final DescribedPredicate<? super CodeUnitCallTarget> predicate) {
+        public static DescribedPredicate<JavaCodeUnitReference<?>> target(final DescribedPredicate<? super CodeUnitReferenceTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
@@ -28,6 +28,7 @@ import com.tngtech.archunit.core.MayResolveTypesViaReflection;
 import com.tngtech.archunit.core.ResolvesTypesViaReflection;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorBuilder;
 
+import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
@@ -65,13 +66,18 @@ public final class JavaConstructor extends JavaCodeUnit {
 
     @PublicAPI(usage = ACCESS)
     public Set<JavaConstructorCall> getCallsOfSelf() {
-        return getAccessesToSelf();
+        return getReverseDependencies().getCallsTo(this);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaConstructorReference> getReferencesToSelf() {
+        return getReverseDependencies().getReferencesTo(this);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public Set<JavaConstructorCall> getAccessesToSelf() {
-        return getReverseDependencies().getCallsTo(this);
+    public Set<JavaCodeUnitAccess<?>> getAccessesToSelf() {
+        return union(getCallsOfSelf(), getReferencesToSelf());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorReference.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorReferenceTarget;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorReferenceBuilder;
+
+public class JavaConstructorReference extends JavaCodeUnitReference<ConstructorReferenceTarget> {
+    JavaConstructorReference(JavaConstructorReferenceBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected String descriptionVerb() {
+        return "references";
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
+import com.tngtech.archunit.core.domain.JavaAccess.Predicates.TargetPredicate;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaFieldAccessBuilder;
 import org.objectweb.asm.Opcodes;
 
@@ -109,7 +110,7 @@ public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaFieldAccess> target(final DescribedPredicate<? super FieldAccessTarget> predicate) {
-            return new TargetPredicate(predicate);
+            return new TargetPredicate<>(predicate);
         }
 
         private static class AccessTypePredicate extends DescribedPredicate<JavaFieldAccess> {
@@ -123,20 +124,6 @@ public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
             @Override
             public boolean apply(JavaFieldAccess input) {
                 return accessType == input.getAccessType();
-            }
-        }
-
-        private static class TargetPredicate extends DescribedPredicate<JavaFieldAccess> {
-            private final DescribedPredicate<? super FieldAccessTarget> predicate;
-
-            TargetPredicate(DescribedPredicate<? super FieldAccessTarget> predicate) {
-                super("target " + predicate.getDescription());
-                this.predicate = predicate;
-            }
-
-            @Override
-            public boolean apply(JavaFieldAccess input) {
-                return predicate.apply(input.getTarget());
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.core.MayResolveTypesViaReflection;
 import com.tngtech.archunit.core.ResolvesTypesViaReflection;
 import com.tngtech.archunit.core.importer.DomainBuilders;
 
+import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
@@ -71,13 +72,18 @@ public class JavaMethod extends JavaCodeUnit {
 
     @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getCallsOfSelf() {
-        return getAccessesToSelf();
+        return getReverseDependencies().getCallsTo(this);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaMethodReference> getReferencesToSelf() {
+        return getReverseDependencies().getReferencesTo(this);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
-    public Set<JavaMethodCall> getAccessesToSelf() {
-        return getReverseDependencies().getCallsTo(this);
+    public Set<JavaCodeUnitAccess<?>> getAccessesToSelf() {
+        return union(getCallsOfSelf(), getReferencesToSelf());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodReference.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodReferenceBuilder;
+
+public class JavaMethodReference extends JavaCodeUnitReference<MethodReferenceTarget> {
+    JavaMethodReference(JavaMethodReferenceBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected String descriptionVerb() {
+        return "references";
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -37,13 +37,13 @@ import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMethod;
-import com.tngtech.archunit.core.importer.DomainBuilders.ConstructorCallTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.MethodCallTargetBuilder;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 import com.tngtech.archunit.core.importer.RawAccessRecord.TargetInfo;
 
 import static com.tngtech.archunit.core.domain.JavaModifier.STATIC;
+import static com.tngtech.archunit.core.importer.DomainBuilders.newConstructorCallTargetBuilder;
+import static com.tngtech.archunit.core.importer.DomainBuilders.newMethodCallTargetBuilder;
 
 interface AccessRecord<TARGET extends AccessTarget> {
     JavaCodeUnit getCaller();
@@ -112,11 +112,11 @@ interface AccessRecord<TARGET extends AccessTarget> {
                 Supplier<Optional<JavaConstructor>> constructorSupplier = new ConstructorTargetSupplier(targetOwner, record.target);
                 List<JavaClass> paramTypes = getArgumentTypesFrom(record.target.desc, classes);
                 JavaClass returnType = classes.getOrResolve(void.class.getName());
-                return new ConstructorCallTargetBuilder()
+                return newConstructorCallTargetBuilder()
                         .withOwner(targetOwner)
                         .withParameters(paramTypes)
                         .withReturnType(returnType)
-                        .withConstructor(constructorSupplier)
+                        .withMember(constructorSupplier)
                         .build();
             }
 
@@ -169,12 +169,12 @@ interface AccessRecord<TARGET extends AccessTarget> {
                 Supplier<Optional<JavaMethod>> methodsSupplier = new MethodTargetSupplier(targetOwner, record.target);
                 List<JavaClass> parameters = getArgumentTypesFrom(record.target.desc, classes);
                 JavaClass returnType = classes.getOrResolve(JavaClassDescriptorImporter.importAsmMethodReturnType(record.target.desc).getFullyQualifiedClassName());
-                return new MethodCallTargetBuilder()
+                return newMethodCallTargetBuilder()
                         .withOwner(targetOwner)
                         .withName(record.target.name)
                         .withParameters(parameters)
                         .withReturnType(returnType)
-                        .withMethod(methodsSupplier)
+                        .withMember(methodsSupplier)
                         .build();
             }
 
@@ -230,7 +230,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
                         .withOwner(targetOwner)
                         .withName(record.target.name)
                         .withType(fieldType)
-                        .withField(fieldSupplier)
+                        .withMember(fieldSupplier)
                         .build();
             }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -65,6 +65,8 @@ class ClassFileImportRecord {
     private final Set<RawAccessRecord.ForField> rawFieldAccessRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawMethodCallRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawConstructorCallRecords = new HashSet<>();
+    private final Set<RawAccessRecord> rawMethodReferenceRecords = new HashSet<>();
+    private final Set<RawAccessRecord> rawConstructorReferenceRecords = new HashSet<>();
 
     void setSuperclass(String ownerName, String superclassName) {
         checkState(!superclassNamesByOwner.containsKey(ownerName),
@@ -262,6 +264,14 @@ class ClassFileImportRecord {
         rawConstructorCallRecords.add(record);
     }
 
+    void registerMethodReference(RawAccessRecord record) {
+        rawMethodReferenceRecords.add(record);
+    }
+
+    void registerConstructorReference(RawAccessRecord record) {
+        rawConstructorReferenceRecords.add(record);
+    }
+
     Set<RawAccessRecord.ForField> getRawFieldAccessRecords() {
         return ImmutableSet.copyOf(rawFieldAccessRecords);
     }
@@ -272,6 +282,14 @@ class ClassFileImportRecord {
 
     Set<RawAccessRecord> getRawConstructorCallRecords() {
         return ImmutableSet.copyOf(rawConstructorCallRecords);
+    }
+
+    Set<RawAccessRecord> getRawMethodReferenceRecords() {
+        return ImmutableSet.copyOf(rawMethodReferenceRecords);
+    }
+
+    Set<RawAccessRecord> getRawConstructorReferenceRecords() {
+        return ImmutableSet.copyOf(rawConstructorReferenceRecords);
     }
 
     void addAll(Collection<JavaClass> javaClasses) {
@@ -289,6 +307,8 @@ class ClassFileImportRecord {
                 .addAll(rawFieldAccessRecords)
                 .addAll(rawMethodCallRecords)
                 .addAll(rawConstructorCallRecords)
+                .addAll(rawMethodReferenceRecords)
+                .addAll(rawConstructorReferenceRecords)
                 .build();
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -189,6 +189,17 @@ class ClassFileProcessor {
             }
         }
 
+        @Override
+        public void handleMethodReferenceInstruction(String owner, String name, String desc) {
+            LOG.trace("Found method reference {}.{}:{} in line {}", owner, name, desc, lineNumber);
+            TargetInfo targetInfo = new TargetInfo(owner, name, desc);
+            if (CONSTRUCTOR_NAME.equals(name)) {
+                importRecord.registerConstructorReference(filled(new RawAccessRecord.Builder(), targetInfo).build());
+            } else {
+                importRecord.registerMethodReference(filled(new RawAccessRecord.Builder(), targetInfo).build());
+            }
+        }
+
         private <BUILDER extends RawAccessRecord.BaseBuilder<BUILDER>> BUILDER filled(BUILDER builder, TargetInfo target) {
             return builder
                     .withCaller(codeUnit)

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -181,11 +181,10 @@ class ClassFileProcessor {
         @Override
         public void handleMethodInstruction(String owner, String name, String desc) {
             LOG.trace("Found call of method {}.{}:{} in line {}", owner, name, desc, lineNumber);
+            TargetInfo target = new TargetInfo(owner, name, desc);
             if (CONSTRUCTOR_NAME.equals(name)) {
-                TargetInfo target = new TargetInfo(owner, name, desc);
                 importRecord.registerConstructorCall(filled(new RawAccessRecord.Builder(), target).build());
             } else {
-                TargetInfo target = new TargetInfo(owner, name, desc);
                 importRecord.registerMethodCall(filled(new RawAccessRecord.Builder(), target).build());
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -35,9 +35,12 @@ import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorReferenceTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
 import com.tngtech.archunit.core.domain.DomainObjectCreationContext;
 import com.tngtech.archunit.core.domain.Formatters;
 import com.tngtech.archunit.core.domain.InstanceofCheck;
@@ -47,6 +50,7 @@ import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaConstructorReference;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
@@ -54,6 +58,7 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.domain.JavaParameterizedType;
@@ -971,12 +976,32 @@ public final class DomainBuilders {
     }
 
     @Internal
+    public static final class JavaMethodReferenceBuilder extends JavaAccessBuilder<MethodReferenceTarget, JavaMethodReferenceBuilder> {
+        JavaMethodReferenceBuilder() {
+        }
+
+        JavaMethodReference build() {
+            return DomainObjectCreationContext.createJavaMethodReference(this);
+        }
+    }
+
+    @Internal
     public static class JavaConstructorCallBuilder extends JavaAccessBuilder<ConstructorCallTarget, JavaConstructorCallBuilder> {
         JavaConstructorCallBuilder() {
         }
 
         JavaConstructorCall build() {
             return DomainObjectCreationContext.createJavaConstructorCall(this);
+        }
+    }
+
+    @Internal
+    public static class JavaConstructorReferenceBuilder extends JavaAccessBuilder<ConstructorReferenceTarget, JavaConstructorReferenceBuilder> {
+        JavaConstructorReferenceBuilder() {
+        }
+
+        JavaConstructorReference build() {
+            return DomainObjectCreationContext.createJavaConstructorReference(this);
         }
     }
 
@@ -1062,21 +1087,21 @@ public final class DomainBuilders {
     }
 
     @Internal
-    public static class CodeUnitCallTargetBuilder<CODE_UNIT extends JavaCodeUnit, ACCESS_TARGET extends AccessTarget.CodeUnitCallTarget>
-            extends AccessTargetBuilder<CODE_UNIT, ACCESS_TARGET, CodeUnitCallTargetBuilder<CODE_UNIT, ACCESS_TARGET>> {
+    public static class CodeUnitAccessTargetBuilder<CODE_UNIT extends JavaCodeUnit, ACCESS_TARGET extends CodeUnitAccessTarget>
+            extends AccessTargetBuilder<CODE_UNIT, ACCESS_TARGET, CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET>> {
         private List<JavaClass> parameters;
         private JavaClass returnType;
 
-        private CodeUnitCallTargetBuilder(Function<CodeUnitCallTargetBuilder<CODE_UNIT, ACCESS_TARGET>, ACCESS_TARGET> createTarget) {
+        private CodeUnitAccessTargetBuilder(Function<CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET>, ACCESS_TARGET> createTarget) {
             super(createTarget);
         }
 
-        CodeUnitCallTargetBuilder<CODE_UNIT, ACCESS_TARGET> withParameters(final List<JavaClass> parameters) {
+        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withParameters(final List<JavaClass> parameters) {
             this.parameters = parameters;
             return self();
         }
 
-        CodeUnitCallTargetBuilder<CODE_UNIT, ACCESS_TARGET> withReturnType(final JavaClass returnType) {
+        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withReturnType(final JavaClass returnType) {
             this.returnType = returnType;
             return self();
         }
@@ -1094,27 +1119,51 @@ public final class DomainBuilders {
         }
     }
 
-    public static CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget> newConstructorCallTargetBuilder() {
-        return new CodeUnitCallTargetBuilder<>(CREATE_CONSTRUCTOR_CALL_TARGET).withName(CONSTRUCTOR_NAME);
+    public static CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget> newConstructorCallTargetBuilder() {
+        return new CodeUnitAccessTargetBuilder<>(CREATE_CONSTRUCTOR_CALL_TARGET).withName(CONSTRUCTOR_NAME);
     }
 
-    public static CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget> newMethodCallTargetBuilder() {
-        return new CodeUnitCallTargetBuilder<>(CREATE_METHOD_CALL_TARGET);
+    public static CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget> newConstructorReferenceTargetBuilder() {
+        return new CodeUnitAccessTargetBuilder<>(CREATE_CONSTRUCTOR_REFERENCE_TARGET).withName(CONSTRUCTOR_NAME);
     }
 
-    private static final Function<CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget>, ConstructorCallTarget> CREATE_CONSTRUCTOR_CALL_TARGET =
-            new Function<CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget>, ConstructorCallTarget>() {
+    public static CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget> newMethodCallTargetBuilder() {
+        return new CodeUnitAccessTargetBuilder<>(CREATE_METHOD_CALL_TARGET);
+    }
+
+    public static CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget> newMethodReferenceTargetBuilder() {
+        return new CodeUnitAccessTargetBuilder<>(CREATE_METHOD_REFERENCE_TARGET);
+    }
+
+    private static final Function<CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget>, ConstructorCallTarget> CREATE_CONSTRUCTOR_CALL_TARGET =
+            new Function<CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget>, ConstructorCallTarget>() {
                 @Override
-                public ConstructorCallTarget apply(CodeUnitCallTargetBuilder<JavaConstructor, ConstructorCallTarget> targetBuilder) {
+                public ConstructorCallTarget apply(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget> targetBuilder) {
                     return DomainObjectCreationContext.createConstructorCallTarget(targetBuilder);
                 }
             };
 
-    private static final Function<CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget>, MethodCallTarget> CREATE_METHOD_CALL_TARGET =
-            new Function<CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget>, MethodCallTarget>() {
+    private static final Function<CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget>, ConstructorReferenceTarget> CREATE_CONSTRUCTOR_REFERENCE_TARGET =
+            new Function<CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget>, ConstructorReferenceTarget>() {
                 @Override
-                public MethodCallTarget apply(CodeUnitCallTargetBuilder<JavaMethod, MethodCallTarget> targetBuilder) {
+                public ConstructorReferenceTarget apply(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget> targetBuilder) {
+                    return DomainObjectCreationContext.createConstructorReferenceTarget(targetBuilder);
+                }
+            };
+
+    private static final Function<CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget>, MethodCallTarget> CREATE_METHOD_CALL_TARGET =
+            new Function<CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget>, MethodCallTarget>() {
+                @Override
+                public MethodCallTarget apply(CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget> targetBuilder) {
                     return DomainObjectCreationContext.createMethodCallTarget(targetBuilder);
+                }
+            };
+
+    private static final Function<CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget>, MethodReferenceTarget> CREATE_METHOD_REFERENCE_TARGET =
+            new Function<CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget>, MethodReferenceTarget>() {
+                @Override
+                public MethodReferenceTarget apply(CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget> targetBuilder) {
+                    return DomainObjectCreationContext.createMethodReferenceTarget(targetBuilder);
                 }
             };
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -73,7 +73,7 @@ import static com.tngtech.archunit.core.domain.Formatters.ensureSimpleName;
 import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_ACCESSES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_ACCESSES_TO_SELF;
-import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CALLS_FROM_SELF;
+import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CODE_UNIT_CALLS_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CONSTRUCTORS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_CONSTRUCTOR_CALLS_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_DIRECT_DEPENDENCIES_FROM_SELF;
@@ -246,7 +246,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> callCodeUnitWhere(DescribedPredicate<? super JavaCall<?>> predicate) {
-        return new ClassAccessesCondition<>(predicate, GET_CALLS_FROM_SELF)
+        return new ClassAccessesCondition<>(predicate, GET_CODE_UNIT_CALLS_FROM_SELF)
                 .as("call code unit where " + predicate.getDescription());
     }
 
@@ -255,7 +255,7 @@ public final class ArchConditions {
         ChainableFunction<JavaCall<?>, CodeUnitCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaCodeUnit>forSubtype()).or(DescribedPredicate.<JavaCodeUnit>optionalEmpty()));
-        return new ClassOnlyAccessesCondition<>(callPredicate, GET_CALLS_FROM_SELF)
+        return new ClassOnlyAccessesCondition<>(callPredicate, GET_CODE_UNIT_CALLS_FROM_SELF)
                 .as("only call code units that " + predicate.getDescription());
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -172,7 +172,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyAccessFieldsThat(final DescribedPredicate<? super JavaField> predicate) {
         ChainableFunction<JavaFieldAccess, FieldAccessTarget> getTarget = JavaAccess.Functions.Get.target();
-        DescribedPredicate<JavaFieldAccess> accessPredicate = getTarget.then(FieldAccessTarget.Functions.RESOLVE)
+        DescribedPredicate<JavaFieldAccess> accessPredicate = getTarget.then(FieldAccessTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaField>forSubtype()).or(DescribedPredicate.<JavaField>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(accessPredicate, GET_FIELD_ACCESSES_FROM_SELF)
                 .as("only access fields that " + predicate.getDescription());
@@ -205,7 +205,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyCallMethodsThat(final DescribedPredicate<? super JavaMethod> predicate) {
         ChainableFunction<JavaMethodCall, MethodCallTarget> getTarget = JavaAccess.Functions.Get.target();
-        DescribedPredicate<JavaMethodCall> callPredicate = getTarget.then(MethodCallTarget.Functions.RESOLVE)
+        DescribedPredicate<JavaMethodCall> callPredicate = getTarget.then(MethodCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaMethod>forSubtype()).or(DescribedPredicate.<JavaMethod>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_METHOD_CALLS_FROM_SELF)
                 .as("only call methods that " + predicate.getDescription());
@@ -238,7 +238,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyCallConstructorsThat(final DescribedPredicate<? super JavaConstructor> predicate) {
         ChainableFunction<JavaConstructorCall, ConstructorCallTarget> getTarget = JavaAccess.Functions.Get.target();
-        DescribedPredicate<JavaConstructorCall> callPredicate = getTarget.then(ConstructorCallTarget.Functions.RESOLVE)
+        DescribedPredicate<JavaConstructorCall> callPredicate = getTarget.then(ConstructorCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaConstructor>forSubtype()).or(DescribedPredicate.<JavaConstructor>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CONSTRUCTOR_CALLS_FROM_SELF)
                 .as("only call constructors that " + predicate.getDescription());
@@ -253,7 +253,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyCallCodeUnitsThat(final DescribedPredicate<? super JavaCodeUnit> predicate) {
         ChainableFunction<JavaCall<?>, CodeUnitCallTarget> getTarget = JavaAccess.Functions.Get.target();
-        DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE)
+        DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaCodeUnit>forSubtype()).or(DescribedPredicate.<JavaCodeUnit>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CALLS_FROM_SELF)
                 .as("only call code units that " + predicate.getDescription());

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
@@ -298,12 +298,18 @@ public class AccessTargetTest {
     }
 
     private CodeUnitCallTarget getTarget(JavaClass javaClass, String targetName) {
-        for (JavaCall<?> call : javaClass.getCallsFromSelf()) {
+        for (JavaCall<?> call : getCodeUnitCallsFromSelf(javaClass)) {
             if (call.getTarget().getName().equals(targetName)) {
                 return call.getTarget();
             }
         }
         throw new AssertionError(String.format("Couldn't find target %s.%s", javaClass.getSimpleName(), targetName));
+    }
+
+    private Set<JavaCall<?>> getCodeUnitCallsFromSelf(JavaClass javaClass) {
+        Set<JavaCall<?>> result = javaClass.getCodeUnitCallsFromSelf();
+        assertThat(result).isEqualTo(javaClass.getCallsFromSelf());
+        return result;
     }
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AccessTargetTest.java
@@ -3,10 +3,15 @@ package com.tngtech.archunit.core.domain;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.AccessTarget.Predicates.constructor;
@@ -165,14 +170,66 @@ public class AccessTargetTest {
         assertDeclarations(target, FirstCheckedException.class, SecondCheckedException.class, ThirdCheckedException.class);
     }
 
+    private static class Data_function_resolve_member {
+        static class Target {
+            String field;
+
+            void method() {
+            }
+        }
+    }
+
     @Test
     public void function_resolve_member() {
-        CodeUnitCallTarget target = getTarget("diamondMethod");
+        class Origin {
+            String access() {
+                Data_function_resolve_member.Target target = new Data_function_resolve_member.Target();
+                target.method();
+                return target.field;
+            }
+        }
+        JavaClass targetClass = new ClassFileImporter().importClasses(Origin.class, Data_function_resolve_member.Target.class).get(Data_function_resolve_member.Target.class);
+        MethodCallTarget methodCallTarget = findTargetWithType(targetClass.getAccessesToSelf(), MethodCallTarget.class);
 
-        assertThat(AccessTarget.Functions.RESOLVE_MEMBER.apply(target))
-                .contains(target.resolveMember().get());
-        assertThat(AccessTarget.Functions.RESOLVE.apply(target))
-                .isEqualTo(ImmutableSet.of(target.resolveMember().get()));
+        assertThat(AccessTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(AccessTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        assertThat(CodeUnitCallTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(CodeUnitCallTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        assertThat(MethodCallTarget.Functions.RESOLVE_MEMBER.apply(methodCallTarget))
+                .contains(methodCallTarget.resolveMember().get());
+        assertThat(MethodCallTarget.Functions.RESOLVE.apply(methodCallTarget))
+                .isEqualTo(ImmutableSet.of(methodCallTarget.resolveMember().get()));
+
+        ConstructorCallTarget constructorCallTarget = findTargetWithType(targetClass.getAccessesToSelf(), ConstructorCallTarget.class);
+
+        assertThat(ConstructorCallTarget.Functions.RESOLVE_MEMBER.apply(constructorCallTarget))
+                .contains(constructorCallTarget.resolveMember().get());
+        assertThat(ConstructorCallTarget.Functions.RESOLVE.apply(constructorCallTarget))
+                .isEqualTo(ImmutableSet.of(constructorCallTarget.resolveMember().get()));
+
+        FieldAccessTarget fieldAccessTarget = findTargetWithType(targetClass.getAccessesToSelf(), FieldAccessTarget.class);
+
+        assertThat(FieldAccessTarget.Functions.RESOLVE_MEMBER.apply(fieldAccessTarget))
+                .contains(fieldAccessTarget.resolveMember().get());
+        assertThat(FieldAccessTarget.Functions.RESOLVE.apply(fieldAccessTarget))
+                .isEqualTo(ImmutableSet.of(fieldAccessTarget.resolveMember().get()));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends AccessTarget> T findTargetWithType(Set<JavaAccess<?>> set, Class<T> type) {
+        for (JavaAccess<?> access : set) {
+            if (type.isInstance(access.getTarget())) {
+                return (T) access.getTarget();
+            }
+        }
+        throw new AssertionError(String.format("Set %s does not contain element of type %s", set, type.getName()));
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -34,7 +34,6 @@ import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyO
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyTarget;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
-import static com.tngtech.archunit.core.domain.TestUtils.simulateCall;
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatDependencies;
@@ -79,16 +78,6 @@ public class DependencyTest {
         }
 
         assertThatDependencies(dependencies).containOnly(expectedDependencies);
-    }
-
-    @Test
-    public void Dependency_from_access() {
-        JavaMethodCall call = simulateCall().from(getClass(), "toString").to(Object.class, "toString");
-
-        Dependency dependency = getOnlyElement(Dependency.tryCreateFromAccess(call));
-        assertThatType(dependency.getTargetClass()).as("target class").isEqualTo(call.getTargetOwner());
-        assertThat(dependency.getDescription())
-                .as("description").isEqualTo(call.getDescription());
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -1989,7 +1989,7 @@ public class JavaClassTest {
         }
     }
 
-    private static class DependencyConditionCreation {
+    static class DependencyConditionCreation {
         private final String descriptionPart;
 
         DependencyConditionCreation(String descriptionPart) {
@@ -2000,7 +2000,7 @@ public class JavaClassTest {
             return new Step2(origin);
         }
 
-        private class Step2 {
+        class Step2 {
             private final Class<?> origin;
             private final String originDescription;
 
@@ -2017,7 +2017,7 @@ public class JavaClassTest {
                 return new Step3(target, targetName);
             }
 
-            private class Step3 {
+            class Step3 {
                 private final Class<?> target;
                 private final String targetDescription;
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
@@ -30,6 +30,7 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.testexamples.callimport.CallsExternalMethod;
 import com.tngtech.archunit.core.importer.testexamples.callimport.CallsMethodReturningArray;
 import com.tngtech.archunit.core.importer.testexamples.callimport.CallsOtherConstructor;
@@ -91,6 +92,7 @@ import static com.tngtech.archunit.core.domain.TestUtils.asClasses;
 import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
 import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.findAnyByName;
 import static com.tngtech.archunit.core.importer.ClassFileImporterTestUtils.getByName;
+import static com.tngtech.archunit.core.importer.DomainBuilders.newMethodCallTargetBuilder;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
@@ -338,11 +340,11 @@ public class ClassFileImporterAccessesTest {
 
         assertThat(accesses).hasSize(2);
         JavaField field = superclassWithAccessedField.getField("field");
-        FieldAccessTarget expectedSuperclassFieldAccess = new DomainBuilders.FieldAccessTargetBuilder()
+        FieldAccessTarget expectedSuperclassFieldAccess = new FieldAccessTargetBuilder()
                 .withOwner(subClassWithAccessedField)
                 .withName(field.getName())
                 .withType(field.getRawType())
-                .withField(Suppliers.ofInstance(Optional.of(field)))
+                .withMember(Suppliers.ofInstance(Optional.of(field)))
                 .build();
         assertThatAccess(getOnly(accesses, "field", GET))
                 .isFrom("accessSuperclassField")
@@ -398,12 +400,12 @@ public class ClassFileImporterAccessesTest {
         JavaCodeUnit callSuperclassMethod = classThatCallsMethodOfSuperclass
                 .getCodeUnitWithParameterTypes(CallOfSuperAndSubclassMethod.callSuperclassMethod);
         JavaMethod expectedSuperclassMethod = superclassWithCalledMethod.getMethod(SuperclassWithCalledMethod.method);
-        AccessTarget.MethodCallTarget expectedSuperclassCall = new DomainBuilders.MethodCallTargetBuilder()
+        AccessTarget.MethodCallTarget expectedSuperclassCall = newMethodCallTargetBuilder()
                 .withOwner(subClassWithCalledMethod)
                 .withName(expectedSuperclassMethod.getName())
                 .withParameters(expectedSuperclassMethod.getRawParameterTypes())
                 .withReturnType(expectedSuperclassMethod.getRawReturnType())
-                .withMethod(Suppliers.ofInstance(Optional.of(expectedSuperclassMethod)))
+                .withMember(Suppliers.ofInstance(Optional.of(expectedSuperclassMethod)))
                 .build();
         assertThatCall(getOnlyByCaller(calls, callSuperclassMethod))
                 .isFrom(callSuperclassMethod)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitAccessTarget;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
@@ -976,10 +976,10 @@ public class ClassFileImporterTest {
         };
     }
 
-    private Condition<MethodCallTarget> targetWithFullName(final String name) {
-        return new Condition<MethodCallTarget>(String.format("target with name '%s'", name)) {
+    private Condition<CodeUnitAccessTarget> targetWithFullName(final String name) {
+        return new Condition<CodeUnitAccessTarget>(String.format("target with name '%s'", name)) {
             @Override
-            public boolean matches(MethodCallTarget value) {
+            public boolean matches(CodeUnitAccessTarget value) {
                 return value.getFullName().equals(name);
             }
         };

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -40,12 +40,15 @@ import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 import org.objectweb.asm.Type;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+import static com.tngtech.archunit.core.importer.DomainBuilders.newConstructorCallTargetBuilder;
+import static com.tngtech.archunit.core.importer.DomainBuilders.newMethodCallTargetBuilder;
 
 public class ImportTestUtils {
 
@@ -224,30 +227,30 @@ public class ImportTestUtils {
     }
 
     public static AccessTarget.ConstructorCallTarget targetFrom(JavaConstructor target) {
-        return new DomainBuilders.ConstructorCallTargetBuilder()
+        return newConstructorCallTargetBuilder()
                 .withOwner(target.getOwner())
                 .withParameters(target.getRawParameterTypes())
                 .withReturnType(target.getRawReturnType())
-                .withConstructor(Suppliers.ofInstance(Optional.of(target)))
+                .withMember(Suppliers.ofInstance(Optional.of(target)))
                 .build();
     }
 
     public static AccessTarget.FieldAccessTarget targetFrom(JavaField field) {
-        return new DomainBuilders.FieldAccessTargetBuilder()
+        return new FieldAccessTargetBuilder()
                 .withOwner(field.getOwner())
                 .withName(field.getName())
                 .withType(field.getRawType())
-                .withField(Suppliers.ofInstance(Optional.of(field)))
+                .withMember(Suppliers.ofInstance(Optional.of(field)))
                 .build();
     }
 
     public static MethodCallTarget targetFrom(JavaMethod target, Supplier<Optional<JavaMethod>> resolveSupplier) {
-        return new DomainBuilders.MethodCallTargetBuilder()
+        return newMethodCallTargetBuilder()
                 .withOwner(target.getOwner())
                 .withName(target.getName())
                 .withParameters(target.getRawParameterTypes())
                 .withReturnType(target.getRawReturnType())
-                .withMethod(resolveSupplier)
+                .withMember(resolveSupplier)
                 .build();
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -30,12 +30,14 @@ import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaConstructorReference;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
@@ -440,6 +442,16 @@ public class ImportTestUtils {
 
         @Override
         public Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit) {
             return Collections.emptySet();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenThatIsTestedConsistentlyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenThatIsTestedConsistentlyTest.java
@@ -4,10 +4,10 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaMethod;
-import com.tngtech.archunit.core.domain.JavaMethodCall;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,8 +33,8 @@ public class GivenThatIsTestedConsistentlyTest {
     }
 
     private void assertAccessFrom(JavaClass test, JavaMethod method) {
-        for (JavaMethodCall call : method.getAccessesToSelf()) {
-            if (call.getOriginOwner().equals(test)) {
+        for (JavaAccess<?> access : method.getAccessesToSelf()) {
+            if (access.getOriginOwner().equals(test)) {
                 return;
             }
         }


### PR DESCRIPTION
This will add a way to detect method references (e.g. `SomeClass::call`) and constructor references (e.g. `SomeClass::new`) within classes. Detecting this is quite challenging because it is hidden behind a `invokeDynamic` instruction in the bytecode. And `invokeDynamic` in turn can be used for many more things than method/constructor references. The way we can detect this is the following:

* analyse `invokeDynamic` instructions within the bytecode by hooking into ASM's `visitInvokeDynamicInsn`
* look for any instructions that target the JDK's `LambdaMetafactory` as a bootstrap method owner
* if the second argument of the bootstrap method on the metafactory is a method handle it is a candidate for a method reference (this seems to be always the way, by convention)
* at this point we have two possibilities: a) the candidate is a method/constructor reference or b) it is a synthetic lambda method (this is a static method the compiler generates whenever a lambda, e.g. `() -> foo + bar`, is declared)
* if the method is not a lambda method (we can detect this by a naming convention, e.g. the method is called sth. like `lambda$someName$0`) we found a method/constructor reference

We introduced a new domain object hierarchy branch, i.e.

```
                               /-- JavaMethodCall
                   /-- JavaCall
                  /            \-- JavaConstructorCall
JavaCodeUnitAccess
                  \                         /-- JavaMethodReference
                   \-- JavaCodeUnitReference
                                            \-- JavaConstructorReference
```

The reason is that each level of the hierarchy might be interesting for users and provide value. A user might be interested in any access to any code unit (e.g. check all parameters of any code unit that has been targeted, be it a method call or a constructor reference, etc.). They might also be interested in any real call of a method/constructor (after all, a reference doesn't mean this method is really called at that moment, in the end we only define a pointer to a method, not call it). Or they might be interested to see only references to declare some assertions which methods/constructors may be referenced. Thus, we decided it makes sense to expose each of these domain objects from the public API.

Note that by integrating references into the domain object hierarchy of `JavaAccess` we automatically have all references also registered as dependencies (i.e. getting picked up by `layeredArchitecture()` and similar).