### PR TITLE
Feature/make arbitrary arch conditions from predicates

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/PublicAPIRules.java
@@ -128,6 +128,7 @@ public class PublicAPIRules {
                     .and(are(declaredIn(modifier(PUBLIC))))
                     .and(are(not(declaredIn(annotatedWith(Internal.class)))))
                     .and(have(modifier(PUBLIC)))
+                    .and(not(have(HasReturnType.Predicates.rawReturnType(is(assignableTo(ArchCondition.class))))))
                     .should(haveContravariantPredicateParameterTypes())
                     .as(String.format(
                             "Public API methods that take a %s<PARAM> should declare the type parameter contravariantly (i.e. %s<? super PARAM>)",

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -116,7 +116,6 @@ import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Pred
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
-import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static java.util.Arrays.asList;
 
 public final class ArchConditions {
@@ -500,7 +499,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleName(final String name) {
-        final DescribedPredicate<JavaClass> haveSimpleName = have(simpleName(name));
+        final DescribedPredicate<JavaClass> haveSimpleName = ArchPredicates.have(simpleName(name));
         return new SimpleNameCondition(haveSimpleName, name);
     }
 
@@ -511,7 +510,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameStartingWith(final String prefix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameStartingWith(prefix));
+        final DescribedPredicate<JavaClass> predicate = ArchPredicates.have(simpleNameStartingWith(prefix));
 
         return new SimpleNameStartingWithCondition(predicate, prefix);
     }
@@ -523,7 +522,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameContaining(final String infix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameContaining(infix));
+        final DescribedPredicate<JavaClass> predicate = ArchPredicates.have(simpleNameContaining(infix));
 
         return new SimpleNameContainingCondition(predicate, infix);
     }
@@ -535,7 +534,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameEndingWith(final String suffix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameEndingWith(suffix));
+        final DescribedPredicate<JavaClass> predicate = ArchPredicates.have(simpleNameEndingWith(suffix));
 
         return new SimpleNameEndingWithCondition(predicate, suffix);
     }
@@ -547,7 +546,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameMatching(final String regex) {
-        final DescribedPredicate<HAS_NAME> haveNameMatching = have(nameMatching(regex)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameMatching = ArchPredicates.have(nameMatching(regex)).forSubtype();
         return new MatchingCondition<>(haveNameMatching, regex);
     }
 
@@ -559,7 +558,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
     ArchCondition<HAS_FULL_NAME> haveFullNameMatching(String regex) {
-        final DescribedPredicate<HAS_FULL_NAME> haveFullNameMatching = have(fullNameMatching(regex)).forSubtype();
+        final DescribedPredicate<HAS_FULL_NAME> haveFullNameMatching = ArchPredicates.have(fullNameMatching(regex)).forSubtype();
         return new MatchingCondition<>(haveFullNameMatching, regex);
     }
 
@@ -572,42 +571,42 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameStartingWith(String prefix) {
-        final DescribedPredicate<HAS_NAME> haveNameStartingWith = have(nameStartingWith(prefix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameStartingWith = ArchPredicates.have(nameStartingWith(prefix)).forSubtype();
         return new StartingCondition<>(haveNameStartingWith, prefix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameNotStartingWith(String prefix) {
-        final DescribedPredicate<HAS_NAME> haveNameStartingWith = have(nameStartingWith(prefix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameStartingWith = ArchPredicates.have(nameStartingWith(prefix)).forSubtype();
         return not(new StartingCondition<>(haveNameStartingWith, prefix)).as("have name not starting with '%s'", prefix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameContaining(String infix) {
-        final DescribedPredicate<HAS_NAME> haveNameContaining = have(nameContaining(infix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameContaining = ArchPredicates.have(nameContaining(infix)).forSubtype();
         return new ContainingCondition<>(haveNameContaining, infix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameNotContaining(String infix) {
-        final DescribedPredicate<HAS_NAME> haveNameContaining = have(nameContaining(infix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameContaining = ArchPredicates.have(nameContaining(infix)).forSubtype();
         return not(new ContainingCondition<>(haveNameContaining, infix)).as("have name not containing '%s'", infix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameEndingWith(String suffix) {
-        final DescribedPredicate<HAS_NAME> haveNameEndingWith = have(nameEndingWith(suffix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameEndingWith = ArchPredicates.have(nameEndingWith(suffix)).forSubtype();
         return new EndingCondition<>(haveNameEndingWith, suffix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
     haveNameNotEndingWith(String suffix) {
-        final DescribedPredicate<HAS_NAME> haveNameEndingWith = have(nameEndingWith(suffix)).forSubtype();
+        final DescribedPredicate<HAS_NAME> haveNameEndingWith = ArchPredicates.have(nameEndingWith(suffix)).forSubtype();
         return not(new EndingCondition<>(haveNameEndingWith, suffix)).as("have name not ending with '%s'", suffix);
     }
 
@@ -1273,6 +1272,16 @@ public final class ArchConditions {
         ChainableFunction<JavaAccess<?>, ? extends JavaCodeUnit> origin = JavaAccess.Functions.Get.origin();
         return new CodeUnitOnlyCallsCondition<>("only be called by constructors that " + predicate.getDescription(),
                 origin.is(constructor().and(predicate)), GET_CALLS_OF_SELF);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static <T extends HasDescription & HasSourceCodeLocation> ArchCondition<T> have( DescribedPredicate<T> predicate ) {
+        return new HaveConditionByPredicate<>(predicate);
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static <T extends HasDescription & HasSourceCodeLocation> ArchCondition<T> be( DescribedPredicate<T> predicate ) {
+        return new IsConditionByPredicate<>(predicate);
     }
 
     private static <T extends HasDescription & HasSourceCodeLocation> String createMessage(T object, String message) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
@@ -28,11 +28,13 @@ import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.Wi
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThatResideIn;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThatResideInAnyPackage;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.be;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.callCodeUnitWhere;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.callMethodWhere;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containAnyElementThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containOnlyElementsThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.declareThrowableOfType;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.have;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.never;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyBeAccessedByAnyPackage;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyHaveDependentsInAnyPackage;
@@ -100,6 +102,25 @@ public class ArchConditionsTest {
         assertThat(containOnlyElementsThat(conditionWithDescription("something")))
                 .hasDescription("contain only elements that something");
     }
+
+    @Test
+    public void descriptionsOfWrappedHavePredicates() {
+        JavaClass accessedClass = importClasses( SomeClass.class ).get( SomeClass.class );
+
+        assertThat( have( JavaClass.Predicates.simpleName( "SimpleName" ) ) )
+                .hasDescription( "have simple name 'SimpleName'" );
+
+        assertThat( have( DescribedPredicate.<JavaClass>alwaysFalse() ) )
+                .checking( accessedClass )
+                .haveOneViolationMessageContaining( "SomeClass> does not have always false" );
+
+        assertThat( be( JavaClass.Predicates.assignableTo( "AnotherClass" ) ) )
+                .hasDescription( "be assignable to AnotherClass" );
+
+        assertThat( be( DescribedPredicate.<JavaClass>alwaysFalse() ) )
+                .checking( accessedClass )
+                .haveOneViolationMessageContaining( "SomeClass> is not always false" );
+   }
 
     @Test
     public void only_have_dependents_where() {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
@@ -114,6 +114,10 @@ public class ArchConditionsTest {
                 .checking( accessedClass )
                 .haveOneViolationMessageContaining( "SomeClass> does not have always false" );
 
+        assertThat (ArchCondition.from( JavaClass.Predicates.simpleName( "SimpleName" ) ).withViolationString( "does not have" ) )
+              .checking( accessedClass )
+              .haveOneViolationMessageContaining( "SomeClass> does not have simple name 'SimpleName'" );
+
         assertThat( be( JavaClass.Predicates.assignableTo( "AnotherClass" ) ) )
                 .hasDescription( "be assignable to AnotherClass" );
 


### PR DESCRIPTION
This is a partial fix for  #855.

I've added two of the methods with some tests.
A couple of points though:

a) I had severe problems, getting this to build (see #437) and test (in IntelliJ lots of tests are executed even if only a few are selected). So formatting might be off

b) I have adapted one architecture check - my reasoning is that just converting from a `DescribedPredicate<T>` to a `ArchCondition<T>` is ok without contravariance. It makes stuff easier to diagnose and doesn't loose any power as ArchConditions are already handled contravariantly.

c) I have also added an 'inverse' test but I cannot get that to fail - beats me why.

I'm looking forward to your feedback!