### PR TITLE
Resolve call targets like Reflection API

### DIFF
--- a/archunit/src/jdk15test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesNewerJavaVersionTest.java
+++ b/archunit/src/jdk15test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesNewerJavaVersionTest.java
@@ -1,0 +1,87 @@
+package com.tngtech.archunit.core.importer;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.ChildOverridesAllMethods;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.DeterminesMethodAnalogouslyToReflectionApi;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.ExpectedMethod;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.LeftAncestorPrecedesRightAncestor;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.OnlyDefinedInCommonAncestor;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.OnlyLeftAncestorOverridesRootMethod;
+import com.tngtech.archunit.core.importer.testexamples.methodresolution.OnlyRightAncestorOverridesRootMethod;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterAccessesNewerJavaVersionTest {
+
+    @DataProvider
+    public static Object[][] method_resolution_scenarios() {
+        return testForEach(
+                OnlyDefinedInCommonAncestor.class,
+                OnlyLeftAncestorOverridesRootMethod.class,
+                OnlyRightAncestorOverridesRootMethod.class,
+                LeftAncestorPrecedesRightAncestor.class,
+                ChildOverridesAllMethods.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftLeftHasPrecedence.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftRightHasPrecedenceOverRight.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.RightLeftHasPrecedenceOverRightRight.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.RightRightIsPickedIfThereIsNoAlternative.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftOverriddenHasPrecedenceOverParents.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.RightOverriddenHasPrecedenceOverParents.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftLeftHasPrecedenceOverOverriddenRight.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftRightHasPrecedenceOverOverriddenRight.class,
+                DeterminesMethodAnalogouslyToReflectionApi.EquivalentMethodsAreChosenDepthFirst.LeftOverriddenHasPrecedenceOverRightOverridden.class,
+                DeterminesMethodAnalogouslyToReflectionApi.ClassHasPrecedenceOverInterface.ParentClassHasPrecedenceOverChildInterfaces.class,
+                DeterminesMethodAnalogouslyToReflectionApi.ClassHasPrecedenceOverInterface.GrandParentClassHasPrecedenceOverChildInterfaces.class,
+                DeterminesMethodAnalogouslyToReflectionApi.InterfaceOnParentHasPrecedenceOverInterfaceOnChild.LeftLeftOnGrandparentHasPrecedenceOverAllOthers.class,
+                DeterminesMethodAnalogouslyToReflectionApi.InterfaceOnParentHasPrecedenceOverInterfaceOnChild.LeftRightOnGrandparentHasPrecedenceOverLeftOnParent.class,
+                DeterminesMethodAnalogouslyToReflectionApi.InterfaceOnParentHasPrecedenceOverInterfaceOnChild.RightLeftOnGrandparentHasPrecedenceOverLeftAndRightOnParent.class,
+                DeterminesMethodAnalogouslyToReflectionApi.InterfaceOnParentHasPrecedenceOverInterfaceOnChild.RightRightOnGrandparentHasPrecedenceOverLeftAndRightOnParent.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.RightWithMoreSpecificReturnOnParentTypeHasPrecedenceOverAllOthers.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.LeftWithMoreSpecificReturnTypeHasPrecedenceRightWithMoreSpecificReturnType.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.ParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllOthers.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.InterfaceWithMoreSpecificReturnTypeHasPrecedenceOverGrandParentClass.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.ParentInterfaceOnParentClassWithMoreSpecificReturnTypeHasPrecedenceOverGrandParentClass.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllOthers.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverFirstParentInterfaceWithMoreSpecificReturnType.class,
+                DeterminesMethodAnalogouslyToReflectionApi.MoreSpecificReturnTypeHasPrecedence.GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllParentInterfacesWithMoreSpecificReturnType.class,
+                DeterminesMethodAnalogouslyToReflectionApi.StaticMethodsInInterfacesAreIgnored.class
+        );
+    }
+
+    @Test
+    @UseDataProvider("method_resolution_scenarios")
+    public void resolves_method_call_targets(Class<?> scenario) throws NoSuchMethodException {
+        JavaMethod origin = new ClassFileImporter().importPackagesOf(scenario).get(scenario).getMethod("scenario");
+
+        MethodCallTarget target = getOnlyElement(origin.getMethodCallsFromSelf()).getTarget();
+
+        Method methodWithAnnotation = findMethodWithAnnotation(scenario, ExpectedMethod.class);
+        // Sanity check that the expected method really is the one that would be found via Reflection, too
+        assertThat(target.getOwner().reflect().getMethod(target.getName())).as("Method resolved via Reflection").isEqualTo(methodWithAnnotation);
+
+        assertThat(target.resolveMember().get()).isEquivalentTo(methodWithAnnotation);
+    }
+
+    private static Method findMethodWithAnnotation(Class<?> scenario, Class<? extends Annotation> annotationType) {
+        for (Class<?> nestedClass : scenario.getDeclaredClasses()) {
+            for (Method method : nestedClass.getMethods()) {
+                if (method.isAnnotationPresent(annotationType)) {
+                    return method;
+                }
+            }
+        }
+        throw new IllegalStateException(String.format("No method of nested type in scenario %s is marked as @%s", scenario.getSimpleName(), annotationType.getSimpleName()));
+    }
+}

--- a/archunit/src/jdk15test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/DeterminesMethodAnalogouslyToReflectionApi.java
+++ b/archunit/src/jdk15test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/DeterminesMethodAnalogouslyToReflectionApi.java
@@ -1,0 +1,874 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+import java.io.Serializable;
+
+@SuppressWarnings({"unused", "ConstantConditions"})
+public class DeterminesMethodAnalogouslyToReflectionApi {
+
+    public static class EquivalentMethodsAreChosenDepthFirst {
+
+        public static class LeftLeftHasPrecedence {
+            interface LeftLeftGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftRightHasPrecedenceOverRight {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class RightLeftHasPrecedenceOverRightRight {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class RightRightIsPickedIfThereIsNoAlternative {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+            }
+
+            interface RightRightGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftOverriddenHasPrecedenceOverParents {
+            interface LeftLeftGrandParent {
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+                @Override
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class RightOverriddenHasPrecedenceOverParents {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                @ExpectedMethod
+                void target();
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftLeftHasPrecedenceOverOverriddenRight {
+            interface LeftLeftGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                void target();
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftRightHasPrecedenceOverOverriddenRight {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                void target();
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftOverriddenHasPrecedenceOverRightOverridden {
+            interface LeftLeftGrandParent {
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+                @Override
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                void target();
+            }
+
+            interface Child extends LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+    }
+
+    public static class ClassHasPrecedenceOverInterface {
+
+        public static class ParentClassHasPrecedenceOverChildInterfaces {
+            interface LeftLeftGrandParent {
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+                @Override
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                void target();
+            }
+
+            abstract static class ParentClass {
+                @ExpectedMethod
+                public abstract void target();
+            }
+
+            abstract static class Child extends ParentClass implements LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class GrandParentClassHasPrecedenceOverChildInterfaces {
+            interface LeftLeftGrandParent {
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent extends LeftLeftGrandParent, LeftRightGrandParent {
+                @Override
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent extends RightLeftGrandParent, RightRightGrandParent {
+                @Override
+                void target();
+            }
+
+            abstract static class GrandParentClass {
+                @ExpectedMethod
+                public abstract void target();
+            }
+
+            abstract static class ParentClass extends GrandParentClass {
+            }
+
+            abstract static class Child extends ParentClass implements LeftParent, RightParent {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+    }
+
+    public static class InterfaceOnParentHasPrecedenceOverInterfaceOnChild {
+
+        public static class LeftLeftOnGrandparentHasPrecedenceOverAllOthers {
+            interface LeftLeftGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftRightGrandParent {
+                void target();
+            }
+
+            interface LeftParent {
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent {
+                void target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftRightOnGrandparentHasPrecedenceOverLeftOnParent {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface LeftParent {
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent {
+                void target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class RightLeftOnGrandparentHasPrecedenceOverLeftAndRightOnParent {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+            }
+
+            interface LeftParent {
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightRightGrandParent {
+                void target();
+            }
+
+            interface RightParent {
+                void target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class RightRightOnGrandparentHasPrecedenceOverLeftAndRightOnParent {
+            interface LeftLeftGrandParent {
+            }
+
+            interface LeftRightGrandParent {
+            }
+
+            interface LeftParent {
+                void target();
+            }
+
+            interface RightLeftGrandParent {
+            }
+
+            interface RightRightGrandParent {
+                @ExpectedMethod
+                void target();
+            }
+
+            interface RightParent {
+                void target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+    }
+
+    public static class MoreSpecificReturnTypeHasPrecedence {
+
+        public static class RightWithMoreSpecificReturnOnParentTypeHasPrecedenceOverAllOthers {
+            interface LeftLeftGrandParent {
+                Serializable target();
+            }
+
+            interface LeftRightGrandParent {
+                Serializable target();
+            }
+
+            interface LeftParent {
+            }
+
+            interface RightLeftGrandParent {
+                Serializable target();
+            }
+
+            interface RightRightGrandParent {
+                Serializable target();
+            }
+
+            interface RightParent {
+                @ExpectedMethod
+                String target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class LeftWithMoreSpecificReturnTypeHasPrecedenceRightWithMoreSpecificReturnType {
+            interface LeftLeftGrandParent {
+                Serializable target();
+            }
+
+            interface LeftRightGrandParent {
+                Serializable target();
+            }
+
+            interface LeftParent {
+                @ExpectedMethod
+                String target();
+            }
+
+            interface RightLeftGrandParent {
+                Serializable target();
+            }
+
+            interface RightRightGrandParent {
+                Serializable target();
+            }
+
+            interface RightParent {
+                String target();
+            }
+
+            abstract static class GrandParentClass implements LeftLeftGrandParent, LeftRightGrandParent, RightLeftGrandParent, RightRightGrandParent {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements LeftParent, RightParent {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class ParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllOthers {
+            interface FirstParentInterface {
+                Serializable target();
+            }
+
+            interface SecondParentInterface {
+                Serializable target();
+            }
+
+            interface ThirdParentInterface {
+                @ExpectedMethod
+                String target();
+            }
+
+            abstract static class ParentClass implements FirstParentInterface, SecondParentInterface, ThirdParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class InterfaceWithMoreSpecificReturnTypeHasPrecedenceOverGrandParentClass {
+            interface FirstParentInterface {
+                Serializable target();
+            }
+
+            interface SecondParentInterface {
+                @ExpectedMethod
+                String target();
+            }
+
+            abstract static class GrandParentClass {
+                public abstract Serializable target();
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements FirstParentInterface, SecondParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class ParentInterfaceOnParentClassWithMoreSpecificReturnTypeHasPrecedenceOverGrandParentClass {
+            interface SecondParentInterfaceParentInterface1 {
+                Serializable target();
+            }
+
+            interface SecondParentInterfaceParentInterface2 {
+                @ExpectedMethod
+                String target();
+            }
+
+            interface FirstParentInterface {
+                Serializable target();
+            }
+
+            interface SecondParentInterface extends SecondParentInterfaceParentInterface1, SecondParentInterfaceParentInterface2 {
+            }
+
+            abstract static class GrandParentClass {
+                public abstract Serializable target();
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements FirstParentInterface, SecondParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllOthers {
+            interface FirstGrandParentInterface {
+                Serializable target();
+            }
+
+            interface SecondGrandParentInterface {
+                Serializable target();
+            }
+
+            interface ThirdGrandParentInterface {
+                @ExpectedMethod
+                String target();
+            }
+
+            interface FirstParentInterface {
+                Serializable target();
+            }
+
+            interface SecondParentInterface {
+                Serializable target();
+            }
+
+            abstract static class GrandParentClass implements FirstGrandParentInterface, SecondGrandParentInterface, ThirdGrandParentInterface {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements FirstParentInterface, SecondParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverFirstParentInterfaceWithMoreSpecificReturnType {
+            interface FirstGrandParentInterface {
+                Serializable target();
+            }
+
+            interface SecondGrandParentInterface {
+                Serializable target();
+            }
+
+            interface ThirdGrandParentInterface {
+                @ExpectedMethod
+                String target();
+            }
+
+            interface FirstParentInterface {
+                String target();
+            }
+
+            interface SecondParentInterface {
+                Serializable target();
+            }
+
+            abstract static class GrandParentClass implements FirstGrandParentInterface, SecondGrandParentInterface, ThirdGrandParentInterface {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements FirstParentInterface, SecondParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+
+        public static class GrandParentInterfaceWithMoreSpecificReturnTypeHasPrecedenceOverAllParentInterfacesWithMoreSpecificReturnType {
+            interface FirstGrandParentInterface {
+                Serializable target();
+            }
+
+            interface SecondGrandParentInterface {
+                Serializable target();
+            }
+
+            interface ThirdGrandParentInterface {
+                @ExpectedMethod
+                String target();
+            }
+
+            interface FirstParentInterfaceParentInterface1 {
+                String target();
+            }
+
+            interface FirstParentInterfaceParentInterface2 {
+                String target();
+            }
+
+            interface FirstParentInterface extends FirstParentInterfaceParentInterface1, FirstParentInterfaceParentInterface2 {
+            }
+
+            interface SecondParentInterface {
+                String target();
+            }
+
+            abstract static class GrandParentClass implements FirstGrandParentInterface, SecondGrandParentInterface, ThirdGrandParentInterface {
+            }
+
+            abstract static class ParentClass extends GrandParentClass implements FirstParentInterface, SecondParentInterface {
+            }
+
+            abstract static class Child extends ParentClass {
+            }
+
+            void scenario() {
+                Child child = null;
+                child.target();
+            }
+        }
+    }
+
+    public static class StaticMethodsInInterfacesAreIgnored {
+
+        interface FirstInterface {
+            static String target() {
+                return null;
+            }
+        }
+
+        interface SecondInterface {
+            static String target() {
+                return null;
+            }
+        }
+
+        interface ThirdInterface {
+            @ExpectedMethod
+            String target();
+        }
+
+        abstract static class Child implements FirstInterface, SecondInterface, ThirdInterface {
+        }
+
+        void scenario() {
+            Child child = null;
+            child.target();
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -28,9 +28,9 @@ public interface ImportContext {
 
     Optional<JavaType> createGenericSuperclass(JavaClass owner);
 
-    Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner);
+    Optional<List<JavaType>> createGenericInterfaces(JavaClass owner);
 
-    Set<JavaClass> createInterfaces(JavaClass owner);
+    List<JavaClass> createInterfaces(JavaClass owner);
 
     List<JavaTypeVariable<JavaClass>> createTypeParameters(JavaClass owner);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1316,7 +1316,7 @@ public class JavaClass
     }
 
     private void completeInterfacesFrom(ImportContext context) {
-        Set<JavaClass> rawInterfaces = context.createInterfaces(this);
+        List<JavaClass> rawInterfaces = context.createInterfaces(this);
         for (JavaClass i : rawInterfaces) {
             i.subclasses.add(this);
         }
@@ -1349,7 +1349,7 @@ public class JavaClass
     }
 
     void completeGenericInterfacesFrom(ImportContext context) {
-        Optional<Set<JavaType>> genericInterfaces = context.createGenericInterfaces(this);
+        Optional<List<JavaType>> genericInterfaces = context.createGenericInterfaces(this);
         if (genericInterfaces.isPresent()) {
             interfaces = interfaces.withGenericTypes(genericInterfaces.get());
         }
@@ -1481,11 +1481,11 @@ public class JavaClass
             return (ImmutableSet) getRaw();
         }
 
-        Interfaces withRawTypes(Set<JavaClass> rawTypes) {
+        Interfaces withRawTypes(List<JavaClass> rawTypes) {
             return new Interfaces(ImmutableSet.copyOf(rawTypes), types);
         }
 
-        Interfaces withGenericTypes(Set<JavaType> genericTypes) {
+        Interfaces withGenericTypes(List<JavaType> genericTypes) {
             return new Interfaces(rawTypes, ImmutableSet.copyOf(genericTypes));
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import com.tngtech.archunit.base.Optional;
 
 final class ReverseDependencies {
 
@@ -261,7 +262,8 @@ final class ReverseDependencies {
             ImmutableSet.Builder<ACCESS> result = ImmutableSet.builder();
             for (final JavaClass javaClass : getPossibleTargetClassesForAccess(member.getOwner())) {
                 for (ACCESS access : this.accessesToSelf.get(javaClass)) {
-                    if (access.getTarget().resolve().contains(member)) {
+                    Optional<? extends JavaMember> target = access.getTarget().resolveMember();
+                    if (target.isPresent() && target.get().equals(member)) {
                         result.add(access);
                     }
                 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -19,12 +19,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.SetMultimap;
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -47,10 +50,10 @@ class ClassFileImportRecord {
     private final Map<String, JavaClass> classes = new HashMap<>();
 
     private final Map<String, String> superclassNamesByOwner = new HashMap<>();
-    private final SetMultimap<String, String> interfaceNamesByOwner = HashMultimap.create();
+    private final ListMultimap<String, String> interfaceNamesByOwner = ArrayListMultimap.create();
     private final Map<String, JavaClassTypeParametersBuilder> typeParametersBuilderByOwner = new HashMap<>();
     private final Map<String, JavaParameterizedTypeBuilder<JavaClass>> genericSuperclassBuilderByOwner = new HashMap<>();
-    private final Map<String, Set<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuildersByOwner = new HashMap<>();
+    private final Map<String, List<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuildersByOwner = new HashMap<>();
     private final SetMultimap<String, DomainBuilders.JavaFieldBuilder> fieldBuildersByOwner = HashMultimap.create();
     private final SetMultimap<String, DomainBuilders.JavaMethodBuilder> methodBuildersByOwner = HashMultimap.create();
     private final SetMultimap<String, DomainBuilders.JavaConstructorBuilder> constructorBuildersByOwner = HashMultimap.create();
@@ -70,7 +73,7 @@ class ClassFileImportRecord {
         superclassNamesByOwner.put(ownerName, superclassName);
     }
 
-    void addInterfaces(String ownerName, Set<String> interfaceNames) {
+    void addInterfaces(String ownerName, List<String> interfaceNames) {
         interfaceNamesByOwner.putAll(ownerName, interfaceNames);
     }
 
@@ -82,7 +85,7 @@ class ClassFileImportRecord {
         genericSuperclassBuilderByOwner.put(ownerName, genericSuperclassBuilder);
     }
 
-    public void addGenericInterfaces(String ownerName, Set<JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
+    public void addGenericInterfaces(String ownerName, List<JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
         genericInterfaceBuildersByOwner.put(ownerName, genericInterfaceBuilders);
     }
 
@@ -129,7 +132,7 @@ class ClassFileImportRecord {
         return Optional.ofNullable(superclassNamesByOwner.get(name));
     }
 
-    Set<String> getInterfaceNamesFor(String ownerName) {
+    List<String> getInterfaceNamesFor(String ownerName) {
         return interfaceNamesByOwner.get(ownerName);
     }
 
@@ -144,7 +147,7 @@ class ClassFileImportRecord {
         return Optional.ofNullable(genericSuperclassBuilderByOwner.get(owner.getName()));
     }
 
-    Optional<Set<JavaParameterizedTypeBuilder<JavaClass>>> getGenericInterfacesFor(JavaClass owner) {
+    Optional<List<JavaParameterizedTypeBuilder<JavaClass>>> getGenericInterfacesFor(JavaClass owner) {
         return Optional.ofNullable(genericInterfaceBuildersByOwner.get(owner.getName()));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit.core.importer;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.List;
 import java.util.Set;
 
 import com.tngtech.archunit.ArchConfiguration;
@@ -77,7 +78,7 @@ class ClassFileProcessor {
         }
 
         @Override
-        public void onNewClass(String className, Optional<String> superclassName, Set<String> interfaceNames) {
+        public void onNewClass(String className, Optional<String> superclassName, List<String> interfaceNames) {
             ownerName = className;
             if (superclassName.isPresent()) {
                 importRecord.setSuperclass(ownerName, superclassName.get());
@@ -96,7 +97,7 @@ class ClassFileProcessor {
         }
 
         @Override
-        public void onGenericInterfaces(Set<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
+        public void onGenericInterfaces(List<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
             importRecord.addGenericInterfaces(ownerName, genericInterfaceBuilders);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -1101,18 +1101,18 @@ public final class DomainBuilders {
 
     @Internal
     public static final class MethodCallTargetBuilder extends CodeUnitCallTargetBuilder<MethodCallTargetBuilder> {
-        private Supplier<Set<JavaMethod>> methods;
+        private Supplier<Optional<JavaMethod>> method;
 
         MethodCallTargetBuilder() {
         }
 
-        MethodCallTargetBuilder withMethods(final Supplier<Set<JavaMethod>> methods) {
-            this.methods = methods;
+        MethodCallTargetBuilder withMethod(final Supplier<Optional<JavaMethod>> method) {
+            this.method = method;
             return this;
         }
 
-        public Supplier<Set<JavaMethod>> getMethods() {
-            return methods;
+        public Supplier<Optional<JavaMethod>> getMethod() {
+            return method;
         }
 
         MethodCallTarget build() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import com.google.common.primitives.Booleans;
@@ -100,7 +101,7 @@ class JavaClassProcessor extends ClassVisitor {
             return;
         }
 
-        ImmutableSet<String> interfaceNames = createInterfaceNames(interfaces);
+        List<String> interfaceNames = createInterfaceNames(interfaces);
         LOG.trace("Found interfaces {} on class '{}'", interfaceNames, name);
         boolean opCodeForInterfaceIsPresent = (access & Opcodes.ACC_INTERFACE) != 0;
         boolean opCodeForEnumIsPresent = (access & Opcodes.ACC_ENUM) != 0;
@@ -211,8 +212,8 @@ class JavaClassProcessor extends ClassVisitor {
         }
     }
 
-    private ImmutableSet<String> createInterfaceNames(String[] interfaces) {
-        ImmutableSet.Builder<String> result = ImmutableSet.builder();
+    private List<String> createInterfaceNames(String[] interfaces) {
+        ImmutableList.Builder<String> result = ImmutableList.builder();
         for (String i : interfaces) {
             result.add(createTypeName(i));
         }
@@ -461,13 +462,13 @@ class JavaClassProcessor extends ClassVisitor {
     interface DeclarationHandler {
         boolean isNew(String className);
 
-        void onNewClass(String className, Optional<String> superclassName, Set<String> interfaceNames);
+        void onNewClass(String className, Optional<String> superclassName, List<String> interfaceNames);
 
         void onDeclaredTypeParameters(DomainBuilders.JavaClassTypeParametersBuilder typeParametersBuilder);
 
         void onGenericSuperclass(DomainBuilders.JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder);
 
-        void onGenericInterfaces(Set<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders);
+        void onGenericInterfaces(List<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders);
 
         void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -15,9 +15,8 @@
  */
 package com.tngtech.archunit.core.importer;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -71,7 +70,7 @@ class JavaClassSignatureImporter {
             return Optional.ofNullable(superclassProcessor.superclass);
         }
 
-        Set<JavaParameterizedTypeBuilder<JavaClass>> getGenericInterfaces() {
+        List<JavaParameterizedTypeBuilder<JavaClass>> getGenericInterfaces() {
             return interfacesProcessor.interfaces;
         }
 
@@ -125,7 +124,7 @@ class JavaClassSignatureImporter {
         }
 
         private static class GenericInterfacesProcessor extends SignatureVisitor {
-            private final Set<JavaParameterizedTypeBuilder<JavaClass>> interfaces = new HashSet<>();
+            private final List<JavaParameterizedTypeBuilder<JavaClass>> interfaces = new ArrayList<>();
             private JavaParameterizedTypeBuilder<JavaClass> currentInterface;
 
             GenericInterfacesProcessor() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
@@ -145,7 +145,7 @@ class RawAccessRecord {
         }
     }
 
-    static class TargetInfo {
+    static final class TargetInfo {
         final JavaClassDescriptor owner;
         final String name;
         final String desc;

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -64,8 +64,7 @@ import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassGet
 import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassSetsFieldCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
-import static com.tngtech.archunit.base.DescribedPredicate.anyElementThat;
-import static com.tngtech.archunit.base.DescribedPredicate.empty;
+import static com.tngtech.archunit.base.DescribedPredicate.optionalContains;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_ORIGIN_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_TARGET_CLASS;
 import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependencyOrigin;
@@ -174,7 +173,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyAccessFieldsThat(final DescribedPredicate<? super JavaField> predicate) {
         ChainableFunction<JavaFieldAccess, FieldAccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaFieldAccess> accessPredicate = getTarget.then(FieldAccessTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaField>forSubtype()).or(empty()));
+                .is(optionalContains(predicate.<JavaField>forSubtype()).or(DescribedPredicate.<JavaField>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(accessPredicate, GET_FIELD_ACCESSES_FROM_SELF)
                 .as("only access fields that " + predicate.getDescription());
     }
@@ -207,7 +206,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallMethodsThat(final DescribedPredicate<? super JavaMethod> predicate) {
         ChainableFunction<JavaMethodCall, MethodCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaMethodCall> callPredicate = getTarget.then(MethodCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaMethod>forSubtype()).or(empty()));
+                .is(optionalContains(predicate.<JavaMethod>forSubtype()).or(DescribedPredicate.<JavaMethod>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_METHOD_CALLS_FROM_SELF)
                 .as("only call methods that " + predicate.getDescription());
     }
@@ -240,7 +239,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallConstructorsThat(final DescribedPredicate<? super JavaConstructor> predicate) {
         ChainableFunction<JavaConstructorCall, ConstructorCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaConstructorCall> callPredicate = getTarget.then(ConstructorCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaConstructor>forSubtype()).or(empty()));
+                .is(optionalContains(predicate.<JavaConstructor>forSubtype()).or(DescribedPredicate.<JavaConstructor>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CONSTRUCTOR_CALLS_FROM_SELF)
                 .as("only call constructors that " + predicate.getDescription());
     }
@@ -255,7 +254,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaClass> onlyCallCodeUnitsThat(final DescribedPredicate<? super JavaCodeUnit> predicate) {
         ChainableFunction<JavaCall<?>, CodeUnitCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaCodeUnit>forSubtype()).or(empty()));
+                .is(optionalContains(predicate.<JavaCodeUnit>forSubtype()).or(DescribedPredicate.<JavaCodeUnit>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(callPredicate, GET_CALLS_FROM_SELF)
                 .as("only call code units that " + predicate.getDescription());
     }
@@ -263,8 +262,8 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> onlyAccessMembersThat(final DescribedPredicate<? super JavaMember> predicate) {
         ChainableFunction<JavaAccess<?>, AccessTarget> getTarget = JavaAccess.Functions.Get.target();
-        DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(AccessTarget.Functions.RESOLVE)
-                .is(anyElementThat(predicate.<JavaMember>forSubtype()).or(empty()));
+        DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(AccessTarget.Functions.RESOLVE_MEMBER)
+                .is(optionalContains(predicate.<JavaMember>forSubtype()).or(DescribedPredicate.<JavaMember>optionalEmpty()));
         return new ClassOnlyAccessesCondition<>(accessPredicate, GET_ACCESSES_FROM_SELF)
                 .as("only access members that " + predicate.getDescription());
     }
@@ -1324,12 +1323,11 @@ public final class ArchConditions {
 
     private static class NumberOfElementsCondition extends ArchCondition<JavaClass> {
         private final DescribedPredicate<Integer> predicate;
-        private SortedSet<String> allClassNames;
+        private final SortedSet<String> allClassNames = new TreeSet<>();
 
         NumberOfElementsCondition(DescribedPredicate<? super Integer> predicate) {
             super("contain number of elements " + predicate.getDescription());
             this.predicate = predicate.forSubtype();
-            allClassNames = new TreeSet<>();
         }
 
         @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -3,7 +3,6 @@ package com.tngtech.archunit.core.domain;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -110,11 +109,11 @@ public class TestUtils {
     }
 
     public static MethodCallTarget resolvedTargetFrom(JavaMethod target) {
-        return ImportTestUtils.targetFrom(target, Suppliers.ofInstance(Collections.singleton(target)));
+        return ImportTestUtils.targetFrom(target, Suppliers.ofInstance(Optional.of(target)));
     }
 
     private static MethodCallTarget unresolvedTargetFrom(JavaMethod target) {
-        return ImportTestUtils.targetFrom(target, Suppliers.ofInstance(Collections.<JavaMethod>emptySet()));
+        return ImportTestUtils.targetFrom(target, Suppliers.ofInstance(Optional.<JavaMethod>empty()));
     }
 
     public static Class<?>[] asClasses(List<JavaClass> parameters) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -50,6 +50,16 @@ import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.Subi
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyimport.YetAnotherInterface;
 import com.tngtech.archunit.core.importer.testexamples.innerclassimport.CalledClass;
 import com.tngtech.archunit.core.importer.testexamples.innerclassimport.ClassWithInnerClass;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.Five;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.FiveGeneric;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.Four;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.FourGeneric;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.One;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.OneGeneric;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.Three;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.ThreeGeneric;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.Two;
+import com.tngtech.archunit.core.importer.testexamples.interfaceorder.TwoGeneric;
 import com.tngtech.archunit.core.importer.testexamples.nestedimport.ClassWithNestedClass;
 import com.tngtech.archunit.core.importer.testexamples.pathone.Class11;
 import com.tngtech.archunit.core.importer.testexamples.pathone.Class12;
@@ -100,6 +110,7 @@ import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 import static com.tngtech.archunit.testutil.TestUtils.uriOf;
 import static com.tngtech.archunit.testutil.TestUtils.urlOf;
+import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
@@ -274,6 +285,46 @@ public class ClassFileImporterTest {
                 .isInterface(true)
                 .isEnum(false)
                 .isRecord(false);
+    }
+
+    @Test
+    public void imports_raw_interfaces_in_correct_order() {
+        class Ascending implements One, Two, Three, Four, Five {
+        }
+        class Descending implements Five, Four, Three, Two, One {
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(Ascending.class, Descending.class);
+
+        assertThatTypes(classes.get(Ascending.class).getRawInterfaces())
+                .matchExactly(One.class, Two.class, Three.class, Four.class, Five.class);
+        assertThatTypes(classes.get(Descending.class).getRawInterfaces())
+                .matchExactly(Five.class, Four.class, Three.class, Two.class, One.class);
+    }
+
+    @Test
+    public void imports_generic_interfaces_in_correct_order() {
+        class Ascending implements OneGeneric<String>, TwoGeneric<String>, ThreeGeneric<String>, FourGeneric<String>, FiveGeneric<String> {
+        }
+        class Descending implements FiveGeneric<String>, FourGeneric<String>, ThreeGeneric<String>, TwoGeneric<String>, OneGeneric<String> {
+        }
+
+        JavaClasses classes = new ClassFileImporter().importClasses(Ascending.class, Descending.class);
+
+        assertThatTypes(classes.get(Ascending.class).getInterfaces())
+                .matchExactly(
+                        parameterizedType(OneGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(TwoGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(ThreeGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(FourGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(FiveGeneric.class).withTypeArguments(String.class));
+        assertThatTypes(classes.get(Descending.class).getInterfaces())
+                .matchExactly(
+                        parameterizedType(FiveGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(FourGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(ThreeGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(TwoGeneric.class).withTypeArguments(String.class),
+                        parameterizedType(OneGeneric.class).withTypeArguments(String.class));
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -371,13 +371,13 @@ public class ImportTestUtils {
         }
 
         @Override
-        public Optional<Set<JavaType>> createGenericInterfaces(JavaClass owner) {
+        public Optional<List<JavaType>> createGenericInterfaces(JavaClass owner) {
             return Optional.empty();
         }
 
         @Override
-        public Set<JavaClass> createInterfaces(JavaClass owner) {
-            return Collections.emptySet();
+        public List<JavaClass> createInterfaces(JavaClass owner) {
+            return Collections.emptyList();
         }
 
         @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -241,13 +241,13 @@ public class ImportTestUtils {
                 .build();
     }
 
-    public static MethodCallTarget targetFrom(JavaMethod target, Supplier<Set<JavaMethod>> resolveSupplier) {
+    public static MethodCallTarget targetFrom(JavaMethod target, Supplier<Optional<JavaMethod>> resolveSupplier) {
         return new DomainBuilders.MethodCallTargetBuilder()
                 .withOwner(target.getOwner())
                 .withName(target.getName())
                 .withParameters(target.getRawParameterTypes())
                 .withReturnType(target.getRawReturnType())
-                .withMethods(resolveSupplier)
+                .withMethod(resolveSupplier)
                 .build();
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ClassWithInterfacesWithFields.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ClassWithInterfacesWithFields.java
@@ -1,4 +1,0 @@
-package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces;
-
-public class ClassWithInterfacesWithFields implements InterfaceWithFields, OtherInterfaceWithFields {
-}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ChildExtendingParentWithSameInterfaceFields.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ChildExtendingParentWithSameInterfaceFields.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ambiguous_in_hierarchy;
+
+public class ChildExtendingParentWithSameInterfaceFields extends ParentClassWithSameFieldsAsInterfaces {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ClassAccessingChildExtendingParentWithSameInterfaceFields.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ClassAccessingChildExtendingParentWithSameInterfaceFields.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ambiguous_in_hierarchy;
+
+@SuppressWarnings({"ConstantConditions", "unused"})
+public class ClassAccessingChildExtendingParentWithSameInterfaceFields {
+    Object access(ChildExtendingParentWithSameInterfaceFields child) {
+        return child.objectFieldOne != null ? child.objectFieldOne : child.otherObjectFieldOne;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/GrandParentClassWithSameFieldsAsInterfaces.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/GrandParentClassWithSameFieldsAsInterfaces.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ambiguous_in_hierarchy;
+
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.InterfaceWithFields;
+
+@SuppressWarnings({"unused"})
+public class GrandParentClassWithSameFieldsAsInterfaces extends GreatGrandParentClass implements InterfaceWithFields {
+    private final Object otherObjectFieldOne = "otherObjectFieldOne";
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/GreatGrandParentClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/GreatGrandParentClass.java
@@ -1,0 +1,6 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ambiguous_in_hierarchy;
+
+@SuppressWarnings("unused")
+public class GreatGrandParentClass {
+    private final Object objectFieldOne = "objectFieldOne";
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ParentClassWithSameFieldsAsInterfaces.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/ambiguous_in_hierarchy/ParentClassWithSameFieldsAsInterfaces.java
@@ -1,0 +1,6 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.ambiguous_in_hierarchy;
+
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.OtherInterfaceWithFields;
+
+public class ParentClassWithSameFieldsAsInterfaces extends GrandParentClassWithSameFieldsAsInterfaces implements OtherInterfaceWithFields {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/unique_in_hierarchy/ClassAccessingInterfaceFields.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/unique_in_hierarchy/ClassAccessingInterfaceFields.java
@@ -1,5 +1,6 @@
-package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces;
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.unique_in_hierarchy;
 
+@SuppressWarnings("unused")
 public class ClassAccessingInterfaceFields {
     private ClassWithInterfacesWithFields classWithInterfacesWithFields;
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/unique_in_hierarchy/ClassWithInterfacesWithFields.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/fieldaccesstointerfaces/unique_in_hierarchy/ClassWithInterfacesWithFields.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.unique_in_hierarchy;
+
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.InterfaceWithFields;
+import com.tngtech.archunit.core.importer.testexamples.fieldaccesstointerfaces.OtherInterfaceWithFields;
+
+public class ClassWithInterfacesWithFields implements InterfaceWithFields, OtherInterfaceWithFields {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Five.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Five.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+public interface Five {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/FiveGeneric.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/FiveGeneric.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+@SuppressWarnings("unused")
+public interface FiveGeneric<T> {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Four.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Four.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+public interface Four {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/FourGeneric.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/FourGeneric.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+@SuppressWarnings("unused")
+public interface FourGeneric<T> {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/One.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/One.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+public interface One {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/OneGeneric.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/OneGeneric.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+@SuppressWarnings("unused")
+public interface OneGeneric<T> {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Three.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Three.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+public interface Three {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/ThreeGeneric.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/ThreeGeneric.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+@SuppressWarnings("unused")
+public interface ThreeGeneric<T> {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Two.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/Two.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+public interface Two {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/TwoGeneric.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/interfaceorder/TwoGeneric.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.interfaceorder;
+
+@SuppressWarnings("unused")
+public interface TwoGeneric<T> {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/ChildOverridesAllMethods.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/ChildOverridesAllMethods.java
@@ -1,0 +1,29 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+@SuppressWarnings("unused")
+public class ChildOverridesAllMethods {
+    interface Root {
+        void target();
+    }
+
+    interface Left extends Root {
+        @Override
+        void target();
+    }
+
+    interface Right extends Root {
+        @Override
+        void target();
+    }
+
+    interface Child extends Left, Right {
+        @Override
+        @ExpectedMethod
+        void target();
+    }
+
+    void scenario() {
+        Child child = null;
+        child.target();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/ExpectedMethod.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/ExpectedMethod.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+public @interface ExpectedMethod {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/LeftAncestorPrecedesRightAncestor.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/LeftAncestorPrecedesRightAncestor.java
@@ -1,0 +1,21 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+@SuppressWarnings("unused")
+public class LeftAncestorPrecedesRightAncestor {
+    interface Left {
+        @ExpectedMethod
+        void target();
+    }
+
+    interface Right {
+        void target();
+    }
+
+    interface Child extends Left, Right {
+    }
+
+    void scenario() {
+        Child child = null;
+        child.target();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyDefinedInCommonAncestor.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyDefinedInCommonAncestor.java
@@ -1,0 +1,23 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+@SuppressWarnings("unused")
+public class OnlyDefinedInCommonAncestor {
+    interface Root {
+        @ExpectedMethod
+        void target();
+    }
+
+    interface Left extends Root {
+    }
+
+    interface Right extends Root {
+    }
+
+    interface Child extends Left, Right {
+    }
+
+    void scenario() {
+        Child child = null;
+        child.target();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyLeftAncestorOverridesRootMethod.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyLeftAncestorOverridesRootMethod.java
@@ -1,0 +1,25 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+@SuppressWarnings("unused")
+public class OnlyLeftAncestorOverridesRootMethod {
+    interface Root {
+        void target();
+    }
+
+    interface Left extends Root {
+        @Override
+        @ExpectedMethod
+        void target();
+    }
+
+    interface Right extends Root {
+    }
+
+    interface Child extends Left, Right {
+    }
+
+    void scenario() {
+        Child child = null;
+        child.target();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyRightAncestorOverridesRootMethod.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/methodresolution/OnlyRightAncestorOverridesRootMethod.java
@@ -1,0 +1,25 @@
+package com.tngtech.archunit.core.importer.testexamples.methodresolution;
+
+@SuppressWarnings("unused")
+public class OnlyRightAncestorOverridesRootMethod {
+    interface Root {
+        void target();
+    }
+
+    interface Left extends Root {
+    }
+
+    interface Right extends Root {
+        @Override
+        @ExpectedMethod
+        void target();
+    }
+
+    interface Child extends Left, Right {
+    }
+
+    void scenario() {
+        Child child = null;
+        child.target();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -161,7 +161,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
     }
 
     public static JavaFieldAssertion assertThat(FieldAccessTarget target) {
-        return assertThat(target.resolveField().get());
+        return assertThat(target.resolveMember().get());
     }
 
     public static JavaFieldAssertion assertThat(JavaField field) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaTypesAssertion.java
@@ -59,6 +59,10 @@ public class JavaTypesAssertion extends AbstractObjectAssert<JavaTypesAssertion,
         }
     }
 
+    public void matchExactly(ExpectedConcreteType... expected) {
+        matchExactly(ImmutableList.copyOf(expected), new DescriptionContext(""));
+    }
+
     public void matchExactly(Class<?>... classes) {
         assertThat(HasName.Utils.namesOf(actual)).as(descriptionText()).containsExactlyElementsOf(formatNamesOf(classes));
         matchInAnyOrder(classes);


### PR DESCRIPTION
Instead of having a complicated `JavaMethodCallTarget.resolve()` API that returns a `Set<JavaMethod>` we can follow the same logic as the Reflection API, which always offers one `Method` matching a certain signature. This should make the vast majority of cases a lot simpler, and for diamond scenarios we are following an established precedence logic. Thus, the argument why method x is chosen in a specific case is a lot simpler ("we just follow the established precedence of the Java Reflection API").

Note that this also fixes a bug in the field resolution logic. Earlier accesses of constants in interfaces of parent classes were not resolved correctly (i.e. if we find a field in an interface it should have precedence).
