### PR TITLE
Issue: #735 Throw Exception if no components are found in diagram

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
@@ -33,6 +33,7 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.Guava.toGuava;
 import static com.tngtech.archunit.core.domain.Dependency.Functions.GET_ORIGIN_CLASS;
@@ -186,6 +187,8 @@ public class PlantUmlArchCondition extends ArchCondition<JavaClass> {
 
     private static PlantUmlArchCondition create(URL url, Configuration configuration) {
         PlantUmlDiagram diagram = new PlantUmlParser().parse(url);
+        checkState(!diagram.getAllComponents().isEmpty(), "No components defined in diagram <%s>", url);
+
         JavaClassDiagramAssociation javaClassDiagramAssociation = new JavaClassDiagramAssociation(diagram);
         DescribedPredicate<Dependency> ignorePredicate = configuration.asIgnorePredicate(javaClassDiagramAssociation);
         return new PlantUmlArchCondition(getDescription(url, ignorePredicate.getDescription()), ignorePredicate, javaClassDiagramAssociation);

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/PlantUmlArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/PlantUmlArchConditionTest.java
@@ -1,9 +1,12 @@
 package com.tngtech.archunit.library.plantuml;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.List;
+import java.util.UUID;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -36,6 +39,7 @@ import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Config
 import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configurations.consideringOnlyDependenciesInAnyPackage;
 import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configurations.consideringOnlyDependenciesInDiagram;
 import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.adhereToPlantUmlDiagram;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(DataProviderRunner.class)
@@ -218,6 +222,16 @@ public class PlantUmlArchConditionTest {
                         .ignoreDependenciesWithTarget(equivalentTo(SomeOrigin.class))
                         .ignoreDependencies(SomeOrigin.class, SomeTarget.class),
                 0);
+    }
+
+    @Test
+    public void diagram_with_unparseable_content() throws IOException {
+        File file = temporaryFolder.newFile("plantuml_diagram_" + UUID.randomUUID() + ".puml");
+        Files.write(file.toPath(), "XXX-someUnparseableContent-XXX".getBytes(UTF_8));
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage(String.format("No components defined in diagram <%s>", toUrl(file)));
+        adhereToPlantUmlDiagram(file, consideringOnlyDependenciesInDiagram());
     }
 
     private ListAssert<String> assertThatEvaluatedConditionWithConfiguration(


### PR DESCRIPTION
An empty diagram never makes sense to define architecture rules, but accepting it can easily hide a user error where an incompatible file has been passed.

Resolves #735 