### PR TITLE
Deprecate unwanted `ConditionEvents` API

### DIFF
--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -88,7 +88,8 @@ dependencies {
     runtimeOnly sourceSets.jdk9main.output
 }
 
-compileJdk9mainJava.with {
+compileJdk9mainJava {
+    dependsOn(compileJava)
     ext.minimumJavaVersion = JavaVersion.VERSION_1_9
 
     destinationDir = compileJava.destinationDir

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
@@ -157,7 +157,7 @@ public abstract class ArchCondition<T> {
         }
 
         private static <T> ConditionEvents check(ArchCondition<T> condition, T item) {
-            ConditionEvents events = new ConditionEvents();
+            ConditionEvents events = ConditionEvents.Factory.create();
             condition.check(item, events);
             return events;
         }
@@ -208,7 +208,7 @@ public abstract class ArchCondition<T> {
         }
 
         ConditionWithEvents<T> invert(ConditionWithEvents<T> evaluation) {
-            ConditionEvents invertedEvents = new ConditionEvents();
+            ConditionEvents invertedEvents = ConditionEvents.Factory.create();
             for (ConditionEvent event : evaluation.events) {
                 event.addInvertedTo(invertedEvents);
             }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
@@ -214,7 +214,7 @@ public interface ArchRule extends CanBeEvaluated, CanOverrideDescription<ArchRul
                 verifyNoEmptyShouldIfEnabled(allObjects);
 
                 condition.init(allObjects);
-                ConditionEvents events = new ConditionEvents();
+                ConditionEvents events = ConditionEvents.Factory.create();
                 for (T object : allObjects) {
                     condition.check(object, events);
                 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvents.java
@@ -48,8 +48,11 @@ public interface ConditionEvents extends Iterable<ConditionEvent> {
     Collection<ConditionEvent> getViolating();
 
     /**
+     * @deprecated This method will be removed without any replacement. If you think you need this method, please
+     *             file an issue at https://github.com/TNG/ArchUnit/issues
      * @return All {@link ConditionEvent events} that correspond to non-violating elements.
      */
+    @Deprecated
     Collection<ConditionEvent> getAllowed();
 
     /**
@@ -58,8 +61,11 @@ public interface ConditionEvents extends Iterable<ConditionEvent> {
     boolean containViolation();
 
     /**
+     * @deprecated This method will be removed without any replacement. If you think you need this method, please
+     *             file an issue at https://github.com/TNG/ArchUnit/issues
      * @return {@code true}, if these events contain any event, be it {@link #getViolating() violating} or {@link #getAllowed() allowed}.
      */
+    @Deprecated
     boolean isEmpty();
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEventsInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEventsInternal.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
+import com.google.common.reflect.TypeToken;
+import com.tngtech.archunit.base.Optional;
+
+final class ConditionEventsInternal implements ConditionEvents {
+    private final Multimap<Type, ConditionEvent> eventsByViolation = ArrayListMultimap.create();
+    private Optional<String> informationAboutNumberOfViolations = Optional.empty();
+
+    ConditionEventsInternal() {
+    }
+
+    @Override
+    public void add(ConditionEvent event) {
+        eventsByViolation.get(Type.from(event.isViolation())).add(event);
+    }
+
+    @Override
+    public void setInformationAboutNumberOfViolations(String informationAboutNumberOfViolations) {
+        this.informationAboutNumberOfViolations = Optional.of(informationAboutNumberOfViolations);
+    }
+
+    @Override
+    public Collection<ConditionEvent> getViolating() {
+        return eventsByViolation.get(Type.VIOLATION);
+    }
+
+    @Override
+    public Collection<ConditionEvent> getAllowed() {
+        return eventsByViolation.get(Type.ALLOWED);
+    }
+
+    @Override
+    public boolean containViolation() {
+        return !getViolating().isEmpty();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getAllowed().isEmpty() && getViolating().isEmpty();
+    }
+
+    @Override
+    public FailureMessages getFailureMessages() {
+        ImmutableList<String> result = FluentIterable.from(getViolating())
+                .transformAndConcat(TO_DESCRIPTION_LINES)
+                .toSortedList(Ordering.natural());
+        return new FailureMessages(result, informationAboutNumberOfViolations);
+    }
+
+    @Override
+    public void handleViolations(ViolationHandler<?> violationHandler) {
+        ConditionEvent.Handler eventHandler = convertToEventHandler(violationHandler);
+        for (final ConditionEvent event : eventsByViolation.get(Type.VIOLATION)) {
+            event.handleWith(eventHandler);
+        }
+    }
+
+    private <T> ConditionEvent.Handler convertToEventHandler(final ViolationHandler<T> handler) {
+        final Class<?> supportedElementType = TypeToken.of(handler.getClass())
+                .resolveType(ViolationHandler.class.getTypeParameters()[0]).getRawType();
+
+        return new ConditionEvent.Handler() {
+            @Override
+            public void handle(Collection<?> correspondingObjects, String message) {
+                if (allElementTypesMatch(correspondingObjects, supportedElementType)) {
+                    // If all elements are assignable to T (= supportedElementType), covariance of Collection allows this cast
+                    @SuppressWarnings("unchecked")
+                    Collection<T> collection = (Collection<T>) correspondingObjects;
+                    handler.handle(collection, message);
+                }
+            }
+        };
+    }
+
+    private boolean allElementTypesMatch(Collection<?> violatingObjects, Class<?> supportedElementType) {
+        for (Object violatingObject : violatingObjects) {
+            if (!supportedElementType.isInstance(violatingObject)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public Iterator<ConditionEvent> iterator() {
+        return ImmutableSet.copyOf(eventsByViolation.values()).iterator();
+    }
+
+    @Override
+    public String toString() {
+        return "ConditionEvents{" +
+                "Allowed Events: " + getAllowed() +
+                "; Violating Events: " + getViolating() +
+                '}';
+    }
+
+    private static final Function<ConditionEvent, Iterable<String>> TO_DESCRIPTION_LINES = new Function<ConditionEvent, Iterable<String>>() {
+        @Override
+        public Iterable<String> apply(ConditionEvent input) {
+            return input.getDescriptionLines();
+        }
+    };
+
+    private enum Type {
+        ALLOWED, VIOLATION;
+
+        private static Type from(boolean violation) {
+            return violation ? VIOLATION : ALLOWED;
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
@@ -47,7 +47,7 @@ public final class EvaluationResult {
 
     @PublicAPI(usage = ACCESS)
     public EvaluationResult(HasDescription rule, Priority priority) {
-        this(rule, new ConditionEvents(), priority);
+        this(rule, ConditionEvents.Factory.create(), priority);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -96,7 +96,7 @@ public final class EvaluationResult {
      */
     @PublicAPI(usage = ACCESS)
     public EvaluationResult filterDescriptionsMatching(Predicate<String> linePredicate) {
-        ConditionEvents filtered = new ConditionEvents();
+        ConditionEvents filtered = ConditionEvents.Factory.create();
         for (ConditionEvent event : events) {
             filtered.add(new FilteredEvent(event, linePredicate));
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainAnyCondition.java
@@ -35,7 +35,7 @@ class ContainAnyCondition<T> extends ArchCondition<Collection<? extends T>> {
 
     @Override
     public void check(Collection<? extends T> collection, ConditionEvents events) {
-        ConditionEvents subEvents = new ConditionEvents();
+        ConditionEvents subEvents = ConditionEvents.Factory.create();
         for (T element : collection) {
             condition.check(element, subEvents);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ContainsOnlyCondition.java
@@ -34,7 +34,7 @@ class ContainsOnlyCondition<T> extends ArchCondition<Collection<? extends T>> {
 
     @Override
     public void check(Collection<? extends T> collection, ConditionEvents events) {
-        ConditionEvents subEvents = new ConditionEvents();
+        ConditionEvents subEvents = ConditionEvents.Factory.create();
         for (T item : collection) {
             condition.check(item, subEvents);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/NeverCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/NeverCondition.java
@@ -34,7 +34,7 @@ class NeverCondition<T> extends ArchCondition<T> {
 
     @Override
     public void finish(ConditionEvents events) {
-        ConditionEvents subEvents = new ConditionEvents();
+        ConditionEvents subEvents = ConditionEvents.Factory.create();
         condition.finish(subEvents);
         for (ConditionEvent event : subEvents) {
             event.addInvertedTo(events);
@@ -43,7 +43,7 @@ class NeverCondition<T> extends ArchCondition<T> {
 
     @Override
     public void check(T item, ConditionEvents events) {
-        ConditionEvents subEvents = new ConditionEvents();
+        ConditionEvents subEvents = ConditionEvents.Factory.create();
         condition.check(item, subEvents);
         for (ConditionEvent event : subEvents) {
             event.addInvertedTo(events);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
@@ -35,7 +35,7 @@ public class ArchConditionTest {
     public void as_finishes_delegate() {
         ConditionWithInitAndFinish original = someCondition("any");
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         original.as("changed").finish(events);
 
         assertThat(original.eventsFromFinish).isEqualTo(events);
@@ -45,18 +45,18 @@ public class ArchConditionTest {
     public void and_checks_all_conditions() {
         ArchCondition<Integer> greaterThan10_14And20 = greaterThan(10).and(greaterThan(14, 20));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         greaterThan10_14And20.check(15, events);
         assertThat(events).containViolations("15 is not greater than 20");
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         greaterThan10_14And20.check(5, events);
         assertThat(events).containViolations(
                 "5 is not greater than 10",
                 "5 is not greater than 14",
                 "5 is not greater than 20");
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         greaterThan10_14And20.check(21, events);
         assertThat(events).containNoViolation();
     }
@@ -65,7 +65,7 @@ public class ArchConditionTest {
     public void and_handles_each_violating_object_separately() {
         ArchCondition<Integer> condition = greaterThan(1).and(greaterThan(2)).and(greaterThan(3));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(2, events);
         final List<HandledViolation> handledViolations = new ArrayList<>();
         events.handleViolations(new ViolationHandler<Integer>() {
@@ -85,16 +85,16 @@ public class ArchConditionTest {
         ArchCondition<Integer> greaterThan15OrGreater14And20 =
                 greaterThan(15).or(greaterThan(14, 20));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         greaterThan15OrGreater14And20.check(15, events);
         assertThat(events).containViolations("15 is not greater than 15 and 15 is not greater than 20");
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         greaterThan15OrGreater14And20.check(5, events);
         assertThat(events).containViolations(
                 "5 is not greater than 14 and 5 is not greater than 15 and 5 is not greater than 20");
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         greaterThan15OrGreater14And20.check(16, events);
         assertThat(events).containNoViolation();
     }
@@ -104,7 +104,7 @@ public class ArchConditionTest {
         ArchCondition<Integer> isGreaterThan15OrEndsWith1 =
                 greaterThan(15).or(endsWith(1));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         isGreaterThan15OrEndsWith1.check(12, events);
         assertThat(events).containViolations("12 does not end with 1 and 12 is not greater than 15");
     }
@@ -113,7 +113,7 @@ public class ArchConditionTest {
     public void or_handles_all_violated_conditions_as_unit() {
         ArchCondition<Integer> condition = greaterThan(1).or(greaterThan(2)).or(greaterThan(3));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(1, events);
         final List<HandledViolation> handledViolations = new ArrayList<>();
         events.handleViolations(new ViolationHandler<Integer>() {
@@ -163,7 +163,7 @@ public class ArchConditionTest {
         ConditionWithInitAndFinish one = someCondition("one");
         ConditionWithInitAndFinish two = someCondition("two");
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         combination.combine(one, two).finish(events);
 
         assertThat(one.eventsFromFinish).isEqualTo(events);
@@ -185,11 +185,11 @@ public class ArchConditionTest {
     public void never_and() {
         ArchCondition<Integer> condition = never(greaterThan(3, 9).and(greaterThan(5, 7)));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(4, events);
         assertThat(events.containViolation()).as("Events contain violation").isFalse();
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         condition.check(6, events);
         assertThat(events.containViolation()).as("Events contain violation").isTrue();
     }
@@ -198,11 +198,11 @@ public class ArchConditionTest {
     public void double_never_and() {
         ArchCondition<Integer> condition = never(never(greaterThan(3, 9).and(greaterThan(5, 7))));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(9, events);
         assertThat(events.containViolation()).as("Events contain violation").isTrue();
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         condition.check(10, events);
         assertThat(events.containViolation()).as("Events contain violation").isFalse();
     }
@@ -211,11 +211,11 @@ public class ArchConditionTest {
     public void never_or() {
         ArchCondition<Integer> condition = never(greaterThan(3, 9).or(greaterThan(5, 7)));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(3, events);
         assertThat(events.containViolation()).as("Events contain violation").isFalse();
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         condition.check(4, events);
         assertThat(events.containViolation()).as("Events contain violation").isTrue();
     }
@@ -224,11 +224,11 @@ public class ArchConditionTest {
     public void double_never_or() {
         ArchCondition<Integer> condition = never(never(greaterThan(3, 9).or(greaterThan(5, 7))));
 
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(7, events);
         assertThat(events.containViolation()).as("Events contain violation").isTrue();
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         condition.check(8, events);
         assertThat(events.containViolation()).as("Events contain violation").isFalse();
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ConditionEventsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ConditionEventsTest.java
@@ -25,7 +25,7 @@ public class ConditionEventsTest {
         return $$(
                 $(events(SimpleConditionEvent.satisfied("irrelevant", "irrelevant")), false),
                 $(events(SimpleConditionEvent.violated("irrelevant", "irrelevant")), false),
-                $(new ConditionEvents(), true));
+                $(ConditionEvents.Factory.create(), true));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class ConditionEventsTest {
     }
 
     private static ConditionEvents events(ConditionEvent... events) {
-        ConditionEvents result = new ConditionEvents();
+        ConditionEvents result = ConditionEvents.Factory.create();
         for (ConditionEvent event : events) {
             result.add(event);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
@@ -81,7 +81,7 @@ public class EvaluationResultTest {
     }
 
     private ConditionEvents events(ConditionEvent... events) {
-        ConditionEvents result = new ConditionEvents();
+        ConditionEvents result = ConditionEvents.Factory.create();
         for (ConditionEvent event : events) {
             result.add(event);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassAccessesFieldConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassAccessesFieldConditionTest.java
@@ -58,7 +58,7 @@ public class ClassAccessesFieldConditionTest {
 
     @Theory
     public void condition_works(PositiveTestCase testCase) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
 
         testCase.condition.check(CALLER_CLASS, events);
 
@@ -67,7 +67,7 @@ public class ClassAccessesFieldConditionTest {
 
     @Theory
     public void condition_works(NegativeTestCase testCase) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
 
         testCase.condition.check(CALLER_CLASS, events);
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassCallsCodeUnitConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassCallsCodeUnitConditionTest.java
@@ -56,7 +56,7 @@ public class ClassCallsCodeUnitConditionTest {
     }
 
     private ConditionEvents checkCondition(ArchCondition<JavaClass> condition) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(CALLER_CLASS, events);
         return events;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainAnyConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainAnyConditionTest.java
@@ -22,18 +22,18 @@ public class ContainAnyConditionTest {
 
     @Test
     public void satisfied_works_and_description_contains_mismatches() {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containAnyElementThat(IS_SERIALIZABLE).check(TWO_NONSERIALIZABLE_OBJECTS, events);
         assertThat(events).containViolations(messageForTwoTimes(isSerializableMessageFor(Object.class)));
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         containAnyElementThat(IS_SERIALIZABLE).check(ONE_SERIALIZABLE_AND_ONE_NON_SERIALIZABLE_OBJECT, events);
         assertThat(events).containNoViolation();
     }
 
     @Test
     public void inverting_works() throws Exception {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containAnyElementThat(IS_SERIALIZABLE).check(ONE_SERIALIZABLE_AND_ONE_NON_SERIALIZABLE_OBJECT, events);
 
         assertThat(events).containNoViolation();
@@ -44,7 +44,7 @@ public class ContainAnyConditionTest {
 
     @Test
     public void if_there_are_no_input_events_no_ContainsAnyEvent_is_added() {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containOnlyElementsThat(IS_SERIALIZABLE).check(emptyList(), events);
         assertThat(events.isEmpty()).as("events are empty").isTrue();
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainsOnlyConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ContainsOnlyConditionTest.java
@@ -32,12 +32,12 @@ public class ContainsOnlyConditionTest {
 
     @Test
     public void satisfied_works_and_description_contains_mismatches() {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containOnlyElementsThat(IS_SERIALIZABLE).check(ONE_SERIALIZABLE_AND_ONE_NON_SERIALIZABLE_OBJECT, events);
 
         assertThat(events).containViolations(isSerializableMessageFor(Object.class));
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         containOnlyElementsThat(IS_SERIALIZABLE).check(TWO_SERIALIZABLE_OBJECTS, events);
 
         assertThat(events).containNoViolation();
@@ -45,7 +45,7 @@ public class ContainsOnlyConditionTest {
 
     @Test
     public void inverting_works() throws Exception {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containOnlyElementsThat(IS_SERIALIZABLE).check(TWO_SERIALIZABLE_OBJECTS, events);
 
         assertThat(events).containNoViolation();
@@ -56,13 +56,13 @@ public class ContainsOnlyConditionTest {
 
     @Test
     public void if_there_are_no_input_events_no_ContainsOnlyEvent_is_added() {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         containOnlyElementsThat(IS_SERIALIZABLE).check(emptyList(), events);
         assertThat(events.isEmpty()).as("events are empty").isTrue();
     }
 
     static ConditionEvents getInverted(ConditionEvents events) {
-        ConditionEvents inverted = new ConditionEvents();
+        ConditionEvents inverted = ConditionEvents.Factory.create();
         for (ConditionEvent event : events) {
             event.addInvertedTo(inverted);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/FieldAccessConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/FieldAccessConditionTest.java
@@ -80,7 +80,7 @@ public class FieldAccessConditionTest {
     }
 
     private ConditionEvents checkCondition(FieldAccessCondition getFieldCondition, JavaFieldAccess access) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         getFieldCondition.check(access, events);
         return events;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/JavaAccessConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/JavaAccessConditionTest.java
@@ -60,7 +60,7 @@ public class JavaAccessConditionTest {
 
     private ConditionEventsAssertion assertThatOnlyAccessToSomeClassFor(JavaClass clazz, JavaAccessCondition<JavaAccess<?>> condition) {
         Set<JavaAccess<?>> accesses = filterByTarget(clazz.getAccessesFromSelf(), SomeClass.class);
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         for (JavaAccess<?> access : accesses) {
             condition.check(access, events);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/NeverConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/NeverConditionTest.java
@@ -55,14 +55,14 @@ public class NeverConditionTest {
     @Test
     @UseDataProvider("conditions")
     public void inverts_condition(ArchCondition<Object> condition) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(new Object(), events);
         condition.finish(events);
 
         assertThat(events).containAllowed(ORIGINALLY_NO_MISMATCH);
         assertThat(events).containViolations(ORIGINALLY_MISMATCH);
 
-        events = new ConditionEvents();
+        events = ConditionEvents.Factory.create();
         never(condition).check(new Object(), events);
         never(condition).finish(events);
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchConditionAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchConditionAssertion.java
@@ -18,7 +18,7 @@ public class ArchConditionAssertion<T> extends AbstractObjectAssert<ArchConditio
     }
 
     public ConditionEventsAssertion checking(T item) {
-        ConditionEvents events = new ConditionEvents();
+        ConditionEvents events = ConditionEvents.Factory.create();
         actual.check(item, events);
         return assertThat(events);
     }


### PR DESCRIPTION
At the moment the implementation of `ConditionEvents` is fairly suboptimal. But at the same time changes are hard, because the public API gives too much access. In particular, that `ConditionEvents` allow to publicly retrieve all allowed events wastes a lot of memory. Because usually there are a lot more allowed events than violating events, but the allowed events should be irrelevant for the vast majority of (all?) users.

To improve this situation we change `ConditionEvents` to an interface which should make it more flexible to achieve everything that was achievable so far but to not lock us into a concrete implementation. But we still need to eliminate all public API that forces to keep allowed events. We thus deprecate these methods for now so we can remove them later on.