### PR TITLE
#704: added onlyBeCalledByClassesThat conjuntion - initial part

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -172,6 +172,9 @@ public abstract class JavaCodeUnit
     }
 
     @PublicAPI(usage = ACCESS)
+    public abstract Set<? extends JavaCall<?>> getCallsOfSelf();
+
+    @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getMethodCallsFromSelf() {
         return methodCalls;
     }
@@ -222,6 +225,11 @@ public abstract class JavaCodeUnit
 
     @PublicAPI(usage = ACCESS)
     public boolean isConstructor() {
+        return false;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public boolean isMethod() {
         return false;
     }
 
@@ -354,6 +362,16 @@ public abstract class JavaCodeUnit
                 }
             };
         }
+
+        @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<JavaCodeUnit> method() {
+            return new DescribedPredicate<JavaCodeUnit>("method") {
+                @Override
+                public boolean apply(JavaCodeUnit input) {
+                    return input.isMethod();
+                }
+            };
+        }
     }
 
     @PublicAPI(usage = ACCESS)
@@ -377,6 +395,15 @@ public abstract class JavaCodeUnit
                     }
                 };
             }
+
+            @PublicAPI(usage = ACCESS)
+            public static final ChainableFunction<JavaCodeUnit, Set<? extends JavaCall<?>>> GET_CALLS_OF_SELF =
+                    new ChainableFunction<JavaCodeUnit, Set<? extends JavaCall<?>>>() {
+                        @Override
+                        public Set<? extends JavaCall<?>> apply(JavaCodeUnit input) {
+                            return input.getCallsOfSelf();
+                        }
+                    };
         }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -70,6 +70,12 @@ public class JavaMethod extends JavaCodeUnit {
         return annotationDefaultValue;
     }
 
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public boolean isMethod() {
+        return true;
+    }
+
     @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getCallsOfSelf() {
         return getReverseDependencies().getCallsTo(this);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
@@ -76,4 +76,9 @@ public class JavaStaticInitializer extends JavaCodeUnit {
     public ThrowsClause<JavaStaticInitializer> getThrowsClause() {
         return ThrowsClause.empty(this);
     }
+
+    @Override
+    public Set<? extends JavaCall<?>> getCallsOfSelf() {
+        return emptySet();
+    }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllAttributesMatchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllAttributesMatchCondition.java
@@ -17,26 +17,25 @@ package com.tngtech.archunit.lang.conditions;
 
 import java.util.Collection;
 
-import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containOnlyElementsThat;
 
-abstract class AllAttributesMatchCondition<T> extends ArchCondition<JavaClass> {
-    private final ArchCondition<T> condition;
+abstract class AllAttributesMatchCondition<ATTRIBUTE, OWNER> extends ArchCondition<OWNER> {
+    private final ArchCondition<ATTRIBUTE> condition;
 
-    AllAttributesMatchCondition(String description, ArchCondition<T> condition) {
+    AllAttributesMatchCondition(String description, ArchCondition<ATTRIBUTE> condition) {
         super(description);
         this.condition = condition;
     }
 
     @Override
-    public final void check(JavaClass item, ConditionEvents events) {
+    public final void check(OWNER item, ConditionEvents events) {
         containOnlyElementsThat(condition).check(relevantAttributes(item), events);
     }
 
-    abstract Collection<T> relevantAttributes(JavaClass item);
+    abstract Collection<? extends ATTRIBUTE> relevantAttributes(OWNER item);
 
     @Override
     public String toString() {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 @PublicAPI(usage = ACCESS)
-public final class AllDependenciesCondition extends AllAttributesMatchCondition<Dependency> {
+public final class AllDependenciesCondition extends AllAttributesMatchCondition<Dependency, JavaClass> {
     private final DescribedPredicate<? super Dependency> conditionPredicate;
     private final Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies;
     private final DescribedPredicate<Dependency> ignorePredicate;

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ClassOnlyAccessesCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ClassOnlyAccessesCondition.java
@@ -22,7 +22,7 @@ import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 
-class ClassOnlyAccessesCondition<T extends JavaAccess<?>> extends AllAttributesMatchCondition<T> {
+class ClassOnlyAccessesCondition<T extends JavaAccess<?>> extends AllAttributesMatchCondition<T, JavaClass> {
     private final Function<JavaClass, ? extends Collection<T>> getRelevantAccesses;
 
     ClassOnlyAccessesCondition(DescribedPredicate<? super T> predicate, Function<JavaClass, ? extends Collection<T>> getRelevantAccesses) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/CodeUnitOnlyCallsCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/CodeUnitOnlyCallsCondition.java
@@ -17,23 +17,22 @@ package com.tngtech.archunit.lang.conditions;
 
 import java.util.Collection;
 
-import com.google.common.base.Joiner;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.Function;
 import com.tngtech.archunit.core.domain.JavaAccess;
-import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 
-class AllAccessesCondition extends AllAttributesMatchCondition<JavaAccess<?>, JavaClass> {
-    private final Function<JavaClass, ? extends Collection<JavaAccess<?>>> getRelevantAccesses;
+class CodeUnitOnlyCallsCondition<T extends JavaAccess<?>> extends AllAttributesMatchCondition<T, JavaCodeUnit> {
+    private final Function<? super JavaCodeUnit, ? extends Collection<? extends T>> getRelevantAccesses;
 
-    AllAccessesCondition(String prefix, DescribedPredicate<JavaAccess<?>> predicate,
-            Function<JavaClass, ? extends Collection<JavaAccess<?>>> getRelevantAccesses) {
-        super(Joiner.on(" ").join(prefix, predicate.getDescription()), new JavaAccessCondition<>(predicate));
+    CodeUnitOnlyCallsCondition(String description, DescribedPredicate<T> predicate,
+            Function<? super JavaCodeUnit, ? extends Collection<? extends T>> getRelevantAccesses) {
+        super(description, new JavaAccessCondition<>(predicate));
         this.getRelevantAccesses = getRelevantAccesses;
     }
 
     @Override
-    Collection<JavaAccess<?>> relevantAttributes(JavaClass item) {
+    Collection<? extends T> relevantAttributes(JavaCodeUnit item) {
         return getRelevantAccesses.apply(item);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractCodeUnitsShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractCodeUnitsShouldInternal.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.lang.Priority;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.elements.CodeUnitsShould;
 import com.tngtech.archunit.lang.syntax.elements.CodeUnitsShouldConjunction;
+import com.tngtech.archunit.lang.syntax.elements.OnlyBeCalledSpecification;
 
 import static com.tngtech.archunit.lang.conditions.ArchConditions.not;
 
@@ -146,6 +147,11 @@ abstract class AbstractCodeUnitsShouldInternal<CODE_UNIT extends JavaCodeUnit, S
     @Override
     public SELF notDeclareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(not(ArchConditions.declareThrowableOfType(predicate)));
+    }
+
+    @Override
+    public OnlyBeCalledSpecification<SELF> onlyBeCalled() {
+        return new OnlyBeCalledSpecificationInternal<>(self());
     }
 
     static class CodeUnitsShouldInternal extends AbstractCodeUnitsShouldInternal<JavaCodeUnit, CodeUnitsShouldInternal> {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/AbstractMembersShouldInternal.java
@@ -333,6 +333,11 @@ abstract class AbstractMembersShouldInternal<MEMBER extends JavaMember, SELF ext
         return copyWithNewCondition(conditionAggregator.thatORsWith(ObjectsShouldInternal.<MEMBER>prependDescription("should")));
     }
 
+    @SuppressWarnings("unchecked")
+    SELF self() {
+        return (SELF) this;
+    }
+
     static class MembersShouldInternal extends AbstractMembersShouldInternal<JavaMember, MembersShouldInternal> {
 
         MembersShouldInternal(

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/OnlyBeCalledSpecificationInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/OnlyBeCalledSpecificationInternal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.syntax;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.Function;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
+import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
+import com.tngtech.archunit.lang.syntax.elements.OnlyBeCalledSpecification;
+
+class OnlyBeCalledSpecificationInternal<SHOULD extends AbstractMembersShouldInternal<? extends JavaCodeUnit, SHOULD>> implements OnlyBeCalledSpecification<SHOULD> {
+    private final SHOULD codeUnitsShould;
+
+    OnlyBeCalledSpecificationInternal(SHOULD codeUnitsShould) {
+        this.codeUnitsShould = codeUnitsShould;
+    }
+
+    @Override
+    public SHOULD byClassesThat(DescribedPredicate<? super JavaClass> predicate) {
+        return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByClassesThat(predicate));
+    }
+
+    @Override
+    public ClassesThat<SHOULD> byClassesThat() {
+        return new ClassesThatInternal<>(new Function<DescribedPredicate<? super JavaClass>, SHOULD>() {
+            @Override
+            public SHOULD apply(DescribedPredicate<? super JavaClass> predicate) {
+                return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByClassesThat(predicate));
+            }
+        });
+    }
+
+    @Override
+    public SHOULD byCodeUnitsThat(DescribedPredicate<? super JavaMember> predicate) {
+        return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByCodeUnitsThat(predicate));
+    }
+
+    @Override
+    public SHOULD byMethodsThat(DescribedPredicate<? super JavaMember> predicate) {
+        return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByMethodsThat(predicate));
+    }
+
+    @Override
+    public SHOULD byConstructorsThat(DescribedPredicate<? super JavaMember> predicate) {
+        return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByConstructorsThat(predicate));
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
@@ -70,6 +70,19 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
     CONJUNCTION notHaveRawParameterTypes(Class<?>... parameterTypes);
 
     /**
+     * Asserts that only certain objects call the code units selected by this rule.
+     * <br><br>
+     * E.g.
+     * <pre><code>
+     * {@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#should() should()}.{@link CodeUnitsShould#onlyBeCalled() onlyBeCalled()}.{@link OnlyBeCalledSpecification#byClassesThat() byClassesThat()}.{@link ClassesThat#belongToAnyOf(Class[]) belongToAnyOf(SomeClass.class)}
+     * </code></pre>
+     *
+     * @return A syntax element that allows restricting how code units can be called
+     */
+    @PublicAPI(usage = ACCESS)
+    OnlyBeCalledSpecification<CONJUNCTION> onlyBeCalled();
+
+    /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} have the specified fully qualified raw parameter type names.
      * <br><br>
      * E.g.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.syntax.elements;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaMember;
+
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+public interface OnlyBeCalledSpecification<CONJUNCTION> {
+
+    /**
+     * @param predicate Restricts which classes the call should originate from. Every class that calls the respective {@link JavaCodeUnit} must match the predicate.
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION byClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
+    /**
+     * @return A syntax element that allows restricting which classes the call should be from
+     */
+    @PublicAPI(usage = ACCESS)
+    ClassesThat<CONJUNCTION> byClassesThat();
+
+    /**
+     * @param predicate Restricts which code units the call should originate from
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION byCodeUnitsThat(DescribedPredicate<? super JavaMember> predicate);
+
+    /**
+     * @param predicate Restricts which methods the call should originate from. Calls from constructors are treated as mismatch.
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION byMethodsThat(DescribedPredicate<? super JavaMember> predicate);
+
+    /**
+     * @param predicate Restricts which constructors the call should originate from. Calls from methods are treated as mismatch.
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION byConstructorsThat(DescribedPredicate<? super JavaMember> predicate);
+}


### PR DESCRIPTION
Initial part of work for issue #704. Work is in progress but it would be great to receive some feedback if it goes in right direction.

I’ve started from adding method onlyBeCalledByClassesThat(DescribedPredicate predicate) to CodeUnitsShould.
Now I’m working on possibility to have a rule like: 
should().onlyBeCalled().{byClassesThat()/methodsThat()/constructorsThat()}.

Could you let me know if my understanding of the issue is correct for below points?
1. I’ve implemented condition “code unit should only be called by”, but few possibilities came to my mind, not sure if I’ve decided on the correct one:
    * code unit should be called only by classes that,
    * code unit should be called by at least one class that,
    * code unit should be called by all classes that (but can be called also by other)
    * code unit should be called by all classes that (and can’t be called by any other).
2. should().onlyBeCalled().byMethodsThat() - here I’m checking if methods calling selected code unit meet provided criteria but still this code unit can be called by constructors not meeting criteria. Is it correct?

I would appreciate any feedback.
Justyna

Signed-off-by: Justyna Kubica-Ledzion <justyna.kubica-ledzion@digitalnewagency.com>