### PR TITLE
fix memory leak in `ArchUnitTestDescriptor`

### DIFF
--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Suppliers.memoize;
 import static com.tngtech.archunit.junit.ArchTestInitializationException.WRAP_CAUSE;
 import static com.tngtech.archunit.junit.DisplayNameResolver.determineDisplayName;
 import static com.tngtech.archunit.junit.ReflectionUtils.getAllFields;
@@ -80,8 +79,7 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
 
     @Override
     public void createChildren(ElementResolver resolver) {
-        Supplier<JavaClasses> classes =
-                memoize(() -> classCache.getClassesToAnalyzeFor(testClass, new JUnit5ClassAnalysisRequest(testClass)))::get;
+        Supplier<JavaClasses> classes = () -> classCache.getClassesToAnalyzeFor(testClass, new JUnit5ClassAnalysisRequest(testClass));
 
         getAllFields(testClass, withAnnotation(ArchTest.class))
                 .forEach(field -> resolveField(resolver, classes, field));


### PR DESCRIPTION
The JUnit platform keeps a reference to all test descriptors during the whole test run. `Suppliers.memoize(..)` in turn keeps a reference to the instantiated object once called. Altogether this meant that during the test run, no matter what `CacheMode` was selected, a reference to all classes imported for a given rule was kept through the whole test run.
Since the `memoize` actually makes no sense anyway (why memoize the result of a cache call which is in itself already optimized for repeated access?) I simply removed it and when testing locally this seems to solve the memory leak reported.

Resolves: #695
Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>