### PR TITLE
Prevent infinite recursion of javaClass.getAllRawInterfaces()

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -130,7 +130,7 @@ public class JavaClass
                     result.addAll(subclass.getAllSubclasses());
                 }
             }
-            return result;
+            return ImmutableSet.copyOf(result);
         }
     });
     private EnclosingDeclaration enclosingDeclaration = EnclosingDeclaration.ABSENT;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -101,13 +101,14 @@ public class JavaClass
     private final Supplier<Set<JavaClass>> allRawInterfaces = Suppliers.memoize(new Supplier<Set<JavaClass>>() {
         @Override
         public Set<JavaClass> get() {
-            ImmutableSet.Builder<JavaClass> result = ImmutableSet.builder();
+            Set<JavaClass> result = new HashSet<>();
             for (JavaClass i : interfaces.getRaw()) {
-                result.add(i);
-                result.addAll(i.getAllRawInterfaces());
+                if (result.add(i)) {
+                    result.addAll(i.getAllRawInterfaces());
+                }
             }
             result.addAll(superclass.getAllRawInterfaces());
-            return result.build();
+            return ImmutableSet.copyOf(result);
         }
     });
     private final Supplier<List<JavaClass>> classHierarchy = Suppliers.memoize(new Supplier<List<JavaClass>>() {
@@ -125,8 +126,9 @@ public class JavaClass
         public Set<JavaClass> get() {
             Set<JavaClass> result = new HashSet<>();
             for (JavaClass subclass : subclasses) {
-                result.add(subclass);
-                result.addAll(subclass.getAllSubclasses());
+                if (result.add(subclass)) {
+                    result.addAll(subclass.getAllSubclasses());
+                }
             }
             return result;
         }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -451,11 +451,11 @@ public class ClassFileImporterTest {
 
         assertThat(baseClass.getRawSuperclass().get().reflect()).isEqualTo(Object.class);
         assertThat(baseClass.getSubclasses()).containsOnly(subclass, otherSubclass);
-        assertThat(baseClass.getSubclasses()).containsOnly(subclass, otherSubclass);
+        assertThat(baseClass.getSubClasses()).containsOnly(subclass, otherSubclass);
         assertThat(baseClass.getAllSubclasses()).containsOnly(subclass, otherSubclass, subSubclass, subSubSubclass, subSubSubSubclass);
-        assertThat(baseClass.getAllSubclasses()).containsOnly(subclass, otherSubclass, subSubclass, subSubSubclass, subSubSubSubclass);
+        assertThat(baseClass.getAllSubClasses()).containsOnly(subclass, otherSubclass, subSubclass, subSubSubclass, subSubSubSubclass);
         assertThat(subclass.getRawSuperclass()).contains(baseClass);
-        assertThat(subclass.getRawSuperclass()).contains(baseClass);
+        assertThat(subclass.getSuperClass()).contains(baseClass);
         assertThat(subclass.getAllSubclasses()).containsOnly(subSubclass, subSubSubclass, subSubSubSubclass);
         assertThat(subSubclass.getRawSuperclass()).contains(subclass);
     }


### PR DESCRIPTION
Only recurse into getAllRawInterfaces()/getAllSubclasses() when interface/subclass has not been added before.

ProGuard seems to produce classes that appear to be their own interface.
For those, an unconditional recursion in the `Supplier<Set<JavaClass>> allRawInterfaces` led to a `StackOverflowError`.

Resolves #754