### PR TITLE
make `Members-/Methods-/...That` reusable in other contexts

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
@@ -25,7 +25,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public interface CodeUnitsThat<CONJUNCTION extends GivenCodeUnitsConjunction<?>> extends MembersThat<CONJUNCTION> {
+public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
 
     /**
      * Matches {@link JavaCodeUnit JavaCodeUnits} that have the specified raw parameter types.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
@@ -22,7 +22,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public interface FieldsThat<CONJUNCTION extends GivenFieldsConjunction> extends MembersThat<CONJUNCTION> {
+public interface FieldsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
 
     /**
      * Matches fields by their raw type. Take for example

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFields.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFields.java
@@ -26,7 +26,7 @@ public interface GivenFields extends GivenMembers<JavaField> {
 
     @Override
     @PublicAPI(usage = ACCESS)
-    FieldsThat<?> that();
+    FieldsThat<? extends GivenFieldsConjunction> that();
 
     @Override
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFieldsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFieldsConjunction.java
@@ -26,11 +26,11 @@ public interface GivenFieldsConjunction extends GivenMembersConjunction<JavaFiel
 
     @Override
     @PublicAPI(usage = ACCESS)
-    FieldsThat<?> and();
+    FieldsThat<? extends GivenFieldsConjunction> and();
 
     @Override
     @PublicAPI(usage = ACCESS)
-    FieldsThat<?> or();
+    FieldsThat<? extends GivenFieldsConjunction> or();
 
     @Override
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethods.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethods.java
@@ -26,7 +26,7 @@ public interface GivenMethods extends GivenCodeUnits<JavaMethod> {
 
     @Override
     @PublicAPI(usage = ACCESS)
-    MethodsThat<?> that();
+    MethodsThat<? extends GivenMethodsConjunction> that();
 
     @Override
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethodsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethodsConjunction.java
@@ -26,11 +26,11 @@ public interface GivenMethodsConjunction extends GivenCodeUnitsConjunction<JavaM
 
     @Override
     @PublicAPI(usage = ACCESS)
-    MethodsThat<?> and();
+    MethodsThat<? extends GivenMethodsConjunction> and();
 
     @Override
     @PublicAPI(usage = ACCESS)
-    MethodsThat<?> or();
+    MethodsThat<? extends GivenMethodsConjunction> or();
 
     @Override
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
@@ -27,7 +27,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public interface MembersThat<CONJUNCTION extends GivenMembersConjunction<?>> {
+public interface MembersThat<CONJUNCTION> {
 
     /**
      * Matches members by their name (i.e. field name, method name or {@link JavaConstructor#CONSTRUCTOR_NAME}).

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsThat.java
@@ -19,7 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public interface MethodsThat<CONJUNCTION extends GivenMethodsConjunction> extends CodeUnitsThat<CONJUNCTION> {
+public interface MethodsThat<CONJUNCTION> extends CodeUnitsThat<CONJUNCTION> {
 
     /**
      * Matches static methods.


### PR DESCRIPTION
By specifying bounds like `MethodsThat<CONJUNCTION extends GivenMethodsConjunction>` on the type `MethodsThat` we are tying this to the `methods()` API. This way we cannot use the syntax element in another context, e.g. `OnlyBeCalledBy -> MethodsThat`. We should control the bound on the methods within the `members()/methods()/...` API to keep the elements themselves reusable, but still support all the specific syntax paths for the subtypes (e.g. `methods.that().areFinal()` which would not work on `members().that()`).