### PR TITLE
move `JavaCodeUnit.Parameter` to toplevel `JavaParameter`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -177,8 +177,8 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
             JavaClass clazz = (JavaClass) originCandidate;
             return new Origin(clazz, clazz.getDescription());
         }
-        if (originCandidate instanceof JavaCodeUnit.Parameter) {
-            JavaCodeUnit.Parameter parameter = (JavaCodeUnit.Parameter) originCandidate;
+        if (originCandidate instanceof JavaParameter) {
+            JavaParameter parameter = (JavaParameter) originCandidate;
             return new Origin(parameter.getOwner().getOwner(), parameter.getDescription());
         }
         throw new IllegalStateException("Could not find suitable dependency origin for " + dependencyCause);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -15,18 +15,14 @@
  */
 package com.tngtech.archunit.core.domain;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
@@ -34,27 +30,15 @@ import com.tngtech.archunit.base.ForwardingList;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.MayResolveTypesViaReflection;
 import com.tngtech.archunit.core.ResolvesTypesViaReflection;
-import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
-import com.tngtech.archunit.core.domain.properties.HasAnnotations;
-import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasParameterTypes;
 import com.tngtech.archunit.core.domain.properties.HasReturnType;
 import com.tngtech.archunit.core.domain.properties.HasThrowsClause;
-import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.core.domain.properties.HasTypeParameters;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaCodeUnitBuilder;
-import com.tngtech.archunit.core.importer.DomainBuilders.JavaCodeUnitBuilder.ParameterAnnotationsBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
-import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
-import static com.tngtech.archunit.base.Guava.toGuava;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
-import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Utils.toAnnotationOfType;
-import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
-import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 
 /**
  * Represents a unit of code containing accesses to other units of code. A unit of code can be
@@ -139,7 +123,7 @@ public abstract class JavaCodeUnit
     }
 
     /**
-     * @return the {@link Parameter parameters} of this {@link JavaCodeUnit}. On the contrary to the Reflection API this will only contain
+     * @return the {@link JavaParameter parameters} of this {@link JavaCodeUnit}. On the contrary to the Reflection API this will only contain
      *         the parameters from the signature and not synthetic parameters, if the signature is generic. In these cases
      *         {@link #getParameters()}{@code .size()} will always be equal to {@link #getParameterTypes()}{@code .size()},
      *         but not necessarily to {@link #getRawParameterTypes()}{@code .size()} in case the compiler adds synthetic parameters.<br>
@@ -151,7 +135,7 @@ public abstract class JavaCodeUnit
      * @see #getParameterTypes()
      */
     @PublicAPI(usage = ACCESS)
-    public List<Parameter> getParameters() {
+    public List<JavaParameter> getParameters() {
         return parameters;
     }
 
@@ -249,7 +233,7 @@ public abstract class JavaCodeUnit
     }
 
     @PublicAPI(usage = ACCESS)
-    public List<Set<JavaAnnotation<Parameter>>> getParameterAnnotations() {
+    public List<Set<JavaAnnotation<JavaParameter>>> getParameterAnnotations() {
         return parameters.getAnnotations();
     }
 
@@ -269,137 +253,11 @@ public abstract class JavaCodeUnit
         return result.toArray(new Class<?>[0]);
     }
 
-    /**
-     * A parameter of a {@link JavaCodeUnit}, i.e. encapsulates the raw parameter type, the (possibly) generic
-     * parameter type and any annotations this parameter has.
-     */
-    @PublicAPI(usage = ACCESS)
-    public static final class Parameter implements HasType, HasOwner<JavaCodeUnit>, HasAnnotations<Parameter> {
-        private static final ChainableFunction<HasType, String> GET_ANNOTATION_TYPE_NAME = GET_RAW_TYPE.then(GET_NAME);
-        private static final Function<HasType, String> GUAVA_GET_ANNOTATION_TYPE_NAME = toGuava(GET_ANNOTATION_TYPE_NAME);
-
-        private final JavaCodeUnit owner;
-        private final int index;
-        private final JavaType type;
-        private final JavaClass rawType;
-        private final Map<String, JavaAnnotation<Parameter>> annotations;
-
-        private Parameter(JavaCodeUnit owner, ParameterAnnotationsBuilder builder, int index, JavaType type) {
-            this.owner = owner;
-            this.index = index;
-            this.type = type;
-            this.rawType = type.toErasure();
-            this.annotations = buildIndexedByTypeName(builder);
-        }
-
-        private Map<String, JavaAnnotation<Parameter>> buildIndexedByTypeName(ParameterAnnotationsBuilder builder) {
-            Set<JavaAnnotation<Parameter>> annotations = builder.build(this);
-            return Maps.uniqueIndex(annotations, GUAVA_GET_ANNOTATION_TYPE_NAME);
-        }
-
-        @Override
-        @PublicAPI(usage = ACCESS)
-        public JavaCodeUnit getOwner() {
-            return owner;
-        }
-
-        @PublicAPI(usage = ACCESS)
-        public int getIndex() {
-            return index;
-        }
-
-        @Override
-        @PublicAPI(usage = ACCESS)
-        public JavaType getType() {
-            return type;
-        }
-
-        @Override
-        @PublicAPI(usage = ACCESS)
-        public JavaClass getRawType() {
-            return rawType;
-        }
-
-        @Override
-        public boolean isAnnotatedWith(Class<? extends Annotation> annotationType) {
-            return annotations.containsKey(annotationType.getName());
-        }
-
-        @Override
-        public boolean isAnnotatedWith(String annotationTypeName) {
-            return annotations.containsKey(annotationTypeName);
-        }
-
-        @Override
-        public boolean isAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-            return anyElementThat(predicate).apply(annotations.values());
-        }
-
-        @Override
-        public boolean isMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
-            return isMetaAnnotatedWith(GET_RAW_TYPE.is(equivalentTo(annotationType)));
-        }
-
-        @Override
-        public boolean isMetaAnnotatedWith(String annotationTypeName) {
-            return isMetaAnnotatedWith(GET_ANNOTATION_TYPE_NAME.is(equalTo(annotationTypeName)));
-        }
-
-        @Override
-        public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-            return CanBeAnnotated.Utils.isMetaAnnotatedWith(annotations.values(), predicate);
-        }
-
-        @Override
-        public Set<JavaAnnotation<Parameter>> getAnnotations() {
-            return ImmutableSet.copyOf(annotations.values());
-        }
-
-        @Override
-        public <A extends Annotation> A getAnnotationOfType(Class<A> type) {
-            return getAnnotationOfType(type.getName()).as(type);
-        }
-
-        @Override
-        public JavaAnnotation<Parameter> getAnnotationOfType(String typeName) {
-            Optional<JavaAnnotation<Parameter>> annotation = tryGetAnnotationOfType(typeName);
-            if (!annotation.isPresent()) {
-                throw new IllegalArgumentException(String.format("%s is not annotated with @%s", getDescription(), typeName));
-            }
-            return annotation.get();
-        }
-
-        @Override
-        public <A extends Annotation> Optional<A> tryGetAnnotationOfType(Class<A> type) {
-            return tryGetAnnotationOfType(type.getName()).map(toAnnotationOfType(type));
-        }
-
-        @Override
-        public Optional<JavaAnnotation<Parameter>> tryGetAnnotationOfType(String typeName) {
-            return Optional.ofNullable(annotations.get(typeName));
-        }
-
-        @Override
-        @PublicAPI(usage = ACCESS)
-        public String getDescription() {
-            return "Parameter <" + type.getName() + "> of " + startWithLowercase(owner.getDescription());
-        }
-
-        @Override
-        public String toString() {
-            return "JavaParameter{owner='" + owner.getFullName() + "', index='" + index + "', type='" + type.getName() + "'}";
-        }
-
-        static String startWithLowercase(String string) {
-            return Character.toLowerCase(string.charAt(0)) + string.substring(1);
-        }
-    }
-
-    private static class Parameters extends ForwardingList<Parameter> {
+    private static class Parameters extends ForwardingList<JavaParameter> {
         private final List<JavaClass> rawParameterTypes;
         private final List<JavaType> parameterTypes;
-        private final List<Set<JavaAnnotation<Parameter>>> parameterAnnotations;
-        private final List<Parameter> parameters;
+        private final List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations;
+        private final List<JavaParameter> parameters;
 
         Parameters(JavaCodeUnit owner, JavaCodeUnitBuilder<?, ?> builder) {
             rawParameterTypes = builder.getRawParameterTypes();
@@ -408,18 +266,18 @@ public abstract class JavaCodeUnit
             parameterAnnotations = annotationsOf(parameters);
         }
 
-        private List<Set<JavaAnnotation<Parameter>>> annotationsOf(List<Parameter> parameters) {
-            ImmutableList.Builder<Set<JavaAnnotation<Parameter>>> result = ImmutableList.builder();
-            for (Parameter parameter : parameters) {
+        private List<Set<JavaAnnotation<JavaParameter>>> annotationsOf(List<JavaParameter> parameters) {
+            ImmutableList.Builder<Set<JavaAnnotation<JavaParameter>>> result = ImmutableList.builder();
+            for (JavaParameter parameter : parameters) {
                 result.add(parameter.getAnnotations());
             }
             return result.build();
         }
 
-        private static List<Parameter> createParameters(JavaCodeUnit owner, JavaCodeUnitBuilder<?, ?> builder, List<JavaType> parameterTypes) {
-            ImmutableList.Builder<Parameter> result = ImmutableList.builder();
+        private static List<JavaParameter> createParameters(JavaCodeUnit owner, JavaCodeUnitBuilder<?, ?> builder, List<JavaType> parameterTypes) {
+            ImmutableList.Builder<JavaParameter> result = ImmutableList.builder();
             for (int i = 0; i < parameterTypes.size(); i++) {
-                result.add(new Parameter(owner, builder.getParameterAnnotationsBuilder(i), i, parameterTypes.get(i)));
+                result.add(new JavaParameter(owner, builder.getParameterAnnotationsBuilder(i), i, parameterTypes.get(i)));
             }
             return result.build();
         }
@@ -437,12 +295,12 @@ public abstract class JavaCodeUnit
             return parameterTypes;
         }
 
-        List<Set<JavaAnnotation<Parameter>>> getAnnotations() {
+        List<Set<JavaAnnotation<JavaParameter>>> getAnnotations() {
             return parameterAnnotations;
         }
 
         @Override
-        protected List<Parameter> delegate() {
+        protected List<JavaParameter> delegate() {
             return parameters;
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameter.java
@@ -1,0 +1,152 @@
+package com.tngtech.archunit.core.domain;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.ChainableFunction;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.properties.HasAnnotations;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasType;
+import com.tngtech.archunit.core.importer.DomainBuilders;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
+import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
+import static com.tngtech.archunit.base.Guava.toGuava;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Utils.toAnnotationOfType;
+import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
+import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
+
+/**
+ * A parameter of a {@link JavaCodeUnit}, i.e. encapsulates the raw parameter type, the (possibly) generic
+ * parameter type and any annotations this parameter has.
+ */
+@PublicAPI(usage = ACCESS)
+public final class JavaParameter implements HasType, HasOwner<JavaCodeUnit>, HasAnnotations<JavaParameter> {
+    private static final ChainableFunction<HasType, String> GET_ANNOTATION_TYPE_NAME = GET_RAW_TYPE.then(GET_NAME);
+    private static final Function<HasType, String> GUAVA_GET_ANNOTATION_TYPE_NAME = toGuava(GET_ANNOTATION_TYPE_NAME);
+
+    private final JavaCodeUnit owner;
+    private final int index;
+    private final JavaType type;
+    private final JavaClass rawType;
+    private final Map<String, JavaAnnotation<JavaParameter>> annotations;
+
+    JavaParameter(JavaCodeUnit owner, DomainBuilders.JavaCodeUnitBuilder.ParameterAnnotationsBuilder builder, int index, JavaType type) {
+        this.owner = owner;
+        this.index = index;
+        this.type = type;
+        this.rawType = type.toErasure();
+        this.annotations = buildIndexedByTypeName(builder);
+    }
+
+    private Map<String, JavaAnnotation<JavaParameter>> buildIndexedByTypeName(DomainBuilders.JavaCodeUnitBuilder.ParameterAnnotationsBuilder builder) {
+        Set<JavaAnnotation<JavaParameter>> annotations = builder.build(this);
+        return Maps.uniqueIndex(annotations, GUAVA_GET_ANNOTATION_TYPE_NAME);
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaCodeUnit getOwner() {
+        return owner;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public int getIndex() {
+        return index;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaType getType() {
+        return type;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getRawType() {
+        return rawType;
+    }
+
+    @Override
+    public boolean isAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return annotations.containsKey(annotationType.getName());
+    }
+
+    @Override
+    public boolean isAnnotatedWith(String annotationTypeName) {
+        return annotations.containsKey(annotationTypeName);
+    }
+
+    @Override
+    public boolean isAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+        return anyElementThat(predicate).apply(annotations.values());
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return isMetaAnnotatedWith(GET_RAW_TYPE.is(equivalentTo(annotationType)));
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(String annotationTypeName) {
+        return isMetaAnnotatedWith(GET_ANNOTATION_TYPE_NAME.is(equalTo(annotationTypeName)));
+    }
+
+    @Override
+    public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+        return Utils.isMetaAnnotatedWith(annotations.values(), predicate);
+    }
+
+    @Override
+    public Set<JavaAnnotation<JavaParameter>> getAnnotations() {
+        return ImmutableSet.copyOf(annotations.values());
+    }
+
+    @Override
+    public <A extends Annotation> A getAnnotationOfType(Class<A> type) {
+        return getAnnotationOfType(type.getName()).as(type);
+    }
+
+    @Override
+    public JavaAnnotation<JavaParameter> getAnnotationOfType(String typeName) {
+        Optional<JavaAnnotation<JavaParameter>> annotation = tryGetAnnotationOfType(typeName);
+        if (!annotation.isPresent()) {
+            throw new IllegalArgumentException(String.format("%s is not annotated with @%s", getDescription(), typeName));
+        }
+        return annotation.get();
+    }
+
+    @Override
+    public <A extends Annotation> Optional<A> tryGetAnnotationOfType(Class<A> type) {
+        return tryGetAnnotationOfType(type.getName()).map(toAnnotationOfType(type));
+    }
+
+    @Override
+    public Optional<JavaAnnotation<JavaParameter>> tryGetAnnotationOfType(String typeName) {
+        return Optional.ofNullable(annotations.get(typeName));
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public String getDescription() {
+        return "Parameter <" + type.getName() + "> of " + startWithLowercase(owner.getDescription());
+    }
+
+    @Override
+    public String toString() {
+        return "JavaParameter{owner='" + owner.getFullName() + "', index='" + index + "', type='" + type.getName() + "'}";
+    }
+
+    static String startWithLowercase(String string) {
+        return Character.toLowerCase(string.charAt(0)) + string.substring(1);
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -54,6 +54,7 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.domain.JavaParameterizedType;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
@@ -378,8 +379,8 @@ public final class DomainBuilders {
                 this.importedClasses = importedClasses;
             }
 
-            public Set<JavaAnnotation<JavaCodeUnit.Parameter>> build(JavaCodeUnit.Parameter owner) {
-                ImmutableSet.Builder<JavaAnnotation<JavaCodeUnit.Parameter>> result = ImmutableSet.builder();
+            public Set<JavaAnnotation<JavaParameter>> build(JavaParameter owner) {
+                ImmutableSet.Builder<JavaAnnotation<JavaParameter>> result = ImmutableSet.builder();
                 for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : annotationBuilders) {
                     result.add(annotationBuilder.build(owner, importedClasses));
                 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -236,7 +236,7 @@ public class DependencyTest {
             }
         }
 
-        JavaCodeUnit.Parameter parameter = getOnlyElement(
+        JavaParameter parameter = getOnlyElement(
                 new ClassFileImporter().importClass(SomeClass.class)
                         .getMethod("method", Object.class).getParameters());
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
-import static com.tngtech.archunit.core.domain.JavaCodeUnit.Parameter.startWithLowercase;
+import static com.tngtech.archunit.core.domain.JavaParameter.startWithLowercase;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
@@ -158,7 +158,7 @@ public class JavaCodeUnitTest {
     @Test
     @UseDataProvider("code_units_with_four_different_parameters")
     public void adds_description_to_parameters_of_code_unit(JavaCodeUnit codeUnit) {
-        List<JavaCodeUnit.Parameter> parameters = codeUnit.getParameters();
+        List<JavaParameter> parameters = codeUnit.getParameters();
 
         assertThat(parameters.get(0).getDescription()).isEqualTo("Parameter <" + List.class.getName() + "<" + String.class.getName() + ">> of " + startWithLowercase(codeUnit.getDescription()));
         assertThat(parameters.get(1).getDescription()).isEqualTo("Parameter <T> of " + startWithLowercase(codeUnit.getDescription()));
@@ -169,7 +169,7 @@ public class JavaCodeUnitTest {
     @Test
     @UseDataProvider("code_units_with_four_different_parameters")
     public void adds_index_to_parameters_of_code_unit(JavaCodeUnit codeUnit) {
-        List<JavaCodeUnit.Parameter> parameters = codeUnit.getParameters();
+        List<JavaParameter> parameters = codeUnit.getParameters();
 
         assertThat(parameters.get(0).getIndex()).isEqualTo(0);
         assertThat(parameters.get(1).getIndex()).isEqualTo(1);
@@ -196,7 +196,7 @@ public class JavaCodeUnitTest {
     @Test
     @UseDataProvider
     public void test_adds_owner_to_parameters_of_code_unit(JavaCodeUnit codeUnit) {
-        for (JavaCodeUnit.Parameter parameter : codeUnit.getParameters()) {
+        for (JavaParameter parameter : codeUnit.getParameters()) {
             assertThat(parameter.getOwner()).isEqualTo(codeUnit);
         }
     }
@@ -209,7 +209,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        JavaCodeUnit.Parameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         assertThat(parameter.isAnnotatedWith(SomeParameterAnnotation.class))
@@ -236,7 +236,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        JavaCodeUnit.Parameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         assertThat(parameter.isMetaAnnotatedWith(SomeMetaAnnotation.class))
@@ -263,7 +263,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        final JavaCodeUnit.Parameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        final JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         SomeParameterAnnotation annotation = parameter.getAnnotationOfType(SomeParameterAnnotation.class);
@@ -276,7 +276,7 @@ public class JavaCodeUnitTest {
             }
         }).isInstanceOf(IllegalArgumentException.class);
 
-        JavaAnnotation<JavaCodeUnit.Parameter> javaAnnotation = parameter.getAnnotationOfType(SomeParameterAnnotation.class.getName());
+        JavaAnnotation<JavaParameter> javaAnnotation = parameter.getAnnotationOfType(SomeParameterAnnotation.class.getName());
         assertThatAnnotation(javaAnnotation).hasType(SomeParameterAnnotation.class);
         assertThat(javaAnnotation.get("value")).contains("test");
         assertThatThrownBy(new ThrowingCallable() {
@@ -295,7 +295,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        final JavaCodeUnit.Parameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        final JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         assertThat(parameter.tryGetAnnotationOfType(SomeParameterAnnotation.class).get()).isInstanceOf(SomeParameterAnnotation.class);

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -13,11 +13,11 @@ import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassAnnotationWithArrays;
@@ -453,11 +453,11 @@ public class ClassFileImporterAnnotationsTest {
                 .get(ClassWithMethodWithAnnotatedParameters.class)
                 .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoUnannotatedParameters, String.class, int.class);
 
-        for (JavaCodeUnit.Parameter parameter : method.getParameters()) {
+        for (JavaParameter parameter : method.getParameters()) {
             assertThat(parameter.getAnnotations()).isEmpty();
         }
         assertThat(method.getParameterAnnotations()).containsExactly(
-                Collections.<JavaAnnotation<JavaCodeUnit.Parameter>>emptySet(), Collections.<JavaAnnotation<JavaCodeUnit.Parameter>>emptySet());
+                Collections.<JavaAnnotation<JavaParameter>>emptySet(), Collections.<JavaAnnotation<JavaParameter>>emptySet());
     }
 
     @Test
@@ -466,10 +466,10 @@ public class ClassFileImporterAnnotationsTest {
                 .get(ClassWithMethodWithAnnotatedParameters.class)
                 .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithOneAnnotation, String.class);
 
-        List<Set<JavaAnnotation<JavaCodeUnit.Parameter>>> parameterAnnotations = method.getParameterAnnotations();
+        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
 
-        JavaCodeUnit.Parameter parameter = getOnlyElement(method.getParameters());
-        JavaAnnotation<JavaCodeUnit.Parameter> annotation = getOnlyElement(getOnlyElement(parameterAnnotations));
+        JavaParameter parameter = getOnlyElement(method.getParameters());
+        JavaAnnotation<JavaParameter> annotation = getOnlyElement(getOnlyElement(parameterAnnotations));
 
         assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
         assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
@@ -505,9 +505,9 @@ public class ClassFileImporterAnnotationsTest {
                 .get(ClassWithMethodWithAnnotatedParameters.class)
                 .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithTwoAnnotations, String.class);
 
-        List<Set<JavaAnnotation<JavaCodeUnit.Parameter>>> parameterAnnotations = method.getParameterAnnotations();
+        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
 
-        Set<JavaAnnotation<JavaCodeUnit.Parameter>> annotations = getOnlyElement(parameterAnnotations);
+        Set<JavaAnnotation<JavaParameter>> annotations = getOnlyElement(parameterAnnotations);
 
         assertThat(annotations).isEqualTo(getOnlyElement(method.getParameters()).getAnnotations());
         assertThatAnnotations(annotations).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[0]));
@@ -519,9 +519,9 @@ public class ClassFileImporterAnnotationsTest {
                 .get(ClassWithMethodWithAnnotatedParameters.class)
                 .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoAnnotatedParameters, String.class, int.class);
 
-        List<Set<JavaAnnotation<JavaCodeUnit.Parameter>>> parameterAnnotations = method.getParameterAnnotations();
+        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
 
-        List<JavaCodeUnit.Parameter> parameters = method.getParameters();
+        List<JavaParameter> parameters = method.getParameters();
         for (int i = 0; i < 2; i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
             assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[i]));
@@ -534,14 +534,14 @@ public class ClassFileImporterAnnotationsTest {
                 .get(ClassWithMethodWithAnnotatedParameters.class)
                 .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithAnnotatedParametersGap, String.class, int.class, Object.class, List.class);
 
-        List<Set<JavaAnnotation<JavaCodeUnit.Parameter>>> parameterAnnotations = method.getParameterAnnotations();
+        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
 
         assertThatAnnotations(parameterAnnotations.get(0)).isNotEmpty();
         assertThatAnnotations(parameterAnnotations.get(1)).isEmpty();
         assertThatAnnotations(parameterAnnotations.get(2)).isEmpty();
         assertThatAnnotations(parameterAnnotations.get(3)).isNotEmpty();
 
-        List<JavaCodeUnit.Parameter> parameters = method.getParameters();
+        List<JavaParameter> parameters = method.getParameters();
         for (int i = 0; i < 4; i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
             assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[i]));
@@ -560,13 +560,13 @@ public class ClassFileImporterAnnotationsTest {
                 .get(LocalClassThusSyntheticFirstConstructorParameter.class)
                 .getConstructors());
 
-        List<Set<JavaAnnotation<JavaCodeUnit.Parameter>>> parameterAnnotations = constructor.getParameterAnnotations();
+        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = constructor.getParameterAnnotations();
 
         assertThat(parameterAnnotations).as("parameter annotations").hasSize(2);
         assertThatAnnotations(parameterAnnotations.get(0)).isEmpty();
         assertThatAnnotations(parameterAnnotations.get(1)).isNotEmpty();
 
-        List<JavaCodeUnit.Parameter> parameters = constructor.getParameters();
+        List<JavaParameter> parameters = constructor.getParameters();
         for (int i = 0; i < parameterAnnotations.size(); i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
             assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(constructor.reflect().getParameterAnnotations()[i]));


### PR DESCRIPTION
Originally I decided for `JavaCodeUnit.Parameter` because
* the concept is very closely related to `JavaCodeUnit`
* as a nested class it would enable to import as `Parameter` in a clear narrow scope or as `JavaCodeUnit.Parameter` in a wider scope
* I considered "parameter" alone to be too generic as a name

However, I have now decided to name it `JavaParameter` after all. The reason is simply, that it is consistent with the Reflection API. And since we followed this philosophy with most other classes (`Class` -> `JavaClass`, `Method` -> `JavaMethod`, ...) I consider this to be the way of least surprise. Which in the end is one of the most important guiding principles we should follow.

Resolves: #706

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>