### PR TITLE
Add `javaClass` to `FieldSource`

### DIFF
--- a/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/FieldSource.java
+++ b/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/FieldSource.java
@@ -25,17 +25,22 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 @PublicAPI(usage = ACCESS)
 public final class FieldSource implements TestSource {
-    private final String className;
+    private final Class<?> javaClass;
     private final String fieldName;
 
     private FieldSource(Field field) {
-        className = field.getDeclaringClass().getName();
+        javaClass = field.getDeclaringClass();
         fieldName = field.getName();
     }
 
     @PublicAPI(usage = ACCESS)
     public String getClassName() {
-        return className;
+        return javaClass.getName();
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Class<?> getJavaClass() {
+        return javaClass;
     }
 
     @PublicAPI(usage = ACCESS)
@@ -45,7 +50,7 @@ public final class FieldSource implements TestSource {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(className, fieldName);
+        return Objects.hash(javaClass, fieldName);
 	}
 
 	@Override
@@ -57,13 +62,13 @@ public final class FieldSource implements TestSource {
 			return false;
 		}
 		final FieldSource other = (FieldSource) obj;
-		return Objects.equals(this.className, other.className)
-				&& Objects.equals(this.fieldName, other.fieldName);
+        return Objects.equals(this.javaClass, other.javaClass)
+                && Objects.equals(this.fieldName, other.fieldName);
 	}
 
 	@Override
 	public String toString() {
-		return getClass().getSimpleName() + "{" + className + '.' + fieldName + '}';
+        return getClass().getSimpleName() + "{" + getClassName() + '.' + fieldName + '}';
 	}
 
     static FieldSource from(Field field) {

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
@@ -185,6 +185,7 @@ class ArchUnitTestEngineTest {
 
             assertThat(ruleDescriptor.getUniqueId()).isEqualTo(simpleRuleFieldTestId(engineId));
             FieldSource testSource = ((FieldSource) ruleDescriptor.getSource().get());
+            assertThat(testSource.getJavaClass()).isEqualTo(SimpleRuleField.class);
             assertThat(testSource.getClassName()).isEqualTo(SimpleRuleField.class.getName());
             assertThat(testSource.getFieldName()).isEqualTo(SIMPLE_RULE_FIELD_NAME);
         }


### PR DESCRIPTION
Relates to #781 and would make the integration into Quarkus continuous testing a bit easier, see https://github.com/quarkusio/quarkus/pull/23358#discussion_r809498247

/cc @codecholeric

PS: Naming is inspired by `org.junit.platform.engine.support.descriptor.MethodSource.javaMethod`.