### PR TITLE
add JUnit5-support for `@ArchTest` members in abstract base classes

### DIFF
--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
@@ -37,6 +37,9 @@ import com.tngtech.archunit.junit.internal.testexamples.TestMethodWithMetaTag;
 import com.tngtech.archunit.junit.internal.testexamples.TestMethodWithMetaTags;
 import com.tngtech.archunit.junit.internal.testexamples.TestMethodWithTags;
 import com.tngtech.archunit.junit.internal.testexamples.UnwantedClass;
+import com.tngtech.archunit.junit.internal.testexamples.abstractbase.ArchTestWithAbstractBaseClassWithFieldRule;
+import com.tngtech.archunit.junit.internal.testexamples.abstractbase.ArchTestWithAbstractBaseClassWithMethodRule;
+import com.tngtech.archunit.junit.internal.testexamples.abstractbase.ArchTestWithLibraryWithAbstractBaseClass;
 import com.tngtech.archunit.junit.internal.testexamples.ignores.IgnoredClass;
 import com.tngtech.archunit.junit.internal.testexamples.ignores.IgnoredField;
 import com.tngtech.archunit.junit.internal.testexamples.ignores.IgnoredLibrary;
@@ -834,6 +837,17 @@ class ArchUnitTestEngineTest {
         }
 
         @Test
+        void instance_field_rule_in_abstract_base_class() {
+            simulateCachedClassesForTest(ArchTestWithAbstractBaseClassWithFieldRule.class, UnwantedClass.CLASS_SATISFYING_RULES);
+
+            EngineExecutionTestListener testListener = execute(engineId, ArchTestWithAbstractBaseClassWithFieldRule.class);
+
+            testListener.verifySuccessful(engineId
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithFieldRule.class.getName())
+                    .append(FIELD_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithFieldRule.INSTANCE_FIELD_NAME));
+        }
+
+        @Test
         void a_simple_rule_method_without_violation() {
             simulateCachedClassesForTest(SimpleRuleMethod.class, UnwantedClass.CLASS_SATISFYING_RULES);
 
@@ -849,6 +863,17 @@ class ArchUnitTestEngineTest {
             EngineExecutionTestListener testListener = execute(engineId, SimpleRuleMethod.class);
 
             testListener.verifyViolation(simpleRuleMethodTestId(engineId), UnwantedClass.CLASS_VIOLATING_RULES.getSimpleName());
+        }
+
+        @Test
+        void instance_method_rule_in_abstract_base_class() {
+            simulateCachedClassesForTest(ArchTestWithAbstractBaseClassWithMethodRule.class, UnwantedClass.CLASS_SATISFYING_RULES);
+
+            EngineExecutionTestListener testListener = execute(engineId, ArchTestWithAbstractBaseClassWithMethodRule.class);
+
+            testListener.verifySuccessful(engineId
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithMethodRule.class.getName())
+                    .append(METHOD_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithMethodRule.INSTANCE_METHOD_NAME));
         }
 
         @Test
@@ -878,6 +903,26 @@ class ArchUnitTestEngineTest {
 
             privateRuleLibraryIds(engineId).forEach(testId ->
                     testListener.verifyViolation(testId, UnwantedClass.CLASS_VIOLATING_RULES.getSimpleName()));
+        }
+
+        @Test
+        public void library_with_rules_in_abstract_base_class() {
+            simulateCachedClassesForTest(ArchTestWithLibraryWithAbstractBaseClass.class, UnwantedClass.CLASS_SATISFYING_RULES);
+
+            EngineExecutionTestListener testListener = execute(engineId, ArchTestWithLibraryWithAbstractBaseClass.class);
+
+            testListener.verifySuccessful(engineId
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithLibraryWithAbstractBaseClass.class.getName())
+                    .append(FIELD_SEGMENT_TYPE, ArchTestWithLibraryWithAbstractBaseClass.FIELD_RULE_LIBRARY_NAME)
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithFieldRule.class.getName())
+                    .append(FIELD_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithFieldRule.INSTANCE_FIELD_NAME)
+                    );
+            testListener.verifySuccessful(engineId
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithLibraryWithAbstractBaseClass.class.getName())
+                    .append(FIELD_SEGMENT_TYPE, ArchTestWithLibraryWithAbstractBaseClass.METHOD_RULE_LIBRARY_NAME)
+                    .append(CLASS_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithMethodRule.class.getName())
+                    .append(METHOD_SEGMENT_TYPE, ArchTestWithAbstractBaseClassWithMethodRule.INSTANCE_METHOD_NAME)
+                    );
         }
 
         @Test

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithFieldRule.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithFieldRule.java
@@ -1,0 +1,13 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.internal.testexamples.RuleThatFails;
+import com.tngtech.archunit.junit.internal.testexamples.UnwantedClass;
+import com.tngtech.archunit.lang.ArchRule;
+
+public abstract class AbstractBaseClassWithFieldRule {
+    public static final String INSTANCE_FIELD_NAME = "abstractBaseClassInstanceField";
+
+    @ArchTest
+    ArchRule abstractBaseClassInstanceField = RuleThatFails.on(UnwantedClass.CLASS_VIOLATING_RULES);
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithLibraryWithAbstractBaseClass.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithLibraryWithAbstractBaseClass.java
@@ -1,0 +1,13 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+
+public abstract class AbstractBaseClassWithLibraryWithAbstractBaseClass {
+    public static final String FIELD_RULE_LIBRARY_NAME = "fieldRules";
+    public static final String METHOD_RULE_LIBRARY_NAME = "methodRules";
+    @ArchTest
+    ArchTests fieldRules = ArchTests.in(ArchTestWithAbstractBaseClassWithFieldRule.class);
+    @ArchTest
+    ArchTests methodRules = ArchTests.in(ArchTestWithAbstractBaseClassWithMethodRule.class);
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithMethodRule.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/AbstractBaseClassWithMethodRule.java
@@ -1,0 +1,15 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.internal.testexamples.RuleThatFails;
+import com.tngtech.archunit.junit.internal.testexamples.UnwantedClass;
+
+public abstract class AbstractBaseClassWithMethodRule {
+    public static final String INSTANCE_METHOD_NAME = "abstractBaseClassInstanceMethod";
+
+    @ArchTest
+    void abstractBaseClassInstanceMethod(JavaClasses classes) {
+        RuleThatFails.on(UnwantedClass.CLASS_VIOLATING_RULES).check(classes);
+    }
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithAbstractBaseClassWithFieldRule.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithAbstractBaseClassWithFieldRule.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+
+@AnalyzeClasses(packages = "some.dummy.package")
+public class ArchTestWithAbstractBaseClassWithFieldRule extends AbstractBaseClassWithFieldRule {
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithAbstractBaseClassWithMethodRule.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithAbstractBaseClassWithMethodRule.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+
+@AnalyzeClasses(packages = "some.dummy.package")
+public class ArchTestWithAbstractBaseClassWithMethodRule extends AbstractBaseClassWithMethodRule {
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithLibraryWithAbstractBaseClass.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/abstractbase/ArchTestWithLibraryWithAbstractBaseClass.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.junit.internal.testexamples.abstractbase;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+
+@AnalyzeClasses(packages = "some.dummy.package")
+public class ArchTestWithLibraryWithAbstractBaseClass extends AbstractBaseClassWithLibraryWithAbstractBaseClass {
+}


### PR DESCRIPTION
So far, having `@ArchTest` fields or methods in an abstract base class would cause the JUnit 5 engine to crash. This also made the pattern to "share" tests via extending a common base class impossible, which some users would like to have.

Similar to #105 for JUnit 4, resolves #104.