### PR TITLE
Improve automatic resolution of class import dependencies

### DIFF
--- a/archunit-integration-test/src/test/resources/archunit.properties
+++ b/archunit-integration-test/src/test/resources/archunit.properties
@@ -1,3 +1,5 @@
+import.dependencyResolutionProcess.maxIterationsForEnclosingTypes=0
+import.dependencyResolutionProcess.maxIterationsForGenericSignatureTypes=0
 extension.archunit-example-extension.enabled=false
 extension.archunit-example-extension.example-prop=exampleValue
 freeze.store.default.path=../archunit-example/example-plain/src/test/resources/frozen

--- a/archunit-junit/junit4/src/test/resources/archunit.properties
+++ b/archunit-junit/junit4/src/test/resources/archunit.properties
@@ -1,4 +1,2 @@
-enableMd5InClassSources=true
-archRule.failOnEmptyShould=false
 import.dependencyResolutionProcess.maxIterationsForEnclosingTypes=0
 import.dependencyResolutionProcess.maxIterationsForGenericSignatureTypes=0

--- a/archunit-junit/junit5/engine/src/test/resources/archunit.properties
+++ b/archunit-junit/junit5/engine/src/test/resources/archunit.properties
@@ -1,4 +1,2 @@
-enableMd5InClassSources=true
-archRule.failOnEmptyShould=false
 import.dependencyResolutionProcess.maxIterationsForEnclosingTypes=0
 import.dependencyResolutionProcess.maxIterationsForGenericSignatureTypes=0

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -1,0 +1,458 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.Buffer;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaConstructorReference;
+import com.tngtech.archunit.core.domain.JavaEnumConstant;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
+import com.tngtech.archunit.core.domain.properties.HasAnnotations;
+import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
+import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithUnimportedAnnotation;
+import com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters;
+import com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters.SomeParameterAnnotation;
+import com.tngtech.archunit.core.importer.testexamples.annotationfieldimport.ClassWithAnnotatedFields;
+import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods;
+import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.OTHER_VALUE;
+import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.SOME_VALUE;
+import static com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithTwoAnnotations;
+import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.methodAnnotatedWithAnnotationFromParentPackage;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotation;
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion.annotationProperty;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+
+@RunWith(DataProviderRunner.class)
+public class ClassFileImporterAutomaticResolutionTest {
+
+    @Test
+    public void automatically_resolves_field_types() {
+        @SuppressWarnings("unused")
+        class FieldTypeWithoutAnyFurtherReference {
+            String field;
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(FieldTypeWithoutAnyFurtherReference.class);
+
+        assertThat(javaClass.getField("field").getRawType()).as("field type").isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_constructor_parameter_types() {
+        @SuppressWarnings("unused")
+        class ConstructorParameterTypesWithoutAnyFurtherReference {
+            ConstructorParameterTypesWithoutAnyFurtherReference(FileSystem constructorParam1, Buffer constructorParam2) {
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(ConstructorParameterTypesWithoutAnyFurtherReference.class);
+
+        JavaConstructor constructor = javaClass.getConstructor(getClass(), FileSystem.class, Buffer.class);
+        assertThat(constructor.getRawParameterTypes().get(0)).as("constructor parameter type").isFullyImported(true);
+        assertThat(constructor.getRawParameterTypes().get(1)).as("constructor parameter type").isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_method_return_types() {
+        @SuppressWarnings("unused")
+        class MemberTypesWithoutAnyFurtherReference {
+            File returnType() {
+                return null;
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
+
+        assertThat(javaClass.getMethod("returnType").getRawReturnType()).as("method return type").isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_method_parameter_types() {
+        @SuppressWarnings("unused")
+        class MemberTypesWithoutAnyFurtherReference {
+            void methodParameters(Path methodParam1, PrintStream methodParam2) {
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
+
+        JavaMethod method = javaClass.getMethod("methodParameters", Path.class, PrintStream.class);
+        assertThat(method.getRawParameterTypes().get(0)).as("method parameter type").isFullyImported(true);
+        assertThat(method.getRawParameterTypes().get(1)).as("method parameter type").isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_class_annotations() {
+        JavaClass clazz = new ClassFileImporter().importClass(ClassWithUnimportedAnnotation.class);
+
+        JavaAnnotation<?> annotation = clazz.getAnnotationOfType(SomeAnnotation.class.getName());
+
+        assertThat(annotation.getRawType()).isFullyImported(true);
+
+        assertThat(annotation.get("mandatory")).contains("mandatory");
+        assertThat(annotation.get("optional")).contains("optional");
+        assertThat((JavaEnumConstant) annotation.get("mandatoryEnum").get()).isEquivalentTo(SOME_VALUE);
+        assertThat((JavaEnumConstant) annotation.get("optionalEnum").get()).isEquivalentTo(OTHER_VALUE);
+
+        SomeAnnotation reflected = clazz.getAnnotationOfType(SomeAnnotation.class);
+        assertThat(reflected.mandatory()).isEqualTo("mandatory");
+        assertThat(reflected.optional()).isEqualTo("optional");
+        assertThat(reflected.mandatoryEnum()).isEqualTo(SOME_VALUE);
+        assertThat(reflected.optionalEnum()).isEqualTo(OTHER_VALUE);
+    }
+
+    @Test
+    public void automatically_resolves_field_annotations() {
+        JavaClass clazz = new ClassFileImporter().importClass(ClassWithAnnotatedFields.class);
+
+        JavaAnnotation<?> annotation = clazz.getField("fieldAnnotatedWithAnnotationFromParentPackage")
+                .getAnnotationOfType(SomeAnnotation.class.getName());
+
+        assertThat(annotation.getRawType()).isFullyImported(true);
+
+        assertThat(annotation.get("mandatory")).contains("mandatory");
+        assertThat(annotation.get("optional")).contains("optional");
+
+        SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
+        assertThat(reflected.mandatory()).isEqualTo("mandatory");
+        assertThat(reflected.optional()).isEqualTo("optional");
+    }
+
+    @Test
+    public void automatically_resolves_method_annotations() {
+        JavaClass clazz = new ClassFileImporter().importClass(ClassWithAnnotatedMethods.class);
+
+        JavaAnnotation<?> annotation = clazz.getMethod(methodAnnotatedWithAnnotationFromParentPackage)
+                .getAnnotationOfType(SomeAnnotation.class.getName());
+
+        assertThat(annotation.getRawType()).isFullyImported(true);
+
+        assertThat(annotation.get("mandatory")).contains("mandatory");
+        assertThat(annotation.get("optional")).contains("optional");
+
+        SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
+        assertThat(reflected.mandatory()).isEqualTo("mandatory");
+        assertThat(reflected.optional()).isEqualTo("optional");
+    }
+
+    @Test
+    public void automatically_resolves_constructor_annotations() {
+        JavaClass clazz = new ClassFileImporter().importClass(ClassWithAnnotatedMethods.class);
+
+        JavaAnnotation<?> annotation = clazz.getConstructor()
+                .getAnnotationOfType(MethodAnnotationWithEnumAndArrayValue.class.getName());
+
+        assertThat(annotation.getRawType()).isFullyImported(true);
+
+        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+
+        MethodAnnotationWithEnumAndArrayValue reflected = annotation.as(MethodAnnotationWithEnumAndArrayValue.class);
+        assertThat(reflected.value()).isEqualTo(OTHER_VALUE);
+    }
+
+    @Test
+    public void automatically_resolves_parameter_annotations() {
+        JavaClass clazz = new ClassFileImporter().importClass(ClassWithMethodWithAnnotatedParameters.class);
+
+        JavaAnnotation<?> annotation = clazz.getMethod(methodWithOneAnnotatedParameterWithTwoAnnotations, String.class)
+                .getParameters().get(0)
+                .getAnnotationOfType(SomeParameterAnnotation.class.getName());
+
+        assertThat(annotation.getRawType()).isFullyImported(true);
+
+        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+        assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
+
+        SomeParameterAnnotation reflected = annotation.as(SomeParameterAnnotation.class);
+        assertThat(reflected.value()).isEqualTo(OTHER_VALUE);
+        assertThat(reflected.valueWithDefault()).isEqualTo(SOME_VALUE);
+    }
+
+    @Test
+    public void automatically_resolves_meta_annotation_types() {
+        JavaClass javaClass = new ClassFileImporter().importClass(MetaAnnotatedClass.class);
+        JavaAnnotation<JavaClass> someAnnotation = javaClass.getAnnotationOfType(MetaAnnotatedAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaAnnotation = someAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaMetaAnnotation = someMetaAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaMetaAnnotation.class.getName());
+        JavaAnnotation<JavaClass> someMetaMetaMetaAnnotation = someMetaMetaAnnotation.getRawType()
+                .getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
+
+        assertThatType(someMetaMetaMetaAnnotation.getType()).matches(SomeMetaMetaMetaAnnotationWithParameters.class);
+    }
+
+    @DataProvider
+    public static Object[][] elementsAnnotatedWithSomeAnnotation() {
+        return testForEach(
+                new ClassFileImporter().importClass(MetaAnnotatedClass.class),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedField.class).getField("metaAnnotatedField"),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedMethod.class).getMethod("metaAnnotatedMethod"),
+                new ClassFileImporter().importClass(ClassWithMetaAnnotatedConstructor.class).getConstructor(),
+                getOnlyElement(new ClassFileImporter().importClass(ClassWithMetaAnnotatedConstructorParameter.class).getConstructor(String.class).getParameters()),
+                getOnlyElement(new ClassFileImporter().importClass(ClassWithMetaAnnotatedMethodParameter.class).getMethod("method", String.class).getParameters())
+        );
+    }
+
+    @Test
+    @UseDataProvider("elementsAnnotatedWithSomeAnnotation")
+    public void automatically_resolves_parameters_of_meta_annotations(HasAnnotations<?> annotatedWithSomeAnnotation) {
+        JavaAnnotation<?> someAnnotation = annotatedWithSomeAnnotation
+                .getAnnotationOfType(MetaAnnotatedAnnotation.class.getName());
+        JavaAnnotation<?> metaAnnotationWithParameters = someAnnotation.getRawType()
+                .getAnnotationOfType(MetaAnnotationWithParameters.class.getName());
+
+        assertThatAnnotation(metaAnnotationWithParameters)
+                .hasEnumProperty("someEnum", SomeAnnotationEnum.CONSTANT)
+                .hasEnumProperty("someEnumDefault", SomeAnnotationEnum.VARIABLE)
+                .hasAnnotationProperty("parameterAnnotation",
+                        annotationProperty()
+                                .withAnnotationType(ParameterAnnotation.class)
+                                .withClassProperty("value", SomeAnnotationParameterType.class))
+                .hasAnnotationProperty("parameterAnnotationDefault",
+                        annotationProperty()
+                                .withAnnotationType(ParameterAnnotation.class)
+                                .withClassProperty("value", SomeAnnotationDefaultParameterType.class));
+
+        JavaAnnotation<JavaClass> metaMetaMetaAnnotation = someAnnotation
+                .getRawType().getAnnotationOfType(SomeMetaAnnotation.class.getName())
+                .getRawType().getAnnotationOfType(SomeMetaMetaAnnotation.class.getName())
+                .getRawType().getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
+
+        assertThatAnnotation(metaMetaMetaAnnotation)
+                .hasClassProperty("classParam", SomeMetaMetaMetaAnnotationClassParameter.class)
+                .hasClassProperty("classParamDefault", String.class)
+                .hasEnumProperty("enumParam", SomeMetaMetaMetaAnnotationEnumParameter.VALUE)
+                .hasEnumProperty("enumParamDefault", SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT)
+                .hasAnnotationProperty("annotationParam",
+                        annotationProperty()
+                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class)
+                                .withClassProperty("value", SomeMetaMetaMetaParameterAnnotationClassParameter.class))
+                .hasAnnotationProperty("annotationParamDefault",
+                        annotationProperty()
+                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class));
+    }
+
+    @Test
+    public void automatically_resolves_field_access_target_owners() {
+        class Target {
+            String field;
+        }
+        @SuppressWarnings({"unused", "ConstantConditions"})
+        class Origin {
+            Object resolvesFieldAccessOwner() {
+                Target target = null;
+                return target.field;
+            }
+        }
+
+        JavaFieldAccess access = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getMethod("resolvesFieldAccessOwner").getFieldAccesses());
+
+        assertThat(access.getTargetOwner()).isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_method_call_target_owners() {
+        class Target {
+            void method() {
+            }
+        }
+        @SuppressWarnings({"unused", "ConstantConditions"})
+        class Origin {
+            void resolvesMethodCallTargetOwner() {
+                Target target = null;
+                target.method();
+            }
+        }
+
+        JavaMethodCall call = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getMethodCallsFromSelf());
+
+        assertThat(call.getTargetOwner()).isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_method_reference_target_owners() {
+        class Target {
+            void method() {
+            }
+        }
+        @SuppressWarnings({"unused", "ConstantConditions"})
+        class Origin {
+            Runnable resolvesMethodCallTargetOwner() {
+                Target target = null;
+                return target::method;
+            }
+        }
+
+        JavaMethodReference reference = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getMethodReferencesFromSelf());
+
+        assertThat(reference.getTargetOwner()).isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_constructor_call_target_owners() {
+        class Target {
+        }
+        @SuppressWarnings("unused")
+        class Origin {
+            void resolvesConstructorCallTargetOwner() {
+                new Target();
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(Origin.class);
+        JavaConstructorCall call = getOnlyElement(javaClass.getMethod("resolvesConstructorCallTargetOwner").getConstructorCallsFromSelf());
+
+        assertThat(call.getTargetOwner()).isFullyImported(true);
+    }
+
+    private static class Data_automatically_resolves_constructor_reference_target_owners {
+        static class Target {
+        }
+    }
+
+    @Test
+    public void automatically_resolves_constructor_reference_target_owners() {
+        @SuppressWarnings("unused")
+        class Origin {
+            Supplier<?> resolvesConstructorReferenceTargetOwner() {
+                return Data_automatically_resolves_constructor_reference_target_owners.Target::new;
+            }
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(Origin.class);
+        JavaConstructorReference reference = getOnlyElement(javaClass.getMethod("resolvesConstructorReferenceTargetOwner").getConstructorReferencesFromSelf());
+
+        assertThat(reference.getTargetOwner()).isFullyImported(true);
+    }
+
+    @MetaAnnotatedAnnotation
+    private static class MetaAnnotatedClass {
+    }
+
+    @SuppressWarnings("unused")
+    private @interface MetaAnnotationWithParameters {
+        SomeAnnotationEnum someEnum();
+
+        SomeAnnotationEnum someEnumDefault() default SomeAnnotationEnum.VARIABLE;
+
+        ParameterAnnotation parameterAnnotation();
+
+        ParameterAnnotation parameterAnnotationDefault() default @ParameterAnnotation(SomeAnnotationDefaultParameterType.class);
+    }
+
+    private @interface SomeMetaMetaMetaAnnotationWithParameters {
+        Class<?> classParam();
+
+        Class<?> classParamDefault() default String.class;
+
+        SomeMetaMetaMetaAnnotationEnumParameter enumParam();
+
+        SomeMetaMetaMetaAnnotationEnumParameter enumParamDefault() default SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT;
+
+        SomeMetaMetaMetaParameterAnnotation annotationParam();
+
+        SomeMetaMetaMetaParameterAnnotation annotationParamDefault() default @SomeMetaMetaMetaParameterAnnotation(Boolean.class);
+    }
+
+    @SomeMetaMetaMetaAnnotationWithParameters(
+            classParam = SomeMetaMetaMetaAnnotationClassParameter.class,
+            enumParam = SomeMetaMetaMetaAnnotationEnumParameter.VALUE,
+            annotationParam = @SomeMetaMetaMetaParameterAnnotation(SomeMetaMetaMetaParameterAnnotationClassParameter.class)
+    )
+    private @interface SomeMetaMetaAnnotation {
+    }
+
+    @SomeMetaMetaAnnotation
+    private @interface SomeMetaAnnotation {
+    }
+
+    @MetaAnnotationWithParameters(
+            someEnum = SomeAnnotationEnum.CONSTANT,
+            parameterAnnotation = @ParameterAnnotation(SomeAnnotationParameterType.class)
+    )
+    @SomeMetaAnnotation
+    private @interface MetaAnnotatedAnnotation {
+    }
+
+    private enum SomeAnnotationEnum {
+        CONSTANT,
+        VARIABLE
+    }
+
+    private static class SomeAnnotationDefaultParameterType {
+    }
+
+    private @interface ParameterAnnotation {
+        Class<?> value();
+    }
+
+    private static class SomeAnnotationParameterType {
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedField {
+        @MetaAnnotatedAnnotation
+        int metaAnnotatedField;
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedMethod {
+        @MetaAnnotatedAnnotation
+        void metaAnnotatedMethod() {
+        }
+    }
+
+    private static class ClassWithMetaAnnotatedConstructor {
+        @MetaAnnotatedAnnotation
+        ClassWithMetaAnnotatedConstructor() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedConstructorParameter {
+        ClassWithMetaAnnotatedConstructorParameter(@MetaAnnotatedAnnotation String param) {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithMetaAnnotatedMethodParameter {
+        void method(@MetaAnnotatedAnnotation String param) {
+        }
+    }
+
+    private static class SomeMetaMetaMetaAnnotationClassParameter {
+    }
+
+    private enum SomeMetaMetaMetaAnnotationEnumParameter {
+        VALUE,
+        CONSTANT
+    }
+
+    private @interface SomeMetaMetaMetaParameterAnnotation {
+        Class<?> value();
+    }
+
+    private static class SomeMetaMetaMetaParameterAnnotationClassParameter {
+    }
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -53,7 +53,9 @@ import org.junit.runner.RunWith;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ENCLOSING_TYPES_DEFAULT_VALUE;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME;
@@ -597,7 +599,8 @@ public class ClassFileImporterAutomaticResolutionTest {
         }
 
         Class<?> lessInnerClass = Class.forName(Outermost.LessOuter.LeastOuter.class.getName() + "$1LessInner");
-        JavaClass innermost = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME)
+        JavaClass innermost = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_ENCLOSING_TYPES_DEFAULT_VALUE)
                 .importClass(Class.forName(lessInnerClass.getName() + "$Innermost"));
 
         JavaClass lessInner = innermost.getEnclosingClass().get();
@@ -767,32 +770,37 @@ public class ClassFileImporterAutomaticResolutionTest {
     }
 
     private static JavaType importFirstTypeParameterClassBound(Class<?> clazz) {
-        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME)
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE)
                 .importClass(clazz);
         return getOnlyElement(getOnlyElement(javaClass.getTypeParameters()).getBounds());
     }
 
     private static JavaType importFirstTypeParameterMethodBound(Class<?> clazz) {
-        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME)
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE)
                 .importClass(clazz);
         return getOnlyElement(getOnlyElement(javaClass.getMethod("method").getTypeParameters()).getBounds());
     }
 
     private static JavaType importFirstTypeArgumentFieldBound(Class<?> clazz) {
-        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME)
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE)
                 .importClass(clazz);
         return getFirstTypeArgumentUpperBound(javaClass.getField("field").getType());
     }
 
     private static JavaType importFirstTypeArgumentMethodParameterBound(Class<?> clazz) {
-        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME)
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE)
                 .importClass(clazz);
         JavaMethod method = getOnlyElement(javaClass.getMethods());
         return getFirstTypeArgumentUpperBound(method.getParameterTypes().get(0));
     }
 
     private static JavaType importFirstTypeArgumentConstructorParameterBound(Class<?> clazz) {
-        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME)
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE)
                 .importClass(clazz);
         JavaConstructor constructor = getOnlyElement(javaClass.getConstructors());
         return getFirstTypeArgumentUpperBound(constructor.getParameterTypes().get(0));

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -518,6 +518,26 @@ public class ClassFileImporterAutomaticResolutionTest {
         assertThatType(throwsDeclaration.getRawType()).matches(InterruptedException.class);
     }
 
+    @Test
+    public void automatically_resolves_array_component_types() {
+        @SuppressWarnings("unused")
+        class Origin {
+            String[] oneDim;
+
+            File[][] twoDim;
+        }
+
+        JavaClass javaClass = new ClassFileImporter().importClass(Origin.class);
+
+        JavaClass componentType = javaClass.getField("oneDim").getRawType().getComponentType();
+        assertThat(componentType).isFullyImported(true);
+        assertThatType(componentType).matches(String.class);
+
+        componentType = javaClass.getField("twoDim").getRawType().getComponentType().getComponentType();
+        assertThat(componentType).isFullyImported(true);
+        assertThatType(componentType).matches(File.class);
+    }
+
     @MetaAnnotatedAnnotation
     private static class MetaAnnotatedClass {
     }

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithUnimportedAnnotation;
@@ -469,6 +470,21 @@ public class ClassFileImporterAutomaticResolutionTest {
     public void test_automatically_resolves_annotation_parameter_types(JavaClass annotationValue, Class<?> expectedType) {
         assertThat(annotationValue).isFullyImported(true);
         assertThatType(annotationValue).matches(expectedType);
+    }
+
+    @Test
+    public void automatically_resolves_class_objects() {
+        @SuppressWarnings("unused")
+        class Origin {
+            Class<?> call() {
+                return String.class;
+            }
+        }
+
+        ReferencedClassObject classObject = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getReferencedClassObjects());
+
+        assertThat(classObject.getRawType()).isFullyImported(true);
+        assertThatType(classObject.getRawType()).matches(String.class);
     }
 
     @MetaAnnotatedAnnotation

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.ArchConfiguration;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaConstructor;
@@ -485,6 +486,21 @@ public class ClassFileImporterAutomaticResolutionTest {
 
         assertThat(classObject.getRawType()).isFullyImported(true);
         assertThatType(classObject.getRawType()).matches(String.class);
+    }
+
+    @Test
+    public void automatically_resolves_instanceof_check_targets() {
+        @SuppressWarnings("unused")
+        class Origin {
+            boolean call(Object obj) {
+                return obj instanceof String;
+            }
+        }
+
+        InstanceofCheck instanceofCheck = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getInstanceofChecks());
+
+        assertThat(instanceofCheck.getRawType()).isFullyImported(true);
+        assertThatType(instanceofCheck.getRawType()).matches(String.class);
     }
 
     @MetaAnnotatedAnnotation

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.core.importer.testexamples.annotatedparameters.Class
 import com.tngtech.archunit.core.importer.testexamples.annotationfieldimport.ClassWithAnnotatedFields;
 import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods;
 import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue;
+import com.tngtech.archunit.core.importer.testexamples.classhierarchy.Child;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -102,6 +103,26 @@ public class ClassFileImporterAutomaticResolutionTest {
         JavaMethod method = javaClass.getMethod("methodParameters", Path.class, PrintStream.class);
         assertThat(method.getRawParameterTypes().get(0)).as("method parameter type").isFullyImported(true);
         assertThat(method.getRawParameterTypes().get(1)).as("method parameter type").isFullyImported(true);
+    }
+
+    @Test
+    public void automatically_resolves_class_hierarchy() {
+        JavaClass child = new ClassFileImporter().importClass(Child.class);
+
+        JavaClass parent = child.getRawSuperclass().get();
+        assertThat(parent).isFullyImported(true);
+
+        JavaClass grandparent = parent.getRawSuperclass().get();
+        assertThat(grandparent).isFullyImported(true);
+
+        JavaClass parentInterfaceDirect = getOnlyElement(child.getRawInterfaces());
+        assertThat(parentInterfaceDirect).isFullyImported(true);
+
+        JavaClass grandParentInterfaceDirect = getOnlyElement(parentInterfaceDirect.getRawInterfaces());
+        assertThat(grandParentInterfaceDirect).isFullyImported(true);
+
+        JavaClass grandParentInterfaceIndirect = getOnlyElement(getOnlyElement(grandparent.getRawInterfaces()).getRawInterfaces());
+        assertThat(grandParentInterfaceIndirect).isFullyImported(true);
     }
 
     @Test

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
+import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithUnimportedAnnotation;
@@ -501,6 +502,20 @@ public class ClassFileImporterAutomaticResolutionTest {
 
         assertThat(instanceofCheck.getRawType()).isFullyImported(true);
         assertThatType(instanceofCheck.getRawType()).matches(String.class);
+    }
+
+    @Test
+    public void automatically_resolves_types_of_throws_declarations() {
+        @SuppressWarnings({"unused", "RedundantThrows"})
+        class Origin {
+            void call() throws InterruptedException {
+            }
+        }
+
+        ThrowsDeclaration<?> throwsDeclaration = getOnlyElement(new ClassFileImporter().importClass(Origin.class).getThrowsDeclarations());
+
+        assertThat(throwsDeclaration.getRawType()).isFullyImported(true);
+        assertThatType(throwsDeclaration.getRawType()).matches(InterruptedException.class);
     }
 
     @MetaAnnotatedAnnotation

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/AnotherAnnotationWithAnnotationParameter.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/AnotherAnnotationWithAnnotationParameter.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.annotations;
+
+public @interface AnotherAnnotationWithAnnotationParameter {
+    SomeAnnotationWithAnnotationParameter value();
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/SomeAnnotationWithAnnotationParameter.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/SomeAnnotationWithAnnotationParameter.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.annotations;
+
+public @interface SomeAnnotationWithAnnotationParameter {
+    SomeAnnotationWithClassParameter value();
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/SomeAnnotationWithClassParameter.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/annotations/SomeAnnotationWithClassParameter.java
@@ -1,0 +1,5 @@
+package com.tngtech.archunit.core.importer.testexamples.annotations;
+
+public @interface SomeAnnotationWithClassParameter {
+    Class<?> value();
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/Child.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/Child.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public class Child extends Parent implements ParentInterfaceDirect {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParent.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParent.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public class GrandParent implements ParentInterfaceIndirect {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParentInterfaceDirect.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParentInterfaceDirect.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public interface GrandParentInterfaceDirect {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParentInterfaceIndirect.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/GrandParentInterfaceIndirect.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public interface GrandParentInterfaceIndirect {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/Parent.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/Parent.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public class Parent extends GrandParent {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/ParentInterfaceDirect.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/ParentInterfaceDirect.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public interface ParentInterfaceDirect extends GrandParentInterfaceDirect {
+}

--- a/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/ParentInterfaceIndirect.java
+++ b/archunit/src/jdk9test/java/com/tngtech/archunit/core/importer/testexamples/classhierarchy/ParentInterfaceIndirect.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.classhierarchy;
+
+public interface ParentInterfaceIndirect extends GrandParentInterfaceIndirect {
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -650,6 +650,11 @@ public class JavaClass
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<InstanceofCheck> getInstanceofChecks() {
+        return members.getInstanceofChecks();
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<ReferencedClassObject> getReferencedClassObjects() {
         return members.getReferencedClassObjects();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1551,6 +1551,19 @@ public class JavaClass
         return formatNamesOf(paramTypes);
     }
 
+    /**
+     * @return all throws declarations on any method or constructor of this class
+     *         (e.g. {@code void method() throws SomeException})
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<ThrowsDeclaration<? extends JavaCodeUnit>> getThrowsDeclarations() {
+        ImmutableSet.Builder<ThrowsDeclaration<? extends JavaCodeUnit>> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : getCodeUnits()) {
+            result.addAll(codeUnit.getThrowsClause());
+        }
+        return result.build();
+    }
+
     private static class Superclass {
         private static final Superclass ABSENT = new Superclass(Optional.<JavaType>empty());
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -136,7 +136,7 @@ public class JavaClass
     private Map<String, JavaAnnotation<JavaClass>> annotations = emptyMap();
     private JavaClassDependencies javaClassDependencies = new JavaClassDependencies(this);  // just for stubs; will be overwritten for imported classes
     private ReverseDependencies reverseDependencies = ReverseDependencies.EMPTY;  // just for stubs; will be overwritten for imported classes
-    private final CompletionProcess completionProcess = CompletionProcess.start();
+    private final CompletionProcess completionProcess;
 
     JavaClass(JavaClassBuilder builder) {
         source = checkNotNull(builder.getSource());
@@ -151,6 +151,7 @@ public class JavaClass
         reflectSupplier = Suppliers.memoize(new ReflectClassSupplier());
         sourceCodeLocation = SourceCodeLocation.of(this);
         javaPackage = JavaPackage.simple(this);
+        completionProcess = builder.isStub() ? CompletionProcess.stub() : CompletionProcess.start();
     }
 
     /**
@@ -1646,7 +1647,74 @@ public class JavaClass
         }
     }
 
-    private static class CompletionProcess {
+    private abstract static class CompletionProcess {
+        private static final CompletionProcess stubCompletionProcess = new CompletionProcess() {
+            @Override
+            boolean hasFinished() {
+                return false;
+            }
+
+            @Override
+            public void markClassHierarchyComplete() {
+            }
+
+            @Override
+            public void markEnclosingDeclarationComplete() {
+            }
+
+            @Override
+            public void markTypeParametersComplete() {
+            }
+
+            @Override
+            public void markGenericSuperclassComplete() {
+            }
+
+            @Override
+            public void markGenericInterfacesComplete() {
+            }
+
+            @Override
+            public void markMembersComplete() {
+            }
+
+            @Override
+            public void markAnnotationsComplete() {
+            }
+
+            @Override
+            public void markDependenciesComplete() {
+            }
+        };
+
+        abstract boolean hasFinished();
+
+        public abstract void markClassHierarchyComplete();
+
+        public abstract void markEnclosingDeclarationComplete();
+
+        public abstract void markTypeParametersComplete();
+
+        public abstract void markGenericSuperclassComplete();
+
+        public abstract void markGenericInterfacesComplete();
+
+        public abstract void markMembersComplete();
+
+        public abstract void markAnnotationsComplete();
+
+        public abstract void markDependenciesComplete();
+
+        static CompletionProcess start() {
+            return new FullCompletionProcess();
+        }
+
+        static CompletionProcess stub() {
+            return stubCompletionProcess;
+        }
+    }
+
+    private static class FullCompletionProcess extends CompletionProcess {
         private boolean classHierarchyComplete = false;
         private boolean enclosingDeclarationComplete = false;
         private boolean typeParametersComplete = false;
@@ -1656,9 +1724,7 @@ public class JavaClass
         private boolean annotationsComplete = false;
         private boolean dependenciesComplete = false;
 
-        private CompletionProcess() {
-        }
-
+        @Override
         boolean hasFinished() {
             return classHierarchyComplete
                     && enclosingDeclarationComplete
@@ -1670,40 +1736,44 @@ public class JavaClass
                     && dependenciesComplete;
         }
 
+        @Override
         public void markClassHierarchyComplete() {
             this.classHierarchyComplete = true;
         }
 
+        @Override
         public void markEnclosingDeclarationComplete() {
             this.enclosingDeclarationComplete = true;
         }
 
+        @Override
         public void markTypeParametersComplete() {
             this.typeParametersComplete = true;
         }
 
+        @Override
         public void markGenericSuperclassComplete() {
             this.genericSuperclassComplete = true;
         }
 
+        @Override
         public void markGenericInterfacesComplete() {
             this.genericInterfacesComplete = true;
         }
 
+        @Override
         public void markMembersComplete() {
             this.membersComplete = true;
         }
 
+        @Override
         public void markAnnotationsComplete() {
             this.annotationsComplete = true;
         }
 
+        @Override
         public void markDependenciesComplete() {
             this.dependenciesComplete = true;
-        }
-
-        static CompletionProcess start() {
-            return new CompletionProcess();
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -185,10 +185,8 @@ class JavaClassDependencies {
 
     private Set<Dependency> throwsDeclarationDependenciesFromSelf() {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
-        for (JavaCodeUnit codeUnit : javaClass.getCodeUnits()) {
-            for (ThrowsDeclaration<? extends JavaCodeUnit> throwsDeclaration : codeUnit.getThrowsClause()) {
-                result.addAll(Dependency.tryCreateFromThrowsDeclaration(throwsDeclaration));
-            }
+        for (ThrowsDeclaration<? extends JavaCodeUnit> throwsDeclaration : javaClass.getThrowsDeclarations()) {
+            result.addAll(Dependency.tryCreateFromThrowsDeclaration(throwsDeclaration));
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -206,10 +206,8 @@ class JavaClassDependencies {
 
     private Set<Dependency> instanceofCheckDependenciesFromSelf() {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
-        for (JavaCodeUnit codeUnit : javaClass.getCodeUnits()) {
-            for (InstanceofCheck instanceofCheck : codeUnit.getInstanceofChecks()) {
-                result.addAll(Dependency.tryCreateFromInstanceofCheck(instanceofCheck));
-            }
+        for (InstanceofCheck instanceofCheck : javaClass.getInstanceofChecks()) {
+            result.addAll(Dependency.tryCreateFromInstanceofCheck(instanceofCheck));
         }
         return result.build();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -196,6 +196,14 @@ class JavaClassMembers {
         return result.build();
     }
 
+    Set<InstanceofCheck> getInstanceofChecks() {
+        ImmutableSet.Builder<InstanceofCheck> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getInstanceofChecks());
+        }
+        return result.build();
+    }
+
     Set<ReferencedClassObject> getReferencedClassObjects() {
         ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
         for (JavaCodeUnit codeUnit : codeUnits) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -288,16 +288,6 @@ class ClassFileImportRecord {
         return classes;
     }
 
-    Set<RawAccessRecord> getAccessRecords() {
-        return ImmutableSet.<RawAccessRecord>builder()
-                .addAll(rawFieldAccessRecords)
-                .addAll(rawMethodCallRecords)
-                .addAll(rawConstructorCallRecords)
-                .addAll(rawMethodReferenceRecords)
-                .addAll(rawConstructorReferenceRecords)
-                .build();
-    }
-
     Set<String> getAllSuperclassNames() {
         return ImmutableSet.copyOf(superclassNamesByOwner.values());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -158,25 +158,6 @@ class ClassFileImportRecord {
         return Optional.ofNullable(genericInterfaceBuildersByOwner.get(owner.getName()));
     }
 
-    Set<String> getMemberSignatureTypeNames() {
-        ImmutableSet.Builder<String> result = ImmutableSet.builder();
-        for (JavaFieldBuilder fieldBuilder : fieldBuildersByOwner.values()) {
-            result.add(fieldBuilder.getTypeName());
-        }
-        for (JavaConstructorBuilder constructorBuilder : constructorBuildersByOwner.values()) {
-            for (String parameterTypeName : constructorBuilder.getParameterTypeNames()) {
-                result.add(parameterTypeName);
-            }
-        }
-        for (JavaMethodBuilder methodBuilder : methodBuildersByOwner.values()) {
-            result.add(methodBuilder.getReturnTypeName());
-            for (String parameterTypeName : methodBuilder.getParameterTypeNames()) {
-                result.add(parameterTypeName);
-            }
-        }
-        return result.build();
-    }
-
     Set<JavaFieldBuilder> getFieldBuildersFor(String ownerName) {
         return fieldBuildersByOwner.get(ownerName);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -33,10 +33,15 @@ import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassTypeParametersBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaCodeUnitBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaFieldBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMemberBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 
@@ -54,12 +59,12 @@ class ClassFileImportRecord {
     private final Map<String, JavaClassTypeParametersBuilder> typeParametersBuilderByOwner = new HashMap<>();
     private final Map<String, JavaParameterizedTypeBuilder<JavaClass>> genericSuperclassBuilderByOwner = new HashMap<>();
     private final Map<String, List<JavaParameterizedTypeBuilder<JavaClass>>> genericInterfaceBuildersByOwner = new HashMap<>();
-    private final SetMultimap<String, DomainBuilders.JavaFieldBuilder> fieldBuildersByOwner = HashMultimap.create();
-    private final SetMultimap<String, DomainBuilders.JavaMethodBuilder> methodBuildersByOwner = HashMultimap.create();
-    private final SetMultimap<String, DomainBuilders.JavaConstructorBuilder> constructorBuildersByOwner = HashMultimap.create();
-    private final Map<String, DomainBuilders.JavaStaticInitializerBuilder> staticInitializerBuildersByOwner = new HashMap<>();
-    private final SetMultimap<String, DomainBuilders.JavaAnnotationBuilder> annotationsByOwner = HashMultimap.create();
-    private final Map<String, DomainBuilders.JavaAnnotationBuilder.ValueBuilder> annotationDefaultValuesByOwner = new HashMap<>();
+    private final SetMultimap<String, JavaFieldBuilder> fieldBuildersByOwner = HashMultimap.create();
+    private final SetMultimap<String, JavaMethodBuilder> methodBuildersByOwner = HashMultimap.create();
+    private final SetMultimap<String, JavaConstructorBuilder> constructorBuildersByOwner = HashMultimap.create();
+    private final Map<String, JavaStaticInitializerBuilder> staticInitializerBuildersByOwner = new HashMap<>();
+    private final SetMultimap<String, JavaAnnotationBuilder> annotationsByOwner = HashMultimap.create();
+    private final Map<String, JavaAnnotationBuilder.ValueBuilder> annotationDefaultValuesByOwner = new HashMap<>();
     private final EnclosingDeclarationsByInnerClasses enclosingDeclarationsByOwner = new EnclosingDeclarationsByInnerClasses();
 
     private final Set<RawAccessRecord.ForField> rawFieldAccessRecords = new HashSet<>();
@@ -91,34 +96,34 @@ class ClassFileImportRecord {
         genericInterfaceBuildersByOwner.put(ownerName, genericInterfaceBuilders);
     }
 
-    void addField(String ownerName, DomainBuilders.JavaFieldBuilder fieldBuilder) {
+    void addField(String ownerName, JavaFieldBuilder fieldBuilder) {
         fieldBuildersByOwner.put(ownerName, fieldBuilder);
     }
 
-    void addMethod(String ownerName, DomainBuilders.JavaMethodBuilder methodBuilder) {
+    void addMethod(String ownerName, JavaMethodBuilder methodBuilder) {
         methodBuildersByOwner.put(ownerName, methodBuilder);
     }
 
-    void addConstructor(String ownerName, DomainBuilders.JavaConstructorBuilder constructorBuilder) {
+    void addConstructor(String ownerName, JavaConstructorBuilder constructorBuilder) {
         constructorBuildersByOwner.put(ownerName, constructorBuilder);
     }
 
-    void setStaticInitializer(String ownerName, DomainBuilders.JavaStaticInitializerBuilder builder) {
+    void setStaticInitializer(String ownerName, JavaStaticInitializerBuilder builder) {
         checkState(!staticInitializerBuildersByOwner.containsKey(ownerName),
                 "Tried to add a second static initializer to %s, this is most likely a bug",
                 ownerName);
         staticInitializerBuildersByOwner.put(ownerName, builder);
     }
 
-    void addClassAnnotations(String ownerName, Set<DomainBuilders.JavaAnnotationBuilder> annotations) {
+    void addClassAnnotations(String ownerName, Set<JavaAnnotationBuilder> annotations) {
         this.annotationsByOwner.putAll(ownerName, annotations);
     }
 
-    void addMemberAnnotations(String declaringClassName, String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations) {
+    void addMemberAnnotations(String declaringClassName, String memberName, String descriptor, Set<JavaAnnotationBuilder> annotations) {
         this.annotationsByOwner.putAll(getMemberKey(declaringClassName, memberName, descriptor), annotations);
     }
 
-    void addAnnotationDefaultValue(String declaringClassName, String methodName, String descriptor, DomainBuilders.JavaAnnotationBuilder.ValueBuilder valueBuilder) {
+    void addAnnotationDefaultValue(String declaringClassName, String methodName, String descriptor, JavaAnnotationBuilder.ValueBuilder valueBuilder) {
         annotationDefaultValuesByOwner.put(getMemberKey(declaringClassName, methodName, descriptor), valueBuilder);
     }
 
@@ -155,15 +160,15 @@ class ClassFileImportRecord {
 
     Set<String> getMemberSignatureTypeNames() {
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
-        for (DomainBuilders.JavaFieldBuilder fieldBuilder : fieldBuildersByOwner.values()) {
+        for (JavaFieldBuilder fieldBuilder : fieldBuildersByOwner.values()) {
             result.add(fieldBuilder.getTypeName());
         }
-        for (DomainBuilders.JavaConstructorBuilder constructorBuilder : constructorBuildersByOwner.values()) {
+        for (JavaConstructorBuilder constructorBuilder : constructorBuildersByOwner.values()) {
             for (String parameterTypeName : constructorBuilder.getParameterTypeNames()) {
                 result.add(parameterTypeName);
             }
         }
-        for (DomainBuilders.JavaMethodBuilder methodBuilder : methodBuildersByOwner.values()) {
+        for (JavaMethodBuilder methodBuilder : methodBuildersByOwner.values()) {
             result.add(methodBuilder.getReturnTypeName());
             for (String parameterTypeName : methodBuilder.getParameterTypeNames()) {
                 result.add(parameterTypeName);
@@ -172,31 +177,31 @@ class ClassFileImportRecord {
         return result.build();
     }
 
-    Set<DomainBuilders.JavaFieldBuilder> getFieldBuildersFor(String ownerName) {
+    Set<JavaFieldBuilder> getFieldBuildersFor(String ownerName) {
         return fieldBuildersByOwner.get(ownerName);
     }
 
-    Set<DomainBuilders.JavaMethodBuilder> getMethodBuildersFor(String ownerName) {
+    Set<JavaMethodBuilder> getMethodBuildersFor(String ownerName) {
         return methodBuildersByOwner.get(ownerName);
     }
 
-    Set<DomainBuilders.JavaConstructorBuilder> getConstructorBuildersFor(String ownerName) {
+    Set<JavaConstructorBuilder> getConstructorBuildersFor(String ownerName) {
         return constructorBuildersByOwner.get(ownerName);
     }
 
-    Optional<DomainBuilders.JavaStaticInitializerBuilder> getStaticInitializerBuilderFor(String ownerName) {
+    Optional<JavaStaticInitializerBuilder> getStaticInitializerBuilderFor(String ownerName) {
         return Optional.ofNullable(staticInitializerBuildersByOwner.get(ownerName));
     }
 
     Set<String> getAnnotationTypeNamesFor(JavaClass owner) {
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
-        for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : annotationsByOwner.get(owner.getName())) {
+        for (JavaAnnotationBuilder annotationBuilder : annotationsByOwner.get(owner.getName())) {
             result.add(annotationBuilder.getFullyQualifiedClassName());
         }
         return result.build();
     }
 
-    Set<DomainBuilders.JavaAnnotationBuilder> getAnnotationsFor(JavaClass owner) {
+    Set<JavaAnnotationBuilder> getAnnotationsFor(JavaClass owner) {
         return annotationsByOwner.get(owner.getName());
     }
 
@@ -209,7 +214,7 @@ class ClassFileImportRecord {
 
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
         for (JavaMemberBuilder<?, ?> memberBuilder : memberBuilders) {
-            for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : annotationsByOwner.get(getMemberKey(owner.getName(), memberBuilder.getName(), memberBuilder.getDescriptor()))) {
+            for (JavaAnnotationBuilder annotationBuilder : annotationsByOwner.get(getMemberKey(owner.getName(), memberBuilder.getName(), memberBuilder.getDescriptor()))) {
                 result.add(annotationBuilder.getFullyQualifiedClassName());
             }
         }
@@ -223,24 +228,24 @@ class ClassFileImportRecord {
 
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
         for (JavaCodeUnitBuilder<?, ?> codeUnitBuilder : codeUnitBuilders) {
-            for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : codeUnitBuilder.getParameterAnnotationBuilders()) {
+            for (JavaAnnotationBuilder annotationBuilder : codeUnitBuilder.getParameterAnnotationBuilders()) {
                 result.add(annotationBuilder.getFullyQualifiedClassName());
             }
         }
         return result.build();
     }
 
-    private Iterable<JavaMemberBuilder<?, ?>> nullToEmpty(DomainBuilders.JavaStaticInitializerBuilder staticInitializerBuilder) {
+    private Iterable<JavaMemberBuilder<?, ?>> nullToEmpty(JavaStaticInitializerBuilder staticInitializerBuilder) {
         return staticInitializerBuilder != null
                 ? Collections.<JavaMemberBuilder<?, ?>>singleton(staticInitializerBuilder)
                 : Collections.<JavaMemberBuilder<?, ?>>emptySet();
     }
 
-    Set<DomainBuilders.JavaAnnotationBuilder> getAnnotationsFor(JavaMember owner) {
+    Set<JavaAnnotationBuilder> getAnnotationsFor(JavaMember owner) {
         return annotationsByOwner.get(getMemberKey(owner));
     }
 
-    Optional<DomainBuilders.JavaAnnotationBuilder.ValueBuilder> getAnnotationDefaultValueBuilderFor(JavaMethod method) {
+    Optional<JavaAnnotationBuilder.ValueBuilder> getAnnotationDefaultValueBuilderFor(JavaMethod method) {
         return Optional.ofNullable(annotationDefaultValuesByOwner.get(getMemberKey(method)));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -140,11 +140,24 @@ class ClassFileProcessor {
         @Override
         public void onDeclaredClassAnnotations(Set<JavaAnnotationBuilder> annotationBuilders) {
             importRecord.addClassAnnotations(ownerName, annotationBuilders);
+            registerAnnotationTypesToResolve(annotationBuilders);
         }
 
         @Override
-        public void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<JavaAnnotationBuilder> annotations) {
-            importRecord.addMemberAnnotations(ownerName, memberName, descriptor, annotations);
+        public void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<JavaAnnotationBuilder> annotationBuilders) {
+            importRecord.addMemberAnnotations(ownerName, memberName, descriptor, annotationBuilders);
+            registerAnnotationTypesToResolve(annotationBuilders);
+        }
+
+        private void registerAnnotationTypesToResolve(Set<JavaAnnotationBuilder> annotationBuilders) {
+            for (JavaAnnotationBuilder annotationBuilder : annotationBuilders) {
+                dependencyResolutionProcess.registerAnnotationType(annotationBuilder.getFullyQualifiedClassName());
+            }
+        }
+
+        @Override
+        public void onDeclaredAnnotationValueType(String valueTypeName) {
+            dependencyResolutionProcess.registerAnnotationType(valueTypeName);
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -189,6 +189,11 @@ class ClassFileProcessor {
         public void onDeclaredThrowsClause(Collection<String> exceptionTypeNames) {
             dependencyResolutionProcess.registerMemberTypes(exceptionTypeNames);
         }
+
+        @Override
+        public void onDeclaredGenericSignatureType(String typeName) {
+            dependencyResolutionProcess.registerGenericSignatureType(typeName);
+        }
     }
 
     private static class RecordAccessHandler implements AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -179,6 +179,11 @@ class ClassFileProcessor {
         public void onDeclaredClassObject(String typeName) {
             dependencyResolutionProcess.registerAccessToType(typeName);
         }
+
+        @Override
+        public void onDeclaredInstanceofCheck(String typeName) {
+            dependencyResolutionProcess.registerAccessToType(typeName);
+        }
     }
 
     private static class RecordAccessHandler implements AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -184,6 +184,11 @@ class ClassFileProcessor {
         public void onDeclaredInstanceofCheck(String typeName) {
             dependencyResolutionProcess.registerAccessToType(typeName);
         }
+
+        @Override
+        public void onDeclaredThrowsClause(Collection<String> exceptionTypeNames) {
+            dependencyResolutionProcess.registerMemberTypes(exceptionTypeNames);
+        }
     }
 
     private static class RecordAccessHandler implements AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -25,7 +25,13 @@ import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassTypeParametersBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaFieldBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.JavaClassProcessor.AccessHandler;
 import com.tngtech.archunit.core.importer.JavaClassProcessor.DeclarationHandler;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
@@ -92,47 +98,47 @@ class ClassFileProcessor {
         }
 
         @Override
-        public void onGenericSuperclass(DomainBuilders.JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder) {
+        public void onGenericSuperclass(JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder) {
             importRecord.addGenericSuperclass(ownerName, genericSuperclassBuilder);
         }
 
         @Override
-        public void onGenericInterfaces(List<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
+        public void onGenericInterfaces(List<JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders) {
             importRecord.addGenericInterfaces(ownerName, genericInterfaceBuilders);
         }
 
         @Override
-        public void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder) {
+        public void onDeclaredField(JavaFieldBuilder fieldBuilder) {
             importRecord.addField(ownerName, fieldBuilder);
         }
 
         @Override
-        public void onDeclaredConstructor(DomainBuilders.JavaConstructorBuilder constructorBuilder) {
+        public void onDeclaredConstructor(JavaConstructorBuilder constructorBuilder) {
             importRecord.addConstructor(ownerName, constructorBuilder);
         }
 
         @Override
-        public void onDeclaredMethod(DomainBuilders.JavaMethodBuilder methodBuilder) {
+        public void onDeclaredMethod(JavaMethodBuilder methodBuilder) {
             importRecord.addMethod(ownerName, methodBuilder);
         }
 
         @Override
-        public void onDeclaredStaticInitializer(DomainBuilders.JavaStaticInitializerBuilder staticInitializerBuilder) {
+        public void onDeclaredStaticInitializer(JavaStaticInitializerBuilder staticInitializerBuilder) {
             importRecord.setStaticInitializer(ownerName, staticInitializerBuilder);
         }
 
         @Override
-        public void onDeclaredClassAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders) {
+        public void onDeclaredClassAnnotations(Set<JavaAnnotationBuilder> annotationBuilders) {
             importRecord.addClassAnnotations(ownerName, annotationBuilders);
         }
 
         @Override
-        public void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations) {
+        public void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<JavaAnnotationBuilder> annotations) {
             importRecord.addMemberAnnotations(ownerName, memberName, descriptor, annotations);
         }
 
         @Override
-        public void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, DomainBuilders.JavaAnnotationBuilder.ValueBuilder valueBuilder) {
+        public void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, JavaAnnotationBuilder.ValueBuilder valueBuilder) {
             importRecord.addAnnotationDefaultValue(ownerName, methodName, methodDescriptor, valueBuilder);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -174,6 +174,11 @@ class ClassFileProcessor {
         public void registerEnclosingCodeUnit(String ownerName, CodeUnit enclosingCodeUnit) {
             importRecord.setEnclosingCodeUnit(ownerName, enclosingCodeUnit);
         }
+
+        @Override
+        public void onDeclaredClassObject(String typeName) {
+            dependencyResolutionProcess.registerAccessToType(typeName);
+        }
     }
 
     private static class RecordAccessHandler implements AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -34,7 +34,6 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.JavaClassProcessor.AccessHandler;
-import com.tngtech.archunit.core.importer.JavaClassProcessor.DeclarationHandler;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 import com.tngtech.archunit.core.importer.RawAccessRecord.TargetInfo;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -92,8 +92,10 @@ class ClassFileProcessor {
             ownerName = className;
             if (superclassName.isPresent()) {
                 importRecord.setSuperclass(ownerName, superclassName.get());
+                dependencyResolutionProcess.registerSupertype(superclassName.get());
             }
             importRecord.addInterfaces(ownerName, interfaceNames);
+            dependencyResolutionProcess.registerSupertypes(interfaceNames);
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -168,6 +168,7 @@ class ClassFileProcessor {
         @Override
         public void registerEnclosingClass(String ownerName, String enclosingClassName) {
             importRecord.setEnclosingClass(ownerName, enclosingClassName);
+            dependencyResolutionProcess.registerEnclosingType(enclosingClassName);
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -98,7 +98,7 @@ class ClassGraphCreator implements ImportContext {
     }
 
     JavaClasses complete() {
-        dependencyResolutionProcess.resolve(classes, importRecord);
+        dependencyResolutionProcess.resolve(classes);
         completeClasses();
         completeAccesses();
         return createJavaClasses(classes.getDirectlyImported(), classes.getAllWithOuterClassesSortedBeforeInnerClasses(), this);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -122,18 +122,11 @@ class ClassGraphCreator implements ImportContext {
 
     JavaClasses complete() {
         dependencyResolutionProcess.resolve(classes);
-        ensureCallTargetsArePresent();
         ensureClassesOfInheritanceHierarchiesArePresent();
         ensureMetaAnnotationsArePresent();
         completeClasses();
         completeAccesses();
         return createJavaClasses(classes.getDirectlyImported(), classes.getAllWithOuterClassesSortedBeforeInnerClasses(), this);
-    }
-
-    private void ensureCallTargetsArePresent() {
-        for (RawAccessRecord record : importRecord.getAccessRecords()) {
-            classes.ensurePresent(record.target.owner.getFullyQualifiedClassName());
-        }
     }
 
     private void ensureClassesOfInheritanceHierarchiesArePresent() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -99,7 +99,6 @@ class ClassGraphCreator implements ImportContext {
 
     JavaClasses complete() {
         dependencyResolutionProcess.resolve(classes, importRecord);
-        ensureMetaAnnotationsArePresent();
         completeClasses();
         completeAccesses();
         return createJavaClasses(classes.getDirectlyImported(), classes.getAllWithOuterClassesSortedBeforeInnerClasses(), this);
@@ -136,31 +135,6 @@ class ClassGraphCreator implements ImportContext {
             tryProcess(constructorReferenceCallRecord, AccessRecord.Factory.forConstructorReferenceRecord(),
                     processedConstructorReferenceRecords);
         }
-    }
-
-    private void ensureMetaAnnotationsArePresent() {
-        for (JavaClass javaClass : classes.getAllWithOuterClassesSortedBeforeInnerClasses()) {
-            resolveAnnotationHierarchy(javaClass);
-        }
-    }
-
-    private void resolveAnnotationHierarchy(JavaClass javaClass) {
-        for (String annotationTypeName : getAnnotationTypeNamesToResolveFor(javaClass)) {
-            boolean hadBeenPreviouslyResolved = classes.isPresent(annotationTypeName);
-            JavaClass annotationType = classes.getOrResolve(annotationTypeName);
-
-            if (!hadBeenPreviouslyResolved) {
-                resolveAnnotationHierarchy(annotationType);
-            }
-        }
-    }
-
-    private Set<String> getAnnotationTypeNamesToResolveFor(JavaClass javaClass) {
-        return ImmutableSet.<String>builder()
-                .addAll(importRecord.getAnnotationTypeNamesFor(javaClass))
-                .addAll(importRecord.getMemberAnnotationTypeNamesFor(javaClass))
-                .addAll(importRecord.getParameterAnnotationTypeNamesFor(javaClass))
-                .build();
     }
 
     private <T extends AccessRecord<?>, B extends RawAccessRecord> void tryProcess(

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
@@ -58,4 +58,6 @@ interface DeclarationHandler {
     void onDeclaredInstanceofCheck(String typeName);
 
     void onDeclaredThrowsClause(Collection<String> exceptionTypeNames);
+
+    void onDeclaredGenericSignatureType(String typeName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.JavaClass;
+
+interface DeclarationHandler {
+    boolean isNew(String className);
+
+    void onNewClass(String className, Optional<String> superclassName, List<String> interfaceNames);
+
+    void onDeclaredTypeParameters(DomainBuilders.JavaClassTypeParametersBuilder typeParametersBuilder);
+
+    void onGenericSuperclass(DomainBuilders.JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder);
+
+    void onGenericInterfaces(List<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders);
+
+    void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder, String fieldTypeName);
+
+    void onDeclaredConstructor(DomainBuilders.JavaConstructorBuilder constructorBuilder, Collection<String> rawParameterTypeNames);
+
+    void onDeclaredMethod(DomainBuilders.JavaMethodBuilder methodBuilder, Collection<String> rawParameterTypeNames, String rawReturnTypeName);
+
+    void onDeclaredStaticInitializer(DomainBuilders.JavaStaticInitializerBuilder staticInitializerBuilder);
+
+    void onDeclaredClassAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotationBuilders);
+
+    void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations);
+
+    void onDeclaredAnnotationValueType(String valueTypeName);
+
+    void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, DomainBuilders.JavaAnnotationBuilder.ValueBuilder valueBuilder);
+
+    void registerEnclosingClass(String ownerName, String enclosingClassName);
+
+    void registerEnclosingCodeUnit(String ownerName, RawAccessRecord.CodeUnit enclosingCodeUnit);
+
+    void onDeclaredClassObject(String typeName);
+
+    void onDeclaredInstanceofCheck(String typeName);
+
+    void onDeclaredThrowsClause(Collection<String> exceptionTypeNames);
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+class DependencyResolutionProcess {
+    private final Set<String> typeNames = new HashSet<>();
+    private boolean initializationComplete = false;
+
+    void registerMemberType(String typeName) {
+        if (!initializationComplete) {
+            typeNames.add(typeName);
+        }
+    }
+
+    void registerMemberTypes(Collection<String> typeNames) {
+        for (String typeName : typeNames) {
+            registerMemberType(typeName);
+        }
+    }
+
+    void resolve(ImportedClasses importedClasses) {
+        initializationComplete = true;
+        for (String typeName : typeNames) {
+            importedClasses.ensurePresent(typeName);
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -35,6 +35,12 @@ class DependencyResolutionProcess {
         }
     }
 
+    void registerAccessToType(String typeName) {
+        if (!initializationComplete) {
+            typeNames.add(typeName);
+        }
+    }
+
     void resolve(ImportedClasses importedClasses) {
         initializationComplete = true;
         for (String typeName : typeNames) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -29,6 +29,7 @@ class DependencyResolutionProcess {
     private static final int maxRunsForSupertypes = -1;
     private static final int maxRunsForEnclosingTypes = -1;
     private static final int maxRunsForAnnotationTypes = -1;
+    private static final int maxRunsForGenericSignatureTypes = -1;
 
     private Set<String> currentTypeNames = new HashSet<>();
     private int runNumber = 1;
@@ -72,6 +73,12 @@ class DependencyResolutionProcess {
 
     void registerAnnotationType(String typeName) {
         if (runNumberHasNotExceeded(maxRunsForAnnotationTypes)) {
+            currentTypeNames.add(typeName);
+        }
+    }
+
+    void registerGenericSignatureType(String typeName) {
+        if (runNumberHasNotExceeded(maxRunsForGenericSignatureTypes)) {
             currentTypeNames.add(typeName);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -27,6 +27,7 @@ class DependencyResolutionProcess {
     private static final int maxRunsForMemberTypes = 1;
     private static final int maxRunsForAccessesToTypes = 1;
     private static final int maxRunsForSupertypes = -1;
+    private static final int maxRunsForEnclosingTypes = -1;
     private static final int maxRunsForAnnotationTypes = -1;
 
     private Set<String> currentTypeNames = new HashSet<>();
@@ -60,6 +61,12 @@ class DependencyResolutionProcess {
     void registerSupertypes(Collection<String> typeNames) {
         for (String typeName : typeNames) {
             registerSupertype(typeName);
+        }
+    }
+
+    void registerEnclosingType(String typeName) {
+        if (runNumberHasNotExceeded(maxRunsForEnclosingTypes)) {
+            currentTypeNames.add(typeName);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -17,19 +17,52 @@ package com.tngtech.archunit.core.importer;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
+import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.importer.ImportedClasses.ImportedClassState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.tngtech.archunit.core.importer.ImportedClasses.ImportedClassState.HAD_TO_BE_IMPORTED;
+import static java.lang.System.lineSeparator;
 
 class DependencyResolutionProcess {
-    private static final int maxRunsForMemberTypes = 1;
-    private static final int maxRunsForAccessesToTypes = 1;
-    private static final int maxRunsForSupertypes = -1;
-    private static final int maxRunsForEnclosingTypes = -1;
-    private static final int maxRunsForAnnotationTypes = -1;
-    private static final int maxRunsForGenericSignatureTypes = -1;
+    private static final Logger log = LoggerFactory.getLogger(DependencyResolutionProcess.class);
+
+    static final String DEPENDENCY_RESOLUTION_PROCESS_PROPERTY_PREFIX = "import.dependencyResolutionProcess";
+    private final Properties resolutionProcessProperties = ArchConfiguration.get().getSubProperties(DEPENDENCY_RESOLUTION_PROCESS_PROPERTY_PREFIX);
+
+    static final String MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME = "maxIterationsForMemberTypes";
+    static final int MAX_ITERATIONS_FOR_MEMBER_TYPES_DEFAULT_VALUE = 1;
+    private final int maxRunsForMemberTypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_MEMBER_TYPES_DEFAULT_VALUE);
+
+    static final String MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME = "maxIterationsForAccessesToTypes";
+    static final int MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_DEFAULT_VALUE = 1;
+    private final int maxRunsForAccessesToTypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_DEFAULT_VALUE);
+
+    static final String MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME = "maxIterationsForSupertypes";
+    static final int MAX_ITERATIONS_FOR_SUPERTYPES_DEFAULT_VALUE = -1;
+    private final int maxRunsForSupertypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_SUPERTYPES_DEFAULT_VALUE);
+
+    static final String MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME = "maxIterationsForEnclosingTypes";
+    static final int MAX_ITERATIONS_FOR_ENCLOSING_TYPES_DEFAULT_VALUE = -1;
+    private final int maxRunsForEnclosingTypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_ENCLOSING_TYPES_DEFAULT_VALUE);
+
+    static final String MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME = "maxIterationsForAnnotationTypes";
+    static final int MAX_ITERATIONS_FOR_ANNOTATION_TYPES_DEFAULT_VALUE = -1;
+    private final int maxRunsForAnnotationTypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_ANNOTATION_TYPES_DEFAULT_VALUE);
+
+    static final String MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME = "maxIterationsForGenericSignatureTypes";
+    static final int MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE = -1;
+    private final int maxRunsForGenericSignatureTypes = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE);
 
     private Set<String> currentTypeNames = new HashSet<>();
     private int runNumber = 1;
@@ -84,9 +117,24 @@ class DependencyResolutionProcess {
     }
 
     void resolve(ImportedClasses classes) {
+        logConfiguration();
         do {
             executeRun(classes);
         } while (shouldContinue);
+    }
+
+    private void logConfiguration() {
+        log.info("Automatically resolving transitive class dependencies with the following configuration:{}{}{}{}{}{}",
+                formatConfigProperty(MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME, maxRunsForMemberTypes),
+                formatConfigProperty(MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME, maxRunsForAccessesToTypes),
+                formatConfigProperty(MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME, maxRunsForSupertypes),
+                formatConfigProperty(MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME, maxRunsForEnclosingTypes),
+                formatConfigProperty(MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME, maxRunsForAnnotationTypes),
+                formatConfigProperty(MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, maxRunsForGenericSignatureTypes));
+    }
+
+    private String formatConfigProperty(String propertyName, int number) {
+        return lineSeparator() + DEPENDENCY_RESOLUTION_PROCESS_PROPERTY_PREFIX + "." + propertyName + " = " + number;
     }
 
     private void executeRun(ImportedClasses classes) {
@@ -102,5 +150,9 @@ class DependencyResolutionProcess {
 
     private boolean runNumberHasNotExceeded(int maxRuns) {
         return maxRuns < 0 || runNumber <= maxRuns;
+    }
+
+    private int getConfiguredIterations(String propertyName, int defaultValue) {
+        return Integer.parseInt(resolutionProcessProperties.getProperty(propertyName, String.valueOf(defaultValue)));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -589,7 +589,7 @@ public final class DomainBuilders {
         abstract static class ValueBuilder {
             abstract <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses);
 
-            static ValueBuilder ofFinished(final Object value) {
+            static ValueBuilder fromPrimitiveProperty(final Object value) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses unused) {
@@ -598,7 +598,29 @@ public final class DomainBuilders {
                 };
             }
 
-            static ValueBuilder from(final JavaAnnotationBuilder builder) {
+            public static ValueBuilder fromEnumProperty(final JavaClassDescriptor enumType, final String value) {
+                return new ValueBuilder() {
+                    @Override
+                    <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {
+                        return Optional.<Object>of(
+                                new DomainBuilders.JavaEnumConstantBuilder()
+                                        .withDeclaringClass(importedClasses.getOrResolve(enumType.getFullyQualifiedClassName()))
+                                        .withName(value)
+                                        .build());
+                    }
+                };
+            }
+
+            static ValueBuilder fromClassProperty(final JavaClassDescriptor value) {
+                return new ValueBuilder() {
+                    @Override
+                    <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {
+                        return Optional.<Object>of(importedClasses.getOrResolve(value.getFullyQualifiedClassName()));
+                    }
+                };
+            }
+
+            static ValueBuilder fromAnnotationProperty(final JavaAnnotationBuilder builder) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -431,6 +431,7 @@ public final class DomainBuilders {
 
     @Internal
     public static final class JavaClassBuilder {
+        private final boolean stub;
         private Optional<SourceDescriptor> sourceDescriptor = Optional.empty();
         private Optional<String> sourceFileName = Optional.empty();
         private JavaClassDescriptor descriptor;
@@ -443,6 +444,11 @@ public final class DomainBuilders {
         private Set<JavaModifier> modifiers = new HashSet<>();
 
         JavaClassBuilder() {
+            this(false);
+        }
+
+        private JavaClassBuilder(boolean stub) {
+            this.stub = stub;
         }
 
         JavaClassBuilder withSourceDescriptor(SourceDescriptor sourceDescriptor) {
@@ -540,6 +546,14 @@ public final class DomainBuilders {
 
         public Set<JavaModifier> getModifiers() {
             return modifiers;
+        }
+
+        public boolean isStub() {
+            return stub;
+        }
+
+        static JavaClassBuilder forStub() {
+            return new JavaClassBuilder(true);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/GenericMemberTypeProcessor.java
@@ -28,12 +28,14 @@ import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERS
 import static com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess.JavaTypeFinisher.ARRAY_CREATOR;
 
 class GenericMemberTypeProcessor<T extends HasDescription> extends SignatureVisitor {
+    private final DeclarationHandler declarationHandler;
     private JavaParameterizedTypeBuilder<T> parameterizedType;
     private JavaTypeCreationProcess<T> typeCreationProcess;
     private JavaTypeFinisher typeFinisher = JavaTypeFinisher.IDENTITY;
 
-    GenericMemberTypeProcessor() {
+    GenericMemberTypeProcessor(DeclarationHandler declarationHandler) {
         super(ASM_API_VERSION);
+        this.declarationHandler = declarationHandler;
     }
 
     Optional<JavaTypeCreationProcess<T>> getType() {
@@ -62,7 +64,7 @@ class GenericMemberTypeProcessor<T extends HasDescription> extends SignatureVisi
 
     @Override
     public SignatureVisitor visitTypeArgument(char wildcard) {
-        return SignatureTypeArgumentProcessor.create(wildcard, parameterizedType, JavaTypeFinisher.IDENTITY);
+        return SignatureTypeArgumentProcessor.create(wildcard, parameterizedType, JavaTypeFinisher.IDENTITY, declarationHandler);
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.base.Optional;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassBuilder;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 
 import static com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT;
@@ -57,7 +58,7 @@ class ImportedClasses {
         JavaClass javaClass = allClasses.get(typeName);
         if (javaClass == null) {
             Optional<JavaClass> resolved = resolver.tryResolve(typeName);
-            javaClass = resolved.isPresent() ? resolved.get() : simpleClassOf(typeName);
+            javaClass = resolved.isPresent() ? resolved.get() : stubClassOf(typeName);
             allClasses.put(typeName, javaClass);
         }
         return javaClass;
@@ -75,14 +76,14 @@ class ImportedClasses {
         return ImmutableSortedMap.copyOf(allClasses).values();
     }
 
-    private static JavaClass simpleClassOf(String typeName) {
+    private static JavaClass stubClassOf(String typeName) {
         JavaClassDescriptor descriptor = JavaClassDescriptor.From.name(typeName);
-        DomainBuilders.JavaClassBuilder builder = new DomainBuilders.JavaClassBuilder().withDescriptor(descriptor);
+        JavaClassBuilder builder = JavaClassBuilder.forStub().withDescriptor(descriptor);
         addModifiersIfPossible(builder, descriptor);
         return builder.build();
     }
 
-    private static void addModifiersIfPossible(DomainBuilders.JavaClassBuilder builder, JavaClassDescriptor descriptor) {
+    private static void addModifiersIfPossible(JavaClassBuilder builder, JavaClassDescriptor descriptor) {
         if (descriptor.isPrimitive() || descriptor.isArray()) {
             builder.withModifiers(PRIMITIVE_AND_ARRAY_TYPE_MODIFIERS);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
@@ -73,8 +73,19 @@ class ImportedClasses {
     private JavaClass resolve(String typeName) {
         Optional<JavaClass> resolved = resolver.tryResolve(typeName);
         JavaClass javaClass = resolved.isPresent() ? resolved.get() : stubClassOf(typeName);
+        if (javaClass.isArray()) {
+            ensureAllComponentTypesPresent(javaClass);
+        }
         allClasses.put(typeName, javaClass);
         return javaClass;
+    }
+
+    private void ensureAllComponentTypesPresent(JavaClass javaClass) {
+        JavaClassDescriptor current = JavaClassDescriptor.From.javaClass(javaClass);
+        while (current.tryGetComponentType().isPresent()) {
+            current = current.tryGetComponentType().get();
+            ensurePresent(current.getFullyQualifiedClassName());
+        }
     }
 
     Collection<JavaClass> getAllWithOuterClassesSortedBeforeInnerClasses() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportedClasses.java
@@ -33,6 +33,8 @@ import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 import static com.tngtech.archunit.core.domain.JavaModifier.ABSTRACT;
 import static com.tngtech.archunit.core.domain.JavaModifier.FINAL;
 import static com.tngtech.archunit.core.domain.JavaModifier.PUBLIC;
+import static com.tngtech.archunit.core.importer.ImportedClasses.ImportedClassState.HAD_TO_BE_IMPORTED;
+import static com.tngtech.archunit.core.importer.ImportedClasses.ImportedClassState.WAS_ALREADY_PRESENT;
 
 class ImportedClasses {
     private static final ImmutableSet<JavaModifier> PRIMITIVE_AND_ARRAY_TYPE_MODIFIERS =
@@ -56,20 +58,23 @@ class ImportedClasses {
 
     JavaClass getOrResolve(String typeName) {
         JavaClass javaClass = allClasses.get(typeName);
-        if (javaClass == null) {
-            Optional<JavaClass> resolved = resolver.tryResolve(typeName);
-            javaClass = resolved.isPresent() ? resolved.get() : stubClassOf(typeName);
-            allClasses.put(typeName, javaClass);
+        return javaClass != null ? javaClass : resolve(typeName);
+    }
+
+    ImportedClassState ensurePresent(String typeName) {
+        if (allClasses.containsKey(typeName)) {
+            return WAS_ALREADY_PRESENT;
         }
+
+        resolve(typeName);
+        return HAD_TO_BE_IMPORTED;
+    }
+
+    private JavaClass resolve(String typeName) {
+        Optional<JavaClass> resolved = resolver.tryResolve(typeName);
+        JavaClass javaClass = resolved.isPresent() ? resolved.get() : stubClassOf(typeName);
+        allClasses.put(typeName, javaClass);
         return javaClass;
-    }
-
-    boolean isPresent(String typeName) {
-        return allClasses.containsKey(typeName);
-    }
-
-    void ensurePresent(String typeName) {
-        getOrResolve(typeName);
     }
 
     Collection<JavaClass> getAllWithOuterClassesSortedBeforeInnerClasses() {
@@ -95,5 +100,10 @@ class ImportedClasses {
 
     interface MethodReturnTypeGetter {
         Optional<JavaClass> getReturnType(String declaringClassName, String methodName);
+    }
+
+    enum ImportedClassState {
+        HAD_TO_BE_IMPORTED,
+        WAS_ALREADY_PRESENT
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -356,8 +356,9 @@ class JavaClassProcessor extends ClassVisitor {
         @Override
         public void visitLdcInsn(Object value) {
             if (JavaClassDescriptorImporter.isAsmType(value)) {
-                codeUnitBuilder.addReferencedClassObject(
-                        RawReferencedClassObject.from(JavaClassDescriptorImporter.importAsmType(value), actualLineNumber));
+                JavaClassDescriptor type = JavaClassDescriptorImporter.importAsmType(value);
+                codeUnitBuilder.addReferencedClassObject(RawReferencedClassObject.from(type, actualLineNumber));
+                declarationHandler.onDeclaredClassObject(type.getFullyQualifiedClassName());
             }
         }
 
@@ -520,6 +521,8 @@ class JavaClassProcessor extends ClassVisitor {
         void registerEnclosingClass(String ownerName, String enclosingClassName);
 
         void registerEnclosingCodeUnit(String ownerName, CodeUnit enclosingCodeUnit);
+
+        void onDeclaredClassObject(String typeName);
     }
 
     interface AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -503,44 +503,6 @@ class JavaClassProcessor extends ClassVisitor {
         }
     }
 
-    interface DeclarationHandler {
-        boolean isNew(String className);
-
-        void onNewClass(String className, Optional<String> superclassName, List<String> interfaceNames);
-
-        void onDeclaredTypeParameters(DomainBuilders.JavaClassTypeParametersBuilder typeParametersBuilder);
-
-        void onGenericSuperclass(DomainBuilders.JavaParameterizedTypeBuilder<JavaClass> genericSuperclassBuilder);
-
-        void onGenericInterfaces(List<DomainBuilders.JavaParameterizedTypeBuilder<JavaClass>> genericInterfaceBuilders);
-
-        void onDeclaredField(DomainBuilders.JavaFieldBuilder fieldBuilder, String fieldTypeName);
-
-        void onDeclaredConstructor(DomainBuilders.JavaConstructorBuilder constructorBuilder, Collection<String> rawParameterTypeNames);
-
-        void onDeclaredMethod(DomainBuilders.JavaMethodBuilder methodBuilder, Collection<String> rawParameterTypeNames, String rawReturnTypeName);
-
-        void onDeclaredStaticInitializer(DomainBuilders.JavaStaticInitializerBuilder staticInitializerBuilder);
-
-        void onDeclaredClassAnnotations(Set<JavaAnnotationBuilder> annotationBuilders);
-
-        void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<JavaAnnotationBuilder> annotations);
-
-        void onDeclaredAnnotationValueType(String valueTypeName);
-
-        void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, ValueBuilder valueBuilder);
-
-        void registerEnclosingClass(String ownerName, String enclosingClassName);
-
-        void registerEnclosingCodeUnit(String ownerName, CodeUnit enclosingCodeUnit);
-
-        void onDeclaredClassObject(String typeName);
-
-        void onDeclaredInstanceofCheck(String typeName);
-
-        void onDeclaredThrowsClause(Collection<String> exceptionTypeNames);
-    }
-
     interface AccessHandler {
         void handleFieldInstruction(int opcode, String owner, String name, String desc);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -236,7 +236,7 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         JavaClassDescriptor rawType = JavaClassDescriptorImporter.importAsmTypeFromDescriptor(desc);
-        Optional<JavaTypeCreationProcess<JavaField>> genericType = JavaFieldTypeSignatureImporter.parseAsmFieldTypeSignature(signature);
+        Optional<JavaTypeCreationProcess<JavaField>> genericType = JavaFieldTypeSignatureImporter.parseAsmFieldTypeSignature(signature, declarationHandler);
         DomainBuilders.JavaFieldBuilder fieldBuilder = new DomainBuilders.JavaFieldBuilder()
                 .withName(name)
                 .withType(genericType, rawType)
@@ -258,7 +258,7 @@ class JavaClassProcessor extends ClassVisitor {
 
         JavaClassDescriptor rawReturnType = JavaClassDescriptorImporter.importAsmMethodReturnType(desc);
         DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder = addCodeUnitBuilder(name, codeUnit.getRawParameterTypeNames(), rawReturnType.getFullyQualifiedClassName());
-        JavaCodeUnitSignature codeUnitSignature = JavaCodeUnitSignatureImporter.parseAsmMethodSignature(signature);
+        JavaCodeUnitSignature codeUnitSignature = JavaCodeUnitSignatureImporter.parseAsmMethodSignature(signature, declarationHandler);
         List<JavaClassDescriptor> throwsDeclarations = typesFrom(exceptions);
         codeUnitBuilder
                 .withName(name)

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -375,7 +375,9 @@ class JavaClassProcessor extends ClassVisitor {
         @Override
         public void visitTypeInsn(int opcode, String type) {
             if (opcode == Opcodes.INSTANCEOF) {
-                codeUnitBuilder.addInstanceOfCheck(from(JavaClassDescriptorImporter.createFromAsmObjectTypeName(type), actualLineNumber));
+                JavaClassDescriptor instanceOfCheckType = JavaClassDescriptorImporter.createFromAsmObjectTypeName(type);
+                codeUnitBuilder.addInstanceOfCheck(from(instanceOfCheckType, actualLineNumber));
+                declarationHandler.onDeclaredInstanceofCheck(instanceOfCheckType.getFullyQualifiedClassName());
             }
         }
 
@@ -523,6 +525,8 @@ class JavaClassProcessor extends ClassVisitor {
         void registerEnclosingCodeUnit(String ownerName, CodeUnit enclosingCodeUnit);
 
         void onDeclaredClassObject(String typeName);
+
+        void onDeclaredInstanceofCheck(String typeName);
     }
 
     interface AccessHandler {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassSignatureImporter.java
@@ -23,7 +23,6 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassTypeParametersBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
-import com.tngtech.archunit.core.importer.JavaClassProcessor.DeclarationHandler;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.slf4j.Logger;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaFieldTypeSignatureImporter.java
@@ -28,23 +28,24 @@ import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERS
 class JavaFieldTypeSignatureImporter {
     private static final Logger log = LoggerFactory.getLogger(JavaFieldTypeSignatureImporter.class);
 
-    static Optional<JavaTypeCreationProcess<JavaField>> parseAsmFieldTypeSignature(String signature) {
+    static Optional<JavaTypeCreationProcess<JavaField>> parseAsmFieldTypeSignature(String signature, DeclarationHandler declarationHandler) {
         if (signature == null) {
             return Optional.empty();
         }
 
         log.trace("Analyzing field signature: {}", signature);
 
-        SignatureProcessor signatureProcessor = new SignatureProcessor();
+        SignatureProcessor signatureProcessor = new SignatureProcessor(declarationHandler);
         new SignatureReader(signature).accept(signatureProcessor);
         return signatureProcessor.getFieldType();
     }
 
     private static class SignatureProcessor extends SignatureVisitor {
-        private final GenericMemberTypeProcessor<JavaField> genericFieldTypeProcessor = new GenericMemberTypeProcessor<>();
+        private final GenericMemberTypeProcessor<JavaField> genericFieldTypeProcessor;
 
-        SignatureProcessor() {
+        SignatureProcessor(DeclarationHandler declarationHandler) {
             super(ASM_API_VERSION);
+            genericFieldTypeProcessor = new GenericMemberTypeProcessor<>(declarationHandler);
         }
 
         @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeParameterProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeParameterProcessor.java
@@ -35,12 +35,14 @@ class SignatureTypeParameterProcessor<OWNER extends HasDescription> extends Sign
     private static final Logger log = LoggerFactory.getLogger(SignatureTypeParameterProcessor.class);
 
     private final List<JavaTypeParameterBuilder<OWNER>> typeParameterBuilders = new ArrayList<>();
+    private final DeclarationHandler declarationHandler;
 
     private JavaTypeParameterBuilder<OWNER> currentType;
     private JavaParameterizedTypeBuilder<OWNER> currentBound;
 
-    SignatureTypeParameterProcessor() {
+    SignatureTypeParameterProcessor(DeclarationHandler declarationHandler) {
         super(ASM_API_VERSION);
+        this.declarationHandler = declarationHandler;
     }
 
     List<JavaTypeParameterBuilder<OWNER>> getTypeParameterBuilders() {
@@ -58,6 +60,7 @@ class SignatureTypeParameterProcessor<OWNER extends HasDescription> extends Sign
         JavaClassDescriptor type = JavaClassDescriptorImporter.createFromAsmObjectTypeName(internalObjectName);
         log.trace("Encountered upper bound for {}: Class type {}", currentType.getName(), type.getFullyQualifiedClassName());
         currentBound = new JavaParameterizedTypeBuilder<>(type);
+        declarationHandler.onDeclaredGenericSignatureType(type.getFullyQualifiedClassName());
     }
 
     @Override
@@ -74,7 +77,7 @@ class SignatureTypeParameterProcessor<OWNER extends HasDescription> extends Sign
 
     @Override
     public SignatureVisitor visitTypeArgument(char wildcard) {
-        return SignatureTypeArgumentProcessor.create(wildcard, currentBound);
+        return SignatureTypeArgumentProcessor.create(wildcard, currentBound, declarationHandler);
     }
 
     @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -18,13 +18,10 @@ import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaParameter;
-import com.tngtech.archunit.core.domain.properties.HasAnnotations;
-import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassAnnotationWithArrays;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithAnnotationWithEmptyArrays;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithComplexAnnotations;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithOneAnnotation;
-import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithUnimportedAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.SimpleAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.TypeAnnotationWithEnumAndArrayValue;
 import com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters;
@@ -35,9 +32,7 @@ import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.Me
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationParameter;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationToImport;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.EnumToImport;
-import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,7 +40,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.OTHER_VALUE;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.SOME_VALUE;
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.enumAndArrayAnnotatedMethod;
-import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.methodAnnotatedWithAnnotationFromParentPackage;
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.methodAnnotatedWithEmptyArrays;
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.stringAndIntAnnotatedMethod;
 import static com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.ClassWithAnnotatedMethods.stringAnnotatedMethod;
@@ -53,8 +47,6 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotation;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotations;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
-import static com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion.annotationProperty;
-import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterAnnotationsTest {
@@ -205,25 +197,6 @@ public class ClassFileImporterAnnotationsTest {
     }
 
     @Test
-    public void imports_class_annotated_with_unimported_annotation() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithUnimportedAnnotation.class)
-                .get(ClassWithUnimportedAnnotation.class);
-
-        JavaAnnotation<?> annotation = clazz.getAnnotationOfType(SomeAnnotation.class.getName());
-
-        assertThat(annotation.get("mandatory")).contains("mandatory");
-        assertThat(annotation.get("optional")).contains("optional");
-        assertThat((JavaEnumConstant) annotation.get("mandatoryEnum").get()).isEquivalentTo(SOME_VALUE);
-        assertThat((JavaEnumConstant) annotation.get("optionalEnum").get()).isEquivalentTo(OTHER_VALUE);
-
-        SomeAnnotation reflected = clazz.getAnnotationOfType(SomeAnnotation.class);
-        assertThat(reflected.mandatory()).isEqualTo("mandatory");
-        assertThat(reflected.optional()).isEqualTo("optional");
-        assertThat(reflected.mandatoryEnum()).isEqualTo(SOME_VALUE);
-        assertThat(reflected.optionalEnum()).isEqualTo(OTHER_VALUE);
-    }
-
-    @Test
     public void imports_fields_with_one_annotation_correctly() throws Exception {
         JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
                 .get(ClassWithAnnotatedFields.class).getField("stringAnnotatedField");
@@ -322,21 +295,6 @@ public class ClassFileImporterAnnotationsTest {
     }
 
     @Test
-    public void imports_fields_annotated_with_unimported_annotation() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class).get(ClassWithAnnotatedFields.class);
-
-        JavaAnnotation<?> annotation = clazz.getField("fieldAnnotatedWithAnnotationFromParentPackage")
-                .getAnnotationOfType(SomeAnnotation.class.getName());
-
-        assertThat(annotation.get("mandatory")).contains("mandatory");
-        assertThat(annotation.get("optional")).contains("optional");
-
-        SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
-        assertThat(reflected.mandatory()).isEqualTo("mandatory");
-        assertThat(reflected.optional()).isEqualTo("optional");
-    }
-
-    @Test
     public void imports_methods_with_one_annotation_correctly() throws Exception {
         JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
                 .get(ClassWithAnnotatedMethods.class).getMethod(stringAnnotatedMethod);
@@ -430,21 +388,6 @@ public class ClassFileImporterAnnotationsTest {
         assertThat(reflected.enums()).isEmpty();
         assertThat(reflected.classes()).isEmpty();
         assertThat(reflected.annotations()).isEmpty();
-    }
-
-    @Test
-    public void imports_methods_annotated_with_unimported_annotation() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class).get(ClassWithAnnotatedMethods.class);
-
-        JavaAnnotation<?> annotation = clazz.getMethod(methodAnnotatedWithAnnotationFromParentPackage)
-                .getAnnotationOfType(SomeAnnotation.class.getName());
-
-        assertThat(annotation.get("mandatory")).contains("mandatory");
-        assertThat(annotation.get("optional")).contains("optional");
-
-        SomeAnnotation reflected = annotation.as(SomeAnnotation.class);
-        assertThat(reflected.mandatory()).isEqualTo("mandatory");
-        assertThat(reflected.optional()).isEqualTo("optional");
     }
 
     @Test
@@ -640,71 +583,6 @@ public class ClassFileImporterAnnotationsTest {
         assertThat(annotations).as("annotations with parameter type " + String.class.getSimpleName()).containsOnlyElementsOf(expected);
     }
 
-    @Test
-    public void meta_annotation_types_are_transitively_imported() {
-        JavaClass javaClass = new ClassFileImporter().importClass(MetaAnnotatedClass.class);
-        JavaAnnotation<JavaClass> someAnnotation = javaClass.getAnnotationOfType(MetaAnnotatedAnnotation.class.getName());
-        JavaAnnotation<JavaClass> someMetaAnnotation = someAnnotation.getRawType()
-                .getAnnotationOfType(SomeMetaAnnotation.class.getName());
-        JavaAnnotation<JavaClass> someMetaMetaAnnotation = someMetaAnnotation.getRawType()
-                .getAnnotationOfType(SomeMetaMetaAnnotation.class.getName());
-        JavaAnnotation<JavaClass> someMetaMetaMetaAnnotation = someMetaMetaAnnotation.getRawType()
-                .getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
-
-        assertThatType(someMetaMetaMetaAnnotation.getType()).matches(SomeMetaMetaMetaAnnotationWithParameters.class);
-    }
-
-    @DataProvider
-    public static Object[][] elementsAnnotatedWithSomeAnnotation() {
-        return testForEach(
-                new ClassFileImporter().importClass(MetaAnnotatedClass.class),
-                new ClassFileImporter().importClass(ClassWithMetaAnnotatedField.class).getField("metaAnnotatedField"),
-                new ClassFileImporter().importClass(ClassWithMetaAnnotatedMethod.class).getMethod("metaAnnotatedMethod"),
-                new ClassFileImporter().importClass(ClassWithMetaAnnotatedConstructor.class).getConstructor(),
-                getOnlyElement(new ClassFileImporter().importClass(ClassWithMetaAnnotatedConstructorParameter.class).getConstructor(String.class).getParameters()),
-                getOnlyElement(new ClassFileImporter().importClass(ClassWithMetaAnnotatedMethodParameter.class).getMethod("method", String.class).getParameters())
-        );
-    }
-
-    @Test
-    @UseDataProvider("elementsAnnotatedWithSomeAnnotation")
-    public void parameters_of_meta_annotations_are_transitively_imported(HasAnnotations<?> annotatedWithSomeAnnotation) {
-        JavaAnnotation<?> someAnnotation = annotatedWithSomeAnnotation
-                .getAnnotationOfType(MetaAnnotatedAnnotation.class.getName());
-        JavaAnnotation<?> metaAnnotationWithParameters = someAnnotation.getRawType()
-                .getAnnotationOfType(MetaAnnotationWithParameters.class.getName());
-
-        assertThatAnnotation(metaAnnotationWithParameters)
-                .hasEnumProperty("someEnum", SomeEnum.CONSTANT)
-                .hasEnumProperty("someEnumDefault", SomeEnum.VARIABLE)
-                .hasAnnotationProperty("parameterAnnotation",
-                        annotationProperty()
-                                .withAnnotationType(ParameterAnnotation.class)
-                                .withClassProperty("value", SomeAnnotationParameterType.class))
-                .hasAnnotationProperty("parameterAnnotationDefault",
-                        annotationProperty()
-                                .withAnnotationType(ParameterAnnotation.class)
-                                .withClassProperty("value", SomeAnnotationDefaultParameterType.class));
-
-        JavaAnnotation<JavaClass> metaMetaMetaAnnotation = someAnnotation
-                .getRawType().getAnnotationOfType(SomeMetaAnnotation.class.getName())
-                .getRawType().getAnnotationOfType(SomeMetaMetaAnnotation.class.getName())
-                .getRawType().getAnnotationOfType(SomeMetaMetaMetaAnnotationWithParameters.class.getName());
-
-        assertThatAnnotation(metaMetaMetaAnnotation)
-                .hasClassProperty("classParam", SomeMetaMetaMetaAnnotationClassParameter.class)
-                .hasClassProperty("classParamDefault", String.class)
-                .hasEnumProperty("enumParam", SomeMetaMetaMetaAnnotationEnumParameter.VALUE)
-                .hasEnumProperty("enumParamDefault", SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT)
-                .hasAnnotationProperty("annotationParam",
-                        annotationProperty()
-                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class)
-                                .withClassProperty("value", SomeMetaMetaMetaParameterAnnotationClassParameter.class))
-                .hasAnnotationProperty("annotationParamDefault",
-                        annotationProperty()
-                                .withAnnotationType(SomeMetaMetaMetaParameterAnnotation.class));
-    }
-
     @SuppressWarnings({"unchecked", "unused"})
     private static <T> T getAnnotationDefaultValue(JavaClass javaClass, String methodName, Class<T> valueType) {
         return (T) javaClass.getMethod(methodName).getDefaultValue().get();
@@ -729,7 +607,7 @@ public class ClassFileImporterAnnotationsTest {
 
         ParameterAnnotation parameterAnnotation();
 
-        ParameterAnnotation parameterAnnotationDefault() default @ParameterAnnotation(SomeAnnotationDefaultParameterType.class);
+        ParameterAnnotation parameterAnnotationDefault() default @ParameterAnnotation(Integer.class);
     }
 
     @SuppressWarnings("unused")
@@ -779,12 +657,6 @@ public class ClassFileImporterAnnotationsTest {
     private static class SomeAnnotationParameterType {
     }
 
-    private static class SomeAnnotationDefaultParameterType {
-    }
-
-    @MetaAnnotatedAnnotation
-    private static class MetaAnnotatedClass {
-    }
 
     @SuppressWarnings("unused")
     private static class ClassWithMetaAnnotatedField {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
@@ -7,18 +7,18 @@ import java.lang.ref.Reference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
+import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
@@ -34,9 +34,6 @@ import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterGenericClassesTest {
 
-    @Rule
-    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
-
     @Test
     public void imports_empty_list_of_type_parameters_for_non_generic_class() {
         JavaClass javaClass = new ClassFileImporter().importClass(getClass());
@@ -50,9 +47,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithoutBound<T> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithoutBound.class, Object.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithoutBound.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithoutBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(Object.class);
     }
@@ -74,9 +69,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithSimpleClassBound<T extends String> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithSimpleClassBound.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithSimpleClassBound.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithSimpleClassBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(String.class);
     }
@@ -87,10 +80,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithThreeTypeParametersWithSimpleClassBounds<A extends String, B extends System, C extends File> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThreeTypeParametersWithSimpleClassBounds.class,
-                String.class, System.class, File.class);
-
-        JavaClass javaClass = classes.get(ClassWithThreeTypeParametersWithSimpleClassBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithThreeTypeParametersWithSimpleClassBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameters("A", "B", "C")
@@ -105,9 +95,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithSimpleInterfaceBound<T extends Serializable> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithSimpleInterfaceBound.class, Serializable.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithSimpleInterfaceBound.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithSimpleInterfaceBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(Serializable.class);
     }
@@ -118,10 +106,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds<T extends String & Serializable & Runnable> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds.class,
-                String.class, Serializable.class, Runnable.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(String.class, Serializable.class, Runnable.class);
     }
@@ -133,10 +118,7 @@ public class ClassFileImporterGenericClassesTest {
                 A extends String & Serializable, B extends System & Runnable, C extends File & Serializable & Closeable> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithThreeTypeParametersWithMultipleSimpleClassAndInterfaceBounds.class,
-                String.class, Serializable.class, System.class, Runnable.class, File.class, Serializable.class, Closeable.class);
-
-        JavaClass javaClass = classes.get(ClassWithThreeTypeParametersWithMultipleSimpleClassAndInterfaceBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithThreeTypeParametersWithMultipleSimpleClassAndInterfaceBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameters("A", "B", "C")
@@ -151,10 +133,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass<T extends ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String.class));
@@ -166,10 +145,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<String[]>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String[].class));
@@ -181,10 +157,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<int[]>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(int[].class));
@@ -199,10 +172,7 @@ public class ClassFileImporterGenericClassesTest {
                 C extends InterfaceParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes.class,
-                ClassParameterWithSingleTypeParameter.class, File.class, InterfaceParameterWithSingleTypeParameter.class, Serializable.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B", "C")
                 .hasTypeParameter("A").withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(File.class))
@@ -218,11 +188,7 @@ public class ClassFileImporterGenericClassesTest {
                 B extends Map<String, Serializable> & Iterable<File> & Function<Integer, Long>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithTwoTypeParametersWithMultipleGenericClassAndInterfaceBoundsAssignedToConcreteTypes.class,
-                ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                Map.class, Iterable.class, Function.class, String.class, Serializable.class, File.class, Integer.class, Long.class);
-
-        JavaClass javaClass = classes.get(ClassWithTwoTypeParametersWithMultipleGenericClassAndInterfaceBoundsAssignedToConcreteTypes.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTwoTypeParametersWithMultipleGenericClassAndInterfaceBoundsAssignedToConcreteTypes.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B")
                 .hasTypeParameter("A")
@@ -242,9 +208,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard<T extends List<?>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard.class, List.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameter());
@@ -268,9 +232,7 @@ public class ClassFileImporterGenericClassesTest {
     @Test
     @UseDataProvider
     public void test_imports_single_type_bound_with_upper_bound_wildcard(Class<?> classWithWildcard, Class<?> expectedUpperBound) {
-        JavaClasses classes = new ClassFileImporter().importClasses(classWithWildcard, List.class, expectedUpperBound);
-
-        JavaClass javaClass = classes.get(classWithWildcard);
+        JavaClass javaClass = new ClassFileImporter().importClass(classWithWildcard);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(expectedUpperBound));
@@ -294,9 +256,7 @@ public class ClassFileImporterGenericClassesTest {
     @Test
     @UseDataProvider
     public void test_imports_single_type_bound_with_lower_bound_wildcard(Class<?> classWithWildcard, Class<?> expectedLowerBound) {
-        JavaClasses classes = new ClassFileImporter().importClasses(classWithWildcard, List.class, expectedLowerBound);
-
-        JavaClass javaClass = classes.get(classWithWildcard);
+        JavaClass javaClass = new ClassFileImporter().importClass(classWithWildcard);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameterWithLowerBound(expectedLowerBound));
@@ -308,10 +268,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds<A extends Map<? extends Serializable, ? super File>, B extends Reference<? super String> & Map<?, ?>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds.class,
-                Map.class, Serializable.class, File.class, Reference.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B")
                 .hasTypeParameter("A")
@@ -340,9 +297,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithTypeParameterWithTypeVariableBound<U extends T, T extends String, V extends T> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithTypeParameterWithTypeVariableBound.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithTypeParameterWithTypeVariableBound.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithTypeVariableBound.class);
 
         assertThatType(javaClass).hasTypeParameters("U", "T", "V")
                 .hasTypeParameter("U").withBoundsMatching(typeVariable("T").withUpperBounds(String.class))
@@ -362,13 +317,7 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.class,
-                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.class,
-                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.class,
-                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class,
-                String.class);
-
-        JavaClass javaClass = classes.get(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -392,12 +341,7 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithTypeParameterBoundByInnerClass.class,
-                ClassWithTypeParameterBoundByInnerClass.SomeInner.class,
-                ClassWithTypeParameterBoundByInnerClass.SomeInner.EvenMoreInner.class,
-                String.class);
-
-        JavaClass javaClass = classes.get(ClassWithTypeParameterBoundByInnerClass.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterBoundByInnerClass.class);
 
         assertThatType(javaClass).hasTypeParameters("T", "U")
                 .hasTypeParameter("T")
@@ -420,10 +364,14 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(
-                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
-
-        JavaClass javaClass = classes.get(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
+        JavaClass javaClass = resetConfigurationAround(new Callable<JavaClass>() {
+            @Override
+            public JavaClass call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClass(
+                        ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
+            }
+        });
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -447,12 +395,8 @@ public class ClassFileImporterGenericClassesTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3$1Level5");
-        JavaClasses classes = new ClassFileImporter().importClasses(
-                Class.forName(Level1.class.getName() + "$1Level3"),
-                innermostClass,
-                Level1.class, String.class);
 
-        JavaClass javaClass = classes.get(innermostClass);
+        JavaClass javaClass = new ClassFileImporter().importClass(innermostClass);
 
         assertThatType(javaClass).hasTypeParameters("T51", "T52")
                 .hasTypeParameter("T51")
@@ -471,9 +415,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithWildcardWithTypeVariableBounds<T extends String, U extends List<? extends T>, V extends List<? super T>> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithWildcardWithTypeVariableBounds.class, List.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithWildcardWithTypeVariableBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithWildcardWithTypeVariableBounds.class);
 
         assertThatType(javaClass).hasTypeParameters("T", "U", "V")
                 .hasTypeParameter("U")
@@ -496,13 +438,7 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(
-                ClassWithWildcardWithTypeVariableBounds.class,
-                ClassWithWildcardWithTypeVariableBounds.Inner.class,
-                ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class,
-                List.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -527,10 +463,15 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class,
-                List.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
+        JavaClass javaClass = resetConfigurationAround(new Callable<JavaClass>() {
+            @Override
+            public JavaClass call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter()
+                        .importClasses(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class, List.class)
+                        .get(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
+            }
+        });
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -558,10 +499,7 @@ public class ClassFileImporterGenericClassesTest {
                 RAW extends List> {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithComplexTypeParameters.class,
-                List.class, Serializable.class, Comparable.class, Map.class, Map.Entry.class, String.class, Set.class, Iterable.class, Object.class);
-
-        JavaClass javaClass = classes.get(ClassWithComplexTypeParameters.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParameters.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")
@@ -615,10 +553,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithComplexTypeParametersWithConcreteArrayBounds.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithComplexTypeParametersWithConcreteArrayBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParametersWithConcreteArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")
@@ -650,10 +585,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithTypeParameterWithParameterizedArrayBounds.class,
-                ClassWithThreeTypeParameters.class, List.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithTypeParameterWithParameterizedArrayBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithParameterizedArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T")
@@ -682,10 +614,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithComplexTypeParametersWithGenericArrayBounds.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaClass javaClass = classes.get(ClassWithComplexTypeParametersWithGenericArrayBounds.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParametersWithGenericArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericClassesTest.java
@@ -18,6 +18,8 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassWithOnlyGenericTypeResolution;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
@@ -36,7 +38,7 @@ public class ClassFileImporterGenericClassesTest {
 
     @Test
     public void imports_empty_list_of_type_parameters_for_non_generic_class() {
-        JavaClass javaClass = new ClassFileImporter().importClass(getClass());
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(getClass());
 
         assertThat(javaClass.getTypeParameters()).as("type parameters of non generic class").isEmpty();
     }
@@ -47,7 +49,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithoutBound<T> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithoutBound.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithoutBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(Object.class);
     }
@@ -58,7 +60,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithThreeTypeParametersWithoutBounds<A, B, C> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithThreeTypeParametersWithoutBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithThreeTypeParametersWithoutBounds.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B", "C");
     }
@@ -69,7 +71,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithSimpleClassBound<T extends String> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithSimpleClassBound.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithSimpleClassBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(String.class);
     }
@@ -80,7 +82,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithThreeTypeParametersWithSimpleClassBounds<A extends String, B extends System, C extends File> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithThreeTypeParametersWithSimpleClassBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithThreeTypeParametersWithSimpleClassBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameters("A", "B", "C")
@@ -95,7 +97,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithSimpleInterfaceBound<T extends Serializable> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithSimpleInterfaceBound.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithSimpleInterfaceBound.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(Serializable.class);
     }
@@ -106,7 +108,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds<T extends String & Serializable & Runnable> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithMultipleSimpleClassAndInterfaceBounds.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T").withBoundsMatching(String.class, Serializable.class, Runnable.class);
     }
@@ -118,7 +120,7 @@ public class ClassFileImporterGenericClassesTest {
                 A extends String & Serializable, B extends System & Runnable, C extends File & Serializable & Closeable> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithThreeTypeParametersWithMultipleSimpleClassAndInterfaceBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithThreeTypeParametersWithMultipleSimpleClassAndInterfaceBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameters("A", "B", "C")
@@ -133,7 +135,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass<T extends ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToConcreteClass.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String.class));
@@ -145,7 +147,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<String[]>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(String[].class));
@@ -157,7 +159,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType<T extends ClassParameterWithSingleTypeParameter<int[]>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterWithGenericClassBoundAssignedToArrayType.class);
 
         assertThatType(javaClass).hasOnlyTypeParameter("T")
                 .withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(int[].class));
@@ -172,7 +174,7 @@ public class ClassFileImporterGenericClassesTest {
                 C extends InterfaceParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithMultipleTypeParametersWithGenericClassOrInterfaceBoundsAssignedToConcreteTypes.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B", "C")
                 .hasTypeParameter("A").withBoundsMatching(parameterizedType(ClassParameterWithSingleTypeParameter.class).withTypeArguments(File.class))
@@ -188,7 +190,7 @@ public class ClassFileImporterGenericClassesTest {
                 B extends Map<String, Serializable> & Iterable<File> & Function<Integer, Long>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTwoTypeParametersWithMultipleGenericClassAndInterfaceBoundsAssignedToConcreteTypes.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithTwoTypeParametersWithMultipleGenericClassAndInterfaceBoundsAssignedToConcreteTypes.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B")
                 .hasTypeParameter("A")
@@ -208,7 +210,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard<T extends List<?>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithSingleTypeParameterBoundByTypeWithUnboundWildcard.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameter());
@@ -232,7 +234,7 @@ public class ClassFileImporterGenericClassesTest {
     @Test
     @UseDataProvider
     public void test_imports_single_type_bound_with_upper_bound_wildcard(Class<?> classWithWildcard, Class<?> expectedUpperBound) {
-        JavaClass javaClass = new ClassFileImporter().importClass(classWithWildcard);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(classWithWildcard);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameterWithUpperBound(expectedUpperBound));
@@ -256,7 +258,7 @@ public class ClassFileImporterGenericClassesTest {
     @Test
     @UseDataProvider
     public void test_imports_single_type_bound_with_lower_bound_wildcard(Class<?> classWithWildcard, Class<?> expectedLowerBound) {
-        JavaClass javaClass = new ClassFileImporter().importClass(classWithWildcard);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(classWithWildcard);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T").withBoundsMatching(parameterizedType(List.class).withWildcardTypeParameterWithLowerBound(expectedLowerBound));
@@ -268,7 +270,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds<A extends Map<? extends Serializable, ? super File>, B extends Reference<? super String> & Map<?, ?>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithMultipleTypeParametersBoundByTypesWithDifferentBounds.class);
 
         assertThatType(javaClass).hasTypeParameters("A", "B")
                 .hasTypeParameter("A")
@@ -297,7 +299,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithTypeParameterWithTypeVariableBound<U extends T, T extends String, V extends T> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithTypeVariableBound.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithTypeParameterWithTypeVariableBound.class);
 
         assertThatType(javaClass).hasTypeParameters("U", "T", "V")
                 .hasTypeParameter("U").withBoundsMatching(typeVariable("T").withUpperBounds(String.class))
@@ -317,7 +319,12 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
+        JavaClass javaClass = importClassesWithOnlyGenericTypeResolution(
+                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class,
+                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.class,
+                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.class,
+                ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.class
+        ).get(ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -341,7 +348,7 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterBoundByInnerClass.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithTypeParameterBoundByInnerClass.class);
 
         assertThatType(javaClass).hasTypeParameters("T", "U")
                 .hasTypeParameter("T")
@@ -368,7 +375,7 @@ public class ClassFileImporterGenericClassesTest {
             @Override
             public JavaClass call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClass(
+                return importClassWithOnlyGenericTypeResolution(
                         ClassWithTypeParameterWithInnerClassesWithTypeVariableBound.SomeInner.EvenMoreInnerDeclaringOwn.AndEvenMoreInner.class);
             }
         });
@@ -394,9 +401,10 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3$1Level5");
+        Class<?> middleClass = Class.forName(Level1.class.getName() + "$1Level3");
+        Class<?> innermostClass = Class.forName(middleClass.getName() + "$1Level5");
 
-        JavaClass javaClass = new ClassFileImporter().importClass(innermostClass);
+        JavaClass javaClass = importClassesWithOnlyGenericTypeResolution(innermostClass, middleClass, Level1.class).get(innermostClass);
 
         assertThatType(javaClass).hasTypeParameters("T51", "T52")
                 .hasTypeParameter("T51")
@@ -415,7 +423,7 @@ public class ClassFileImporterGenericClassesTest {
         class ClassWithWildcardWithTypeVariableBounds<T extends String, U extends List<? extends T>, V extends List<? super T>> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithWildcardWithTypeVariableBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithWildcardWithTypeVariableBounds.class);
 
         assertThatType(javaClass).hasTypeParameters("T", "U", "V")
                 .hasTypeParameter("U")
@@ -438,7 +446,11 @@ public class ClassFileImporterGenericClassesTest {
             }
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
+        JavaClass javaClass = importClassesWithOnlyGenericTypeResolution(
+                ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class,
+                ClassWithWildcardWithTypeVariableBounds.Inner.class,
+                ClassWithWildcardWithTypeVariableBounds.class
+        ).get(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
 
         assertThatType(javaClass).hasTypeParameters("MOST_INNER1", "MOST_INNER2")
                 .hasTypeParameter("MOST_INNER1")
@@ -467,8 +479,7 @@ public class ClassFileImporterGenericClassesTest {
             @Override
             public JavaClass call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter()
-                        .importClasses(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class, List.class)
+                return importClassesWithOnlyGenericTypeResolution(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class, List.class)
                         .get(ClassWithWildcardWithTypeVariableBounds.Inner.MoreInner.class);
             }
         });
@@ -499,7 +510,7 @@ public class ClassFileImporterGenericClassesTest {
                 RAW extends List> {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParameters.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithComplexTypeParameters.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")
@@ -553,7 +564,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParametersWithConcreteArrayBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithComplexTypeParametersWithConcreteArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")
@@ -585,7 +596,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithTypeParameterWithParameterizedArrayBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithTypeParameterWithParameterizedArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("T")
@@ -614,7 +625,7 @@ public class ClassFileImporterGenericClassesTest {
                 > {
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(ClassWithComplexTypeParametersWithGenericArrayBounds.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(ClassWithComplexTypeParametersWithGenericArrayBounds.class);
 
         assertThatType(javaClass)
                 .hasTypeParameter("A")

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
@@ -8,22 +8,20 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
@@ -41,9 +39,6 @@ import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
-    @Rule
-    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
-
     @DataProvider
     public static Object[][] data_imports_non_generic_code_unit_parameter_type() {
         class NonGenericParameterType {
@@ -60,8 +55,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         }
         Object[][] testCases = testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 NoGenericSignatureOnConstructor.class,
-                NoGenericSignatureOnMethod.class,
-                NonGenericParameterType.class);
+                NoGenericSignatureOnMethod.class
+        );
         return $$(
                 $(testCases[0][0], NonGenericParameterType.class),
                 $(testCases[1][0], NonGenericParameterType.class)
@@ -89,8 +84,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                Object.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -116,8 +111,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -139,10 +134,7 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         }
 
         JavaConstructor constructor = new ClassFileImporter()
-                .importClasses(
-                        LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter.class,
-                        getClass(), ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter.class)
+                .importClass(LocalClassThatWillHaveEnclosingClassAsFirstRawConstructorParameter.class)
                 .getConstructor(getClass(), ClassParameterWithSingleTypeParameter.class);
 
         assertThatTypes(constructor.getRawParameterTypes()).matchExactly(getClass(), ClassParameterWithSingleTypeParameter.class);
@@ -167,8 +159,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -194,8 +186,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -223,8 +215,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -252,8 +244,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithThreeTypeParameters.class, Serializable.class, File.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -281,8 +273,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -317,9 +309,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithThreeTypeParameters.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                File.class, Serializable.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -352,8 +343,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -379,8 +370,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -413,8 +404,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -449,8 +440,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, Map.class, Serializable.class, File.class, Reference.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -485,8 +476,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -514,8 +505,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -541,8 +532,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -571,8 +562,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, ClassParameterWithSingleTypeParameter.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -605,8 +596,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
-                OuterWithTypeParameter.class, OuterWithTypeParameter.SomeInner.class, ClassParameterWithSingleTypeParameter.class, String.class);
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -636,10 +627,20 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
             }
         }
 
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+        JavaClasses classes = resetConfigurationAround(new Callable<JavaClasses>() {
+            @Override
+            public JavaClasses call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(
+                        OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                        OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class);
+            }
+        });
+
+        return testForEach(
+                getOnlyElement(classes.get(OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class).getConstructors()),
+                getOnlyElement(classes.get(OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class).getMethods())
+        );
     }
 
     @Test
@@ -670,8 +671,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 Class.forName(Level1.class.getName() + "$1GenericSignatureOnConstructor"),
-                Class.forName(Level1.class.getName() + "$1GenericSignatureOnMethod"),
-                Level1.class, ClassParameterWithSingleTypeParameter.class, String.class);
+                Class.forName(Level1.class.getName() + "$1GenericSignatureOnMethod")
+        );
     }
 
     @Test
@@ -706,8 +707,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -748,9 +749,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
-                OuterWithTypeParameter.class, OuterWithTypeParameter.SomeInner.class, ClassParameterWithTwoTypeParameters.class,
-                ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -789,10 +789,21 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
             }
         }
 
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
-                ClassParameterWithTwoTypeParameters.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class);
+        JavaClasses classes = resetConfigurationAround(new Callable<JavaClasses>() {
+            @Override
+            public JavaClasses call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(
+                        OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
+                        OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                        ClassParameterWithSingleTypeParameter.class);
+            }
+        });
+
+        return testForEach(
+                getOnlyElement(classes.get(OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class).getConstructors()),
+                getOnlyElement(classes.get(OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class).getMethods())
+        );
     }
 
     @Test
@@ -843,9 +854,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithThreeTypeParameters.class, String.class, Serializable.class, Cloneable.class, List.class,
-                Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -903,8 +913,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                List.class, Serializable.class, Map.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -949,8 +959,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithThreeTypeParameters.class, List.class, Serializable.class, Map.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -985,8 +995,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithThreeTypeParameters.class, List.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -1021,8 +1031,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                Serializable.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -1060,8 +1070,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithFourTypeParameters.class, List.class, Serializable.class, Map.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -1130,9 +1140,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class, Cloneable.class,
-                List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -1176,18 +1185,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         // @formatter:on
     }
 
-    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(
-            Class<?> genericSignatureOnConstructor,
-            Class<?> genericSignatureOnMethod,
-            Class<?>... additionalImports) {
-        final List<Class<?>> toImport = FluentIterable.from(additionalImports).append(genericSignatureOnConstructor).append(genericSignatureOnMethod).toList();
-        JavaClasses classes = ArchConfigurationRule.resetConfigurationAround(new Callable<JavaClasses>() {
-            @Override
-            public JavaClasses call() {
-                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClasses(toImport);
-            }
-        });
+    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(Class<?> genericSignatureOnConstructor, Class<?> genericSignatureOnMethod) {
+        JavaClasses classes = new ClassFileImporter().importClasses(genericSignatureOnConstructor, genericSignatureOnMethod);
 
         return testForEach(
                 getOnlyElement(classes.get(genericSignatureOnConstructor).getConstructors()),

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericCodeUnitParameterTypesTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
@@ -21,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
@@ -596,7 +598,9 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
         );
     }
 
@@ -631,7 +635,7 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
             @Override
             public JavaClasses call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClasses(
+                return importClassesWithOnlyGenericTypeResolution(
                         OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
                         OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class);
             }
@@ -671,7 +675,8 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 Class.forName(Level1.class.getName() + "$1GenericSignatureOnConstructor"),
-                Class.forName(Level1.class.getName() + "$1GenericSignatureOnMethod")
+                Class.forName(Level1.class.getName() + "$1GenericSignatureOnMethod"),
+                Level1.class
         );
     }
 
@@ -749,7 +754,9 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
-                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class
+                OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
         );
     }
 
@@ -793,7 +800,7 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
             @Override
             public JavaClasses call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClasses(
+                return importClassesWithOnlyGenericTypeResolution(
                         OuterWithTypeParameter.SomeInner.GenericSignatureOnConstructor.class,
                         OuterWithTypeParameter.SomeInner.GenericSignatureOnMethod.class,
                         ClassParameterWithSingleTypeParameter.class);
@@ -1185,8 +1192,15 @@ public class ClassFileImporterGenericCodeUnitParameterTypesTest {
         // @formatter:on
     }
 
-    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(Class<?> genericSignatureOnConstructor, Class<?> genericSignatureOnMethod) {
-        JavaClasses classes = new ClassFileImporter().importClasses(genericSignatureOnConstructor, genericSignatureOnMethod);
+    @SuppressWarnings("rawtypes")
+    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(
+            Class<?> genericSignatureOnConstructor,
+            Class<?> genericSignatureOnMethod,
+            Class<?>... additionalClasses
+    ) {
+        JavaClasses classes = importClassesWithOnlyGenericTypeResolution(
+                FluentIterable.<Class>from(additionalClasses).append(genericSignatureOnConstructor, genericSignatureOnMethod).toArray(Class.class)
+        );
 
         return testForEach(
                 getOnlyElement(classes.get(genericSignatureOnConstructor).getConstructors()),

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
@@ -6,17 +6,17 @@ import java.lang.ref.Reference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
+import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
@@ -28,9 +28,6 @@ import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.Expec
 
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterGenericFieldTypesTest {
-
-    @Rule
-    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
 
     @Test
     public void imports_non_generic_field_type() {
@@ -56,8 +53,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -74,8 +70,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType field;
         }
 
-        JavaType rawGenericFieldType = new ClassFileImporter().importClasses(SomeClass.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType rawGenericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(rawGenericFieldType).as("raw generic field type").matches(GenericFieldType.class);
     }
@@ -90,8 +85,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String[]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -108,8 +102,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<int[]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, int.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -126,8 +119,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String, Serializable, File> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class, Serializable.class, File.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -144,8 +136,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<String>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -166,11 +157,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     InterfaceParameterWithSingleTypeParameter<String>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(
-                        SomeClass.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                        File.class, Serializable.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -192,8 +179,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<?> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(wildcardType());
     }
@@ -208,8 +194,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<?>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -229,8 +214,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     ClassParameterWithSingleTypeParameter<? super File>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -252,11 +236,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     ClassParameterWithSingleTypeParameter<Reference<? super String>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(
-                        SomeClass.class, ClassParameterWithSingleTypeParameter.class,
-                        Map.class, Serializable.class, File.class, Reference.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -277,8 +257,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             T field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .isInstanceOf(JavaTypeVariable.class)
@@ -295,8 +274,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<OF_CLASS> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(typeVariable("OF_CLASS"));
     }
@@ -311,8 +289,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<OF_CLASS>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -330,8 +307,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<OF_CLASS>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -354,13 +330,8 @@ public class ClassFileImporterGenericFieldTypesTest {
             }
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        String.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                .getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -381,9 +352,14 @@ public class ClassFileImporterGenericFieldTypesTest {
             }
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, String.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                        .getField("field").getType();
+            }
+        });
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 typeVariable("OUTER").withoutUpperBounds()
@@ -403,8 +379,7 @@ public class ClassFileImporterGenericFieldTypesTest {
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
         JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(innermostClass, Level1.class, String.class)
-                .get(innermostClass).getField("field").getType();
+                .importClass(innermostClass).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .matches(
@@ -426,8 +401,7 @@ public class ClassFileImporterGenericFieldTypesTest {
         }
 
         JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(SomeClass.class).getField("field").getType();
+                .importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -456,12 +430,7 @@ public class ClassFileImporterGenericFieldTypesTest {
         }
 
         JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+                .importClass(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -490,11 +459,15 @@ public class ClassFileImporterGenericFieldTypesTest {
             }
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter()
+                        .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                        .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+            }
+        });
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -525,10 +498,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Comparable<SomeClass<FIRST, SECOND>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClasses(SomeClass.class, String.class, Serializable.class, Cloneable.class,
-                        List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         // @formatter:off
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
@@ -575,10 +545,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] field;
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).matches(
                 genericArray(
@@ -609,10 +576,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> field;
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -637,8 +601,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<List<String>[], List<String[]>[][], List<String[][]>[][][]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClasses(SomeClass.class, List.class, String.class)
-                .get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -660,8 +623,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             T[][] field2Dim;
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
 
         assertThatType(javaClass.getField("field").getType()).as("generic field type")
                 .hasErasure(String[].class)
@@ -688,10 +650,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> field;
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericFieldType = classes.get(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericFieldTypesTest.java
@@ -16,6 +16,8 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassWithOnlyGenericTypeResolution;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
@@ -38,7 +40,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             NonGenericFieldType field;
         }
 
-        JavaType fieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType fieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(fieldType).as("generic field type").matches(NonGenericFieldType.class);
     }
@@ -53,7 +55,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -70,7 +72,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType field;
         }
 
-        JavaType rawGenericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType rawGenericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(rawGenericFieldType).as("raw generic field type").matches(GenericFieldType.class);
     }
@@ -85,7 +87,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String[]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -102,7 +104,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<int[]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -119,7 +121,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<String, Serializable, File> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .hasErasure(GenericFieldType.class)
@@ -136,7 +138,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<String>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -157,7 +159,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     InterfaceParameterWithSingleTypeParameter<String>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -179,7 +181,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<?> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(wildcardType());
     }
@@ -194,7 +196,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<?>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -214,7 +216,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     ClassParameterWithSingleTypeParameter<? super File>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -236,7 +238,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     ClassParameterWithSingleTypeParameter<Reference<? super String>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -257,7 +259,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             T field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .isInstanceOf(JavaTypeVariable.class)
@@ -274,7 +276,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<OF_CLASS> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(typeVariable("OF_CLASS"));
     }
@@ -289,7 +291,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<OF_CLASS>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -307,7 +309,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<ClassParameterWithSingleTypeParameter<OF_CLASS>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -330,8 +332,11 @@ public class ClassFileImporterGenericFieldTypesTest {
             }
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
-                .getField("field").getType();
+        JavaType genericFieldType = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.SomeClass.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -356,7 +361,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                return importClassWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.SomeClass.class)
                         .getField("field").getType();
             }
         });
@@ -378,8 +383,9 @@ public class ClassFileImporterGenericFieldTypesTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClass(innermostClass).getField("field").getType();
+        JavaType genericFieldType = importClassesWithOnlyGenericTypeResolution(
+                innermostClass, Level1.class
+        ).get(innermostClass).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type")
                 .matches(
@@ -400,8 +406,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     ClassParameterWithSingleTypeParameter<? super SECOND>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -429,8 +434,11 @@ public class ClassFileImporterGenericFieldTypesTest {
             }
         }
 
-        JavaType genericFieldType = new ClassFileImporter()
-                .importClass(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.SomeClass.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -463,8 +471,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter()
-                        .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                return importClassesWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
                         .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getField("field").getType();
             }
         });
@@ -498,7 +505,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Comparable<SomeClass<FIRST, SECOND>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         // @formatter:off
         assertThatType(genericFieldType).as("generic field type").hasActualTypeArguments(
@@ -545,7 +552,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<Map<? super String, Map<Map<? super String, ?>, Serializable>>>[] field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).matches(
                 genericArray(
@@ -576,7 +583,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Map<? super String[], Map<Map<? super String[][][], ?>, Serializable[][]>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -601,7 +608,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             GenericFieldType<List<String>[], List<String[]>[][], List<String[][]>[][][]> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -623,7 +630,7 @@ public class ClassFileImporterGenericFieldTypesTest {
             T[][] field2Dim;
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(SomeClass.class);
 
         assertThatType(javaClass.getField("field").getType()).as("generic field type")
                 .hasErasure(String[].class)
@@ -650,7 +657,7 @@ public class ClassFileImporterGenericFieldTypesTest {
                     Map<? super Y[], Map<Map<? super Y[][][], ?>, X[][]>>> field;
         }
 
-        JavaType genericFieldType = new ClassFileImporter().importClass(SomeClass.class).getField("field").getType();
+        JavaType genericFieldType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getField("field").getType();
 
         assertThatType(genericFieldType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericInterfacesTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassWithOnlyGenericTypeResolution;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
@@ -41,7 +43,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements SomeInterface {
         }
 
-        Set<JavaType> genericInterfaces = new ClassFileImporter().importClass(Child.class).getInterfaces();
+        Set<JavaType> genericInterfaces = importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces();
 
         assertThatTypes(genericInterfaces).as("generic interfaces").matchExactly(SomeInterface.class);
     }
@@ -51,7 +53,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithOneTypeParameter<String> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasErasure(InterfaceWithOneTypeParameter.class)
@@ -64,7 +66,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithOneTypeParameter {
         }
 
-        JavaType rawGenericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType rawGenericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(rawGenericInterface).as("raw generic interface").matches(InterfaceWithOneTypeParameter.class);
     }
@@ -75,7 +77,7 @@ public class ClassFileImporterGenericInterfacesTest {
         }
 
         JavaType genericInterface = getOnlyElement(
-                new ClassFileImporter().importClass(Child.class).getInterfaces());
+                importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasErasure(InterfaceWithOneTypeParameter.class)
@@ -87,7 +89,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithOneTypeParameter<int[]> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasErasure(InterfaceWithOneTypeParameter.class)
@@ -100,7 +102,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithThreeTypeParameters<String, Serializable, File> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasErasure(InterfaceWithThreeTypeParameters.class)
@@ -112,7 +114,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -128,7 +130,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 InterfaceWithOneTypeParameter<String>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -145,7 +147,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<?>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -160,7 +162,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 ClassParameterWithSingleTypeParameter<? super File>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -177,7 +179,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 ClassParameterWithSingleTypeParameter<Reference<? super String>>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -196,7 +198,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child<SUB> implements InterfaceWithOneTypeParameter<SUB> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(typeVariable("SUB"));
     }
@@ -206,7 +208,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child<SUB> implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -219,7 +221,7 @@ public class ClassFileImporterGenericInterfacesTest {
         class Child<SUB extends String> implements InterfaceWithOneTypeParameter<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -237,7 +239,12 @@ public class ClassFileImporterGenericInterfacesTest {
             }
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(
+                importClassesWithOnlyGenericTypeResolution(
+                        OuterWithTypeParameter.SomeInner.Child.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.class
+                ).get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -258,7 +265,7 @@ public class ClassFileImporterGenericInterfacesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return getOnlyElement(new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+                return getOnlyElement(importClassWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
             }
         });
 
@@ -278,7 +285,8 @@ public class ClassFileImporterGenericInterfacesTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(innermostClass).getInterfaces());
+        JavaType genericInterface = getOnlyElement(
+                importClassesWithOnlyGenericTypeResolution(innermostClass, Level1.class).get(innermostClass).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasActualTypeArguments(
@@ -294,7 +302,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 ClassParameterWithSingleTypeParameter<? super SECOND>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -318,7 +326,12 @@ public class ClassFileImporterGenericInterfacesTest {
             }
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(
+                importClassesWithOnlyGenericTypeResolution(
+                        OuterWithTypeParameter.SomeInner.Child.class,
+                        OuterWithTypeParameter.SomeInner.class,
+                        OuterWithTypeParameter.class
+                ).get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -346,9 +359,9 @@ public class ClassFileImporterGenericInterfacesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return getOnlyElement(new ClassFileImporter()
-                        .importClasses(OuterWithTypeParameter.SomeInner.Child.class, ClassParameterWithSingleTypeParameter.class)
-                        .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
+                return getOnlyElement(
+                        importClassesWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.Child.class, ClassParameterWithSingleTypeParameter.class)
+                                .get(OuterWithTypeParameter.SomeInner.Child.class).getInterfaces());
             }
         });
 
@@ -399,7 +412,7 @@ public class ClassFileImporterGenericInterfacesTest {
     @Test
     @UseDataProvider
     public void test_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_self_referencing_type_definitions(Class<?> testInput) {
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(testInput).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(testInput).getInterfaces());
 
         // @formatter:off
         assertThatType(genericInterface).as("generic interface").hasActualTypeArguments(
@@ -461,7 +474,7 @@ public class ClassFileImporterGenericInterfacesTest {
     @Test
     @UseDataProvider
     public void test_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_concrete_array_bounds(Class<?> testInput) {
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(testInput).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(testInput).getInterfaces());
 
         assertThatType(genericInterface).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -494,7 +507,7 @@ public class ClassFileImporterGenericInterfacesTest {
     @Test
     @UseDataProvider
     public void test_imports_type_of_generic_interface_with_parameterized_array_bounds(Class<?> testInput) {
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(testInput).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(testInput).getInterfaces());
 
         assertThatType(genericInterface).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -533,7 +546,7 @@ public class ClassFileImporterGenericInterfacesTest {
     @Test
     @UseDataProvider
     public void test_imports_complex_type_with_multiple_nested_actual_type_arguments_of_generic_interface_with_generic_array_bounds(Class<?> testInput) {
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(testInput).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(testInput).getInterfaces());
 
         assertThatType(genericInterface).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(
@@ -586,7 +599,7 @@ public class ClassFileImporterGenericInterfacesTest {
     @Test
     @UseDataProvider
     public void test_imports_multiple_generic_interfaces(Class<?> testInput) {
-        JavaClass child = new ClassFileImporter().importClass(testInput);
+        JavaClass child = importClassWithOnlyGenericTypeResolution(testInput);
 
         assertThatType(getGenericInterface(child, InterfaceWithOneTypeParameter.class)).as("generic interface")
                 .hasActualTypeArguments(Path.class);
@@ -613,7 +626,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 implements InterfaceWithOneTypeParameter<Path>, InterfaceWithTwoTypeParameters<T, String> {
         }
 
-        JavaClass child = new ClassFileImporter().importClass(Child.class);
+        JavaClass child = importClassWithOnlyGenericTypeResolution(Child.class);
 
         assertThatType(child.getSuperclass().get())
                 .hasErasure(BaseClass.class)
@@ -633,7 +646,7 @@ public class ClassFileImporterGenericInterfacesTest {
                 SomeDeeplyNestedInterface<File, SomeNestedInterface<Path, Path>> {
         }
 
-        JavaType genericInterface = getOnlyElement(new ClassFileImporter().importClass(Child.class).getInterfaces());
+        JavaType genericInterface = getOnlyElement(importClassWithOnlyGenericTypeResolution(Child.class).getInterfaces());
 
         assertThatType(genericInterface).as("generic interface")
                 .hasErasure(SomeDeeplyNestedInterface.class)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
@@ -16,6 +16,8 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassWithOnlyGenericTypeResolution;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
@@ -40,7 +42,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType returnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType returnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(returnType).as("return type").matches(NonGenericReturnType.class);
     }
@@ -58,7 +60,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(SomeClass.class);
 
         JavaType returnType = javaClass.getMethod("method", Object.class).getReturnType();
         assertThatType(returnType).as("return type").matches(Object.class);
@@ -79,7 +81,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .hasErasure(GenericReturnType.class)
@@ -98,7 +100,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType rawGenericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType rawGenericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(rawGenericReturnType).as("raw generic method return type").matches(GenericReturnType.class);
     }
@@ -115,7 +117,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .hasErasure(GenericReturnType.class)
@@ -134,7 +136,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .hasErasure(GenericReturnType.class)
@@ -153,7 +155,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .hasErasure(GenericReturnType.class)
@@ -172,7 +174,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -195,7 +197,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -219,7 +221,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(wildcardType());
     }
@@ -236,7 +238,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -258,7 +260,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -282,7 +284,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -305,7 +307,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .isInstanceOf(JavaTypeVariable.class)
@@ -324,7 +326,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(typeVariable("OF_CLASS"));
     }
@@ -341,7 +343,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -361,7 +363,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -386,8 +388,11 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
-                .getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.SomeClass.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -414,7 +419,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                return importClassWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.SomeClass.class)
                         .getMethod("method").getReturnType();
             }
         });
@@ -438,8 +443,9 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClass(innermostClass).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassesWithOnlyGenericTypeResolution(
+                innermostClass, Level1.class
+        ).get(innermostClass).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .matches(
@@ -463,8 +469,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -494,8 +499,11 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClass(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.SomeClass.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -530,7 +538,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                return importClassesWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
                         .get(OuterWithTypeParameter.SomeInner.SomeClass.class)
                         .getMethod("method").getReturnType();
             }
@@ -567,7 +575,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         // @formatter:off
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
@@ -616,7 +624,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).matches(
                 genericArray(
@@ -649,7 +657,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -676,7 +684,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -699,7 +707,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             abstract T[][] method2Dim();
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
+        JavaClass javaClass = importClassWithOnlyGenericTypeResolution(SomeClass.class);
 
         assertThatType(javaClass.getMethod("method").getReturnType())
                 .hasErasure(String[].class)
@@ -729,7 +737,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = importClassWithOnlyGenericTypeResolution(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 genericArray("X[]").withComponentType(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodReturnTypesTest.java
@@ -6,17 +6,17 @@ import java.lang.ref.Reference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
+import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
@@ -28,9 +28,6 @@ import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.Expec
 
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterGenericMethodReturnTypesTest {
-
-    @Rule
-    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
 
     @Test
     public void imports_non_generic_method_return_type() {
@@ -61,7 +58,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClasses(SomeClass.class, Object.class).get(SomeClass.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
 
         JavaType returnType = javaClass.getMethod("method", Object.class).getReturnType();
         assertThatType(returnType).as("return type").matches(Object.class);
@@ -82,8 +79,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .hasErasure(GenericReturnType.class)
@@ -102,8 +98,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType rawGenericReturnType = new ClassFileImporter().importClasses(SomeClass.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType rawGenericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(rawGenericReturnType).as("raw generic method return type").matches(GenericReturnType.class);
     }
@@ -120,8 +115,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .hasErasure(GenericReturnType.class)
@@ -140,8 +134,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, int.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .hasErasure(GenericReturnType.class)
@@ -160,8 +153,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class, Serializable.class, File.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .hasErasure(GenericReturnType.class)
@@ -180,8 +172,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -204,11 +195,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(
-                        SomeClass.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                        File.class, Serializable.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -232,8 +219,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(wildcardType());
     }
@@ -250,8 +236,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -273,8 +258,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -298,11 +282,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(
-                        SomeClass.class, ClassParameterWithSingleTypeParameter.class,
-                        Map.class, Serializable.class, File.class, Reference.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -325,8 +305,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericMethodReturnType = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericMethodReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericMethodReturnType).as("generic method return type")
                 .isInstanceOf(JavaTypeVariable.class)
@@ -345,8 +324,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(typeVariable("OF_CLASS"));
     }
@@ -363,8 +341,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -384,8 +361,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -410,13 +386,8 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        String.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                .getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -439,9 +410,14 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, String.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                        .getMethod("method").getReturnType();
+            }
+        });
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 typeVariable("OUTER").withoutUpperBounds()
@@ -463,8 +439,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
         JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(innermostClass, Level1.class, String.class)
-                .get(innermostClass).getMethod("method").getReturnType();
+                .importClass(innermostClass).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type")
                 .matches(
@@ -489,8 +464,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
         }
 
         JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(SomeClass.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+                .importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -521,12 +495,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
         }
 
         JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+                .importClass(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -557,11 +526,15 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.SomeInner.SomeClass.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(OuterWithTypeParameter.SomeInner.SomeClass.class, ClassParameterWithSingleTypeParameter.class)
+                        .get(OuterWithTypeParameter.SomeInner.SomeClass.class)
+                        .getMethod("method").getReturnType();
+            }
+        });
 
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -594,10 +567,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter()
-                .importClasses(SomeClass.class, String.class, Serializable.class, Cloneable.class,
-                        List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         // @formatter:off
         assertThatType(genericReturnType).as("generic return type").hasActualTypeArguments(
@@ -646,10 +616,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                Serializable.class, Map.class, String.class);
-
-        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).matches(
                 genericArray(
@@ -682,10 +649,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -712,8 +676,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaType genericReturnType = new ClassFileImporter().importClasses(SomeClass.class, List.class, String.class)
-                .get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -736,8 +699,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             abstract T[][] method2Dim();
         }
 
-        JavaClass javaClass = new ClassFileImporter().importClasses(SomeClass.class, String.class)
-                .get(SomeClass.class);
+        JavaClass javaClass = new ClassFileImporter().importClass(SomeClass.class);
 
         assertThatType(javaClass.getMethod("method").getReturnType())
                 .hasErasure(String[].class)
@@ -767,10 +729,7 @@ public class ClassFileImporterGenericMethodReturnTypesTest {
             }
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(SomeClass.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericReturnType = classes.get(SomeClass.class).getMethod("method").getReturnType();
+        JavaType genericReturnType = new ClassFileImporter().importClass(SomeClass.class).getMethod("method").getReturnType();
 
         assertThatType(genericReturnType).hasActualTypeArguments(
                 genericArray("X[]").withComponentType(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodSignaturesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericMethodSignaturesTest.java
@@ -9,12 +9,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import com.google.common.collect.FluentIterable;
 import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -22,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCodeUnit;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
@@ -69,8 +68,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                Object.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -112,8 +110,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends String> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -134,8 +131,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <A extends String, B extends System, C extends File> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                String.class, System.class, File.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -160,8 +156,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends Serializable> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                Serializable.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -182,8 +177,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends String & Serializable & Runnable> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                String.class, Serializable.class, Runnable.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -204,8 +198,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <A extends String & Serializable, B extends System & Runnable, C extends File & Serializable & Closeable> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                String.class, Serializable.class, System.class, Runnable.class, File.class, Serializable.class, Closeable.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -230,8 +223,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends ClassParameterWithSingleTypeParameter<String>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -253,8 +245,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends ClassParameterWithSingleTypeParameter<String[]>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -276,8 +267,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends ClassParameterWithSingleTypeParameter<int[]>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -307,8 +297,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     > void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, File.class, InterfaceParameterWithSingleTypeParameter.class, Serializable.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -336,9 +325,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     B extends Map<String, Serializable> & Iterable<File> & Function<Integer, Long>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                Map.class, Iterable.class, Function.class, String.class, Serializable.class, File.class, Integer.class, Long.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -368,7 +355,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <T extends List<?>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class, List.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -391,8 +378,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             }
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, String.class);
+                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -417,8 +404,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             }
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, Serializable.class);
+                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -443,8 +430,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             }
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, String.class);
+                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -469,8 +456,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             }
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, Serializable.class);
+                GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -494,8 +481,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <A extends Map<? extends Serializable, ? super File>, B extends Reference<? super String> & Map<?, ?>> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                Map.class, Serializable.class, File.class, Reference.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -534,7 +520,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
             <U extends T, T extends String, V extends T> void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -567,11 +553,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnConstructor.class,
-                Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnMethod.class,
-                Outer.class,
-                Outer.SomeInner.class,
-                Outer.SomeInner.EvenMoreInnerDeclaringOwn.class,
-                String.class);
+                Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -613,12 +596,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
 
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 ConstructorWithTypeParameterBoundByInnerClass.class,
-                MethodWithTypeParameterBoundByInnerClass.class,
-                ConstructorWithTypeParameterBoundByInnerClass.SomeInner.class,
-                ConstructorWithTypeParameterBoundByInnerClass.SomeInner.EvenMoreInner.class,
-                MethodWithTypeParameterBoundByInnerClass.SomeInner.class,
-                MethodWithTypeParameterBoundByInnerClass.SomeInner.EvenMoreInner.class,
-                String.class);
+                MethodWithTypeParameterBoundByInnerClass.class
+        );
     }
 
     @Test
@@ -656,9 +635,21 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                 }
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnConstructor.class,
-                Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnMethod.class);
+
+        JavaClasses classes = resetConfigurationAround(new Callable<JavaClasses>() {
+            @Override
+            public JavaClasses call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(
+                        Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnConstructor.class,
+                        Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnMethod.class);
+            }
+        });
+
+        return testForEach(
+                getOnlyElement(classes.get(Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnConstructor.class).getConstructors()),
+                getOnlyElement(classes.get(Outer.SomeInner.EvenMoreInnerDeclaringOwn.GenericSignatureOnMethod.class).getMethods())
+        );
     }
 
     @Test
@@ -694,8 +685,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
         String level3ClassName = Level1.class.getName() + "$1Level3";
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 Class.forName(level3ClassName + "$GenericSignatureOnConstructor"),
-                Class.forName(level3ClassName + "$GenericSignatureOnMethod"),
-                Class.forName(level3ClassName), Level1.class, String.class);
+                Class.forName(level3ClassName + "$GenericSignatureOnMethod"));
     }
 
     @Test
@@ -725,8 +715,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 GenericSignatureOnConstructor.class,
-                GenericSignatureOnMethod.class,
-                List.class, String.class);
+                GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -763,10 +753,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
         }
         return testCasesFromSameGenericSignatureOnConstructorAndMethod(
                 Outer.Inner.GenericSignatureOnConstructor.class,
-                Outer.Inner.GenericSignatureOnMethod.class,
-                Outer.class,
-                Outer.Inner.class,
-                List.class, String.class);
+                Outer.Inner.GenericSignatureOnMethod.class
+        );
     }
 
     @Test
@@ -803,10 +791,22 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                 }
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(
-                Outer.Inner.GenericSignatureOnConstructor.class,
-                Outer.Inner.GenericSignatureOnMethod.class,
-                List.class, String.class);
+
+        JavaClasses classes = resetConfigurationAround(new Callable<JavaClasses>() {
+            @Override
+            public JavaClasses call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClasses(
+                        Outer.Inner.GenericSignatureOnConstructor.class,
+                        Outer.Inner.GenericSignatureOnMethod.class,
+                        List.class);
+            }
+        });
+
+        return testForEach(
+                getOnlyElement(classes.get(Outer.Inner.GenericSignatureOnConstructor.class).getConstructors()),
+                getOnlyElement(classes.get(Outer.Inner.GenericSignatureOnMethod.class).getMethods())
+        );
     }
 
     @Test
@@ -855,8 +855,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     > void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, Serializable.class, Comparable.class, Map.class, Map.Entry.class, String.class, Set.class, Iterable.class, Object.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -916,8 +915,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     > void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, Serializable.class, Map.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -958,8 +956,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     > void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                ClassWithThreeTypeParameters.class, List.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -1004,8 +1001,7 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                     > void genericSignatureOnMethod() {
             }
         }
-        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class,
-                List.class, Serializable.class, Map.class, String.class);
+        return testCasesFromSameGenericSignatureOnConstructorAndMethod(GenericSignatureOnConstructor.class, GenericSignatureOnMethod.class);
     }
 
     @Test
@@ -1042,18 +1038,8 @@ public class ClassFileImporterGenericMethodSignaturesTest {
                 );
     }
 
-    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(
-            Class<?> genericSignatureOnConstructor,
-            Class<?> genericSignatureOnMethod,
-            Class<?>... additionalImports) {
-        final List<Class<?>> toImport = FluentIterable.from(additionalImports).append(genericSignatureOnConstructor).append(genericSignatureOnMethod).toList();
-        JavaClasses classes = ArchConfigurationRule.resetConfigurationAround(new Callable<JavaClasses>() {
-            @Override
-            public JavaClasses call() {
-                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClasses(toImport);
-            }
-        });
+    private static Object[][] testCasesFromSameGenericSignatureOnConstructorAndMethod(Class<?> genericSignatureOnConstructor, Class<?> genericSignatureOnMethod) {
+        JavaClasses classes = new ClassFileImporter().importClasses(genericSignatureOnConstructor, genericSignatureOnMethod);
 
         return testForEach(
                 getOnlyElement(classes.get(genericSignatureOnConstructor).getConstructors()),

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -14,6 +14,8 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassWithOnlyGenericTypeResolution;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.importClassesWithOnlyGenericTypeResolution;
 import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
@@ -34,7 +36,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").matches(BaseClass.class);
     }
@@ -47,7 +49,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -63,7 +65,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass {
         }
 
-        JavaType rawGenericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType rawGenericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(rawGenericSuperclass).as("raw generic superclass").matches(BaseClass.class);
     }
@@ -76,7 +78,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String[]> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperClass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperClass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -91,7 +93,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<int[]> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperClass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperClass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -107,7 +109,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String, Serializable, File> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -122,7 +124,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -141,7 +143,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 InterfaceParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -161,7 +163,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<?>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -179,7 +181,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super File>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -199,7 +201,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<Reference<? super String>>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -221,7 +223,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB> extends BaseClass<SUB> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(typeVariable("SUB"));
     }
@@ -234,7 +236,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -250,7 +252,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB extends String> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -272,7 +274,11 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.Child.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -297,7 +303,7 @@ public class ClassFileImporterGenericSuperclassTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+                return importClassWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
             }
         });
         ;
@@ -320,7 +326,9 @@ public class ClassFileImporterGenericSuperclassTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
-        JavaType genericSuperclass = new ClassFileImporter().importClass(innermostClass).getSuperclass().get();
+        JavaType genericSuperclass = importClassesWithOnlyGenericTypeResolution(
+                innermostClass, Level1.class
+        ).get(innermostClass).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasActualTypeArguments(
@@ -340,7 +348,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super SECOND>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -368,7 +376,11 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassesWithOnlyGenericTypeResolution(
+                OuterWithTypeParameter.SomeInner.Child.class,
+                OuterWithTypeParameter.SomeInner.class,
+                OuterWithTypeParameter.class
+        ).get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -400,8 +412,7 @@ public class ClassFileImporterGenericSuperclassTest {
             @Override
             public JavaType call() {
                 ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                return new ClassFileImporter()
-                        .importClasses(OuterWithTypeParameter.SomeInner.Child.class, ClassParameterWithSingleTypeParameter.class)
+                return importClassesWithOnlyGenericTypeResolution(OuterWithTypeParameter.SomeInner.Child.class, ClassParameterWithSingleTypeParameter.class)
                         .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
             }
         });
@@ -434,7 +445,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 Comparable<Child<FIRST, SECOND>>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         // @formatter:off
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
@@ -485,7 +496,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 > {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -508,7 +519,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<List<String>[], List<String[]>[][], List<String[][]>[][][]> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -536,7 +547,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 > {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = importClassWithOnlyGenericTypeResolution(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterGenericSuperclassTest.java
@@ -6,15 +6,15 @@ import java.lang.ref.Reference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
-import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.ArchConfiguration;
 import com.tngtech.archunit.core.domain.JavaType;
-import com.tngtech.archunit.testutil.ArchConfigurationRule;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteClass.concreteClass;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteGenericArray.genericArray;
@@ -26,9 +26,6 @@ import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.Expec
 
 @RunWith(DataProviderRunner.class)
 public class ClassFileImporterGenericSuperclassTest {
-
-    @Rule
-    public final ArchConfigurationRule configurationRule = new ArchConfigurationRule().resolveAdditionalDependenciesFromClassPath(false);
 
     @Test
     public void imports_non_generic_superclass() {
@@ -50,7 +47,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, String.class).get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -66,8 +63,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass {
         }
 
-        JavaType rawGenericSuperclass = new ClassFileImporter().importClasses(Child.class, BaseClass.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType rawGenericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(rawGenericSuperclass).as("raw generic superclass").matches(BaseClass.class);
     }
@@ -80,8 +76,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String[]> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperClass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperClass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -96,8 +91,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<int[]> {
         }
 
-        JavaType genericSuperClass = new ClassFileImporter().importClasses(Child.class, int.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperClass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperClass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -113,8 +107,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<String, Serializable, File> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, String.class, Serializable.class, File.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasErasure(BaseClass.class)
@@ -129,8 +122,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -149,11 +141,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 InterfaceParameterWithSingleTypeParameter<String>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(
-                        Child.class, ClassParameterWithSingleTypeParameter.class, InterfaceParameterWithSingleTypeParameter.class,
-                        File.class, Serializable.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -173,8 +161,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<ClassParameterWithSingleTypeParameter<?>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -192,8 +179,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super File>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class, File.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -213,11 +199,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<Reference<? super String>>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(
-                        Child.class, ClassParameterWithSingleTypeParameter.class,
-                        Map.class, Serializable.class, File.class, Reference.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -239,8 +221,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB> extends BaseClass<SUB> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, BaseClass.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(typeVariable("SUB"));
     }
@@ -253,8 +234,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -270,8 +250,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child<SUB extends String> extends BaseClass<ClassParameterWithSingleTypeParameter<SUB>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -293,13 +272,7 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.Child.class,
-                        String.class)
-                .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 typeVariable("OUTER").withUpperBounds(String.class)
@@ -320,9 +293,14 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(OuterWithTypeParameter.SomeInner.Child.class, String.class)
-                .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+            }
+        });
+        ;
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 typeVariable("OUTER").withoutUpperBounds()
@@ -342,9 +320,7 @@ public class ClassFileImporterGenericSuperclassTest {
         }
 
         Class<?> innermostClass = Class.forName(Level1.class.getName() + "$1Level3");
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(innermostClass, Level1.class, String.class)
-                .get(innermostClass).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(innermostClass).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass")
                 .hasActualTypeArguments(
@@ -364,9 +340,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 ClassParameterWithSingleTypeParameter<? super SECOND>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(Child.class, ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -394,13 +368,7 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.class,
-                        OuterWithTypeParameter.SomeInner.class,
-                        OuterWithTypeParameter.SomeInner.Child.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -428,11 +396,15 @@ public class ClassFileImporterGenericSuperclassTest {
             }
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(
-                        OuterWithTypeParameter.SomeInner.Child.class,
-                        ClassParameterWithSingleTypeParameter.class, String.class, Serializable.class)
-                .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+        JavaType genericSuperclass = resetConfigurationAround(new Callable<JavaType>() {
+            @Override
+            public JavaType call() {
+                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
+                return new ClassFileImporter()
+                        .importClasses(OuterWithTypeParameter.SomeInner.Child.class, ClassParameterWithSingleTypeParameter.class)
+                        .get(OuterWithTypeParameter.SomeInner.Child.class).getSuperclass().get();
+            }
+        });
 
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
                 parameterizedType(ClassParameterWithSingleTypeParameter.class)
@@ -462,10 +434,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 Comparable<Child<FIRST, SECOND>>> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter()
-                .importClasses(Child.class, String.class, Serializable.class, Cloneable.class,
-                        List.class, Map.class, Map.Entry.class, Set.class, Iterable.class, Comparable.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         // @formatter:off
         assertThatType(genericSuperclass).as("generic superclass").hasActualTypeArguments(
@@ -516,10 +485,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 > {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(Child.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericSuperclass = classes.get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(Serializable[].class),
@@ -542,8 +508,7 @@ public class ClassFileImporterGenericSuperclassTest {
         class Child extends BaseClass<List<String>[], List<String[]>[][], List<String[][]>[][][]> {
         }
 
-        JavaType genericSuperclass = new ClassFileImporter().importClasses(Child.class, List.class, String.class)
-                .get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 genericArray(parameterizedTypeArrayName(List.class, String.class, 1)).withComponentType(
@@ -571,10 +536,7 @@ public class ClassFileImporterGenericSuperclassTest {
                 > {
         }
 
-        JavaClasses classes = new ClassFileImporter().importClasses(Child.class,
-                List.class, Serializable.class, Map.class, String.class);
-
-        JavaType genericSuperclass = classes.get(Child.class).getSuperclass().get();
+        JavaType genericSuperclass = new ClassFileImporter().importClass(Child.class).getSuperclass().get();
 
         assertThatType(genericSuperclass).hasActualTypeArguments(
                 parameterizedType(List.class).withTypeArguments(

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
@@ -2,7 +2,6 @@ package com.tngtech.archunit.core.importer;
 
 import java.io.File;
 import java.io.FilterInputStream;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -351,61 +350,5 @@ public class ClassFileImporterMembersTest {
             origins.add(instanceofCheck.getOwner().getOwner());
         }
         assertThatTypes(origins).matchInAnyOrder(ChecksInstanceofInMethod.class, ChecksInstanceofInConstructor.class, ChecksInstanceofInStaticInitializer.class);
-    }
-
-    @Test
-    public void automatically_resolves_field_types() {
-        @SuppressWarnings("unused")
-        class FieldTypeWithoutAnyFurtherReference {
-            String field;
-        }
-
-        JavaClass javaClass = new ClassFileImporter().importClass(FieldTypeWithoutAnyFurtherReference.class);
-
-        assertThat(javaClass.getField("field").getRawType()).as("field type").isFullyImported(true);
-    }
-
-    @Test
-    public void automatically_resolves_constructor_parameter_types() {
-        @SuppressWarnings("unused")
-        class ConstructorParameterTypesWithoutAnyFurtherReference {
-            ConstructorParameterTypesWithoutAnyFurtherReference(FileSystem constructorParam1, Buffer constructorParam2) {
-            }
-        }
-
-        JavaClass javaClass = new ClassFileImporter().importClass(ConstructorParameterTypesWithoutAnyFurtherReference.class);
-
-        JavaConstructor constructor = javaClass.getConstructor(getClass(), FileSystem.class, Buffer.class);
-        assertThat(constructor.getRawParameterTypes().get(0)).as("constructor parameter type").isFullyImported(true);
-        assertThat(constructor.getRawParameterTypes().get(1)).as("constructor parameter type").isFullyImported(true);
-    }
-
-    @Test
-    public void automatically_resolves_method_return_types() {
-        @SuppressWarnings("unused")
-        class MemberTypesWithoutAnyFurtherReference {
-            File returnType() {
-                return null;
-            }
-        }
-
-        JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
-
-        assertThat(javaClass.getMethod("returnType").getRawReturnType()).as("method return type").isFullyImported(true);
-    }
-
-    @Test
-    public void automatically_resolves_method_parameter_types() {
-        @SuppressWarnings("unused")
-        class MemberTypesWithoutAnyFurtherReference {
-            void methodParameters(Path methodParam1, PrintStream methodParam2) {
-            }
-        }
-
-        JavaClass javaClass = new ClassFileImporter().importClass(MemberTypesWithoutAnyFurtherReference.class);
-
-        JavaMethod method = javaClass.getMethod("methodParameters", Path.class, PrintStream.class);
-        assertThat(method.getRawParameterTypes().get(0)).as("method parameter type").isFullyImported(true);
-        assertThat(method.getRawParameterTypes().get(1)).as("method parameter type").isFullyImported(true);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -111,8 +110,6 @@ import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 import static com.tngtech.archunit.testutil.TestUtils.uriOf;
 import static com.tngtech.archunit.testutil.TestUtils.urlOf;
 import static com.tngtech.archunit.testutil.assertion.ExpectedConcreteType.ExpectedConcreteParameterizedType.parameterizedType;
-import static com.tngtech.java.junit.dataprovider.DataProviders.$;
-import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assume.assumeTrue;
@@ -784,55 +781,6 @@ public class ClassFileImporterTest {
         clazz = new ClassFileImporter().importUrl(getClass().getResource("testexamples/simpleimport")).get(ClassToImportOne.class);
 
         assertThat(clazz.getRawSuperclass().get().getMethods()).isEmpty();
-    }
-
-    @DataProvider
-    public static Object[][] classes_not_fully_imported() {
-        class Element {
-        }
-        @SuppressWarnings("unused")
-        class DependsOnArray {
-            Element[] array;
-        }
-
-        return ArchConfigurationRule.resetConfigurationAround(new Callable<Object[][]>() {
-            @Override
-            public Object[][] call() {
-                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(true);
-                JavaClass resolvedFromClasspath = new ClassFileImporter().importClasses(DependsOnArray.class)
-                        .get(DependsOnArray.class).getField("array").getRawType().getComponentType();
-
-                ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(false);
-                JavaClass stub = new ClassFileImporter().importClasses(DependsOnArray.class)
-                        .get(DependsOnArray.class).getField("array").getRawType().getComponentType();
-
-                return $$(
-                        $("Resolved from classpath", resolvedFromClasspath),
-                        $("Stub class", stub)
-                );
-            }
-        });
-    }
-
-    @Test
-    @UseDataProvider("classes_not_fully_imported")
-    public void classes_not_fully_imported_have_flag_fullyImported_false_and_empty_dependencies(@SuppressWarnings("unused") String description, JavaClass notFullyImported) {
-        assertThat(notFullyImported).isFullyImported(false);
-        assertThat(notFullyImported.getDirectDependenciesFromSelf()).isEmpty();
-        assertThat(notFullyImported.getDirectDependenciesToSelf()).isEmpty();
-        assertThat(notFullyImported.getFieldAccessesToSelf()).isEmpty();
-        assertThat(notFullyImported.getMethodCallsToSelf()).isEmpty();
-        assertThat(notFullyImported.getConstructorCallsToSelf()).isEmpty();
-        assertThat(notFullyImported.getAccessesToSelf()).isEmpty();
-        assertThat(notFullyImported.getFieldsWithTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getMethodsWithParameterTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getMethodsWithReturnTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getMethodThrowsDeclarationsWithTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getConstructorsWithParameterTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getConstructorsWithThrowsDeclarationTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getAnnotationsWithTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getAnnotationsWithParameterTypeOfSelf()).isEmpty();
-        assertThat(notFullyImported.getInstanceofChecksWithTypeOfSelf()).isEmpty();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/DependencyResolutionProcessTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/DependencyResolutionProcessTestUtils.java
@@ -1,0 +1,92 @@
+package com.tngtech.archunit.core.importer;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.ArchConfiguration;
+import com.tngtech.archunit.base.Optional;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Sets.newHashSet;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.DEPENDENCY_RESOLUTION_PROCESS_PROPERTY_PREFIX;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.testutil.ArchConfigurationRule.resetConfigurationAround;
+import static java.util.Collections.singleton;
+
+public class DependencyResolutionProcessTestUtils {
+
+    static JavaClasses importClassesWithOnlyGenericTypeResolution(final Class<?>... classes) {
+        return ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(
+                MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE
+        ).importClasses(classes);
+    }
+
+    static JavaClass importClassWithOnlyGenericTypeResolution(final Class<?> clazz) {
+        return importClassesWithOnlyGenericTypeResolution(clazz).get(clazz);
+    }
+
+    static class ImporterWithAdjustedResolutionRuns {
+        private final Set<String> propertyNames;
+        private final Optional<Integer> number;
+
+        private ImporterWithAdjustedResolutionRuns(Set<String> propertyNames, Optional<Integer> number) {
+            this.propertyNames = propertyNames;
+            this.number = number;
+        }
+
+        static ImporterWithAdjustedResolutionRuns disableAllIterationsExcept(String... propertyNames) {
+            return new ImporterWithAdjustedResolutionRuns(ImmutableSet.copyOf(propertyNames), Optional.<Integer>empty());
+        }
+
+        static ImporterWithAdjustedResolutionRuns disableAllIterationsExcept(String propertyName, int number) {
+            return new ImporterWithAdjustedResolutionRuns(singleton(propertyName), Optional.of(number));
+        }
+
+        JavaClass importClass(final Class<?> clazz) {
+            return importClasses(clazz).get(clazz);
+        }
+
+        public JavaClasses importClasses(final Class<?>... classes) {
+            return resetConfigurationAround(new Callable<JavaClasses>() {
+                @Override
+                public JavaClasses call() {
+                    ImporterWithAdjustedResolutionRuns.this.setAllIterationsToZeroExcept(propertyNames);
+                    return new ClassFileImporter().importClasses(classes);
+                }
+            });
+        }
+
+        private void setAllIterationsToZeroExcept(Set<String> propertyNames) {
+            Set<String> allPropertyNames = newHashSet(
+                    MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME,
+                    MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME,
+                    MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME,
+                    MAX_ITERATIONS_FOR_ENCLOSING_TYPES_PROPERTY_NAME,
+                    MAX_ITERATIONS_FOR_ANNOTATION_TYPES_PROPERTY_NAME,
+                    MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME
+            );
+            allPropertyNames.removeAll(propertyNames);
+
+            for (String propertyNameToDisable : allPropertyNames) {
+                setResolutionProperty(propertyNameToDisable, 0);
+            }
+
+            if (number.isPresent()) {
+                setResolutionProperty(getOnlyElement(propertyNames), number.get());
+            }
+        }
+
+        private void setResolutionProperty(String propertyName, int number) {
+            ArchConfiguration.get().setProperty(DEPENDENCY_RESOLUTION_PROCESS_PROPERTY_PREFIX + "." + propertyName, String.valueOf(number));
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -43,6 +43,7 @@ import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder.ValueBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeCreationProcess;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
@@ -270,7 +271,7 @@ public class ImportTestUtils {
         DomainBuilders.JavaAnnotationBuilder builder = new DomainBuilders.JavaAnnotationBuilder()
                 .withType(JavaClassDescriptor.From.name(annotation.annotationType().getName()));
         for (Map.Entry<String, Object> entry : mapOf(annotation, annotatedClass, importedClasses).entrySet()) {
-            builder.addProperty(entry.getKey(), DomainBuilders.JavaAnnotationBuilder.ValueBuilder.ofFinished(entry.getValue()));
+            builder.addProperty(entry.getKey(), ValueBuilder.fromPrimitiveProperty(entry.getValue()));
         }
         return builder;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedparameters/ClassWithMethodWithAnnotatedParameters.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedparameters/ClassWithMethodWithAnnotatedParameters.java
@@ -78,7 +78,7 @@ public class ClassWithMethodWithAnnotatedParameters {
     }
 
     @Retention(RUNTIME)
-    @interface SomeParameterAnnotation {
+    public @interface SomeParameterAnnotation {
         SomeEnum value();
 
         SomeEnum valueWithDefault() default SOME_VALUE;

--- a/archunit/src/test/java/com/tngtech/archunit/lang/extension/ArchUnitExtensionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/extension/ArchUnitExtensionsTest.java
@@ -1,6 +1,5 @@
 package com.tngtech.archunit.lang.extension;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import com.google.common.collect.ImmutableSet;
@@ -39,7 +38,7 @@ public class ArchUnitExtensionsTest {
     private ArchUnitExtensions extensions;
 
     @Test
-    public void extensions_are_configured() throws IOException {
+    public void extensions_are_configured() {
         TestExtension extensionOne = new TestExtension("one");
         TestExtension extensionTwo = new TestExtension("two");
         when(extensionLoader.getAll()).thenReturn(ImmutableSet.<ArchUnitExtension>of(extensionOne, extensionTwo));

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
@@ -64,7 +64,12 @@ class ClassesShouldEvaluator {
     private List<String> getRelevantFailures(JavaClasses classes) {
         List<String> relevant = new ArrayList<>();
         for (String line : linesIn(rule.evaluate(classes).getFailureReport())) {
-            if (!isDefaultConstructor(line) && !isSelfReference(line) && !isExtendsJavaLangAnnotation(line)) {
+            if (
+                    !isDefaultConstructor(line)
+                            && !isSelfReference(line)
+                            && !isExtendsJavaLangAnnotation(line)
+                            && !isDirectDependencyFromTest(line)
+            ) {
                 relevant.add(line);
             }
         }
@@ -81,6 +86,10 @@ class ClassesShouldEvaluator {
 
     private boolean isExtendsJavaLangAnnotation(String line) {
         return line.matches(String.format(".*extends.*<%s> in.*", Annotation.class.getName()));
+    }
+
+    private boolean isDirectDependencyFromTest(String line) {
+        return line.matches("^Method <.*Test\\..*> .*");
     }
 
     private List<String> linesIn(FailureReport failureReport) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldEvaluator.java
@@ -64,12 +64,7 @@ class ClassesShouldEvaluator {
     private List<String> getRelevantFailures(JavaClasses classes) {
         List<String> relevant = new ArrayList<>();
         for (String line : linesIn(rule.evaluate(classes).getFailureReport())) {
-            if (
-                    !isDefaultConstructor(line)
-                            && !isSelfReference(line)
-                            && !isExtendsJavaLangAnnotation(line)
-                            && !isDirectDependencyFromTest(line)
-            ) {
+            if (!isDefaultConstructor(line) && !isSelfReference(line) && !isExtendsJavaLangAnnotation(line)) {
                 relevant.add(line);
             }
         }
@@ -86,10 +81,6 @@ class ClassesShouldEvaluator {
 
     private boolean isExtendsJavaLangAnnotation(String line) {
         return line.matches(String.format(".*extends.*<%s> in.*", Annotation.class.getName()));
-    }
-
-    private boolean isDirectDependencyFromTest(String line) {
-        return line.matches("^Method <.*Test\\..*> .*");
     }
 
     private List<String> linesIn(FailureReport failureReport) {

--- a/docs/userguide/010_Advanced_Configuration.adoc
+++ b/docs/userguide/010_Advanced_Configuration.adoc
@@ -79,6 +79,49 @@ classResolver.args=myArgOne,myArgTwo
 
 For further details, compare the sources of `SelectedClassResolverFromClasspath`.
 
+==== Configuring the Number of Resolution Iterations
+
+It is also possible to apply a more fine-grained configuration to the import dependency resolution behavior.
+
+In particular, the ArchUnit importer distinguishes 6 types of import dependencies:
+
+- member types (e.g. the type of a field of a class, type of a method parameter, etc.)
+- accesses to types (e.g. a method calls another method of a different class)
+- supertypes (i.e. superclasses that are extended and interfaces that are implemented)
+- enclosing types (i.e. outer classes of nested classes)
+- annotation types, including parameters of annotations
+- generic signature types (i.e. types that comprise a parameterized type, like `List` and `String` for `List<String>`)
+
+For each of these dependency types it is possible to configure the maximum number of iterations to traverse the dependencies.
+E.g. let us assume we configure the maximum iterations as `2` for member types and we have a class `A` that declares a field of type `B` which in turn holds a field of type `C`.
+On the first run we would automatically resolve the type `B` as a dependency of `A`.
+On the second run we would then also resolve `C` as a member type dependency of `B`.
+
+The configuration parameters with their defaults are the following:
+
+[source,options="nowrap"]
+.archunit.properties
+----
+import.dependencyResolutionProcess.maxIterationsForMemberTypes = 1
+import.dependencyResolutionProcess.maxIterationsForAccessesToTypes = 1
+import.dependencyResolutionProcess.maxIterationsForSupertypes = -1
+import.dependencyResolutionProcess.maxIterationsForEnclosingTypes = -1
+import.dependencyResolutionProcess.maxIterationsForAnnotationTypes = -1
+import.dependencyResolutionProcess.maxIterationsForGenericSignatureTypes = -1
+----
+
+Note that setting a property to a negative value (e.g. `-1`) will not stop the resolution until all types for the given sort of dependency have been resolved.
+E.g. for generic type signatures a value of `-1` will by default lead to all types comprising the signature `Map<?, List<? extends String>>` (that is `Map`, `List` and `String`) to be automatically resolved.
+
+Setting a property to `0` will disable the automatic resolution,
+which can lead to types being only partially imported or stubbed.
+For these types the information is likely not complete or even wrong (e.g. an interface might be reported as class if the bytecode was never analyzed, or annotations might be missing).
+
+On the other hand, bigger (or negative) values can have a massive performance impact.
+The defaults should provide a reasonable behavior.
+They include the class graph for all types that are used by members or accesses directly and cut the resolution at that point.
+However, relevant information for these types is fully imported, no matter how many iterations it takes (e.g. supertypes or generic signatures).
+
 === MD5 Sums of Classes
 
 Sometimes it can be valuable to record the MD5 sums of classes being imported to track


### PR DESCRIPTION
When importing classes there will always be some dependencies that are missing. E.g. we import package `com.myapp`, but naturally those classes will at least depend on classes in `java.lang`. ArchUnit has an automatic import dependency resolution process to pick up such missing classes from the classpath (by default).
However, this resolution process was somewhat inconsistent. It would in a first run resolve all missing member types, then in a second run resolve all missing access targets, then supertypes and then annotations. Thus, e.g. classes that were discovered when resolving supertypes would not have their member types resolved anymore, which could lead to surprising behavior. Also, some dependencies were not automatically resolved, in particular:

* generic type signatures
* enclosing classes of nested classes
* component types of array types
* types of declared thrown exceptions
* target types of instanceof checks
* referenced class objects

This PR consolidates the resolution process and fixes these shortcomings. It does so by registering all import dependencies already withing the ASM visitors. This way, once all the classes picked originally are imported we now have a set of class names that are needed as dependencies. When we run the importer again to resolve these missing types we will again transitively register the types these types were missing. By distinguishing 6 types of dependencies (member types, accesses, supertypes, enclosing types, annotations and generic type signatures) we can control how deeply we want to resolve each of these sort of dependencies. How many iterations we make for each such type is now configurable via `archunit.properties`. The defaults are configured in a way that the behavior is similar to before, except that the mentioned shortcomings are now fixed. I.e. we resolve one level for member types and accesses, so all the "used types" of the imported classes are present. The other types of dependencies we resolve until we have registered all needed types. That way (meta-)annotations, generic signatures, etc., are all fully resolved. This should provide a reasonable default behavior and also fix most issues that ever occurred because of inconsistent resolution behavior.

Resolves: #728