### PR TITLE
Draft: Build on Java 8, 11 & 17 using Gradle 7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  build_java_version: 15
+  build_java_version: 17
 
 jobs:
   build:
@@ -41,6 +41,8 @@ jobs:
           - 13
           - 14
           - 15
+          - 16
+          - 17
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -90,6 +92,8 @@ jobs:
           - 13
           - 14
           - 15
+          - 16
+          - 17
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - macos-latest
           - windows-latest
         test_java_version:
-          - 7
           - 8
           - 9
           - 10
@@ -83,7 +82,6 @@ jobs:
           - macos-latest
           - windows-latest
         java_version:
-          - 7
           - 8
           - 9
           - 10

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Gradle JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 17
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1.0.15

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _site
 .jekyll-cache
 .asciidoctor
 verification-results
+bin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Contributions are very welcome. The following will provide some helpful guidelin
 
 ## How to build the project
 
-ArchUnit requires at least JDK 15 to build.
+ArchUnit requires at least JDK 17 to build.
 The following is just an example input/output from a Unix command line.
 Windows users should use `gradlew.bat` instead.
 
 ```
 $ cd /path/to/git/clone/of/ArchUnit
 $ ./gradlew showJdkVersion
-Configured JDK: 15
+Configured JDK: 17
 $ ./gradlew build
 ```
 

--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -96,4 +96,3 @@ ext.configureJUnitArchive = { configureDependencies ->
 this.with addCleanThirdPartyTask
 
 javadoc.enabled = false
-uploadArchives.enabled = false

--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -108,14 +108,6 @@ task jdk15Test(type: Test) {
     testClassesDirs = sourceSets.jdk15test.output.classesDirs
     classpath = sourceSets.jdk15test.runtimeClasspath
     jvmArgs += "--enable-preview"
-
-    // workaround for issue in Gradle 6.7, see https://github.com/gradle/gradle/issues/14714
-    exclude '**/ClassFileImporterRecordsTest\$*RecordToImport.class'
-    exclude '**/GivenClassesThatRecordsTest\$*SomeRecord.class'
-    exclude '**/GivenMembersDeclaredInClassesThatRecordsTest\$*SomeRecord.class'
-    exclude '**/ShouldClassesThatRecordsTest\$*SomeRecord.class'
-    exclude '**/ShouldOnlyByClassesThatRecordsTest\$*RecordAccessingRecord.class'
-    exclude '**/ShouldOnlyByClassesThatRecordsTest\$*SomeRecord.class'
 }
 
 [jar, test]*.dependsOn compileJdk9mainJava

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -20,11 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
@@ -48,7 +48,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
-import static com.tngtech.archunit.base.Guava.toGuava;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 
@@ -344,9 +343,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         @Override
         @PublicAPI(usage = ACCESS)
         public ThrowsClause<CodeUnitCallTarget> getThrowsClause() {
-            List<ThrowsClause<JavaCodeUnit>> resolvedThrowsClauses = FluentIterable.from(resolve())
-                    .transform(toGuava(JavaCodeUnit.Functions.Get.throwsClause()))
-                    .toList();
+            List<ThrowsClause<JavaCodeUnit>> resolvedThrowsClauses = resolve().stream()
+                    .map(unit -> JavaCodeUnit.Functions.Get.throwsClause().apply(unit))
+                    .collect(Collectors.toList());
 
             if (resolvedThrowsClauses.isEmpty()) {
                 return ThrowsClause.empty(this);

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -1,6 +1,5 @@
 def unquote = { string -> string.replaceAll(/^"(.*)"$/, '$1')}
 def testJdksDefinition = [
-        [suffix: "Jre7", javaVersion: JavaVersion.VERSION_1_7, jdkProp: "java7Home"],
         [suffix: "Jre8", javaVersion: JavaVersion.VERSION_1_8, jdkProp: "java8Home"],
         [suffix: "Jre9", javaVersion: JavaVersion.VERSION_1_9, jdkProp: "java9Home"],
         [suffix: "Jre10", javaVersion: JavaVersion.VERSION_1_10, jdkProp: "java10Home"],

--- a/build-steps/testing/testing.gradle
+++ b/build-steps/testing/testing.gradle
@@ -7,7 +7,9 @@ def testJdksDefinition = [
         [suffix: "Jre12", javaVersion: JavaVersion.VERSION_12, jdkProp: "java12Home"],
         [suffix: "Jre13", javaVersion: JavaVersion.VERSION_13, jdkProp: "java13Home"],
         [suffix: "Jre14", javaVersion: JavaVersion.VERSION_14, jdkProp: "java14Home"],
-        [suffix: "Jre15", javaVersion: JavaVersion.VERSION_15, jdkProp: "java15Home"]
+        [suffix: "Jre15", javaVersion: JavaVersion.VERSION_15, jdkProp: "java15Home"],
+        [suffix: "Jre16", javaVersion: JavaVersion.VERSION_16, jdkProp: "java16Home"],
+        [suffix: "Jre17", javaVersion: JavaVersion.VERSION_17, jdkProp: "java17Home"]
 ]
         .findAll { project.hasProperty(it.jdkProp) }
         .collect { config -> config + [jdkPath: unquote(project[config.jdkProp])] }

--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,8 @@ configure(subprojects.findAll { it.name != 'docs' }) {
 
     description createModuleDescription(rootProject.description, project)
 
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     javadoc {
         options.addBooleanOption('html5', true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 archunit.version=0.23.0-SNAPSHOT
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi! Hope it's ok to just open a pull request like this unprompted; I had wanted to look into #179 originally, but had some issues getting JDK 15 to play nice. Then I read in #565 that you had planned to drop Java 7 support in the near future, so I figured couldn't hurt to start a pull request with some of the required changes.

There's a few puzzling test failures that might need a second look:
```
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[0: JavaClass{name='com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$MetaAnnotatedClass'}]
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[1: JavaField{com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$ClassWithMetaAnnotatedField.metaAnnotatedField}]
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[2: JavaMethod{com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$ClassWithMetaAnnotatedMethod.metaAnnotatedMethod()}]
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[3: JavaConstructor{com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$ClassWithMetaAnnotatedConstructor.<init>()}]
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[4: JavaParameter{owner='com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$ClassWithMetaAnnotatedConstructorParameter.<init>(java.lang.String)', index='0', type='java.lang.String'}]
ClassFileImporterAnnotationsTest. parameters_of_meta_annotations_are_transitively_imported[5: JavaParameter{owner='com.tngtech.archunit.core.importer.ClassFileImporterAnnotationsTest$ClassWithMetaAnnotatedMethodParameter.method(java.lang.String)', index='0', type='java.lang.String'}]
MethodCallChainTest. run_test_cases[6: CallChainTestCase{start: [FiveStepsInterfaceChildStep1, FiveStepsHierarchyImplementationStep1], numberOfInvocations: [1], expectedResult: [FiveStepsInterfaceChildStep2, FiveStepsHierarchyImplementationStep2]}]
MethodCallChainTest. run_test_cases[7: CallChainTestCase{start: [FiveStepsInterfaceChildStep1, FiveStepsHierarchyImplementationStep1], numberOfInvocations: [2], expectedResult: [FiveStepsInterfaceChildStep3, FiveStepsHierarchyImplementationStep3]}]
MethodCallChainTest. run_test_cases[9: CallChainTestCase{start: [FiveStepsInterfaceChildStep1, FiveStepsHierarchyImplementationStep1], numberOfInvocations: [4], expectedResult: [FiveStepsInterfaceChildStep5, FiveStepsHierarchyImplementationStep5]}]
```
Other than that I think this should cover most of the odd ends. Any feedback/help much appreciated!

Once Java 7 support is officially dropped one could look into replacing the Guava FluentIterable with Java 8 streams for instance, as that could help with code familiarity to other developers.

I doubted whether you'd want to rename the jdk9/jdk15 folders to for instance jdk11 & jdk17, to target stable JDK versions.

I recon I'll start a separate one for that #179, as this bit of yak shaving got out of hand. :)