### PR TITLE
Speed up JUnit 5 support discovery process

### DIFF
--- a/archunit-junit/junit5/engine/build.gradle
+++ b/archunit-junit/junit5/engine/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     testImplementation dependency.assertj
     testImplementation dependency.mockito
     testImplementation dependency.junit5JupiterApi
+    testImplementation dependency.log4j_core
+    testImplementation dependency.log4j_slf4j
 
     testRuntimeOnly dependency.junit5JupiterEngine
 }

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testutil/LogCaptor.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testutil/LogCaptor.java
@@ -1,0 +1,23 @@
+package com.tngtech.archunit.junit.internal.testutil;
+
+import java.util.List;
+
+import com.tngtech.archunit.testutil.TestLogRecorder;
+import com.tngtech.archunit.testutil.TestLogRecorder.RecordedLogEvent;
+import org.apache.logging.log4j.Level;
+
+public class LogCaptor {
+    private final TestLogRecorder logRecorder = new TestLogRecorder();
+
+    public void watch(Class<?> loggerClass, Level level) {
+        logRecorder.record(loggerClass, level);
+    }
+
+    public void cleanUp() {
+        logRecorder.reset();
+    }
+
+    public List<RecordedLogEvent> getEvents(Level level) {
+        return logRecorder.getEvents(level);
+    }
+}

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testutil/TestLogExtension.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testutil/TestLogExtension.java
@@ -1,0 +1,26 @@
+package com.tngtech.archunit.junit.internal.testutil;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class TestLogExtension implements ParameterResolver, AfterEachCallback {
+    private final LogCaptor logCaptor = new LogCaptor();
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return LogCaptor.class.equals(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return logCaptor;
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        logCaptor.cleanUp();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFactoryTest.java
@@ -158,11 +158,11 @@ public class ClassResolverFactoryTest {
         };
     }
 
-    static class TestResolver implements ClassResolver {
+    private static class TestResolver implements ClassResolver {
         final String first;
         final String second;
 
-        public TestResolver(List<String> args) {
+        private TestResolver(List<String> args) {
             Preconditions.checkArgument(args.size() == 2);
             this.first = args.get(0);
             this.second = args.get(1);
@@ -193,8 +193,8 @@ public class ClassResolverFactoryTest {
         }
     }
 
-    static class ResolverWithDefaultConstructor implements ClassResolver {
-        public ResolverWithDefaultConstructor() {
+    private static class ResolverWithDefaultConstructor implements ClassResolver {
+        private ResolverWithDefaultConstructor() {
         }
 
         @Override
@@ -208,6 +208,7 @@ public class ClassResolverFactoryTest {
     }
 
     static class ResolverWithWrongConstructor implements ClassResolver {
+        @SuppressWarnings("unused")
         ResolverWithWrongConstructor(String bummer) {
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/LogTestRule.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/LogTestRule.java
@@ -1,115 +1,42 @@
 package com.tngtech.archunit.testutil;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
+import com.tngtech.archunit.testutil.TestLogRecorder.RecordedLogEvent;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Assert;
 import org.junit.rules.ExternalResource;
 
-import static java.util.stream.Collectors.toList;
-
 public class LogTestRule extends ExternalResource {
-    private static final String APPENDER_NAME = "test_appender";
-
-    private final List<RecordedLogEvent> logEvents = new ArrayList<>();
-    private Class<?> loggerClass;
-    private Level oldLevel;
+    private final TestLogRecorder testLogRecorder = new TestLogRecorder();
 
     public void watch(Class<?> loggerClass, Level level) {
-        this.loggerClass = loggerClass;
-        Appender appender = new AbstractAppender(APPENDER_NAME, null, PatternLayout.createDefaultLayout()) {
-            @Override
-            public void append(LogEvent event) {
-                logEvents.add(new RecordedLogEvent(event));
-            }
-        };
-        appender.start();
-        final LoggerContext ctx = getLoggerContext();
-        LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
-        oldLevel = loggerConfig.getLevel();
-        loggerConfig.setLevel(level);
-        loggerConfig.addAppender(appender, level, null);
-        ctx.updateLoggers();
+        testLogRecorder.record(loggerClass, level);
     }
 
     @Override
     protected void after() {
-        if (loggerClass == null) {
-            return;
-        }
-
-        final LoggerContext ctx = getLoggerContext();
-        LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
-        loggerConfig.setLevel(oldLevel);
-        loggerConfig.removeAppender(APPENDER_NAME);
-        ctx.updateLoggers();
-    }
-
-    private LoggerContext getLoggerContext() {
-        return (LoggerContext) LogManager.getContext(false);
+        testLogRecorder.reset();
     }
 
     public void assertLogMessage(Level level, String messagePart) {
-        for (RecordedLogEvent event : filterByLevel(logEvents, level)) {
-            if (event.getMessage().contains(messagePart)) {
-                return;
-            }
+        List<RecordedLogEvent> events = testLogRecorder.getEvents(level);
+        if (events.stream().noneMatch(e -> e.getMessage().contains(messagePart))) {
+            Assert.fail(String.format(
+                    "Couldn't find any message with level %s that contains '%s' in%n%s",
+                    level, messagePart, testLogRecorder.getEvents()));
         }
-
-        Assert.fail(String.format(
-                "Couldn't find any message with level %s that contains '%s' in%n%s",
-                level, messagePart, logEvents));
     }
 
     public void assertException(Level level, Class<?> exceptionType, String messagePart) {
-        for (RecordedLogEvent event : filterByLevel(logEvents, level)) {
-            if (exceptionType.isInstance(event.getThrown()) && event.getThrown().getMessage().contains(messagePart)) {
-                return;
-            }
-        }
+        List<RecordedLogEvent> events = testLogRecorder.getEvents(level);
+        Stream<RecordedLogEvent> eventsWithException = events.stream().filter(e -> exceptionType.isInstance(e.getThrown()));
 
-        Assert.fail(String.format(
-                "Couldn't find any log event with level %s that contains a %s with message containing '%s' in%n%s",
-                level, exceptionType.getSimpleName(), messagePart, logEvents));
-    }
-
-    private Iterable<RecordedLogEvent> filterByLevel(List<RecordedLogEvent> events, final Level level) {
-        return events.stream().filter(input -> input.getLevel().equals(level)).collect(toList());
-    }
-
-    private static class RecordedLogEvent {
-        private final Level level;
-        private final String message;
-        private final Throwable thrown;
-
-        private RecordedLogEvent(Level level, String message, Throwable thrown) {
-            this.level = level;
-            this.message = message;
-            this.thrown = thrown;
-        }
-
-        RecordedLogEvent(LogEvent event) {
-            this(event.getLevel(), event.getMessage().getFormattedMessage(), event.getThrown());
-        }
-
-        Level getLevel() {
-            return level;
-        }
-
-        Throwable getThrown() {
-            return thrown;
-        }
-
-        public String getMessage() {
-            return message;
+        if (eventsWithException.noneMatch(e -> e.getThrown().getMessage().contains(messagePart))) {
+            Assert.fail(String.format(
+                    "Couldn't find any log event with level %s that contains a %s with message containing '%s' in%n%s",
+                    level, exceptionType.getSimpleName(), messagePart, testLogRecorder.getEvents()));
         }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/TestLogRecorder.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/TestLogRecorder.java
@@ -1,0 +1,103 @@
+package com.tngtech.archunit.testutil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.toList;
+
+public class TestLogRecorder {
+    private static final String APPENDER_NAME = "test_appender";
+
+    private final List<RecordedLogEvent> logEvents = new ArrayList<>();
+    private Class<?> loggerClass;
+    private Level oldLevel;
+
+    public void record(Class<?> loggerClass, Level level) {
+        this.loggerClass = loggerClass;
+        Appender appender = new AbstractAppender(APPENDER_NAME, null, PatternLayout.createDefaultLayout(), true, new Property[0]) {
+            @Override
+            public void append(LogEvent event) {
+                logEvents.add(new RecordedLogEvent(event));
+            }
+        };
+        appender.start();
+        final LoggerContext ctx = getLoggerContext();
+        LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
+        oldLevel = loggerConfig.getLevel();
+        loggerConfig.setLevel(level);
+        loggerConfig.addAppender(appender, level, null);
+        ctx.updateLoggers();
+    }
+
+    private LoggerContext getLoggerContext() {
+        return (LoggerContext) LogManager.getContext(false);
+    }
+
+    public void reset() {
+        if (loggerClass == null) {
+            return;
+        }
+
+        final LoggerContext ctx = getLoggerContext();
+        LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
+        loggerConfig.setLevel(oldLevel);
+        loggerConfig.removeAppender(APPENDER_NAME);
+        ctx.updateLoggers();
+    }
+
+    public List<RecordedLogEvent> getEvents() {
+        return logEvents;
+    }
+
+    public List<RecordedLogEvent> getEvents(Level level) {
+        return logEvents.stream().filter(input -> input.getLevel().equals(level)).collect(toList());
+    }
+
+    public static class RecordedLogEvent {
+        private final Level level;
+        private final String message;
+        private final Throwable thrown;
+
+        private RecordedLogEvent(Level level, String message, Throwable thrown) {
+            this.level = level;
+            this.message = message;
+            this.thrown = thrown;
+        }
+
+        RecordedLogEvent(LogEvent event) {
+            this(event.getLevel(), event.getMessage().getFormattedMessage(), event.getThrown());
+        }
+
+        Level getLevel() {
+            return level;
+        }
+
+        Throwable getThrown() {
+            return thrown;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        @Override
+        public String toString() {
+            return toStringHelper(this)
+                    .add("level", level)
+                    .add("message", message)
+                    .add("thrown", thrown)
+                    .toString();
+        }
+    }
+}


### PR DESCRIPTION
The JUnit platform API makes it necessary for ArchUnit to provide an implementation to discover test classes from the classpath (e.g. because the discovery request contains a package selector). Since ArchUnit itself is perfectly suited for this and does not demand any third party dependency we simply use the `ClassFileImporter` for this. However, so far we have used the current `ArchConfiguration` of the user, which by default e.g. resolves all further dependencies from the classpath. This is unnecessary overhead and can substantially slow down the discovery process if the test classes e.g. have some framework dependencies like the Spring framework.
We will now switch the `ArchConfiguration` for the discovery process so that it does not import any transitive dependencies of the discovered classes. This way the discovery process via ArchUnit should be quite fast, no matter what further dependencies the test classes have.

Resolves: #546