### PR TITLE
Add ci check for modified files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,15 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
+      - name: Check project files unmodified
+        run: |
+          directoryState="$(git status --porcelain)"
+          if [ -n "$directoryState" ]; then
+            echo "Some files were modified during build. Please run the build locally before checking in, as it ensures some source file conventions (like copyright header)."
+            echo "The following files were modified:"
+            echo "$directoryState"
+            exit 1
+          fi
 
   test:
     strategy:


### PR DESCRIPTION
During the build we ensure some conventions, e.g. that the respective copyright header is created on new files. If developers do not run the build locally and just create a PR we need to ensure that such files cannot pass the CI build. I.e. if at the end of the normal CI build we end up with modified files there are some files checked in that do not adhere to project conventions and are thus "fixed" during the CI run.