### PR TITLE
Improve ArchCondition that checks for transitive dependencies

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
@@ -19,7 +19,10 @@ import java.util.Collection;
 import java.util.List;
 
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 
 import static com.tngtech.archunit.PublicAPI.State.EXPERIMENTAL;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -65,6 +68,21 @@ public interface ConditionEvent {
      */
     @PublicAPI(usage = INHERITANCE, state = EXPERIMENTAL)
     void handleWith(Handler handler);
+
+    /**
+     * Convenience method to create a standard ArchUnit {@link ConditionEvent} message. It will prepend the
+     * description of the object that caused the event (e.g. a {@link JavaClass}) and append the source code
+     * location of the respective object.
+     *
+     * @param object The object to describe, e.g. the {@link JavaClass} {@code com.example.SomeClass}
+     * @param message The message that should be filled into the template, e.g. "does not have simple name 'Correct'"
+     * @return The formatted message, e.g. {@code Class <com.example.SomeClass> does not have simple name 'Correct' in (SomeClass.java:0)}
+     * @param <T> The object described by the event.
+     */
+    @PublicAPI(usage = ACCESS)
+    static <T extends HasDescription & HasSourceCodeLocation> String createMessage(T object, String message) {
+        return object.getDescription() + " " + message + " in " + object.getSourceCodeLocation();
+    }
 
     /**
      * Handles the data of a {@link ConditionEvent} that is the corresponding objects and the description

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -85,7 +85,6 @@ import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELDS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELD_ACCESSES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_METHOD_CALLS_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
-import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_TRANSITIVE_DEPENDENCIES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
@@ -305,10 +304,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> transitivelyDependOnClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
-        return new AnyDependencyCondition(
-                "transitively depend on classes that " + predicate.getDescription(),
-                GET_TARGET_CLASS.is(predicate),
-                GET_TRANSITIVE_DEPENDENCIES_FROM_SELF);
+        return new TransitiveDependencyCondition(predicate);
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -117,6 +117,7 @@ import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Pred
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
+import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static java.util.Arrays.asList;
 
@@ -1282,10 +1283,6 @@ public final class ArchConditions {
         ChainableFunction<JavaAccess<?>, ? extends JavaCodeUnit> origin = JavaAccess.Functions.Get.origin();
         return new CodeUnitOnlyCallsCondition<>("only be called by constructors that " + predicate.getDescription(),
                 origin.is(constructor().and(predicate)), GET_CALLS_OF_SELF);
-    }
-
-    private static <T extends HasDescription & HasSourceCodeLocation> String createMessage(T object, String message) {
-        return object.getDescription() + " " + message + " in " + object.getSourceCodeLocation();
     }
 
     private static final IsConditionByPredicate<JavaClass> BE_TOP_LEVEL_CLASSES =

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/TransitiveDependencyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/TransitiveDependencyCondition.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.lang.conditions;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvent;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.getLast;
+import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+
+public class TransitiveDependencyCondition extends ArchCondition<JavaClass> {
+
+    private final DescribedPredicate<? super JavaClass> conditionPredicate;
+    private final TransitiveDependencyPath transitiveDependencyPath = new TransitiveDependencyPath();
+    private Collection<JavaClass> allClasses;
+
+    public TransitiveDependencyCondition(DescribedPredicate<? super JavaClass> conditionPredicate) {
+        super("transitively depend on classes that " + conditionPredicate.getDescription());
+
+        this.conditionPredicate = checkNotNull(conditionPredicate);
+    }
+
+    @Override
+    public void init(Collection<JavaClass> allObjectsToTest) {
+        this.allClasses = allObjectsToTest;
+    }
+
+    @Override
+    public void check(JavaClass javaClass, ConditionEvents events) {
+        boolean hasTransitiveDependency = false;
+        for (JavaClass target : getDirectDependencyTargetsOutsideOfAnalyzedClasses(javaClass)) {
+            List<JavaClass> dependencyPath = transitiveDependencyPath.findPathTo(target);
+            if (!dependencyPath.isEmpty()) {
+                events.add(newTransitiveDependencyPathFoundEvent(javaClass, dependencyPath));
+                hasTransitiveDependency = true;
+            }
+        }
+        if (!hasTransitiveDependency) {
+            events.add(newNoTransitiveDependencyPathFoundEvent(javaClass));
+        }
+    }
+
+    private static ConditionEvent newTransitiveDependencyPathFoundEvent(JavaClass javaClass, List<JavaClass> transitiveDependencyPath) {
+        String message = String.format("%sdepends on <%s>",
+                transitiveDependencyPath.size() > 1 ? "transitively " : "",
+                getLast(transitiveDependencyPath).getFullName());
+
+        if (transitiveDependencyPath.size() > 1) {
+            message += " by [" + transitiveDependencyPath.stream().map(JavaClass::getName).collect(joining("->")) + "]";
+        }
+
+        return SimpleConditionEvent.satisfied(javaClass, createMessage(javaClass, message));
+    }
+
+    private static ConditionEvent newNoTransitiveDependencyPathFoundEvent(JavaClass javaClass) {
+        return SimpleConditionEvent.violated(javaClass, createMessage(javaClass, "does not transitively depend on any matching class"));
+    }
+
+    private Set<JavaClass> getDirectDependencyTargetsOutsideOfAnalyzedClasses(JavaClass item) {
+        return item.getDirectDependenciesFromSelf().stream()
+                .map(dependency -> dependency.getTargetClass().getBaseComponentType())
+                .filter(targetClass -> !allClasses.contains(targetClass))
+                .collect(toSet());
+    }
+
+    private class TransitiveDependencyPath {
+        /**
+         * @return some outgoing transitive dependency path to the supplied class or empty if there is none
+         */
+        List<JavaClass> findPathTo(JavaClass clazz) {
+            ImmutableList.Builder<JavaClass> transitivePath = ImmutableList.builder();
+            addDependenciesToPathFrom(clazz, transitivePath, new HashSet<>());
+            return transitivePath.build().reverse();
+        }
+
+        private boolean addDependenciesToPathFrom(
+                JavaClass clazz,
+                ImmutableList.Builder<JavaClass> dependencyPath,
+                Set<JavaClass> analyzedClasses
+        ) {
+            if (conditionPredicate.test(clazz)) {
+                dependencyPath.add(clazz);
+                return true;
+            }
+
+            analyzedClasses.add(clazz);
+
+            for (JavaClass directDependency : getDirectDependencyTargetsOutsideOfAnalyzedClasses(clazz)) {
+                if (!analyzedClasses.contains(directDependency)
+                        && addDependenciesToPathFrom(directDependency, dependencyPath, analyzedClasses)) {
+                    dependencyPath.add(clazz);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -1016,7 +1016,10 @@ public interface ClassesShould {
     ClassesShouldConjunction onlyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate);
 
     /**
-     * Asserts that all classes selected by this rule transitively depend on certain classes.<br>
+     * Asserts that all classes selected by this rule transitively depend on any matching classes.<br>
+     * It focuses on detecting all <strong>direct</strong> dependencies of the selected classes that are themselves matched or have any
+     * transitive dependencies on matched classes. Thus, it doesn't discover all possible dependency paths but stops at the first match to be fast and
+     * resource-friendly.<br>
      * NOTE: This usually makes more sense the negated way, e.g.
      * <p>
      * <pre><code>
@@ -1031,7 +1034,10 @@ public interface ClassesShould {
     ClassesThat<ClassesShouldConjunction> transitivelyDependOnClassesThat();
 
     /**
-     * Asserts that all classes selected by this rule transitively depend on certain classes.<br>
+     * Asserts that all classes selected by this rule transitively depend on any matching classes.<br>
+     * It focuses on detecting all <strong>direct</strong> dependencies of the selected classes that are themselves matched or have any
+     * transitive dependencies on matched classes. Thus, it doesn't discover all possible dependency paths but stops at the first match to be fast and
+     * resource-friendly.<br>
      * NOTE: This usually makes more sense the negated way, e.g.
      * <p>
      * <pre><code>


### PR DESCRIPTION
This adds an ArchCondition to the fluent API to check whether there is any matching transitive dependency. This is a much more efficient variant of `#transitivelyDependOnClassesThat` that can be used to detect transitive dependencies in a huge codebase or to classes in large 3rd-party libraries like the Android SDK. It focuses on detecting all *direct* dependencies of the selected classes that are themselves matched or have any transitive dependencies on matched classes. Thus, it doesn't discover all possible dependency paths but stops at the first match to be fast and resource-friendly.

Sample usage:
```
noClasses().that.resideInAPackage(“de.foo.service..”)
    .should().transitivelyDependOnAnyClassesThat.resideInAPackage("android..")
```

Then this Architecture
![image](https://user-images.githubusercontent.com/17569373/172873445-17111662-30e2-4388-912e-840a105cd2bc.png)

would output the following violations:

```
java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'no classes that reside in a package 'de.foo.service..' should transitively depend on any classes that reside in a package ['android..'] was violated (3 times):
Class <de.foo.service.B> transitively depends on <android.I> by [F->E->android.I] in (B.java:0)
Class <de.foo.service.B> transitively depends on <android.I> by [E->android.I] in (B.java:0)
Class <de.foo.service.C> transitively depends on <android.H> by [D->android.H] in (C.java:0)
```

Resolves: #780 
Resolves: #826