### PR TITLE
change log statement `Analyzing...` in `JavaClassProcessor`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -94,7 +94,7 @@ class JavaClassProcessor extends ClassVisitor {
 
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-        LOG.debug("Analyzing class '{}'", name);
+        LOG.debug("Processing class '{}'", name);
         JavaClassDescriptor descriptor = JavaClassDescriptorImporter.createFromAsmObjectTypeName(name);
         if (alreadyImported(descriptor)) {
             return;


### PR DESCRIPTION
as it seems to confuse some users, because it is unrelated to `@AnalyzeClasses` and only refers to the actual files the importer processes during the class import.

See https://github.com/TNG/ArchUnit/pull/291#issuecomment-896969120

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>