### PR TITLE
Add support for alternatives to package identifiers

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/PackageMatcherTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/PackageMatcherTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import com.tngtech.archunit.core.domain.PackageMatcher.Result;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -12,6 +13,7 @@ import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.core.domain.PackageMatcher.TO_GROUPS;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
 @RunWith(DataProviderRunner.class)
 public class PackageMatcherTest {
@@ -20,34 +22,41 @@ public class PackageMatcherTest {
 
     @Test
     @DataProvider(value = {
-            "some.arbitrary.pkg | some.arbitrary.pkg             | true",
-            "some.arbitrary.pkg | some.thing.different           | false",
-            "some..pkg          | some.arbitrary.pkg             | true",
-            "some..middle..pkg  | some.arbitrary.middle.more.pkg | true",
-            "*..pkg             | some.arbitrary.pkg             | true",
-            "some..*            | some.arbitrary.pkg             | true",
-            "*..pkg             | some.arbitrary.pkg.toomuch     | false",
-            "toomuch.some..*    | some.arbitrary.pkg             | false",
-            "*..wrong           | some.arbitrary.pkg             | false",
-            "some..*            | wrong.arbitrary.pkg            | false",
-            "..some             | some                           | true",
-            "some..             | some                           | true",
-            "*..some            | some                           | false",
-            "some..*            | some                           | false",
-            "..some             | asome                          | false",
-            "some..             | somea                          | false",
-            "*.*.*              | wrong.arbitrary.pkg            | true",
-            "*.*.*              | wrong.arbitrary.pkg.toomuch    | false",
-            "some.arbi*.pk*..   | some.arbitrary.pkg.whatever    | true",
-            "some.arbi*..       | some.brbitrary.pkg             | false",
-            "some.*rary.*kg..   | some.arbitrary.pkg.whatever    | true",
-            "some.*rary..       | some.arbitrarz.pkg             | false",
-            "some.pkg           | someepkg                       | false",
-            "..pkg..            | some.random.pkg.maybe.anywhere | true",
-            "..p..              | s.r.p.m.a                      | true",
-            "*..pkg..*          | some.random.pkg.maybe.anywhere | true",
-            "*..p..*            | s.r.p.m.a                      | true"
-    }, splitBy = "\\|")
+            "some.arbitrary.pkg , some.arbitrary.pkg             , true",
+            "some.arbitrary.pkg , some.thing.different           , false",
+            "some..pkg          , some.arbitrary.pkg             , true",
+            "some..middle..pkg  , some.arbitrary.middle.more.pkg , true",
+            "*..pkg             , some.arbitrary.pkg             , true",
+            "some..*            , some.arbitrary.pkg             , true",
+            "*..pkg             , some.arbitrary.pkg.toomuch     , false",
+            "toomuch.some..*    , some.arbitrary.pkg             , false",
+            "*..wrong           , some.arbitrary.pkg             , false",
+            "some..*            , wrong.arbitrary.pkg            , false",
+            "..some             , some                           , true",
+            "some..             , some                           , true",
+            "*..some            , some                           , false",
+            "some..*            , some                           , false",
+            "..some             , asome                          , false",
+            "some..             , somea                          , false",
+            "*.*.*              , wrong.arbitrary.pkg            , true",
+            "*.*.*              , wrong.arbitrary.pkg.toomuch    , false",
+            "some.arbi*.pk*..   , some.arbitrary.pkg.whatever    , true",
+            "some.arbi*..       , some.brbitrary.pkg             , false",
+            "some.*rary.*kg..   , some.arbitrary.pkg.whatever    , true",
+            "some.*rary..       , some.arbitrarz.pkg             , false",
+            "some.pkg           , someepkg                       , false",
+            "..pkg..            , some.random.pkg.maybe.anywhere , true",
+            "..p..              , s.r.p.m.a                      , true",
+            "*..pkg..*          , some.random.pkg.maybe.anywhere , true",
+            "*..p..*            , s.r.p.m.a                      , true",
+            "..[a|b|c].pk*..    , some.a.pkg.whatever            , true",
+            "..[b|c].pk*..      , some.a.pkg.whatever            , false",
+            "..[a|b*].pk*..     , some.bitrary.pkg.whatever      , true",
+            "..[a|b*].pk*..     , some.a.pkg.whatever            , true",
+            "..[a|b*].pk*..     , some.arbitrary.pkg.whatever    , false",
+            "..[*c*|*d*].pk*..  , some.anydinside.pkg.whatever   , true",
+            "..[*c*|*d*].pk*..  , some.nofit.pkg.whatever        , false",
+    })
     public void match(String matcher, String target, boolean matches) {
         assertThat(PackageMatcher.of(matcher).matches(target))
                 .as("package matches")
@@ -56,26 +65,35 @@ public class PackageMatcherTest {
 
     @Test
     @DataProvider(value = {
-            "some.(*).pkg | some.arbitrary.pkg | arbitrary",
-            "some.arb(*)ry.pkg | some.arbitrary.pkg | itra",
-            "some.arb(*)ry.pkg | some.arbit.rary.pkg | null",
-            "some.(*).matches.(*).pkg | some.first.matches.second.pkg | first:second",
-            "(*).matches.(*) | start.matches.end | start:end",
-            "(*).(*).(*).(*) | a.b.c.d | a:b:c:d",
-            "(*) | some | some",
-            "some.(*).pkg | some.in.between.pkg | null",
-            "some.(**).pkg | some.in.between.pkg | in.between",
-            "some.(**).pkg.(*) | some.in.between.pkg.addon | in.between:addon",
-            "some(**)pkg | somerandom.in.between.longpkg | random.in.between.long",
-            "some.(**).pkg | somer.in.between.pkg | null",
-            "some.(**).pkg | some.in.between.gpkg | null",
-            "so(*)me.(**)pkg.an(*).more | soinfme.in.between.gpkg.and.more | inf:in.between.g:d",
-            "so(*)me.(**)pkg.an(*).more | soinfme.in.between.gpkg.an.more | null",
-            "so(**)me | some | null",
-            "so(*)me | some | null",
-            "(**)so | awe.some.aso | awe.some.a",
-            "so(**) | soan.some.we | an.some.we",
-    }, splitBy = "\\|")
+            "some.(*).pkg , some.arbitrary.pkg , arbitrary",
+            "some.arb(*)ry.pkg , some.arbitrary.pkg , itra",
+            "some.arb(*)ry.pkg , some.arbit.rary.pkg , null",
+            "some.(*).matches.(*).pkg , some.first.matches.second.pkg , first:second",
+            "(*).matches.(*) , start.matches.end , start:end",
+            "(*).(*).(*).(*) , a.b.c.d , a:b:c:d",
+            "(*) , some , some",
+            "some.(*).pkg , some.in.between.pkg , null",
+            "some.(**).pkg , some.in.between.pkg , in.between",
+            "some.(**).pkg.(*) , some.in.between.pkg.addon , in.between:addon",
+            "some(**)pkg , somerandom.in.between.longpkg , random.in.between.long",
+            "some.(**).pkg , somer.in.between.pkg , null",
+            "some.(**).pkg , some.in.between.gpkg , null",
+            "so(*)me.(**)pkg.an(*).more , soinfme.in.between.gpkg.and.more , inf:in.between.g:d",
+            "so(*)me.(**)pkg.an(*).more , soinfme.in.between.gpkg.an.more , null",
+            "so(**)me , some , null",
+            "so(*)me , some , null",
+            "(**)so , awe.some.aso , awe.some.a",
+            "so(**) , soan.some.we , an.some.we",
+            "..(a|b).pk*.(c|d).. , some.a.pkg.d.whatever , a:d",
+            "..(a|b).[p|*g].(c|d).. , some.a.pkg.d.whatever , a:d",
+            "..[a|b|c].pk*.(c|d).. , some.c.pkg.d.whatever , d",
+            "..(a|b*|cd).pk*.(**).end , some.bitrary.pkg.in.between.end, bitrary:in.between",
+            "..(a.b|c.d).pk* , some.a.b.pkg , a.b",
+            "..[application|domain.*|infrastructure].(*).. , com.example.application.a.http , a",
+            "..[application|domain.*|infrastructure].(*).. , com.example.domain.api.a , a",
+            "..[application|domain.*|infrastructure].(*).. , com.example.domain.logic.a , a",
+            "..[application|domain.*|infrastructure].(*).. , com.example.infrastructure.a.file , a"
+    })
     public void capture_groups(String matcher, String target, String groupString) {
         assertThat(PackageMatcher.of(matcher).match(target).isPresent())
                 .as("'%s' matching '%s'", matcher, target)
@@ -111,6 +129,41 @@ public class PackageMatcherTest {
         thrown.expectMessage("Package Identifier does not support capturing via (..), use (**) instead");
 
         PackageMatcher.of("some.(..).package");
+    }
+
+    @Test
+    public void should_reject_non_alternating_alternatives() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Package Identifier does not allow alternation brackets '[]' without specifying any alternative via '|' inside");
+
+        PackageMatcher.of("some.[nonalternating].package");
+    }
+
+    @Test
+    public void should_reject_toplevel_alternations() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Package Identifier only supports '|' inside of '[]' or '()'");
+
+        PackageMatcher.of("some.pkg|other.pkg");
+    }
+
+    @DataProvider
+    public static Object[][] data_reject_nesting_of_groups() {
+        return testForEach(
+                "some.(pkg.(other).pkg)..",
+                "some.(pkg.[a|b].pkg)..",
+                "some.[inside.(pkg).it|other.(pkg).it].pkg",
+                "some.[inside.[a|b].it|other].pkg"
+        );
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_reject_nesting_of_groups(String packageIdentifier) {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Package Identifier does not support nesting '()' or '[]' within other '()' or '[]'");
+
+        PackageMatcher.of(packageIdentifier);
     }
 
     @Test


### PR DESCRIPTION
Adds the ability to define alternatives such as `(a|b)` in package identifiers. This allows to support architectures that for some reasons need a namespace for some components by using different packages even though they logically belong to the same architectural entity like a layer, domain, etc. This is especially useful if your code needs to satisfy some "overarching" structural requirements that come from outside your actual project, e.g. from an enterprise architecture.

* `pack.[a.c|b*].d` matches `pack.a.c.d` or `pack.bar.d`, but neither `pack.a.d` nor `pack.b.c.d`
* `..service.(a|b*)..` matches `a.service.bar.more` and group 1 would be `bar`
* Nested alternatives like `(?:..application.(*).*..)|(?:..domain.api|logic.(*)..)` are not allowed to keep the syntax of package identifiers simple and readable.

Resolves: #662