### PR TITLE
Modified the IntelliJ test pattern for test exclusion

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
@@ -91,7 +91,7 @@ public interface ImportOption {
 
         static final PatternPredicate MAVEN_TEST_PATTERN = new PatternPredicate(".*/target/test-classes/.*");
         static final PatternPredicate GRADLE_TEST_PATTERN = new PatternPredicate(".*/build/classes/([^/]+/)?test/.*");
-        static final PatternPredicate INTELLIJ_TEST_PATTERN = new PatternPredicate(".*/out/test/classes/.*");
+        static final PatternPredicate INTELLIJ_TEST_PATTERN = new PatternPredicate(".*/out/test/.*");
         static final Predicate<Location> TEST_LOCATION = or(MAVEN_TEST_PATTERN, GRADLE_TEST_PATTERN, INTELLIJ_TEST_PATTERN);
         static final Predicate<Location> NO_TEST_LOCATION = not(TEST_LOCATION);
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
@@ -90,6 +90,7 @@ public class ImportOptionsTest {
                 // IntelliJ
                 new FolderPattern("out", "production", "classes").expectMainFolder(),
                 new FolderPattern("out", "test", "classes").expectTestFolder(),
+                new FolderPattern("out", "test", "some-module").expectTestFolder(),
                 new FolderPattern("out", "test", "classes", "my", "test").expectTestFolder(),
                 new FolderPattern("out", "some", "classes").expectMainFolder()
         );


### PR DESCRIPTION
Plain IntelliJ projects (i.e. set up without any build tool) now seem to use the pattern `out/test/$MODULE_NAME` to compile class files to. Since we can safely assume that everything built into `out/test` belongs to the test scope, we can adjust the IntelliJ pattern to exclude everything in `.*/out/test/.*` to catch all cases, no matter if set up with a build tool or directly with IntelliJ.

Resolves: #696