### PR TITLE
fix ambiguous/wrong origins for calls from bridge methods

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2021 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.tngtech.archunit.core.domain;
 
 import java.lang.annotation.Annotation;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -363,7 +363,7 @@ class ClassGraphCreator implements ImportContext {
 
         CodeUnit codeUnit = enclosingCodeUnit.get();
         JavaClass enclosingClass = classes.getOrResolve(codeUnit.getDeclaringClassName());
-        return enclosingClass.tryGetCodeUnitWithParameterTypeNames(codeUnit.getName(), codeUnit.getParameters());
+        return enclosingClass.tryGetCodeUnitWithParameterTypeNames(codeUnit.getName(), codeUnit.getRawParameterTypeNames());
     }
 
     @Override


### PR DESCRIPTION
Originally we assumed that comparing declaring class, method name and parameter type names would be good enough to identify the caller of a method, since the compiler does not allow to declare two methods with the same name and parameter types inside the same class. However, the compiler might add methods with the same name and parameter types in certain cases (bridge methods).
Consider

```
class Parent {
  Object method() {
    return null;
  }
}

class Child extends Parent {
  @Override
  String method() {
    return null;
  }
}
```

To implement covariant return types (the child overriding the method using a subtype as return type) the compiler transparently adds a so-called "bridge method" that has the original type as return type (i.e. overrides 1-2-1) and simply forwards to the one with the subtype as return type.
We now take the full descriptor (containing parameter types and return types) to match the origin of a caller. By that the ambiguity is resolved, since the descriptor/full signature actually has to be unique.

Resolves: #513