### PR TITLE
Improve release process

### DIFF
--- a/build-steps/release/check-uploaded-artifacts.gradle
+++ b/build-steps/release/check-uploaded-artifacts.gradle
@@ -136,6 +136,7 @@ task checkUploadedArtifacts {
     }
 }
 closeSonatypeStagingRepository.finalizedBy(checkUploadedArtifacts)
+releaseSonatypeStagingRepository.dependsOn(checkUploadedArtifacts)
 
 releaseProjects.each { Project project ->
     def task = project.task(['dependsOn': project.build], 'checkArtifact') {
@@ -198,3 +199,4 @@ task testRelease() {
     }
 }
 closeSonatypeStagingRepository.finalizedBy(testRelease)
+releaseSonatypeStagingRepository.dependsOn(testRelease)

--- a/release/release.sh
+++ b/release/release.sh
@@ -53,9 +53,5 @@ echo Publishing website and examples...
 
 echo Committing new SNAPSHOT version
 git add -A
-git commit -m "set next SNAPSHOT version"
-
-releaseBranch="$(git rev-parse --abbrev-ref HEAD)"
-git checkout main
-git merge "$releaseBranch"
-git push
+git commit -s -m "set next SNAPSHOT version"
+git push origin "$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
Two more improvements:

* don't automatically merge back into `main`, since this branch is protected -> we will need to create a PR here
* make `releaseStagingRepository` tasks dependent on release artifact checks to ensure the correct order of execution