### PR TITLE
Verify that the rule input is not empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _site
 .jekyll-cache
 .asciidoctor
 verification-results
+.java-version

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
@@ -1,9 +1,14 @@
 package com.tngtech.archunit.testutil;
 
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.Callable;
 
 import com.tngtech.archunit.ArchConfiguration;
 import org.junit.rules.ExternalResource;
+
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
+import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 
 public class ArchConfigurationRule extends ExternalResource {
     private boolean resolveMissingDependenciesFromClassPath = ArchConfiguration.get().resolveMissingDependenciesFromClassPath();
@@ -22,6 +27,20 @@ public class ArchConfigurationRule extends ExternalResource {
     public ArchConfigurationRule resolveAdditionalDependenciesFromClassPath(boolean enabled) {
         resolveMissingDependenciesFromClassPath = enabled;
         return this;
+    }
+
+    public void removeProperty(String propertyName) {
+        try {
+            Object properties = accessible(field(ArchConfiguration.class, "properties")).get(ArchConfiguration.get());
+            accessible(method(properties.getClass(), "remove", String.class)).invoke(properties, propertyName);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T extends AccessibleObject> T accessible(T member) {
+        member.setAccessible(true);
+        return member;
     }
 
     @Override

--- a/archunit/src/test/resources/archunit.properties
+++ b/archunit/src/test/resources/archunit.properties
@@ -1,1 +1,2 @@
 enableMd5InClassSources=true
+archRule.failOnEmptyShould=false

--- a/docs/userguide/010_Advanced_Configuration.adoc
+++ b/docs/userguide/010_Advanced_Configuration.adoc
@@ -98,6 +98,32 @@ If this feature is enabled, the MD5 sum can be queried as
 javaClass.getSource().get().getMd5sum()
 ----
 
+=== Fail Rules on Empty Should
+
+By default, ArchUnit will forbid the should-part of rules to be evaluated against an empty set of classes.
+The reason is that this can lead to rules that by accident do not check any classes at all.
+Take for example
+
+[source,java,options="nowrap"]
+----
+classes().that().resideInAPackage("com.myapp.old").should()...
+----
+
+Now consider somebody renames the package `old` to `newer`.
+The rule will now always evaluate successfully without any reported error.
+However, it actually does not check any classes at all anymore.
+This is likely not what most users want.
+Thus, by default ArchUnit will fail checking the rule in this case.
+If you want to allow evaluating such rules,
+i.e. where the actual input to the should-conditionis empty,
+you can set the following property:
+
+[source,options="nowrap"]
+.archunit.properties
+----
+archRule.failOnEmptyShould=false
+----
+
 === Custom Error Messages
 
 You can configure a custom format to display the failures of a rule.


### PR DESCRIPTION
The input for the should-part of a rule should normally not be empty, since then the test will always be green because it doesn't test anything.
With this change, it is now possible to verify that the input of a rule is not empty. If the input is empty, an `AssertionError` is thrown.

The verification if the input is empty can also be controlled via the configuration.
By setting the value `archRule.failOnEmptyShould` to `true` or `false`, we can turn on or off the verification.
The default value is `true` which means this is a breaking change.
However, with the configuration, the old behavior can easily be restored.

Resolve #178