### PR TITLE
implement containNumberOfElements for members 

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -1261,7 +1261,7 @@ class ExamplesIntegrationTest {
     }
 
     private static MessageAssertionChain.Link classesContaining(final Class<?>... classes) {
-        final String expectedLine = String.format("there is/are %d element(s) in classes %s", classes.length, formatNamesOf(classes));
+        final String expectedLine = String.format("there is/are %d element(s) in %s", classes.length, formatNamesOf(classes));
         return new MessageAssertionChain.Link() {
             @Override
             public Result filterMatching(List<String> lines) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -1083,8 +1083,8 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
-        return new NumberOfElementsCondition(predicate);
+    public static <T extends HasName.AndFullName> ArchCondition<T> containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
+        return new NumberOfElementsCondition<>(predicate);
     }
 
     /**
@@ -1321,9 +1321,9 @@ public final class ArchConditions {
         }
     }
 
-    private static class NumberOfElementsCondition extends ArchCondition<JavaClass> {
+    private static class NumberOfElementsCondition<T extends HasName.AndFullName> extends ArchCondition<T> {
         private final DescribedPredicate<Integer> predicate;
-        private final SortedSet<String> allClassNames = new TreeSet<>();
+        private final SortedSet<String> allElementNames = new TreeSet<>();
 
         NumberOfElementsCondition(DescribedPredicate<? super Integer> predicate) {
             super("contain number of elements " + predicate.getDescription());
@@ -1331,15 +1331,15 @@ public final class ArchConditions {
         }
 
         @Override
-        public void check(JavaClass item, ConditionEvents events) {
-            allClassNames.add(item.getName());
+        public void check(T item, ConditionEvents events) {
+            allElementNames.add(item.getFullName());
         }
 
         @Override
         public void finish(ConditionEvents events) {
-            int size = allClassNames.size();
+            int size = allElementNames.size();
             boolean conditionSatisfied = predicate.apply(size);
-            String message = String.format("there is/are %d element(s) in classes %s", size, join(allClassNames));
+            String message = String.format("there is/are %d element(s) in %s", size, join(allElementNames));
             events.add(new SimpleConditionEvent(size, conditionSatisfied, message));
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
@@ -294,6 +294,11 @@ abstract class AbstractMembersShouldInternal<MEMBER extends JavaMember, SELF ext
         });
     }
 
+    @Override
+    public SELF containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
+        return addCondition(ArchConditions.<JavaMember>containNumberOfElements(predicate));
+    }
+
     private SELF copyWithNewCondition(ArchCondition<? super MEMBER> newCondition) {
         return copyWithNewCondition(new ConditionAggregator<>(newCondition.<MEMBER>forSubtype()));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -671,7 +671,7 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
 
     @Override
     public ClassesShouldConjunction containNumberOfElements(DescribedPredicate<? super Integer> predicate) {
-        return addCondition(ArchConditions.containNumberOfElements(predicate));
+        return addCondition(ArchConditions.<JavaClass>containNumberOfElements(predicate));
     }
 
     private ClassesShouldInternal copyWithNewCondition(ArchCondition<JavaClass> newCondition) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
@@ -473,4 +473,12 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
      */
     @PublicAPI(usage = ACCESS)
     ClassesThat<CONJUNCTION> beDeclaredInClassesThat();
+
+    /**
+     * Asserts that the number of members checked by this rule conforms to the supplied predicate.
+     *
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION containNumberOfElements(DescribedPredicate<? super Integer> predicate);
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1695,7 +1695,7 @@ public class ClassesShouldTest {
     public void containNumberOfElements_fails_on_mismatching_predicate() {
         assertThatRule(classes().should().containNumberOfElements(DescribedPredicate.<Integer>alwaysFalse()))
                 .checking(importClasses(String.class, Integer.class))
-                .hasOnlyViolations("there is/are 2 element(s) in classes [java.lang.Integer, java.lang.String]");
+                .hasOnlyViolations("there is/are 2 element(s) in [java.lang.Integer, java.lang.String]");
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -40,11 +40,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
-import static com.tngtech.archunit.base.DescribedPredicate.greaterThan;
-import static com.tngtech.archunit.base.DescribedPredicate.greaterThanOrEqualTo;
-import static com.tngtech.archunit.base.DescribedPredicate.lessThan;
-import static com.tngtech.archunit.base.DescribedPredicate.lessThanOrEqualTo;
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
@@ -1689,30 +1684,18 @@ public class ClassesShouldTest {
                 .doesNotMatch(String.format(".*%s.* local class.*", quote(satisfied.getName())));
     }
 
-    @DataProvider
-    public static Object[][] containNumberOfElements_rules() {
-        return $$(
-                $(equalTo(999)),
-                $(lessThan(0)),
-                $(lessThan(1)),
-                $(lessThan(2)),
-                $(greaterThan(2)),
-                $(greaterThan(3)),
-                $(greaterThan(999)),
-                $(lessThanOrEqualTo(0)),
-                $(lessThanOrEqualTo(1)),
-                $(greaterThanOrEqualTo(3)),
-                $(greaterThanOrEqualTo(999)));
+    @Test
+    public void containNumberOfElements_passes_on_matching_predicate() {
+        assertThatRule(classes().should().containNumberOfElements(DescribedPredicate.<Integer>alwaysTrue()))
+                .checking(importClasses(String.class, Integer.class))
+                .hasNoViolation();
     }
 
     @Test
-    @UseDataProvider("containNumberOfElements_rules")
-    public void containNumberOfElements(DescribedPredicate<Integer> predicate) {
-        EvaluationResult result = classes().should().containNumberOfElements(predicate).evaluate(importClasses(String.class, Integer.class));
-
-        assertThat(singleLineFailureReportOf(result))
-                .contains("contain number of elements " + predicate.getDescription())
-                .contains("there is/are 2 element(s) in classes [java.lang.Integer, java.lang.String]");
+    public void containNumberOfElements_fails_on_mismatching_predicate() {
+        assertThatRule(classes().should().containNumberOfElements(DescribedPredicate.<Integer>alwaysFalse()))
+                .checking(importClasses(String.class, Integer.class))
+                .hasOnlyViolations("there is/are 2 element(s) in classes [java.lang.Integer, java.lang.String]");
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
@@ -81,6 +82,7 @@ import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.allMemb
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.allMethodsExcept;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.areNoFieldsWithType;
 import static com.tngtech.archunit.lang.syntax.elements.GivenMembersTest.assertViolation;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static java.util.Collections.emptySet;
@@ -651,6 +653,23 @@ public class MembersShouldTest {
                         quote(suffix),
                         quote(suffix),
                         locationPattern(SimpleFieldAndMethod.class)));
+    }
+
+    @Test
+    public void containNumberOfElements_passes_on_matching_predicate() {
+        assertThatRule(members().should().containNumberOfElements(DescribedPredicate.<Integer>alwaysTrue()))
+                .checking(importClasses(SimpleFieldAndMethod.class))
+                .hasNoViolation();
+    }
+
+    @Test
+    public void containNumberOfElements_fails_on_mismatching_predicate() {
+        assertThatRule(members().should().containNumberOfElements(DescribedPredicate.<Integer>alwaysFalse()))
+                .checking(importClasses(SimpleFieldAndMethod.class))
+                .hasOnlyViolations("there is/are 3 element(s) in ["
+                        + "com.tngtech.archunit.lang.syntax.elements.testclasses.SimpleFieldAndMethod.<init>(), "
+                        + "com.tngtech.archunit.lang.syntax.elements.testclasses.SimpleFieldAndMethod.violated, "
+                        + "com.tngtech.archunit.lang.syntax.elements.testclasses.SimpleFieldAndMethod.violated()]");
     }
 
     private Set<String> parseMembers(List<String> details) {


### PR DESCRIPTION
The method `containNumberOfElements` can be used to ensure that the `that`-clause matched a certain number of elements.
E.g. `classes().that().implement(SomeBusinessInterface.class).should().containNumberOfElements(lessThanOrEqualTo(1))`.
Until now, this method only existed for classes, but not for members.
With this commit, we implemented it now also for members.

Closes #179