### PR TITLE
Add support to test caught exceptions (fixes #591)

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -44,6 +44,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodReferenceBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -105,6 +106,10 @@ public class DomainObjectCreationContext {
 
     public static JavaField createJavaField(JavaFieldBuilder builder) {
         return new JavaField(builder);
+    }
+
+    public static TryCatchBlock createTryCatchBlock(TryCatchBlockBuilder builder) {
+        return new TryCatchBlock(builder);
     }
 
     public static JavaFieldAccess createJavaFieldAccess(JavaFieldAccessBuilder builder) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
@@ -89,7 +89,7 @@ public final class Formatters {
      * @return A {@link List} of fully qualified class names of the passed {@link Class} objects
      */
     @PublicAPI(usage = ACCESS)
-    public static List<String> formatNamesOf(Iterable<Class<?>> paramTypes) {
+    public static List<String> formatNamesOf(Iterable<? extends Class<?>> paramTypes) {
         ImmutableList.Builder<String> result = ImmutableList.builder();
         for (Class<?> paramType : paramTypes) {
             result.add(paramType.getName());

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.tngtech.archunit.Internal;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
 
 @Internal
 public interface ImportContext {
@@ -50,15 +51,17 @@ public interface ImportContext {
 
     Optional<JavaCodeUnit> createEnclosingCodeUnit(JavaClass owner);
 
-    Set<JavaFieldAccess> createFieldAccessesFor(JavaCodeUnit codeUnit);
+    Set<JavaFieldAccess> createFieldAccessesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders);
 
-    Set<JavaMethodCall> createMethodCallsFor(JavaCodeUnit codeUnit);
+    Set<JavaMethodCall> createMethodCallsFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders);
 
-    Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit);
+    Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders);
 
-    Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit);
+    Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders);
 
-    Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit);
+    Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders);
+
+    Set<TryCatchBlockBuilder> createTryCatchBlockBuilders(JavaCodeUnit codeUnit);
 
     JavaClass resolveClass(String fullyQualifiedClassName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -16,6 +16,7 @@
 package com.tngtech.archunit.core.domain;
 
 import java.util.Objects;
+import java.util.Set;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
@@ -28,6 +29,7 @@ import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.core.importer.DomainBuilders;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public abstract class JavaAccess<TARGET extends AccessTarget>
@@ -127,6 +129,16 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
     }
 
     protected abstract String descriptionVerb();
+
+    /**
+     * @return All try-catch-blocks where this {@link JavaAccess} is contained within the try-part the try-catch-block
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<TryCatchBlock> getContainingTryBlocks() {
+        return getOrigin().getTryCatchBlocks().stream()
+                .filter(block -> block.getAccessesContainedInTryBlock().contains(this))
+                .collect(toImmutableSet());
+    }
 
     public static final class Predicates {
         private Predicates() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/TryCatchBlock.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/TryCatchBlock.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
+
+@PublicAPI(usage = ACCESS)
+public final class TryCatchBlock implements HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
+    private final JavaCodeUnit owner;
+    private final Set<JavaClass> caughtThrowables;
+    private final SourceCodeLocation sourceCodeLocation;
+    private final Set<JavaAccess<?>> accessesContainedInTryBlock;
+
+    TryCatchBlock(TryCatchBlockBuilder builder) {
+        this.owner = checkNotNull(builder.getOwner());
+        this.caughtThrowables = ImmutableSet.copyOf(builder.getCaughtThrowables());
+        this.sourceCodeLocation = checkNotNull(builder.getSourceCodeLocation());
+        this.accessesContainedInTryBlock = ImmutableSet.copyOf(builder.getAccessesContainedInTryBlock());
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaCodeUnit getOwner() {
+        return owner;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaClass> getCaughtThrowables() {
+        return caughtThrowables;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public SourceCodeLocation getSourceCodeLocation() {
+        return sourceCodeLocation;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaAccess<?>> getAccessesContainedInTryBlock() {
+        return accessesContainedInTryBlock;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("owner", owner.getFullName())
+                .add("caughtThrowables", namesOf(caughtThrowables))
+                .add("location", sourceCodeLocation)
+                .toString();
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -54,6 +54,8 @@ interface AccessRecord<TARGET extends AccessTarget> {
 
     int getLineNumber();
 
+    RawAccessRecord getRaw();
+
     @Internal
     interface FieldAccessRecord extends AccessRecord<FieldAccessTarget> {
         AccessType getAccessType();
@@ -259,6 +261,11 @@ interface AccessRecord<TARGET extends AccessTarget> {
             @Override
             public int getLineNumber() {
                 return record.lineNumber;
+            }
+
+            @Override
+            public RawAccessRecord getRaw() {
+                return record;
             }
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.SetMultimap;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder;
@@ -43,6 +44,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaParameterizedTypeBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaStaticInitializerBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaTypeParameterBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
 import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -66,6 +68,7 @@ class ClassFileImportRecord {
     private final SetMultimap<String, JavaAnnotationBuilder> annotationsByOwner = HashMultimap.create();
     private final Map<String, JavaAnnotationBuilder.ValueBuilder> annotationDefaultValuesByOwner = new HashMap<>();
     private final EnclosingDeclarationsByInnerClasses enclosingDeclarationsByOwner = new EnclosingDeclarationsByInnerClasses();
+    private final SetMultimap<String, TryCatchBlockBuilder> tryCatchBlocksByOwner = HashMultimap.create();
 
     private final Set<RawAccessRecord.ForField> rawFieldAccessRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawMethodCallRecords = new HashSet<>();
@@ -133,6 +136,10 @@ class ClassFileImportRecord {
 
     void setEnclosingCodeUnit(String ownerName, CodeUnit enclosingCodeUnit) {
         enclosingDeclarationsByOwner.registerEnclosingCodeUnit(ownerName, enclosingCodeUnit);
+    }
+
+    void addTryCatchBlocks(String declaringClassName, String methodName, String descriptor, Set<TryCatchBlockBuilder> tryCatchBlocks) {
+        tryCatchBlocksByOwner.putAll(getMemberKey(declaringClassName, methodName, descriptor), tryCatchBlocks);
     }
 
     Optional<String> getSuperclassFor(String name) {
@@ -236,6 +243,10 @@ class ClassFileImportRecord {
 
     Optional<CodeUnit> getEnclosingCodeUnitFor(String ownerName) {
         return enclosingDeclarationsByOwner.getEnclosingCodeUnit(ownerName);
+    }
+
+    Set<TryCatchBlockBuilder> getTryCatchBlockBuildersFor(JavaCodeUnit codeUnit) {
+        return tryCatchBlocksByOwner.get(getMemberKey(codeUnit));
     }
 
     void registerFieldAccess(RawAccessRecord.ForField record) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
@@ -91,20 +91,30 @@ class RawAccessRecord {
             return result.build();
         }
 
-        public String getName() {
+        String getName() {
             return name;
         }
 
-        public List<JavaClassDescriptor> getRawParameterTypes() {
+        List<JavaClassDescriptor> getRawParameterTypes() {
             return rawParameterTypes;
         }
 
-        public List<String> getRawParameterTypeNames() {
+        List<String> getRawParameterTypeNames() {
             return rawParameterTypeNames;
         }
 
         String getDeclaringClassName() {
             return declaringClassName;
+        }
+
+        String getDescriptor() {
+            return descriptor;
+        }
+
+        boolean is(JavaCodeUnit method) {
+            return getName().equals(method.getName())
+                    && descriptor.equals(method.getDescriptor())
+                    && getDeclaringClassName().equals(method.getOwner().getName());
         }
 
         @Override
@@ -134,12 +144,6 @@ class RawAccessRecord {
                     ", descriptor=" + descriptor +
                     ", declaringClassName='" + declaringClassName + '\'' +
                     '}';
-        }
-
-        public boolean is(JavaCodeUnit method) {
-            return getName().equals(method.getName())
-                    && descriptor.equals(method.getDescriptor())
-                    && getDeclaringClassName().equals(method.getOwner().getName());
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/TryCatchRecorder.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/TryCatchRecorder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.tngtech.archunit.core.domain.JavaClassDescriptor;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
+import org.objectweb.asm.Label;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+class TryCatchRecorder {
+    private static final Logger log = LoggerFactory.getLogger(TryCatchRecorder.class);
+
+    private final TryCatchBlocksFinishedListener tryCatchBlocksFinishedListener;
+    private final Map<Label, Map<Label, RawTryCatchBlock>> blocksByEndByStart = new HashMap<>();
+    private final Multimap<Label, RawTryCatchBlock> activeBlocksByEnd = HashMultimap.create();
+    private final Set<Label> handlers = new HashSet<>();
+    private Label lastEncounteredLabelWithoutLineNumber = null;
+    private boolean active = false;
+
+    TryCatchRecorder(TryCatchBlocksFinishedListener tryCatchBlocksFinishedListener) {
+        this.tryCatchBlocksFinishedListener = tryCatchBlocksFinishedListener;
+    }
+
+    void onEncounteredLabel(Label label, int lineNumber) {
+        if (!active) {
+            return;
+        }
+
+        processStartingBlocks(label, lineNumber);
+        processEndingBlocks(label);
+        lastEncounteredLabelWithoutLineNumber = null;
+    }
+
+    /**
+     * Most labels we will encounter twice, once without line number passed into {@link #onEncounteredLabel(Label)}
+     * followed by a second time with line number passed into {@link #onEncounteredLabel(Label, int)}.<br>
+     * Some labels will not have an associated line number, either because<br>
+     * a) they mark the start of a synthetic try-catch-block, or<br>
+     * b) they mark the end of a try-catch-block that ends in a return statement from within the try-block<br>
+     * This means we never want to start a try-catch-block for a label without a line number, but we need to ensure
+     * that try-catch-blocks can still transition from active to finished in this case.
+     */
+    void onEncounteredLabel(Label label) {
+        if (!active) {
+            return;
+        }
+
+        if (lastEncounteredLabelWithoutLineNumber != null) {
+            processLabelWithoutLineNumber(lastEncounteredLabelWithoutLineNumber);
+        }
+        lastEncounteredLabelWithoutLineNumber = label;
+    }
+
+    private void processLabelWithoutLineNumber(Label label) {
+        // normal try-catch-blocks always have a line number associated, so this is a synthetic one which we want to ignore
+        blocksByEndByStart.remove(label);
+
+        processEndingBlocks(label);
+    }
+
+    private void processStartingBlocks(Label start, int lineNumber) {
+        Map<Label, RawTryCatchBlock> blocksByEnd = blocksByEndByStart.remove(start);
+        if (blocksByEnd == null) {
+            return;
+        }
+
+        for (Map.Entry<Label, RawTryCatchBlock> endToBlock : blocksByEnd.entrySet()) {
+            endToBlock.getValue().setLineNumber(lineNumber);
+            activeBlocksByEnd.put(endToBlock.getKey(), endToBlock.getValue());
+        }
+    }
+
+    private void processEndingBlocks(Label end) {
+        Collection<RawTryCatchBlock> finishedBlocks = activeBlocksByEnd.removeAll(end);
+
+        Set<TryCatchBlockBuilder> finishedBuilders = finishedBlocks.stream()
+                .map(block -> new TryCatchBlockBuilder()
+                        .withCaughtThrowables(block.caughtThrowables)
+                        .withLineNumber(block.lineNumber)
+                        .withRawAccessesInTryBlock(block.accessesInTryBlock))
+                .collect(toImmutableSet());
+        tryCatchBlocksFinishedListener.onTryCatchBlocksFinished(finishedBuilders);
+
+        if (blocksByEndByStart.isEmpty() && activeBlocksByEnd.isEmpty()) {
+            active = false;
+        }
+    }
+
+    void registerTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType) {
+        getOrCreateTryCatchBlock(start, end).addThrowable(throwableType);
+        active = true;
+        handlers.add(handler);
+    }
+
+    void registerTryFinallyBlock(Label start, Label end, Label handler) {
+        if (!handlers.contains(start)) {
+            // if the start is a handler, then it is the (additional, synthetic) finally block for the catch-block
+            // we can ignore this, since there will already be a recorded try-finally block starting from try
+            getOrCreateTryCatchBlock(start, end);
+            active = true;
+        }
+        handlers.add(handler);
+    }
+
+    void registerAccess(RawAccessRecord accessRecord) {
+        if (!active) {
+            return;
+        }
+        activeBlocksByEnd.values().forEach(block -> block.addAccess(accessRecord));
+    }
+
+    void onEncounteredMethodEnd() {
+        if (lastEncounteredLabelWithoutLineNumber != null) {
+            processLabelWithoutLineNumber(lastEncounteredLabelWithoutLineNumber);
+            lastEncounteredLabelWithoutLineNumber = null;
+        }
+        handlers.clear();
+
+        if (!blocksByEndByStart.isEmpty()) {
+            log.warn("Failed to process some try-catch-blocks");
+            blocksByEndByStart.clear();
+        }
+        if (!activeBlocksByEnd.isEmpty()) {
+            log.warn("Failed to finish processing of some active try-catch-blocks");
+            activeBlocksByEnd.clear();
+        }
+    }
+
+    private RawTryCatchBlock getOrCreateTryCatchBlock(Label start, Label end) {
+        Map<Label, RawTryCatchBlock> blocksByEnd = blocksByEndByStart.computeIfAbsent(start, __ -> new HashMap<>());
+        return blocksByEnd.computeIfAbsent(end, __ -> new RawTryCatchBlock());
+    }
+
+    private static class RawTryCatchBlock {
+        private final Set<JavaClassDescriptor> caughtThrowables = new HashSet<>();
+        private int lineNumber;
+        private final Set<RawAccessRecord> accessesInTryBlock = new HashSet<>();
+
+        void addThrowable(JavaClassDescriptor throwableType) {
+            caughtThrowables.add(throwableType);
+        }
+
+        void setLineNumber(int lineNumber) {
+            this.lineNumber = lineNumber;
+        }
+
+        void addAccess(RawAccessRecord accessRecord) {
+            accessesInTryBlock.add(accessRecord);
+        }
+    }
+
+    interface TryCatchBlocksFinishedListener {
+        void onTryCatchBlocksFinished(Set<TryCatchBlockBuilder> tryCatchBlocks);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/FormattersTest.java
@@ -1,5 +1,6 @@
 package com.tngtech.archunit.core.domain;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,6 +42,10 @@ public class FormattersTest {
 
         assertThat(Formatters.formatNamesOf(of(List.class, Iterable.class, String.class)))
                 .containsExactly(List.class.getName(), Iterable.class.getName(), String.class.getName());
+
+        // special case because the inferred type of the list is List<Class<? extends Serializable>>
+        assertThat(Formatters.formatNamesOf(of(String.class, Serializable.class)))
+                .containsExactly(String.class.getName(), Serializable.class.getName());
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -32,6 +32,8 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.util.Files.newTemporaryFile;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -163,7 +165,7 @@ public class TestUtils {
             targets.add(methodCallTarget);
             ImportContext context = mock(ImportContext.class);
             Set<JavaMethodCall> calls = targets.stream().map(target -> newMethodCall(method, target, lineNumber)).collect(toSet());
-            when(context.createMethodCallsFor(method)).thenReturn(ImmutableSet.copyOf(calls));
+            when(context.createMethodCallsFor(eq(method), anySet())).thenReturn(ImmutableSet.copyOf(calls));
             method.completeAccessesFrom(context);
             return getCallToTarget(methodCallTarget);
         }
@@ -184,7 +186,7 @@ public class TestUtils {
 
         public void to(JavaField target, AccessType accessType) {
             ImportContext context = mock(ImportContext.class);
-            when(context.createFieldAccessesFor(method))
+            when(context.createFieldAccessesFor(eq(method), anySet()))
                     .thenReturn(ImmutableSet.of(
                             newFieldAccess(method, target, lineNumber, accessType)
                     ));

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -38,6 +38,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.BuilderWithBuildParamet
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder.ValueBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
+import com.tngtech.archunit.core.importer.DomainBuilders.TryCatchBlockBuilder;
 import com.tngtech.archunit.core.importer.resolvers.ClassResolver;
 import org.objectweb.asm.Type;
 
@@ -398,27 +399,32 @@ public class ImportTestUtils {
         }
 
         @Override
-        public Set<JavaFieldAccess> createFieldAccessesFor(JavaCodeUnit codeUnit) {
+        public Set<JavaFieldAccess> createFieldAccessesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders) {
             return Collections.emptySet();
         }
 
         @Override
-        public Set<JavaMethodCall> createMethodCallsFor(JavaCodeUnit codeUnit) {
+        public Set<JavaMethodCall> createMethodCallsFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders) {
             return Collections.emptySet();
         }
 
         @Override
-        public Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit) {
+        public Set<JavaConstructorCall> createConstructorCallsFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders) {
             return Collections.emptySet();
         }
 
         @Override
-        public Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit) {
+        public Set<JavaMethodReference> createMethodReferencesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders) {
             return Collections.emptySet();
         }
 
         @Override
-        public Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit) {
+        public Set<JavaConstructorReference> createConstructorReferencesFor(JavaCodeUnit codeUnit, Set<TryCatchBlockBuilder> tryCatchBlockBuilders) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<TryCatchBlockBuilder> createTryCatchBlockBuilders(JavaCodeUnit codeUnit) {
             return Collections.emptySet();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassHoldingMethods.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassHoldingMethods.java
@@ -1,0 +1,21 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+public class ClassHoldingMethods {
+    int someInt;
+    String someString;
+
+    ClassHoldingMethods() {
+    }
+
+    void setSomeInt(int someInt) {
+        this.someInt = someInt;
+    }
+
+    void setSomeString(String someString) {
+        this.someString = someString;
+    }
+
+    void doSomething() {
+        setSomeInt(5);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithComplexTryCatchBlocks.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithComplexTryCatchBlocks.java
@@ -1,0 +1,30 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+import java.io.Serializable;
+
+@SuppressWarnings("unused")
+public class ClassWithComplexTryCatchBlocks {
+    ClassWithComplexTryCatchBlocks() {
+        ClassHoldingMethods instanceOne = new ClassHoldingMethods();
+        Object someOtherObject = new Object();
+        Serializable someSerializable = new Serializable() {
+        };
+        instanceOne.setSomeInt(2);
+        try {
+            instanceOne.setSomeInt(1);
+            someOtherObject.toString();
+            try {
+                instanceOne.doSomething();
+            } catch (IllegalArgumentException | UnsupportedOperationException e) {
+            }
+        } catch (Exception e) {
+        } finally {
+        }
+        instanceOne.someInt = 5;
+
+        try {
+            instanceOne.setSomeString("hello");
+        } catch (Throwable e) {
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithSimpleTryCatchBlocks.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithSimpleTryCatchBlocks.java
@@ -1,0 +1,23 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+@SuppressWarnings("unused")
+public class ClassWithSimpleTryCatchBlocks {
+    Object method() {
+        try {
+            new Object();
+        } catch (IllegalStateException e) {
+            System.out.println("Error");
+        }
+
+        try {
+            return new Object();
+        } catch (IllegalStateException e) {
+            System.out.println("Error1");
+        } catch (IllegalArgumentException e) {
+            System.out.println("Error2");
+        } finally {
+            System.out.println("finally");
+        }
+        throw new IllegalStateException();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithTryCatchBlockWithoutThrowables.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithTryCatchBlockWithoutThrowables.java
@@ -1,0 +1,12 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+@SuppressWarnings("unused")
+public class ClassWithTryCatchBlockWithoutThrowables {
+    void method() {
+        try {
+            new Object();
+        } finally {
+            System.out.println("finally");
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithTryWithResources.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithTryWithResources.java
@@ -1,0 +1,19 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@SuppressWarnings("unused")
+public class ClassWithTryWithResources {
+    void method() {
+        try (
+                ByteArrayInputStream one = new ByteArrayInputStream(new byte[0]);
+                FileInputStream two = new FileInputStream("any")
+        ) {
+            new Object();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
+import com.tngtech.archunit.core.domain.TryCatchBlock;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
@@ -61,6 +62,8 @@ import com.tngtech.archunit.testutil.assertion.JavaTypesAssertion;
 import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion;
 import com.tngtech.archunit.testutil.assertion.ThrowsClauseAssertion;
 import com.tngtech.archunit.testutil.assertion.ThrowsDeclarationAssertion;
+import com.tngtech.archunit.testutil.assertion.TryCatchBlockAssertion;
+import com.tngtech.archunit.testutil.assertion.TryCatchBlocksAssertion;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     public static <T> ArchConditionAssertion<T> assertThat(ArchCondition<T> archCondition) {
@@ -214,5 +217,13 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static CodeUnitAccessAssertion assertThatCall(JavaConstructorCall call) {
         return assertThatAccess(call);
+    }
+
+    public static TryCatchBlockAssertion assertThatTryCatchBlock(TryCatchBlock tryCatchBlock) {
+        return new TryCatchBlockAssertion(tryCatchBlock);
+    }
+
+    public static TryCatchBlocksAssertion assertThatTryCatchBlocks(Set<TryCatchBlock> tryCatchBlocks) {
+        return new TryCatchBlocksAssertion(tryCatchBlocks);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -1,18 +1,10 @@
 package com.tngtech.archunit.testutil;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import com.tngtech.archunit.base.DescribedPredicate;
-import com.tngtech.archunit.core.domain.AccessTarget;
-import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitAccessTarget;
-import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaAccess;
@@ -35,22 +27,27 @@ import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
-import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.testutil.assertion.AccessToFieldAssertion;
+import com.tngtech.archunit.testutil.assertion.AccessesAssertion;
 import com.tngtech.archunit.testutil.assertion.ArchConditionAssertion;
 import com.tngtech.archunit.testutil.assertion.ArchRuleAssertion;
+import com.tngtech.archunit.testutil.assertion.CodeUnitAccessAssertion;
 import com.tngtech.archunit.testutil.assertion.ConditionEventsAssertion;
 import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
 import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
+import com.tngtech.archunit.testutil.assertion.ExpectedAccessCreation;
 import com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaAnnotationsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaClassAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaClassDescriptorAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaCodeUnitAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaConstructorAssertion;
+import com.tngtech.archunit.testutil.assertion.JavaEnumConstantAssertion;
+import com.tngtech.archunit.testutil.assertion.JavaEnumConstantsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaFieldsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaMemberAssertion;
@@ -62,14 +59,8 @@ import com.tngtech.archunit.testutil.assertion.JavaTypeAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaTypeVariableAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaTypesAssertion;
 import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion;
-import org.assertj.core.api.AbstractObjectAssert;
-import org.assertj.core.api.Condition;
-
-import static com.google.common.base.Strings.emptyToNull;
-import static com.tngtech.archunit.core.domain.Formatters.formatMethodSimple;
-import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
-import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
-import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
+import com.tngtech.archunit.testutil.assertion.ThrowsClauseAssertion;
+import com.tngtech.archunit.testutil.assertion.ThrowsDeclarationAssertion;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     public static <T> ArchConditionAssertion<T> assertThat(ArchCondition<T> archCondition) {
@@ -209,61 +200,6 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new ExpectedAccessCreation();
     }
 
-    public static class ExpectedAccessCreation {
-        private ExpectedAccessCreation() {
-        }
-
-        public Step2 from(Class<?> originClass, String codeUnitName) {
-            return new Step2(originClass, codeUnitName);
-        }
-
-        public static class Step2 {
-            private final Class<?> originClass;
-            private final String originCodeUnitName;
-
-            private Step2(Class<?> originClass, String originCodeUnitName) {
-                this.originClass = originClass;
-                this.originCodeUnitName = originCodeUnitName;
-            }
-
-            public Condition<JavaAccess<?>> to(final Class<?> targetClass, final String targetName) {
-                return new Condition<JavaAccess<?>>(
-                        String.format("%s from %s.%s to %s.%s",
-                                JavaAccess.class.getSimpleName(),
-                                originClass.getName(), originCodeUnitName,
-                                targetClass.getSimpleName(), targetName)) {
-                    @Override
-                    public boolean matches(JavaAccess<?> access) {
-                        return access.getOriginOwner().isEquivalentTo(originClass) &&
-                                access.getOrigin().getName().equals(originCodeUnitName) &&
-                                access.getTargetOwner().isEquivalentTo(targetClass) &&
-                                access.getTarget().getName().equals(targetName);
-                    }
-                };
-            }
-
-            public Condition<JavaAccess<?>> toConstructor(final Class<?> targetClass, final Class<?>... paramTypes) {
-                final List<String> paramTypeNames = formatNamesOf(paramTypes);
-                return new Condition<JavaAccess<?>>(
-                        String.format("%s from %s.%s to %s",
-                                JavaAccess.class.getSimpleName(),
-                                originClass.getName(), originCodeUnitName,
-                                formatMethodSimple(targetClass.getSimpleName(), CONSTRUCTOR_NAME, paramTypeNames))) {
-                    @Override
-                    public boolean matches(JavaAccess<?> access) {
-                        return to(targetClass, CONSTRUCTOR_NAME).matches(access) &&
-                                rawParameterTypeNamesOf(access).equals(paramTypeNames);
-                    }
-
-                    private List<String> rawParameterTypeNamesOf(JavaAccess<?> access) {
-                        ConstructorCallTarget target = (ConstructorCallTarget) access.getTarget();
-                        return HasName.Utils.namesOf(target.getRawParameterTypes());
-                    }
-                };
-            }
-        }
-    }
-
     public static AccessToFieldAssertion assertThatAccess(JavaFieldAccess access) {
         return new AccessToFieldAssertion(access);
     }
@@ -278,209 +214,5 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static CodeUnitAccessAssertion assertThatCall(JavaConstructorCall call) {
         return assertThatAccess(call);
-    }
-
-    public static class JavaEnumConstantAssertion extends AbstractObjectAssert<JavaEnumConstantAssertion, JavaEnumConstant> {
-        private JavaEnumConstantAssertion(JavaEnumConstant enumConstant) {
-            super(enumConstant, JavaEnumConstantAssertion.class);
-        }
-
-        public void isEquivalentTo(Enum<?> enumConstant) {
-            assertThat(actual).as(describePartialAssertion()).isNotNull();
-            assertThat(actual.getDeclaringClass().getName()).as(describePartialAssertion("type")).isEqualTo(enumConstant.getDeclaringClass().getName());
-            assertThat(actual.name()).as(describePartialAssertion("name")).isEqualTo(enumConstant.name());
-        }
-
-        private String describePartialAssertion() {
-            return describePartialAssertion("");
-        }
-
-        private String describePartialAssertion(String partialAssertionDescription) {
-            return Joiner.on(": ").skipNulls().join(emptyToNull(descriptionText()), emptyToNull(partialAssertionDescription));
-        }
-    }
-
-    public static class JavaEnumConstantsAssertion extends AbstractObjectAssert<JavaEnumConstantsAssertion, JavaEnumConstant[]> {
-        private JavaEnumConstantsAssertion(JavaEnumConstant[] enumConstants) {
-            super(enumConstants, JavaEnumConstantsAssertion.class);
-        }
-
-        public void matches(Enum<?>... enumConstants) {
-            assertThat((Object[]) actual).as("Enum constants").hasSize(enumConstants.length);
-            for (int i = 0; i < actual.length; i++) {
-                assertThat(actual[i]).as("Element %d", i).isEquivalentTo(enumConstants[i]);
-            }
-        }
-    }
-
-    public static class ThrowsDeclarationAssertion extends AbstractObjectAssert<ThrowsDeclarationAssertion, ThrowsDeclaration<?>> {
-        private ThrowsDeclarationAssertion(ThrowsDeclaration<?> throwsDeclaration) {
-            super(throwsDeclaration, ThrowsDeclarationAssertion.class);
-        }
-
-        public void matches(Class<?> clazz) {
-            assertThatType(actual.getRawType()).as("Type of " + actual)
-                    .matches(clazz);
-        }
-    }
-
-    public static class ThrowsClauseAssertion extends AbstractObjectAssert<ThrowsClauseAssertion, ThrowsClause<?>> {
-        private ThrowsClauseAssertion(ThrowsClause<?> throwsClause) {
-            super(throwsClause, ThrowsClauseAssertion.class);
-        }
-
-        public void matches(Class<?>... classes) {
-            assertThat(actual).as("ThrowsClause").hasSize(classes.length);
-            for (int i = 0; i < actual.size(); i++) {
-                assertThat(Iterables.get(actual, i)).as("Element %d", i).matches(classes[i]);
-            }
-        }
-
-        public void isEmpty() {
-            assertThat(actual).as("ThrowsClause").isEmpty();
-        }
-    }
-
-    public static class AccessesAssertion {
-        private final Set<JavaAccess<?>> actualRemaining;
-
-        AccessesAssertion(Collection<JavaAccess<?>> accesses) {
-            this.actualRemaining = new HashSet<>(accesses);
-        }
-
-        public AccessesAssertion contain(Condition<? super JavaAccess<?>> condition) {
-            for (Iterator<JavaAccess<?>> iterator = actualRemaining.iterator(); iterator.hasNext(); ) {
-                if (condition.matches(iterator.next())) {
-                    iterator.remove();
-                    return this;
-                }
-            }
-            throw new AssertionError("No access matches " + condition);
-        }
-
-        @SafeVarargs
-        public final AccessesAssertion containOnly(Condition<? super JavaAccess<?>>... conditions) {
-            for (Condition<? super JavaAccess<?>> condition : conditions) {
-                contain(condition);
-            }
-            assertThat(actualRemaining).as("Unexpected " + JavaAccess.class.getSimpleName()).isEmpty();
-            return this;
-        }
-    }
-
-    protected abstract static class BaseAccessAssertion<
-            SELF extends BaseAccessAssertion<SELF, ACCESS, TARGET>,
-            ACCESS extends JavaAccess<TARGET>,
-            TARGET extends AccessTarget> {
-
-        ACCESS access;
-
-        BaseAccessAssertion(ACCESS access) {
-            this.access = access;
-        }
-
-        public SELF isFrom(String name, Class<?>... parameterTypes) {
-            return isFrom(access.getOrigin().getOwner().getCodeUnitWithParameterTypes(name, parameterTypes));
-        }
-
-        public SELF isFrom(Class<?> originClass, String name, Class<?>... parameterTypes) {
-            assertThatType(access.getOriginOwner()).matches(originClass);
-            return isFrom(name, parameterTypes);
-        }
-
-        public SELF isFrom(JavaCodeUnit codeUnit) {
-            assertThat(access.getOrigin()).as("Origin of access").isEqualTo(codeUnit);
-            return newAssertion(access);
-        }
-
-        public SELF isTo(TARGET target) {
-            assertThat(access.getTarget()).as("Target of " + access.getName()).isEqualTo(target);
-            return newAssertion(access);
-        }
-
-        public SELF isTo(Condition<TARGET> target) {
-            assertThat(access.getTarget()).as("Target of " + access.getName()).is(target);
-            return newAssertion(access);
-        }
-
-        public void inLineNumber(int number) {
-            assertThat(access.getLineNumber())
-                    .as("Line number of access to " + access.getName())
-                    .isEqualTo(number);
-        }
-
-        protected abstract SELF newAssertion(ACCESS access);
-    }
-
-    public static class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAssertion, JavaFieldAccess, FieldAccessTarget> {
-        private AccessToFieldAssertion(JavaFieldAccess access) {
-            super(access);
-        }
-
-        @Override
-        protected AccessToFieldAssertion newAssertion(JavaFieldAccess access) {
-            return new AccessToFieldAssertion(access);
-        }
-
-        public AccessToFieldAssertion isTo(final String name) {
-            return isTo(new Condition<FieldAccessTarget>("field with name '" + name + "'") {
-                @Override
-                public boolean matches(FieldAccessTarget fieldAccessTarget) {
-                    return fieldAccessTarget.getName().equals(name);
-                }
-            });
-        }
-
-        public AccessToFieldAssertion isTo(JavaField field) {
-            return isTo(targetFrom(field));
-        }
-
-        public AccessToFieldAssertion isOfType(JavaFieldAccess.AccessType type) {
-            assertThat(access.getAccessType()).isEqualTo(type);
-            return newAssertion(access);
-        }
-    }
-
-    public static class CodeUnitAccessAssertion
-            extends BaseAccessAssertion<CodeUnitAccessAssertion, JavaCodeUnitAccess<CodeUnitAccessTarget>, CodeUnitAccessTarget> {
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        private CodeUnitAccessAssertion(JavaCodeUnitAccess<? extends CodeUnitAccessTarget> call) {
-            super((JavaCodeUnitAccess) call);
-        }
-
-        public CodeUnitAccessAssertion isTo(final JavaCodeUnit target) {
-            return isTo(new Condition<CodeUnitAccessTarget>("method " + target.getFullName()) {
-                @Override
-                public boolean matches(CodeUnitAccessTarget codeUnitAccessTarget) {
-                    return codeUnitAccessTarget.getOwner().equals(target.getOwner())
-                            && codeUnitAccessTarget.getName().equals(target.getName())
-                            && codeUnitAccessTarget.getRawParameterTypes().equals(target.getRawParameterTypes());
-                }
-            });
-        }
-
-        public CodeUnitAccessAssertion isTo(final Class<?> codeUnitOwner) {
-            return isTo(new Condition<CodeUnitAccessTarget>() {
-                @Override
-                public boolean matches(CodeUnitAccessTarget target) {
-                    return target.getOwner().isEquivalentTo(codeUnitOwner);
-                }
-            });
-        }
-
-        public CodeUnitAccessAssertion isTo(final String codeUnitName, final Class<?>... parameterTypes) {
-            return isTo(new Condition<CodeUnitAccessTarget>("code unit " + codeUnitName + "(" + formatNamesOf(parameterTypes) + ")") {
-                @Override
-                public boolean matches(CodeUnitAccessTarget target) {
-                    return target.getName().equals(codeUnitName)
-                            && HasName.Utils.namesOf(target.getRawParameterTypes()).equals(formatNamesOf(parameterTypes));
-                }
-            });
-        }
-
-        @Override
-        protected CodeUnitAccessAssertion newAssertion(JavaCodeUnitAccess<CodeUnitAccessTarget> reference) {
-            return new CodeUnitAccessAssertion(reference);
-        }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/JavaCallQuery.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/JavaCallQuery.java
@@ -1,0 +1,46 @@
+package com.tngtech.archunit.testutil;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaCallQuery {
+    private final Set<JavaMethodCall> calls;
+
+    private JavaCallQuery(Set<JavaMethodCall> calls) {
+        this.calls = requireNonNull(calls);
+    }
+
+    public JavaCallQuery from(JavaCodeUnit source) {
+        return that(hasOrigin(source));
+    }
+
+    public JavaMethodCall inLineNumber(final int lineNumber) {
+        Set<JavaMethodCall> matchingCalls = that(hasLine(lineNumber)).calls;
+        assertThat(matchingCalls).as("matching calls in line number " + lineNumber).isNotEmpty();
+        return matchingCalls.iterator().next();
+    }
+
+    private JavaCallQuery that(Predicate<JavaMethodCall> predicate) {
+        return new JavaCallQuery(calls.stream().filter(predicate).collect(toSet()));
+    }
+
+    public static JavaCallQuery methodCallTo(final JavaMethod method) {
+        return new JavaCallQuery(method.getCallsOfSelf());
+    }
+
+    private static Predicate<JavaMethodCall> hasLine(final int lineNumber) {
+        return input -> input.getLineNumber() == lineNumber;
+    }
+
+    private static Predicate<JavaMethodCall> hasOrigin(final JavaCodeUnit origin) {
+        return input -> origin.equals(input.getOrigin());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessToFieldAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessToFieldAssertion.java
@@ -1,0 +1,38 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import org.assertj.core.api.Condition;
+
+import static com.tngtech.archunit.core.domain.TestUtils.targetFrom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAssertion, JavaFieldAccess, AccessTarget.FieldAccessTarget> {
+    public AccessToFieldAssertion(JavaFieldAccess access) {
+        super(access);
+    }
+
+    @Override
+    protected AccessToFieldAssertion newAssertion(JavaFieldAccess access) {
+        return new AccessToFieldAssertion(access);
+    }
+
+    public AccessToFieldAssertion isTo(final String name) {
+        return isTo(new Condition<AccessTarget.FieldAccessTarget>("field with name '" + name + "'") {
+            @Override
+            public boolean matches(AccessTarget.FieldAccessTarget fieldAccessTarget) {
+                return fieldAccessTarget.getName().equals(name);
+            }
+        });
+    }
+
+    public AccessToFieldAssertion isTo(JavaField field) {
+        return isTo(targetFrom(field));
+    }
+
+    public AccessToFieldAssertion isOfType(JavaFieldAccess.AccessType type) {
+        assertThat(access.getAccessType()).isEqualTo(type);
+        return newAssertion(access);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessesAssertion.java
@@ -1,0 +1,38 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import com.tngtech.archunit.core.domain.JavaAccess;
+import org.assertj.core.api.Condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccessesAssertion {
+    private final Set<JavaAccess<?>> actualRemaining;
+
+    public AccessesAssertion(Collection<JavaAccess<?>> accesses) {
+        this.actualRemaining = new HashSet<>(accesses);
+    }
+
+    public AccessesAssertion contain(Condition<? super JavaAccess<?>> condition) {
+        for (Iterator<JavaAccess<?>> iterator = actualRemaining.iterator(); iterator.hasNext(); ) {
+            if (condition.matches(iterator.next())) {
+                iterator.remove();
+                return this;
+            }
+        }
+        throw new AssertionError("No access matches " + condition);
+    }
+
+    @SafeVarargs
+    public final AccessesAssertion containOnly(Condition<? super JavaAccess<?>>... conditions) {
+        for (Condition<? super JavaAccess<?>> condition : conditions) {
+            contain(condition);
+        }
+        assertThat(actualRemaining).as("Unexpected " + JavaAccess.class.getSimpleName()).isEmpty();
+        return this;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/BaseAccessAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/BaseAccessAssertion.java
@@ -1,0 +1,53 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import org.assertj.core.api.Condition;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class BaseAccessAssertion<
+        SELF extends BaseAccessAssertion<SELF, ACCESS, TARGET>,
+        ACCESS extends JavaAccess<TARGET>,
+        TARGET extends AccessTarget> {
+
+    ACCESS access;
+
+    BaseAccessAssertion(ACCESS access) {
+        this.access = access;
+    }
+
+    public SELF isFrom(String name, Class<?>... parameterTypes) {
+        return isFrom(access.getOrigin().getOwner().getCodeUnitWithParameterTypes(name, parameterTypes));
+    }
+
+    public SELF isFrom(Class<?> originClass, String name, Class<?>... parameterTypes) {
+        assertThatType(access.getOriginOwner()).matches(originClass);
+        return isFrom(name, parameterTypes);
+    }
+
+    public SELF isFrom(JavaCodeUnit codeUnit) {
+        assertThat(access.getOrigin()).as("Origin of access").isEqualTo(codeUnit);
+        return newAssertion(access);
+    }
+
+    public SELF isTo(TARGET target) {
+        assertThat(access.getTarget()).as("Target of " + access.getName()).isEqualTo(target);
+        return newAssertion(access);
+    }
+
+    public SELF isTo(Condition<TARGET> target) {
+        assertThat(access.getTarget()).as("Target of " + access.getName()).is(target);
+        return newAssertion(access);
+    }
+
+    public void inLineNumber(int number) {
+        assertThat(access.getLineNumber())
+                .as("Line number of access to " + access.getName())
+                .isEqualTo(number);
+    }
+
+    protected abstract SELF newAssertion(ACCESS access);
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
@@ -3,10 +3,12 @@ package com.tngtech.archunit.testutil.assertion;
 import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaCodeUnitAccess;
+import com.tngtech.archunit.core.domain.TryCatchBlock;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import org.assertj.core.api.Condition;
 
 import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CodeUnitAccessAssertion
         extends BaseAccessAssertion<CodeUnitAccessAssertion, JavaCodeUnitAccess<AccessTarget.CodeUnitAccessTarget>, AccessTarget.CodeUnitAccessTarget> {
@@ -43,6 +45,30 @@ public class CodeUnitAccessAssertion
                         && HasName.Utils.namesOf(target.getRawParameterTypes()).equals(formatNamesOf(parameterTypes));
             }
         });
+    }
+
+    public CodeUnitAccessAssertion isWrappedWithTryCatchFor(Class<? extends Throwable> throwableType) {
+        assertThat(access.getContainingTryBlocks())
+                .as("containing try blocks")
+                .areExactly(1, caughtThrowableOfType(throwableType));
+        return this;
+    }
+
+    public CodeUnitAccessAssertion isNotWrappedInTryCatch() {
+        assertThat(access.getContainingTryBlocks())
+                .as("not wrapped with try/catch")
+                .isEmpty();
+        return this;
+    }
+
+    private Condition<TryCatchBlock> caughtThrowableOfType(final Class<? extends Throwable> expectedThrowable) {
+        return new Condition<TryCatchBlock>("caught throwable of type " + expectedThrowable.getSimpleName()) {
+            @Override
+            public boolean matches(TryCatchBlock tryCatchBlock) {
+                return tryCatchBlock.getCaughtThrowables().stream()
+                        .anyMatch(throwable -> throwable.isEquivalentTo(expectedThrowable));
+            }
+        };
     }
 
     @Override

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
@@ -1,0 +1,52 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.JavaCodeUnitAccess;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import org.assertj.core.api.Condition;
+
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+
+public class CodeUnitAccessAssertion
+        extends BaseAccessAssertion<CodeUnitAccessAssertion, JavaCodeUnitAccess<AccessTarget.CodeUnitAccessTarget>, AccessTarget.CodeUnitAccessTarget> {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public CodeUnitAccessAssertion(JavaCodeUnitAccess<? extends AccessTarget.CodeUnitAccessTarget> call) {
+        super((JavaCodeUnitAccess) call);
+    }
+
+    public CodeUnitAccessAssertion isTo(final JavaCodeUnit target) {
+        return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>("method " + target.getFullName()) {
+            @Override
+            public boolean matches(AccessTarget.CodeUnitAccessTarget codeUnitAccessTarget) {
+                return codeUnitAccessTarget.getOwner().equals(target.getOwner())
+                        && codeUnitAccessTarget.getName().equals(target.getName())
+                        && codeUnitAccessTarget.getRawParameterTypes().equals(target.getRawParameterTypes());
+            }
+        });
+    }
+
+    public CodeUnitAccessAssertion isTo(final Class<?> codeUnitOwner) {
+        return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>() {
+            @Override
+            public boolean matches(AccessTarget.CodeUnitAccessTarget target) {
+                return target.getOwner().isEquivalentTo(codeUnitOwner);
+            }
+        });
+    }
+
+    public CodeUnitAccessAssertion isTo(final String codeUnitName, final Class<?>... parameterTypes) {
+        return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>("code unit " + codeUnitName + "(" + formatNamesOf(parameterTypes) + ")") {
+            @Override
+            public boolean matches(AccessTarget.CodeUnitAccessTarget target) {
+                return target.getName().equals(codeUnitName)
+                        && HasName.Utils.namesOf(target.getRawParameterTypes()).equals(formatNamesOf(parameterTypes));
+            }
+        });
+    }
+
+    @Override
+    protected CodeUnitAccessAssertion newAssertion(JavaCodeUnitAccess<AccessTarget.CodeUnitAccessTarget> reference) {
+        return new CodeUnitAccessAssertion(reference);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedAccessCreation.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedAccessCreation.java
@@ -1,0 +1,67 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.List;
+
+import com.tngtech.archunit.core.domain.AccessTarget;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import org.assertj.core.api.Condition;
+
+import static com.tngtech.archunit.core.domain.Formatters.formatMethodSimple;
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
+
+public class ExpectedAccessCreation {
+    public ExpectedAccessCreation() {
+    }
+
+    public Step2 from(Class<?> originClass, String codeUnitName) {
+        return new Step2(originClass, codeUnitName);
+    }
+
+    public static class Step2 {
+        private final Class<?> originClass;
+        private final String originCodeUnitName;
+
+        private Step2(Class<?> originClass, String originCodeUnitName) {
+            this.originClass = originClass;
+            this.originCodeUnitName = originCodeUnitName;
+        }
+
+        public Condition<JavaAccess<?>> to(final Class<?> targetClass, final String targetName) {
+            return new Condition<JavaAccess<?>>(
+                    String.format("%s from %s.%s to %s.%s",
+                            JavaAccess.class.getSimpleName(),
+                            originClass.getName(), originCodeUnitName,
+                            targetClass.getSimpleName(), targetName)) {
+                @Override
+                public boolean matches(JavaAccess<?> access) {
+                    return access.getOriginOwner().isEquivalentTo(originClass) &&
+                            access.getOrigin().getName().equals(originCodeUnitName) &&
+                            access.getTargetOwner().isEquivalentTo(targetClass) &&
+                            access.getTarget().getName().equals(targetName);
+                }
+            };
+        }
+
+        public Condition<JavaAccess<?>> toConstructor(final Class<?> targetClass, final Class<?>... paramTypes) {
+            final List<String> paramTypeNames = formatNamesOf(paramTypes);
+            return new Condition<JavaAccess<?>>(
+                    String.format("%s from %s.%s to %s",
+                            JavaAccess.class.getSimpleName(),
+                            originClass.getName(), originCodeUnitName,
+                            formatMethodSimple(targetClass.getSimpleName(), CONSTRUCTOR_NAME, paramTypeNames))) {
+                @Override
+                public boolean matches(JavaAccess<?> access) {
+                    return to(targetClass, CONSTRUCTOR_NAME).matches(access) &&
+                            rawParameterTypeNamesOf(access).equals(paramTypeNames);
+                }
+
+                private List<String> rawParameterTypeNamesOf(JavaAccess<?> access) {
+                    AccessTarget.ConstructorCallTarget target = (AccessTarget.ConstructorCallTarget) access.getTarget();
+                    return HasName.Utils.namesOf(target.getRawParameterTypes());
+                }
+            };
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaEnumConstantAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaEnumConstantAssertion.java
@@ -1,0 +1,28 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.google.common.base.Joiner;
+import com.tngtech.archunit.core.domain.JavaEnumConstant;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaEnumConstantAssertion extends AbstractObjectAssert<JavaEnumConstantAssertion, JavaEnumConstant> {
+    public JavaEnumConstantAssertion(JavaEnumConstant enumConstant) {
+        super(enumConstant, JavaEnumConstantAssertion.class);
+    }
+
+    public void isEquivalentTo(Enum<?> enumConstant) {
+        assertThat(actual).as(describePartialAssertion()).isNotNull();
+        assertThat(actual.getDeclaringClass().getName()).as(describePartialAssertion("type")).isEqualTo(enumConstant.getDeclaringClass().getName());
+        assertThat(actual.name()).as(describePartialAssertion("name")).isEqualTo(enumConstant.name());
+    }
+
+    private String describePartialAssertion() {
+        return describePartialAssertion("");
+    }
+
+    private String describePartialAssertion(String partialAssertionDescription) {
+        return Joiner.on(": ").skipNulls().join(emptyToNull(descriptionText()), emptyToNull(partialAssertionDescription));
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaEnumConstantsAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaEnumConstantsAssertion.java
@@ -1,0 +1,19 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.JavaEnumConstant;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+
+public class JavaEnumConstantsAssertion extends AbstractObjectAssert<JavaEnumConstantsAssertion, JavaEnumConstant[]> {
+    public JavaEnumConstantsAssertion(JavaEnumConstant[] enumConstants) {
+        super(enumConstants, JavaEnumConstantsAssertion.class);
+    }
+
+    public void matches(Enum<?>... enumConstants) {
+        assertThat((Object[]) actual).as("Enum constants").hasSize(enumConstants.length);
+        for (int i = 0; i < actual.length; i++) {
+            assertThat(actual[i]).as("Element %d", i).isEquivalentTo(enumConstants[i]);
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ThrowsClauseAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ThrowsClauseAssertion.java
@@ -1,0 +1,24 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.google.common.collect.Iterables;
+import com.tngtech.archunit.core.domain.ThrowsClause;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+
+public class ThrowsClauseAssertion extends AbstractObjectAssert<ThrowsClauseAssertion, ThrowsClause<?>> {
+    public ThrowsClauseAssertion(ThrowsClause<?> throwsClause) {
+        super(throwsClause, ThrowsClauseAssertion.class);
+    }
+
+    public void matches(Class<?>... classes) {
+        assertThat(actual).as("ThrowsClause").hasSize(classes.length);
+        for (int i = 0; i < actual.size(); i++) {
+            assertThat(Iterables.get(actual, i)).as("Element %d", i).matches(classes[i]);
+        }
+    }
+
+    public void isEmpty() {
+        assertThat(actual).as("ThrowsClause").isEmpty();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ThrowsDeclarationAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ThrowsDeclarationAssertion.java
@@ -1,0 +1,16 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.ThrowsDeclaration;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatType;
+
+public class ThrowsDeclarationAssertion extends AbstractObjectAssert<ThrowsDeclarationAssertion, ThrowsDeclaration<?>> {
+    public ThrowsDeclarationAssertion(ThrowsDeclaration<?> throwsDeclaration) {
+        super(throwsDeclaration, ThrowsDeclarationAssertion.class);
+    }
+
+    public void matches(Class<?> clazz) {
+        assertThatType(actual.getRawType()).as("Type of " + actual).matches(clazz);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TryCatchBlockAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TryCatchBlockAssertion.java
@@ -1,0 +1,24 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.TryCatchBlock;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TryCatchBlockAssertion extends AbstractObjectAssert<TryCatchBlockAssertion, TryCatchBlock> {
+    public TryCatchBlockAssertion(TryCatchBlock tryCatchBlock) {
+        super(tryCatchBlock, TryCatchBlockAssertion.class);
+    }
+
+    public TryCatchBlockAssertion isDeclaredIn(JavaCodeUnit codeUnit) {
+        assertThat(actual.getOwner()).as("owner of " + actual).isEqualTo(codeUnit);
+        return this;
+    }
+
+    public TryCatchBlockAssertion catches(Class<? extends Throwable> throwable) {
+        assertThatTypes(actual.getCaughtThrowables()).contain(throwable);
+        return this;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TryCatchBlocksAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TryCatchBlocksAssertion.java
@@ -1,0 +1,76 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.SourceCodeLocation;
+import com.tngtech.archunit.core.domain.TryCatchBlock;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Condition;
+
+import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
+import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
+import static org.assertj.core.util.Lists.newArrayList;
+
+public class TryCatchBlocksAssertion extends AbstractObjectAssert<TryCatchBlocksAssertion, Set<TryCatchBlock>> {
+    public TryCatchBlocksAssertion(Set<TryCatchBlock> tryCatchBlocks) {
+        super(tryCatchBlocks, TryCatchBlocksAssertion.class);
+    }
+
+    public static TryCatchBlockCondition tryCatchBlock() {
+        return new TryCatchBlockCondition();
+    }
+
+    public static class TryCatchBlockCondition extends Condition<TryCatchBlock> {
+        private final List<String> description = newArrayList("try-catch-block");
+
+        private Set<String> expectedCaughtThrowableNames;
+        private Class<?> expectedSourceClass;
+        private int expectedLineNumber;
+        private JavaCodeUnit expectedOwner;
+
+        private TryCatchBlockCondition() {
+        }
+
+        @Override
+        public boolean matches(TryCatchBlock tryCatchBlock) {
+            as(Joiner.on(" ").join(description));
+
+            boolean ownerMatches = tryCatchBlock.getOwner().equals(expectedOwner);
+            boolean caughtThrowablesMatch = ImmutableSet.copyOf(namesOf(tryCatchBlock.getCaughtThrowables())).equals(expectedCaughtThrowableNames);
+
+            SourceCodeLocation sourceCodeLocation = tryCatchBlock.getSourceCodeLocation();
+            boolean sourceClassMatches = sourceCodeLocation.getSourceClass().isEquivalentTo(expectedSourceClass);
+            boolean lineNumberMatches = sourceCodeLocation.getLineNumber() == expectedLineNumber;
+
+            return ownerMatches && caughtThrowablesMatch && sourceClassMatches && lineNumberMatches;
+        }
+
+        public TryCatchBlockCondition declaredIn(JavaCodeUnit owner) {
+            expectedOwner = owner;
+            return this;
+        }
+
+        @SafeVarargs
+        public final TryCatchBlockCondition catching(Class<? extends Throwable>... throwables) {
+            List<String> throwableNames = formatNamesOf(throwables);
+            description.add(String.format("catching [%s]", Joiner.on(", ").join(throwableNames)));
+            this.expectedCaughtThrowableNames = ImmutableSet.copyOf(throwableNames);
+            return this;
+        }
+
+        public TryCatchBlockCondition catchingNoThrowables() {
+            return catching();
+        }
+
+        public TryCatchBlockCondition atLocation(Class<?> sourceOwner, int lineNumber) {
+            description.add(String.format("at location %s:%d", sourceOwner.getName(), lineNumber));
+            expectedSourceClass = sourceOwner;
+            expectedLineNumber = lineNumber;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This will add `TryCatchBlocks` to the ArchUnit core and introduce `JavaCodeUnit.getTryCatchBlocks()` to examine try-catch blocks that have been parsed from the bytecode of a method or constructor. We also add an extension `JavaAccess.getContainingTryBlocks()` to make it easy to verify that certain accesses in code are wrapped into certain try-catch blocks (e.g. "whenever method x is called there should be a try-catch block to handle exception case y").

Resolves: #591

Signed-off-by: Krzysztof Sierszeń <krzysztof.sierszen@digitalnewagency.com>