### PR TITLE
make `@AnalyzeClasses` import package of test class by default

### DIFF
--- a/archunit-junit/build.gradle
+++ b/archunit-junit/build.gradle
@@ -50,6 +50,10 @@ dependencies {
         exclude module: 'guava'
     }
     testImplementation project(path: ':archunit', configuration: 'tests')
+
+    // This is a hack for running tests with IntelliJ instead of delegating to Gradle,
+    // because for some reason this dependency cannot be resolved otherwise :-(
+    testRuntimeOnly dependency.asm
 }
 
 archUnitTest {

--- a/archunit-junit/junit4/build.gradle
+++ b/archunit-junit/junit4/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testImplementation project(path: ':archunit-junit', configuration: 'tests')
 
     // This is a hack for running tests with IntelliJ instead of delegating to Gradle,
-    // because for some reason this dependency cannot be resolved otherwise only for archunit-junit4 :-(
+    // because for some reason this dependency cannot be resolved otherwise :-(
     testRuntimeOnly dependency.asm
 }
 

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -63,6 +63,12 @@ public @interface AnalyzeClasses {
     Class<? extends LocationProvider>[] locations() default {};
 
     /**
+     * @return Whether to import all classes on the classpath.
+     *         Warning: Without any further filtering this can require a lot of resources.
+     */
+    boolean wholeClasspath() default false;
+
+    /**
      * Allows to filter the class import. The supplied types will be instantiated and used to create the
      * {@link ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
      * {@link ImportOption}.

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/ArchUnitRunner.java
@@ -217,5 +217,10 @@ public class ArchUnitRunner extends ParentRunner<ArchTestExecution> {
         public CacheMode getCacheMode() {
             return analyzeClasses.cacheMode();
         }
+
+        @Override
+        public boolean scanWholeClasspath() {
+            return analyzeClasses.wholeClasspath();
+        }
     }
 }

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/ArchUnitRunnerTest.java
@@ -66,6 +66,7 @@ public class ArchUnitRunnerTest {
         assertThat(analysisRequest.getPackageNames()).isEqualTo(analyzeClasses.packages());
         assertThat(analysisRequest.getPackageRoots()).isEqualTo(analyzeClasses.packagesOf());
         assertThat(analysisRequest.getLocationProviders()).isEqualTo(analyzeClasses.locations());
+        assertThat(analysisRequest.scanWholeClasspath()).as("scan whole classpath").isTrue();
         assertThat(analysisRequest.getImportOptions()).isEqualTo(analyzeClasses.importOptions());
     }
 
@@ -149,6 +150,7 @@ public class ArchUnitRunnerTest {
             packages = {"com.foo", "com.bar"},
             packagesOf = {ArchUnitRunner.class, ArchUnitRunnerTest.class},
             locations = {DummyLocation.class, OtherDummyLocation.class},
+            wholeClasspath = true,
             importOptions = {DummyImportOption.class, OtherDummyImportOption.class}
     )
     public static class MaxAnnotatedTest {

--- a/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -67,6 +67,12 @@ public @interface AnalyzeClasses {
     Class<? extends LocationProvider>[] locations() default {};
 
     /**
+     * @return Whether to look for classes on the whole classpath.
+     *         Warning: Without any further {@link #importOptions() filtering} this can require a lot of resources.
+     */
+    boolean wholeClasspath() default false;
+
+    /**
      * Allows to filter the class import. The supplied types will be instantiated and used to create the
      * {@link ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
      * {@link ImportOption}.

--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestDescriptor.java
@@ -289,5 +289,10 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
         public CacheMode getCacheMode() {
             return analyzeClasses.cacheMode();
         }
+
+        @Override
+        public boolean scanWholeClasspath() {
+            return analyzeClasses.wholeClasspath();
+        }
     }
 }

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/ArchUnitTestEngineTest.java
@@ -879,6 +879,7 @@ class ArchUnitTestEngineTest {
             assertThat(request.getPackageNames()).isEqualTo(expected.packages());
             assertThat(request.getPackageRoots()).isEqualTo(expected.packagesOf());
             assertThat(request.getLocationProviders()).isEqualTo(expected.locations());
+            assertThat(request.scanWholeClasspath()).as("scan whole classpath").isTrue();
             assertThat(request.getImportOptions()).isEqualTo(expected.importOptions());
         }
 

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/FullAnalyzeClassesSpec.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/testexamples/FullAnalyzeClassesSpec.java
@@ -23,6 +23,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
         packages = {"first.pkg", "second.pkg"},
         packagesOf = {Object.class, File.class},
         locations = {FirstLocationProvider.class, SecondLocationProvider.class},
+        wholeClasspath = true,
         importOptions = {DoNotIncludeTests.class, DoNotIncludeJars.class})
 public class FullAnalyzeClassesSpec {
     @ArchTest

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/ClassAnalysisRequest.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/ClassAnalysisRequest.java
@@ -15,4 +15,6 @@ interface ClassAnalysisRequest {
     Class<? extends ImportOption>[] getImportOptions();
 
     CacheMode getCacheMode();
+
+    boolean scanWholeClasspath();
 }

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/TestAnalysisRequest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/TestAnalysisRequest.java
@@ -7,6 +7,7 @@ class TestAnalysisRequest implements ClassAnalysisRequest {
     private String[] packages = new String[0];
     private Class<?>[] packageRoots = new Class<?>[0];
     private Class<? extends LocationProvider>[] locationProviders = new Class[0];
+    private boolean wholeClasspath = false;
     private Class<? extends ImportOption>[] importOptions = new Class[0];
     private CacheMode cacheMode = CacheMode.FOREVER;
 
@@ -23,6 +24,11 @@ class TestAnalysisRequest implements ClassAnalysisRequest {
     @Override
     public Class<? extends LocationProvider>[] getLocationProviders() {
         return locationProviders;
+    }
+
+    @Override
+    public boolean scanWholeClasspath() {
+        return wholeClasspath;
     }
 
     @Override
@@ -48,6 +54,11 @@ class TestAnalysisRequest implements ClassAnalysisRequest {
     @SafeVarargs
     final TestAnalysisRequest withLocationProviders(Class<? extends LocationProvider>... locationProviders) {
         this.locationProviders = locationProviders;
+        return this;
+    }
+
+    final TestAnalysisRequest withWholeClasspath(boolean wholeClasspath) {
+        this.wholeClasspath = wholeClasspath;
         return this;
     }
 


### PR DESCRIPTION
In particular coming from a Spring framework background it is a somewhat surprising behavior that a plain `@AnalyzeClasses` without any options will import the whole classpath. The more intuitive behavior would be to import the package of the annotated class. Since importing the whole classpath is likely not what most users want, and the performance drain is large, we will change the behavior to import the package of the annotated class by default if no further locations are specified.
However, this might break some existing use cases where scanning the whole classpath in combination with `ImportOptions` was used consciously. I.e. something like

```
@AnalyzeClasses(importOptions = MySpecialFilter.class)
```

To make sure ArchUnit can still satisfy this usecase we introduce a new property `@AnalyzeClasses(wholeClasspath = true)`, which is `false` by default, but can be set to `true` to restore the old behavior.

Resolves: #719