### PR TITLE
Add API to create ArchConditions from predicates

### DIFF
--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedNaming.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedNaming.java
@@ -19,20 +19,20 @@ public class ExpectedNaming {
         }
 
         public ExpectedMessage notStartingWith(String prefix) {
-            return expectedSimpleName(String.format("does not start with '%s'", prefix));
+            return expectedClassViolation(String.format("does not have simple name starting with '%s'", prefix));
         }
 
         public ExpectedMessage notEndingWith(String suffix) {
-            return expectedSimpleName(String.format("does not end with '%s'", suffix));
+            return expectedClassViolation(String.format("does not have simple name ending with '%s'", suffix));
         }
 
         public ExpectedMessage containing(String infix) {
-            return expectedSimpleName(String.format("contains '%s'", infix));
+            return expectedClassViolation(String.format("has simple name containing '%s'", infix));
         }
 
-        private ExpectedMessage expectedSimpleName(String suffix) {
-            return new ExpectedMessage(String.format("simple name of %s %s in (%s.java:0)",
-                    className, suffix, simpleName));
+        private ExpectedMessage expectedClassViolation(String description) {
+            return new ExpectedMessage(String.format("Class <%s> %s in (%s.java:0)",
+                    className, description, simpleName));
         }
     }
 }

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedViolation.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedViolation.java
@@ -137,12 +137,12 @@ public class ExpectedViolation {
         }
 
         public MessageAssertionChain.Link havingNameMatching(String regex) {
-            return MessageAssertionChain.containsLine("Class <%s> matches '%s' in (%s.java:0)",
+            return MessageAssertionChain.containsLine("Class <%s> has name matching '%s' in (%s.java:0)",
                     clazz.getName(), regex, clazz.getSimpleName());
         }
 
         public MessageAssertionChain.Link havingSimpleNameContaining(String infix) {
-            return MessageAssertionChain.containsLine("simple name of %s contains '%s' in (%s.java:0)",
+            return MessageAssertionChain.containsLine("Class <%s> has simple name containing '%s' in (%s.java:0)",
                     clazz.getName(), infix, clazz.getSimpleName());
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -84,7 +84,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * Convenience method to downcast the predicate. {@link DescribedPredicate DescribedPredicates} are contravariant by nature,
      * i.e. an {@code DescribedPredicate<T>} is an instance of {@code DescribedPredicate<V>}, if and only if {@code V} is an instance of {@code T}.
      * <br>
-     * Take for example {@code Object > String}. Obviously an {@code DescribedPredicate<Object>} is also a {@code DescribedPredicate<String>}.
+     * Take for example {@code Object > String}. Obviously a {@code DescribedPredicate<Object>} is also a {@code DescribedPredicate<String>}.
      * <br>
      * Unfortunately, the Java type system does not allow us to express this property of the type parameter of {@code DescribedPredicate}.
      * So to avoid forcing users to cast everywhere it is possible to use this method which also documents the intention and reasoning.

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -51,6 +51,19 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
         return description;
     }
 
+    /**
+     * Overwrites the description of this {@link DescribedPredicate}. E.g.
+     *
+     * <pre><code>
+     * classes().that(predicate.as("some customized description with '%s'", "parameter")).should().bePublic()
+     * </code></pre>
+     *
+     * would then yield {@code classes that some customized description with 'parameter' should be public}.
+     *
+     * @param description The new description of this {@link DescribedPredicate}
+     * @param params Optional arguments to fill into the description via {@link String#format(String, Object...)}
+     * @return An {@link DescribedPredicate} with adjusted {@link #getDescription() description}.
+     */
     public DescribedPredicate<T> as(String description, Object... params) {
         return new AsPredicate<>(this, description, params);
     }
@@ -68,7 +81,16 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     }
 
     /**
-     * Workaround for the limitations of the Java type system {@code ->} Can't specify this contravariant type at the language level
+     * Convenience method to downcast the predicate. {@link DescribedPredicate DescribedPredicates} are contravariant by nature,
+     * i.e. an {@code DescribedPredicate<T>} is an instance of {@code DescribedPredicate<V>}, if and only if {@code V} is an instance of {@code T}.
+     * <br>
+     * Take for example {@code Object > String}. Obviously an {@code DescribedPredicate<Object>} is also a {@code DescribedPredicate<String>}.
+     * <br>
+     * Unfortunately, the Java type system does not allow us to express this property of the type parameter of {@code DescribedPredicate}.
+     * So to avoid forcing users to cast everywhere it is possible to use this method which also documents the intention and reasoning.
+     *
+     * @return A {@link DescribedPredicate} accepting a subtype of the predicate's actual type parameter {@code T}
+     * @param <U> A subtype of the {@link DescribedPredicate DescribedPredicate's} type parameter {@code T}
      */
     @SuppressWarnings("unchecked") // DescribedPredicate is contravariant
     public final <U extends T> DescribedPredicate<U> forSubtype() {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
@@ -63,6 +63,19 @@ public abstract class ArchCondition<T> {
         return description;
     }
 
+    /**
+     * Overwrites the description of this {@link ArchCondition}. E.g.
+     *
+     * <pre><code>
+     * classes().should(condition.as("some customized description with '%s'", "parameter"))
+     * </code></pre>
+     *
+     * would then yield {@code classes should some customized description with 'parameter'}.
+     *
+     * @param description The new description of this {@link ArchCondition}
+     * @param args Optional arguments to fill into the description via {@link String#format(String, Object...)}
+     * @return An {@link ArchCondition} with adjusted {@link #getDescription() description}.
+     */
     public ArchCondition<T> as(String description, Object... args) {
         return new ArchCondition<T>(description, args) {
             @Override
@@ -87,6 +100,18 @@ public abstract class ArchCondition<T> {
         return getDescription();
     }
 
+    /**
+     * Convenience method to downcast the condition. {@link ArchCondition ArchConditions} are contravariant by nature,
+     * i.e. an {@code ArchCondition<T>} is an instance of {@code ArchCondition<V>}, if and only if {@code V} is an instance of {@code T}.
+     * <br>
+     * Take for example {@code Object > String}. Obviously an {@code ArchCondition<Object>} is also an {@code ArchCondition<String>}.
+     * <br>
+     * Unfortunately, the Java type system does not allow us to express this property of the type parameter of {@code ArchCondition}.
+     * So to avoid forcing users to cast everywhere it is possible to use this method which also documents the intention and reasoning.
+     *
+     * @return An {@link ArchCondition} accepting a subtype of the condition's actual type parameter {@code T}
+     * @param <U> A subtype of the {@link ArchCondition ArchCondition's} type parameter {@code T}
+     */
     @SuppressWarnings("unchecked") // Cast is safe since input parameter is contravariant
     public <U extends T> ArchCondition<U> forSubtype() {
         return (ArchCondition<U>) this;

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchCondition.java
@@ -18,9 +18,15 @@ package com.tngtech.archunit.lang;
 import java.util.Collection;
 
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
 
 @PublicAPI(usage = INHERITANCE)
 public abstract class ArchCondition<T> {
@@ -115,5 +121,110 @@ public abstract class ArchCondition<T> {
     @SuppressWarnings("unchecked") // Cast is safe since input parameter is contravariant
     public <U extends T> ArchCondition<U> forSubtype() {
         return (ArchCondition<U>) this;
+    }
+
+    /**
+     * Creates an {@link ArchCondition} from a {@link DescribedPredicate}.
+     * For more information see {@link ConditionByPredicate ConditionByPredicate}.
+     * For more convenient versions of this method compare {@link ArchConditions#have(DescribedPredicate)} and {@link ArchConditions#be(DescribedPredicate)}.
+     *
+     * @param predicate Specifies which objects satisfy the condition.
+     * @return A {@link ConditionByPredicate ConditionByPredicate} derived from the supplied {@link DescribedPredicate predicate}
+     * @param <T> The type of object the {@link ArchCondition condition} will check
+     *
+     * @see ArchConditions#have(DescribedPredicate)
+     * @see ArchConditions#be(DescribedPredicate)
+     */
+    @PublicAPI(usage = ACCESS)
+    public static <T extends HasDescription & HasSourceCodeLocation> ConditionByPredicate<T> from(DescribedPredicate<? super T> predicate) {
+        return new ConditionByPredicate<>(predicate);
+    }
+
+    /**
+     * An {@link ArchCondition} that derives which objects satisfy/violate the condition from a {@link DescribedPredicate}.
+     * The description is taken from the defining {@link DescribedPredicate predicate} but can be overridden via {@link #as(String, Object...)}.
+     * How the message of each single {@link ConditionEvent event} is derived can be customized by {@link #describeEventsBy(EventDescriber)}.
+     *
+     * @param <T> The type of object the condition will test
+     */
+    @PublicAPI(usage = ACCESS)
+    public static final class ConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
+        private final DescribedPredicate<T> predicate;
+        private final EventDescriber eventDescriber;
+
+        private ConditionByPredicate(DescribedPredicate<? super T> predicate) {
+            this(predicate, predicate.getDescription(), ((predicateDescription, satisfied) -> (satisfied ? "satisfies " : "does not satisfy ") + predicateDescription));
+        }
+
+        private ConditionByPredicate(
+                DescribedPredicate<? super T> predicate,
+                String description,
+                EventDescriber eventDescriber
+        ) {
+            super(description);
+            this.predicate = predicate.forSubtype();
+            this.eventDescriber = eventDescriber;
+        }
+
+        /**
+         * Adjusts how this {@link ConditionByPredicate condition} will create the description of the {@link ConditionEvent events}.
+         * E.g. assume the {@link DescribedPredicate predicate} of this condition is {@link JavaClass.Predicates#simpleName(String) simpleName(name)},
+         * then this method could be used to adjust the event description as
+         *
+         * <pre><code>
+         * condition.describeEventsBy((predicateDescription, satisfied) ->
+         *     (satisfied ? "has " : "does not have ") + predicateDescription
+         * )</code></pre>
+         *
+         * @param eventDescriber Specifies how to create the description of the {@link ConditionEvent}
+         *                       whenever the predicate is evaluated against an object.
+         * @return A {@link ConditionByPredicate ConditionByPredicate} that describes its {@link ConditionEvent events} with the given {@link EventDescriber EventDescriber}
+         */
+        @PublicAPI(usage = ACCESS)
+        public ConditionByPredicate<T> describeEventsBy(EventDescriber eventDescriber) {
+            return new ConditionByPredicate<>(
+                    predicate,
+                    getDescription(),
+                    eventDescriber
+            );
+        }
+
+        @Override
+        public ConditionByPredicate<T> as(String description, Object... args) {
+            return new ConditionByPredicate<>(predicate, String.format(description, args), eventDescriber);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked") // Cast is safe since input parameter is contravariant
+        public <U extends T> ConditionByPredicate<U> forSubtype() {
+            return (ConditionByPredicate<U>) this;
+        }
+
+        @Override
+        public void check(T object, ConditionEvents events) {
+            boolean satisfied = predicate.test(object);
+            String message = createMessage(object, eventDescriber.describe(predicate.getDescription(), satisfied));
+            events.add(new SimpleConditionEvent(object, satisfied, message));
+        }
+
+        /**
+         * Defines how to describe a single {@link ConditionEvent}. E.g. how to describe the concrete violation of some class
+         * {@code com.Example} that violates the {@link ConditionByPredicate}.
+         */
+        @FunctionalInterface
+        @PublicAPI(usage = INHERITANCE)
+        public interface EventDescriber {
+            /**
+             * Describes a {@link ConditionEvent} created by {@link ConditionByPredicate ConditionByPredicate},
+             * given the description of the defining predicate and whether the predicate was satisfied.<br>
+             * For example, if the defining {@link DescribedPredicate} would be {@link JavaClass.Predicates#simpleName(String)}, then
+             * the created description could be {@code (satisfied ? "has " : "does not have ") + predicateDescription}.
+             *
+             * @param predicateDescription The description of the {@link DescribedPredicate} defining the {@link ConditionByPredicate ConditionByPredicate}
+             * @param satisfied Whether the object tested by the {@link ConditionByPredicate ConditionByPredicate} satisfied the condition
+             * @return The description of the {@link ConditionEvent} to be created
+             */
+            String describe(String predicateDescription, boolean satisfied);
+        }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -729,7 +729,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             Class<? extends Annotation> type) {
-        return new IsConditionByPredicate<>(annotatedWith(type));
+        return new BeConditionByPredicate<>(annotatedWith(type));
     }
 
     /**
@@ -747,7 +747,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             String typeName) {
-        return new IsConditionByPredicate<>(annotatedWith(typeName));
+        return new BeConditionByPredicate<>(annotatedWith(typeName));
     }
 
     /**
@@ -765,7 +765,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        return new IsConditionByPredicate<>(annotatedWith(predicate));
+        return new BeConditionByPredicate<>(annotatedWith(predicate));
     }
 
     /**
@@ -783,7 +783,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             Class<? extends Annotation> type) {
-        return new IsConditionByPredicate<>(metaAnnotatedWith(type));
+        return new BeConditionByPredicate<>(metaAnnotatedWith(type));
     }
 
     /**
@@ -801,7 +801,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             String typeName) {
-        return new IsConditionByPredicate<>(metaAnnotatedWith(typeName));
+        return new BeConditionByPredicate<>(metaAnnotatedWith(typeName));
     }
 
     /**
@@ -819,7 +819,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        return new IsConditionByPredicate<>(metaAnnotatedWith(predicate));
+        return new BeConditionByPredicate<>(metaAnnotatedWith(predicate));
     }
 
     /**
@@ -884,7 +884,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(Class<?> type) {
-        return new IsConditionByPredicate<>(assignableTo(type));
+        return new BeConditionByPredicate<>(assignableTo(type));
     }
 
     /**
@@ -900,7 +900,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(String typeName) {
-        return new IsConditionByPredicate<>(assignableTo(typeName));
+        return new BeConditionByPredicate<>(assignableTo(typeName));
     }
 
     /**
@@ -916,7 +916,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(DescribedPredicate<? super JavaClass> predicate) {
-        return new IsConditionByPredicate<>(assignableTo(predicate));
+        return new BeConditionByPredicate<>(assignableTo(predicate));
     }
 
     /**
@@ -932,7 +932,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(Class<?> type) {
-        return new IsConditionByPredicate<>(assignableFrom(type));
+        return new BeConditionByPredicate<>(assignableFrom(type));
     }
 
     /**
@@ -948,7 +948,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(String typeName) {
-        return new IsConditionByPredicate<>(assignableFrom(typeName));
+        return new BeConditionByPredicate<>(assignableFrom(typeName));
     }
 
     /**
@@ -964,7 +964,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(DescribedPredicate<? super JavaClass> predicate) {
-        return new IsConditionByPredicate<>(assignableFrom(predicate));
+        return new BeConditionByPredicate<>(assignableFrom(predicate));
     }
 
     /**
@@ -1142,7 +1142,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaMember> beDeclaredIn(Class<?> owner) {
-        return new IsConditionByPredicate<>(declaredIn(owner));
+        return new BeConditionByPredicate<>(declaredIn(owner));
     }
 
     /**
@@ -1159,7 +1159,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaMember> beDeclaredIn(String ownerTypeName) {
-        return new IsConditionByPredicate<>(declaredIn(ownerTypeName));
+        return new BeConditionByPredicate<>(declaredIn(ownerTypeName));
     }
 
     /**
@@ -1177,7 +1177,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaMember> beDeclaredInClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         DescribedPredicate<JavaMember> declaredIn = declaredIn(
                 predicate.as("classes that " + predicate.getDescription()));
-        return new IsConditionByPredicate<>(declaredIn);
+        return new BeConditionByPredicate<>(declaredIn);
     }
 
     /**
@@ -1282,18 +1282,18 @@ public final class ArchConditions {
                 origin.is(constructor().and(predicate)), GET_CALLS_OF_SELF);
     }
 
-    private static final IsConditionByPredicate<JavaClass> BE_TOP_LEVEL_CLASSES =
-            new IsConditionByPredicate<>("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
-    private static final IsConditionByPredicate<JavaClass> BE_NESTED_CLASSES =
-            new IsConditionByPredicate<>("a nested class", JavaClass.Predicates.NESTED_CLASSES);
-    private static final IsConditionByPredicate<JavaClass> BE_MEMBER_CLASSES =
-            new IsConditionByPredicate<>("a member class", JavaClass.Predicates.MEMBER_CLASSES);
-    private static final IsConditionByPredicate<JavaClass> BE_INNER_CLASSES =
-            new IsConditionByPredicate<>("an inner class", JavaClass.Predicates.INNER_CLASSES);
-    private static final IsConditionByPredicate<JavaClass> BE_ANONYMOUS_CLASSES =
-            new IsConditionByPredicate<>("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
-    private static final IsConditionByPredicate<JavaClass> BE_LOCAL_CLASSES =
-            new IsConditionByPredicate<>("a local class", JavaClass.Predicates.LOCAL_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_TOP_LEVEL_CLASSES =
+            new BeConditionByPredicate<>("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_NESTED_CLASSES =
+            new BeConditionByPredicate<>("a nested class", JavaClass.Predicates.NESTED_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_MEMBER_CLASSES =
+            new BeConditionByPredicate<>("a member class", JavaClass.Predicates.MEMBER_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_INNER_CLASSES =
+            new BeConditionByPredicate<>("an inner class", JavaClass.Predicates.INNER_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_ANONYMOUS_CLASSES =
+            new BeConditionByPredicate<>("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
+    private static final BeConditionByPredicate<JavaClass> BE_LOCAL_CLASSES =
+            new BeConditionByPredicate<>("a local class", JavaClass.Predicates.LOCAL_CLASSES);
 
     private static class HaveOnlyModifiersCondition<T extends HasModifiers & HasDescription & HasSourceCodeLocation>
             extends AllAttributesMatchCondition<T, JavaClass> {
@@ -1617,15 +1617,15 @@ public final class ArchConditions {
         }
     }
 
-    private static class IsConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
+    private static class BeConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
         private final String eventDescription;
         private final DescribedPredicate<T> predicate;
 
-        IsConditionByPredicate(DescribedPredicate<? super T> predicate) {
+        BeConditionByPredicate(DescribedPredicate<? super T> predicate) {
             this(predicate.getDescription(), predicate);
         }
 
-        IsConditionByPredicate(String eventDescription, DescribedPredicate<? super T> predicate) {
+        BeConditionByPredicate(String eventDescription, DescribedPredicate<? super T> predicate) {
             super(ArchPredicates.be(predicate).getDescription());
             this.eventDescription = eventDescription;
             this.predicate = predicate.forSubtype();

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -60,6 +60,7 @@ import com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With;
 import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.core.domain.properties.HasThrowsClause;
 import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchCondition.ConditionByPredicate;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.conditions.ClassAccessesFieldCondition.ClassGetsFieldCondition;
@@ -86,6 +87,15 @@ import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELDS;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_FIELD_ACCESSES_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_METHOD_CALLS_FROM_SELF;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ANONYMOUS_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.ENUMS;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INNER_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.INTERFACES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.LOCAL_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.MEMBER_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.NESTED_CLASSES;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.RECORDS;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.TOP_LEVEL_CLASSES;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableFrom;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
@@ -117,8 +127,6 @@ import static com.tngtech.archunit.core.domain.properties.HasParameterTypes.Pred
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Predicates.rawReturnType;
 import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predicates.throwsClauseContainingType;
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
-import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
-import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 import static java.util.Arrays.asList;
 
 public final class ArchConditions {
@@ -459,7 +467,9 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> be(final String className) {
-        return new BeClassCondition(className);
+        return be(fullyQualifiedName(className).as(className))
+                .describeEventsBy((__, satisfied) -> (satisfied ? "is " : "is not ") + className)
+                .forSubtype();
     }
 
     @PublicAPI(usage = ACCESS)
@@ -469,29 +479,29 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveName(final String name) {
-        return new HaveConditionByPredicate<>(name(name));
+        return have(name(name));
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> notHaveName(String name) {
-        return not(ArchConditions.haveName(name));
+        return not(haveName(name));
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
     ArchCondition<HAS_FULL_NAME> haveFullName(String fullName) {
-        return new HaveConditionByPredicate<>(fullName(fullName));
+        return have(fullName(fullName));
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
     ArchCondition<HAS_FULL_NAME> notHaveFullName(String fullName) {
-        return not(new HaveConditionByPredicate<>(fullName(fullName)));
+        return not(haveFullName(fullName));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveFullyQualifiedName(final String name) {
-        return new HaveConditionByPredicate<>(fullyQualifiedName(name));
+        return have(fullyQualifiedName(name));
     }
 
     @Internal
@@ -507,8 +517,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleName(final String name) {
-        final DescribedPredicate<JavaClass> haveSimpleName = have(simpleName(name));
-        return new SimpleNameCondition(haveSimpleName, name);
+        return have(simpleName(name));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -518,9 +527,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameStartingWith(final String prefix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameStartingWith(prefix));
-
-        return new SimpleNameStartingWithCondition(predicate, prefix);
+        return have(simpleNameStartingWith(prefix));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -530,9 +537,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameContaining(final String infix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameContaining(infix));
-
-        return new SimpleNameContainingCondition(predicate, infix);
+        return have(simpleNameContaining(infix));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -542,9 +547,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> haveSimpleNameEndingWith(final String suffix) {
-        final DescribedPredicate<JavaClass> predicate = have(simpleNameEndingWith(suffix));
-
-        return new SimpleNameEndingWithCondition(predicate, suffix);
+        return have(simpleNameEndingWith(suffix));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -554,8 +557,7 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameMatching(final String regex) {
-        final DescribedPredicate<HAS_NAME> haveNameMatching = have(nameMatching(regex)).forSubtype();
-        return new MatchingCondition<>(haveNameMatching, regex);
+        return have(nameMatching(regex));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -566,8 +568,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_FULL_NAME extends HasName.AndFullName & HasDescription & HasSourceCodeLocation>
     ArchCondition<HAS_FULL_NAME> haveFullNameMatching(String regex) {
-        final DescribedPredicate<HAS_FULL_NAME> haveFullNameMatching = have(fullNameMatching(regex)).forSubtype();
-        return new MatchingCondition<>(haveFullNameMatching, regex);
+        return have(fullNameMatching(regex));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -577,71 +578,59 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameStartingWith(String prefix) {
-        final DescribedPredicate<HAS_NAME> haveNameStartingWith = have(nameStartingWith(prefix)).forSubtype();
-        return new StartingCondition<>(haveNameStartingWith, prefix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameStartingWith(String prefix) {
+        return have(nameStartingWith(prefix));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameNotStartingWith(String prefix) {
-        final DescribedPredicate<HAS_NAME> haveNameStartingWith = have(nameStartingWith(prefix)).forSubtype();
-        return not(new StartingCondition<>(haveNameStartingWith, prefix)).as("have name not starting with '%s'", prefix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameNotStartingWith(String prefix) {
+        return not(haveNameStartingWith(prefix)).<HAS_NAME>forSubtype().as("have name not starting with '%s'", prefix);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameContaining(String infix) {
-        final DescribedPredicate<HAS_NAME> haveNameContaining = have(nameContaining(infix)).forSubtype();
-        return new ContainingCondition<>(haveNameContaining, infix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameContaining(String infix) {
+        return have(nameContaining(infix));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameNotContaining(String infix) {
-        final DescribedPredicate<HAS_NAME> haveNameContaining = have(nameContaining(infix)).forSubtype();
-        return not(new ContainingCondition<>(haveNameContaining, infix)).as("have name not containing '%s'", infix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameNotContaining(String infix) {
+        return not(haveNameContaining(infix)).<HAS_NAME>forSubtype().as("have name not containing '%s'", infix);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameEndingWith(String suffix) {
-        final DescribedPredicate<HAS_NAME> haveNameEndingWith = have(nameEndingWith(suffix)).forSubtype();
-        return new EndingCondition<>(haveNameEndingWith, suffix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameEndingWith(String suffix) {
+        return have(nameEndingWith(suffix));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME>
-    haveNameNotEndingWith(String suffix) {
-        final DescribedPredicate<HAS_NAME> haveNameEndingWith = have(nameEndingWith(suffix)).forSubtype();
-        return not(new EndingCondition<>(haveNameEndingWith, suffix)).as("have name not ending with '%s'", suffix);
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameNotEndingWith(String suffix) {
+        return not(haveNameEndingWith(suffix)).<HAS_NAME>forSubtype().as("have name not ending with '%s'", suffix);
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> resideInAPackage(final String packageIdentifier) {
-        return new DoesConditionByPredicate<>(JavaClass.Predicates.resideInAPackage(packageIdentifier));
+        return does(JavaClass.Predicates.resideInAPackage(packageIdentifier));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> resideInAnyPackage(String... packageIdentifiers) {
-        return new DoesConditionByPredicate<>(JavaClass.Predicates.resideInAnyPackage(packageIdentifiers));
+        return does(JavaClass.Predicates.resideInAnyPackage(packageIdentifiers));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> resideOutsideOfPackage(String packageIdentifier) {
-        return new DoesConditionByPredicate<>(JavaClass.Predicates.resideOutsideOfPackage(packageIdentifier));
+        return does(JavaClass.Predicates.resideOutsideOfPackage(packageIdentifier));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> resideOutsideOfPackages(String... packageIdentifiers) {
-        return new DoesConditionByPredicate<>(JavaClass.Predicates.resideOutsideOfPackages(packageIdentifiers));
+        return does(JavaClass.Predicates.resideOutsideOfPackages(packageIdentifiers));
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_MODIFIERS extends HasModifiers & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_MODIFIERS> haveModifier(
             final JavaModifier modifier) {
-        return new HaveConditionByPredicate<>(modifier(modifier));
+        return have(modifier(modifier));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -729,7 +718,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             Class<? extends Annotation> type) {
-        return new BeConditionByPredicate<>(annotatedWith(type));
+        return be(annotatedWith(type));
     }
 
     /**
@@ -747,7 +736,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             String typeName) {
-        return new BeConditionByPredicate<>(annotatedWith(typeName));
+        return be(annotatedWith(typeName));
     }
 
     /**
@@ -765,7 +754,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
             final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        return new BeConditionByPredicate<>(annotatedWith(predicate));
+        return be(annotatedWith(predicate));
     }
 
     /**
@@ -783,7 +772,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             Class<? extends Annotation> type) {
-        return new BeConditionByPredicate<>(metaAnnotatedWith(type));
+        return be(metaAnnotatedWith(type));
     }
 
     /**
@@ -801,7 +790,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             String typeName) {
-        return new BeConditionByPredicate<>(metaAnnotatedWith(typeName));
+        return be(metaAnnotatedWith(typeName));
     }
 
     /**
@@ -819,7 +808,7 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
             final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        return new BeConditionByPredicate<>(metaAnnotatedWith(predicate));
+        return be(metaAnnotatedWith(predicate));
     }
 
     /**
@@ -836,7 +825,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(Class<?> interfaceType) {
-        return new ImplementsCondition(JavaClass.Predicates.implement(interfaceType));
+        return does(JavaClass.Predicates.implement(interfaceType));
     }
 
     /**
@@ -852,7 +841,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(String interfaceTypeName) {
-        return new ImplementsCondition(JavaClass.Predicates.implement(interfaceTypeName));
+        return does(JavaClass.Predicates.implement(interfaceTypeName));
     }
 
     /**
@@ -868,7 +857,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> implement(DescribedPredicate<? super JavaClass> predicate) {
-        return new ImplementsCondition(JavaClass.Predicates.implement(predicate));
+        return does(JavaClass.Predicates.implement(predicate));
     }
 
     /**
@@ -884,7 +873,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(Class<?> type) {
-        return new BeConditionByPredicate<>(assignableTo(type));
+        return be(assignableTo(type));
     }
 
     /**
@@ -900,7 +889,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(String typeName) {
-        return new BeConditionByPredicate<>(assignableTo(typeName));
+        return be(assignableTo(typeName));
     }
 
     /**
@@ -916,7 +905,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableTo(DescribedPredicate<? super JavaClass> predicate) {
-        return new BeConditionByPredicate<>(assignableTo(predicate));
+        return be(assignableTo(predicate));
     }
 
     /**
@@ -932,7 +921,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(Class<?> type) {
-        return new BeConditionByPredicate<>(assignableFrom(type));
+        return be(assignableFrom(type));
     }
 
     /**
@@ -948,7 +937,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(String typeName) {
-        return new BeConditionByPredicate<>(assignableFrom(typeName));
+        return be(assignableFrom(typeName));
     }
 
     /**
@@ -964,7 +953,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beAssignableFrom(DescribedPredicate<? super JavaClass> predicate) {
-        return new BeConditionByPredicate<>(assignableFrom(predicate));
+        return be(assignableFrom(predicate));
     }
 
     /**
@@ -981,7 +970,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beInterfaces() {
-        return InterfacesCondition.BE_INTERFACES;
+        return be(INTERFACES).describeEventsBy((__, satisfied) -> (satisfied ? "is an" : "is no") + " interface");
     }
 
     /**
@@ -989,7 +978,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeInterfaces() {
-        return not(InterfacesCondition.BE_INTERFACES);
+        return not(beInterfaces());
     }
 
     /**
@@ -998,7 +987,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beEnums() {
-        return EnumsCondition.BE_ENUMS;
+        return be(ENUMS).describeEventsBy((__, satisfied) -> (satisfied ? "is an" : "is no") + " enum");
     }
 
     /**
@@ -1006,7 +995,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeEnums() {
-        return not(EnumsCondition.BE_ENUMS);
+        return not(beEnums());
     }
 
     /**
@@ -1016,7 +1005,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> beRecords() {
-        return RecordsCondition.BE_RECORDS;
+        return be(RECORDS).describeEventsBy((__, satisfied) -> (satisfied ? "is a" : "is no") + " record");
     }
 
     /**
@@ -1024,7 +1013,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notBeRecords() {
-        return not(RecordsCondition.BE_RECORDS);
+        return not(beRecords());
     }
 
     /**
@@ -1142,7 +1131,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaMember> beDeclaredIn(Class<?> owner) {
-        return new BeConditionByPredicate<>(declaredIn(owner));
+        return be(declaredIn(owner));
     }
 
     /**
@@ -1159,7 +1148,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaMember> beDeclaredIn(String ownerTypeName) {
-        return new BeConditionByPredicate<>(declaredIn(ownerTypeName));
+        return be(declaredIn(ownerTypeName));
     }
 
     /**
@@ -1177,7 +1166,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaMember> beDeclaredInClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         DescribedPredicate<JavaMember> declaredIn = declaredIn(
                 predicate.as("classes that " + predicate.getDescription()));
-        return new BeConditionByPredicate<>(declaredIn);
+        return be(declaredIn);
     }
 
     /**
@@ -1187,7 +1176,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaField> haveRawType(Class<?> type) {
-        return new HaveConditionByPredicate<>(rawType(type));
+        return have(rawType(type));
     }
 
     /**
@@ -1195,7 +1184,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaField> haveRawType(String typeName) {
-        return new HaveConditionByPredicate<>(rawType(typeName));
+        return have(rawType(typeName));
     }
 
     /**
@@ -1203,37 +1192,37 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaField> haveRawType(DescribedPredicate<? super JavaClass> predicate) {
-        return new HaveConditionByPredicate<>(rawType(predicate));
+        return have(rawType(predicate));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawParameterTypes(Class<?>... parameterTypes) {
-        return new HaveConditionByPredicate<>(rawParameterTypes(parameterTypes));
+        return have(rawParameterTypes(parameterTypes));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawParameterTypes(String... parameterTypeNames) {
-        return new HaveConditionByPredicate<>(rawParameterTypes(parameterTypeNames));
+        return have(rawParameterTypes(parameterTypeNames));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
-        return new HaveConditionByPredicate<>(rawParameterTypes(predicate));
+        return have(rawParameterTypes(predicate));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawReturnType(Class<?> type) {
-        return new HaveConditionByPredicate<>(rawReturnType(type));
+        return have(rawReturnType(type));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawReturnType(String typeName) {
-        return new HaveConditionByPredicate<>(rawReturnType(typeName));
+        return have(rawReturnType(typeName));
     }
 
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaCodeUnit> haveRawReturnType(DescribedPredicate<? super JavaClass> predicate) {
-        return new HaveConditionByPredicate<>(rawReturnType(predicate));
+        return have(rawReturnType(predicate));
     }
 
     @PublicAPI(usage = ACCESS)
@@ -1250,7 +1239,7 @@ public final class ArchConditions {
     public static ArchCondition<JavaCodeUnit> declareThrowableOfType(DescribedPredicate<? super JavaClass> predicate) {
         DescribedPredicate<HasThrowsClause<?>> declareThrowableOfType = throwsClauseContainingType(predicate)
                 .as("declare throwable of type " + predicate.getDescription());
-        return new DoesConditionByPredicate<>(declareThrowableOfType);
+        return does(declareThrowableOfType);
     }
 
     @PublicAPI(usage = ACCESS)
@@ -1282,18 +1271,56 @@ public final class ArchConditions {
                 origin.is(constructor().and(predicate)), GET_CALLS_OF_SELF);
     }
 
-    private static final BeConditionByPredicate<JavaClass> BE_TOP_LEVEL_CLASSES =
-            new BeConditionByPredicate<>("a top level class", JavaClass.Predicates.TOP_LEVEL_CLASSES);
-    private static final BeConditionByPredicate<JavaClass> BE_NESTED_CLASSES =
-            new BeConditionByPredicate<>("a nested class", JavaClass.Predicates.NESTED_CLASSES);
-    private static final BeConditionByPredicate<JavaClass> BE_MEMBER_CLASSES =
-            new BeConditionByPredicate<>("a member class", JavaClass.Predicates.MEMBER_CLASSES);
-    private static final BeConditionByPredicate<JavaClass> BE_INNER_CLASSES =
-            new BeConditionByPredicate<>("an inner class", JavaClass.Predicates.INNER_CLASSES);
-    private static final BeConditionByPredicate<JavaClass> BE_ANONYMOUS_CLASSES =
-            new BeConditionByPredicate<>("an anonymous class", JavaClass.Predicates.ANONYMOUS_CLASSES);
-    private static final BeConditionByPredicate<JavaClass> BE_LOCAL_CLASSES =
-            new BeConditionByPredicate<>("a local class", JavaClass.Predicates.LOCAL_CLASSES);
+    /**
+     * Derives an {@link ArchCondition} from a {@link DescribedPredicate}. Similar to {@link ArchCondition#from(DescribedPredicate)},
+     * but more conveniently creates a message to be used within a 'have'-sentence.
+     * <br>
+     * Take e.g. {@code have(simpleName("Demo"))}, then the condition description would be {@code "have simple name 'Demo'"},
+     * each satisfied event would be described as {@code "Class <some.Example> has simple name 'Demo' in (Example.java:0)"}
+     * and each violated one as {@code "Class <some.Example> does not have simple name 'Demo' in (Example.java:0)"}.
+     *
+     * @param predicate The predicate determining which objects satisfy/violate the condition
+     * @return A {@link ConditionByPredicate ConditionByPredicate} derived from the predicate and with 'have'-descriptions
+     * @param <T> The type of object the condition will test, e.g. a {@link JavaClass}
+     */
+    @PublicAPI(usage = ACCESS)
+    public static <T extends HasDescription & HasSourceCodeLocation> ConditionByPredicate<T> have(DescribedPredicate<? super T> predicate) {
+        return ArchCondition.from(predicate.<T>forSubtype())
+                .as(ArchPredicates.have(predicate).getDescription())
+                .describeEventsBy((predicateDescription, satisfied) -> (satisfied ? "has " : "does not have ") + predicateDescription);
+    }
+
+    /**
+     * Derives an {@link ArchCondition} from a {@link DescribedPredicate}. Similar to {@link ArchCondition#from(DescribedPredicate)},
+     * but more conveniently creates a message to be used within a 'be'-sentence.
+     * <br>
+     * Take e.g. {@code be(assignableTo(Demo.class))}, then the condition description would be {@code "be assignable to com.example.Demo"},
+     * each satisfied event would be described as {@code "Class <some.Example> is assignable to com.example.Demo in (Example.java:0)"}
+     * and each violated one as {@code "Class <some.Example> is not assignable to com.example.Demo in (Example.java:0)"}.
+     *
+     * @param predicate The predicate determining which objects satisfy/violate the condition
+     * @return A {@link ConditionByPredicate ConditionByPredicate} derived from the predicate and with 'be'-descriptions
+     * @param <T> The type of object the condition will test, e.g. a {@link JavaClass}
+     */
+    @PublicAPI(usage = ACCESS)
+    public static <T extends HasDescription & HasSourceCodeLocation> ConditionByPredicate<T> be(DescribedPredicate<? super T> predicate) {
+        return ArchCondition.from(predicate.<T>forSubtype())
+                .as(ArchPredicates.be(predicate).getDescription())
+                .describeEventsBy((predicateDescription, satisfied) -> (satisfied ? "is " : "is not ") + predicateDescription);
+    }
+
+    private static final ArchCondition<JavaClass> BE_TOP_LEVEL_CLASSES =
+            be(TOP_LEVEL_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is a" : "is no") + " top level class");
+    private static final ArchCondition<JavaClass> BE_NESTED_CLASSES =
+            be(NESTED_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is a" : "is no") + " nested class");
+    private static final ArchCondition<JavaClass> BE_MEMBER_CLASSES =
+            be(MEMBER_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is a" : "is no") + " member class");
+    private static final ArchCondition<JavaClass> BE_INNER_CLASSES =
+            be(INNER_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is an" : "is no") + " inner class");
+    private static final ArchCondition<JavaClass> BE_ANONYMOUS_CLASSES =
+            be(ANONYMOUS_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is an" : "is no") + " anonymous class");
+    private static final ArchCondition<JavaClass> BE_LOCAL_CLASSES =
+            be(LOCAL_CLASSES).describeEventsBy((__, satisfied) -> (satisfied ? "is a" : "is no") + " local class");
 
     private static class HaveOnlyModifiersCondition<T extends HasModifiers & HasDescription & HasSourceCodeLocation>
             extends AllAttributesMatchCondition<T, JavaClass> {
@@ -1301,96 +1328,13 @@ public final class ArchConditions {
         private final Function<JavaClass, ? extends Collection<T>> getHasModifiers;
 
         HaveOnlyModifiersCondition(String description, final JavaModifier modifier, Function<JavaClass, ? extends Collection<T>> getHasModifiers) {
-            super("have only " + description, new ModifierCondition<>(modifier));
+            super("have only " + description, be(modifier(modifier).as(modifier.toString().toLowerCase())));
             this.getHasModifiers = getHasModifiers;
         }
 
         @Override
         Collection<T> relevantAttributes(JavaClass javaClass) {
             return getHasModifiers.apply(javaClass);
-        }
-    }
-
-    private static class ModifierCondition<T extends HasModifiers & HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final JavaModifier modifier;
-
-        ModifierCondition(JavaModifier modifier) {
-            super("modifier " + modifier);
-            this.modifier = modifier;
-        }
-
-        @Override
-        public void check(T hasModifiers, ConditionEvents events) {
-            boolean satisfied = hasModifiers.getModifiers().contains(modifier);
-            String infix = (satisfied ? "is " : "is not ") + modifier.toString().toLowerCase();
-            events.add(new SimpleConditionEvent(hasModifiers, satisfied, createMessage(hasModifiers, infix)));
-        }
-    }
-
-    private static class ImplementsCondition extends ArchCondition<JavaClass> {
-        private final DescribedPredicate<? super JavaClass> implement;
-
-        ImplementsCondition(DescribedPredicate<? super JavaClass> implement) {
-            super(implement.getDescription());
-            this.implement = implement;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean satisfied = implement.test(javaClass);
-            String description = satisfied
-                    ? implement.getDescription().replace("implement", "implements")
-                    : implement.getDescription().replace("implement", "does not implement");
-            String message = createMessage(javaClass, description);
-            events.add(new SimpleConditionEvent(javaClass, satisfied, message));
-        }
-    }
-
-    private static class InterfacesCondition extends ArchCondition<JavaClass> {
-        private static final InterfacesCondition BE_INTERFACES = new InterfacesCondition();
-
-        InterfacesCondition() {
-            super("be interfaces");
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean isInterface = javaClass.isInterface();
-            String message = createMessage(javaClass,
-                    (isInterface ? "is an" : "is not an") + " interface");
-            events.add(new SimpleConditionEvent(javaClass, isInterface, message));
-        }
-    }
-
-    private static class EnumsCondition extends ArchCondition<JavaClass> {
-        private static final EnumsCondition BE_ENUMS = new EnumsCondition();
-
-        EnumsCondition() {
-            super("be enums");
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean isEnum = javaClass.isEnum();
-            String message = createMessage(javaClass,
-                    (isEnum ? "is an" : "is not an") + " enum");
-            events.add(new SimpleConditionEvent(javaClass, isEnum, message));
-        }
-    }
-
-    private static class RecordsCondition extends ArchCondition<JavaClass> {
-        private static final RecordsCondition BE_RECORDS = new RecordsCondition();
-
-        RecordsCondition() {
-            super("be records");
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean isRecord = javaClass.isRecord();
-            String message = createMessage(javaClass,
-                    (isRecord ? "is a" : "is not a") + " record");
-            events.add(new SimpleConditionEvent(javaClass, isRecord, message));
         }
     }
 
@@ -1421,238 +1365,8 @@ public final class ArchConditions {
         }
     }
 
-    private static class BeClassCondition extends ArchCondition<JavaClass> {
-        private final String className;
-
-        BeClassCondition(String className) {
-            super("be " + className);
-            this.className = className;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean itemEquivalentToClazz = javaClass.getName().equals(className);
-            String message = createMessage(javaClass,
-                    (itemEquivalentToClazz ? "is " : "is not ") + className);
-            events.add(new SimpleConditionEvent(javaClass, itemEquivalentToClazz, message));
-        }
-    }
-
-    private static class SimpleNameCondition extends ArchCondition<JavaClass> {
-        private final DescribedPredicate<JavaClass> haveSimpleName;
-        private final String name;
-
-        SimpleNameCondition(DescribedPredicate<JavaClass> haveSimpleName, String name) {
-            super(haveSimpleName.getDescription());
-            this.haveSimpleName = haveSimpleName;
-            this.name = name;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean satisfied = haveSimpleName.test(javaClass);
-            String message = createMessage(javaClass,
-                    String.format("%s simple name '%s'", satisfied ? "has" : "does not have", name));
-            events.add(new SimpleConditionEvent(javaClass, satisfied, message));
-        }
-    }
-
-    private static class SimpleNameStartingWithCondition extends ArchCondition<JavaClass> {
-        private final DescribedPredicate<JavaClass> predicate;
-        private final String prefix;
-
-        SimpleNameStartingWithCondition(DescribedPredicate<JavaClass> predicate, String prefix) {
-            super(predicate.getDescription());
-            this.predicate = predicate;
-            this.prefix = prefix;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean satisfied = predicate.test(javaClass);
-            String message = String.format("simple name of %s %s with '%s' in %s",
-                    javaClass.getName(),
-                    satisfied ? "starts" : "does not start",
-                    prefix,
-                    javaClass.getSourceCodeLocation());
-            events.add(new SimpleConditionEvent(javaClass, satisfied, message));
-        }
-    }
-
-    private static class SimpleNameContainingCondition extends ArchCondition<JavaClass> {
-        private final DescribedPredicate<JavaClass> predicate;
-        private final String infix;
-
-        SimpleNameContainingCondition(DescribedPredicate<JavaClass> predicate, String infix) {
-            super(predicate.getDescription());
-            this.predicate = predicate;
-            this.infix = infix;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean satisfied = predicate.test(javaClass);
-            String message = String.format("simple name of %s %s '%s' in %s",
-                    javaClass.getName(),
-                    satisfied ? "contains" : "does not contain",
-                    infix,
-                    javaClass.getSourceCodeLocation());
-            events.add(new SimpleConditionEvent(javaClass, satisfied, message));
-        }
-    }
-
-    private static class SimpleNameEndingWithCondition extends ArchCondition<JavaClass> {
-        private final DescribedPredicate<JavaClass> predicate;
-        private final String suffix;
-
-        SimpleNameEndingWithCondition(DescribedPredicate<JavaClass> predicate, String suffix) {
-            super(predicate.getDescription());
-            this.predicate = predicate;
-            this.suffix = suffix;
-        }
-
-        @Override
-        public void check(JavaClass javaClass, ConditionEvents events) {
-            boolean satisfied = predicate.test(javaClass);
-            String message = String.format("simple name of %s %s with '%s' in %s",
-                    javaClass.getName(),
-                    satisfied ? "ends" : "does not end",
-                    suffix,
-                    javaClass.getSourceCodeLocation());
-            events.add(new SimpleConditionEvent(javaClass, satisfied, message));
-        }
-    }
-
-    private static class MatchingCondition<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final DescribedPredicate<T> matcher;
-        private final String regex;
-
-        MatchingCondition(DescribedPredicate<T> matcher, String regex) {
-            super(matcher.getDescription());
-            this.matcher = matcher;
-            this.regex = regex;
-        }
-
-        @Override
-        public void check(T item, ConditionEvents events) {
-            boolean satisfied = matcher.test(item);
-            String message = createMessage(item,
-                    String.format("%s '%s'", satisfied ? "matches" : "does not match", regex));
-            events.add(new SimpleConditionEvent(item, satisfied, message));
-        }
-    }
-
-    private static class StartingCondition<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final DescribedPredicate<T> startingWith;
-        private final String prefix;
-
-        StartingCondition(DescribedPredicate<T> startingWith, String prefix) {
-            super(startingWith.getDescription());
-            this.startingWith = startingWith;
-            this.prefix = prefix;
-        }
-
-        @Override
-        public void check(T item, ConditionEvents events) {
-            boolean satisfied = startingWith.test(item);
-            String message = createMessage(item,
-                    String.format("name %s '%s'", satisfied ? "starts with" : "does not start with", prefix));
-            events.add(new SimpleConditionEvent(item, satisfied, message));
-        }
-    }
-
-    private static class ContainingCondition<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final DescribedPredicate<T> containing;
-        private final String infix;
-
-        ContainingCondition(DescribedPredicate<T> containing, String infix) {
-            super(containing.getDescription());
-            this.containing = containing;
-            this.infix = infix;
-        }
-
-        @Override
-        public void check(T item, ConditionEvents events) {
-            boolean satisfied = containing.test(item);
-            String message = createMessage(item,
-                    String.format("name %s '%s'", satisfied ? "contains" : "does not contain", infix));
-            events.add(new SimpleConditionEvent(item, satisfied, message));
-        }
-    }
-
-    private static class EndingCondition<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final DescribedPredicate<T> endingWith;
-        private final String suffix;
-
-        EndingCondition(DescribedPredicate<T> endingWith, String suffix) {
-            super(endingWith.getDescription());
-            this.endingWith = endingWith;
-            this.suffix = suffix;
-        }
-
-        @Override
-        public void check(T item, ConditionEvents events) {
-            boolean satisfied = endingWith.test(item);
-            String message = createMessage(item,
-                    String.format("name %s '%s'", satisfied ? "ends with" : "does not end with", suffix));
-            events.add(new SimpleConditionEvent(item, satisfied, message));
-        }
-    }
-
-    private static class DoesConditionByPredicate<T extends HasDescription & HasSourceCodeLocation>
-            extends ArchCondition<T> {
-        private final DescribedPredicate<? super T> predicate;
-
-        DoesConditionByPredicate(DescribedPredicate<? super T> predicate) {
-            super(predicate.getDescription());
-            this.predicate = predicate;
-        }
-
-        @Override
-        public void check(T item, ConditionEvents events) {
-            boolean satisfied = predicate.test(item);
-            String message = createMessage(item,
-                    (satisfied ? "does " : "does not ") + predicate.getDescription());
-            events.add(new SimpleConditionEvent(item, satisfied, message));
-        }
-    }
-
-    private static class BeConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final String eventDescription;
-        private final DescribedPredicate<T> predicate;
-
-        BeConditionByPredicate(DescribedPredicate<? super T> predicate) {
-            this(predicate.getDescription(), predicate);
-        }
-
-        BeConditionByPredicate(String eventDescription, DescribedPredicate<? super T> predicate) {
-            super(ArchPredicates.be(predicate).getDescription());
-            this.eventDescription = eventDescription;
-            this.predicate = predicate.forSubtype();
-        }
-
-        @Override
-        public void check(T member, ConditionEvents events) {
-            boolean satisfied = predicate.test(member);
-            String message = createMessage(member,
-                    (satisfied ? "is " : "is not ") + eventDescription);
-            events.add(new SimpleConditionEvent(member, satisfied, message));
-        }
-    }
-
-    private static class HaveConditionByPredicate<T extends HasDescription & HasSourceCodeLocation> extends ArchCondition<T> {
-        private final DescribedPredicate<T> rawType;
-
-        HaveConditionByPredicate(DescribedPredicate<? super T> rawType) {
-            super(ArchPredicates.have(rawType).getDescription());
-            this.rawType = rawType.forSubtype();
-        }
-
-        @Override
-        public void check(T object, ConditionEvents events) {
-            boolean satisfied = rawType.test(object);
-            String message = createMessage(object, (satisfied ? "has " : "does not have ") + rawType.getDescription());
-            events.add(new SimpleConditionEvent(object, satisfied, message));
-        }
+    private static <T extends HasDescription & HasSourceCodeLocation> ArchCondition<T> does(DescribedPredicate<? super T> predicate) {
+        return ArchCondition.from(predicate.<T>forSubtype())
+                .describeEventsBy((predicateDescription, satisfied) -> (satisfied ? "does " : "does not ") + predicateDescription);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
@@ -15,6 +15,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import org.junit.Test;
 
 import static com.tngtech.archunit.base.DescribedPredicate.alwaysFalse;
+import static com.tngtech.archunit.base.DescribedPredicate.alwaysTrue;
 import static com.tngtech.archunit.core.domain.JavaCall.Predicates.target;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
@@ -29,12 +30,15 @@ import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.Wi
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThatResideIn;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.accessClassesThatResideInAnyPackage;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.be;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.callCodeUnitWhere;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.callMethodWhere;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containAnyElementThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containOnlyElementsThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.declareThrowableOfType;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.have;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.never;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.not;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyBeAccessedByAnyPackage;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyHaveDependentsInAnyPackage;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyHaveDependentsWhere;
@@ -100,6 +104,48 @@ public class ArchConditionsTest {
 
         assertThat(containOnlyElementsThat(conditionWithDescription("something")))
                 .hasDescription("contain only elements that something");
+    }
+
+    @Test
+    public void have_predicate() {
+        JavaClass object = importClasses(Object.class).get(Object.class);
+
+        assertThat(have(alwaysTrue().as("some description"))).hasDescription("have some description");
+
+        assertThat(have(DescribedPredicate.<JavaClass>alwaysFalse().as("some description")))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> does not have some description");
+
+        assertThat(have(DescribedPredicate.<JavaClass>alwaysFalse()).describeEventsBy((_1, _2) -> "overwritten"))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> overwritten");
+
+        assertThat(have(DescribedPredicate.<JavaClass>alwaysTrue())).checking(object).containNoViolation();
+
+        assertThat(not(have(DescribedPredicate.<JavaClass>alwaysTrue().as("some description"))))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> has some description");
+    }
+
+    @Test
+    public void be_predicate() {
+        JavaClass object = importClasses(Object.class).get(Object.class);
+
+        assertThat(be(alwaysTrue().as("some description"))).hasDescription("be some description");
+
+        assertThat(be(DescribedPredicate.<JavaClass>alwaysFalse().as("some description")))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> is not some description");
+
+        assertThat(be(DescribedPredicate.<JavaClass>alwaysFalse()).describeEventsBy((_1, _2) -> "overwritten"))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> overwritten");
+
+        assertThat(be(DescribedPredicate.<JavaClass>alwaysTrue())).checking(object).containNoViolation();
+
+        assertThat(not(be(DescribedPredicate.<JavaClass>alwaysTrue().as("some description"))))
+                .checking(object)
+                .haveOneViolationMessageContaining("Class <" + Object.class.getName() + "> is some description");
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -195,7 +195,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have name matching '%s'", regex))
-                .containsPattern(String.format("Class <%s> does not match '%s' in %s",
+                .containsPattern(String.format("Class <%s> does not have name matching '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(regex),
                         locationPattern(WrongNamedClass.class)))
@@ -219,7 +219,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have name not matching '%s'", regex))
-                .containsPattern(String.format("Class <%s> matches '%s' in %s",
+                .containsPattern(String.format("Class <%s> has name matching '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(regex),
                         locationPattern(WrongNamedClass.class)))
@@ -244,7 +244,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name starting with '%s'", prefix))
-                .containsPattern(String.format("simple name of %s does not start with '%s' in %s",
+                .containsPattern(String.format("Class <%s> does not have simple name starting with '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(prefix),
                         locationPattern(WrongNamedClass.class)))
@@ -269,7 +269,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not starting with '%s'", prefix))
-                .containsPattern(String.format("simple name of %s starts with '%s' in %s",
+                .containsPattern(String.format("Class <%s> has simple name starting with '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(prefix),
                         locationPattern(WrongNamedClass.class)))
@@ -294,7 +294,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name containing '%s'", infix))
-                .containsPattern(String.format("simple name of %s does not contain '%s' in %s",
+                .containsPattern(String.format("Class <%s> does not have simple name containing '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(infix),
                         locationPattern(WrongNamedClass.class)))
@@ -319,7 +319,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not containing '%s'", infix))
-                .containsPattern(String.format("simple name of %s contains '%s' in %s",
+                .containsPattern(String.format("Class <%s> has simple name containing '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(infix),
                         locationPattern(WrongNamedClass.class)))
@@ -344,7 +344,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name ending with '%s'", suffix))
-                .containsPattern(String.format("simple name of %s does not end with '%s' in %s",
+                .containsPattern(String.format("Class <%s> does not have simple name ending with '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(suffix),
                         locationPattern(WrongNamedClass.class)))
@@ -369,7 +369,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should have simple name not ending with '%s'", suffix))
-                .containsPattern(String.format("simple name of %s ends with '%s' in %s",
+                .containsPattern(String.format("Class <%s> has simple name ending with '%s' in %s",
                         quote(WrongNamedClass.class.getName()),
                         quote(suffix),
                         locationPattern(WrongNamedClass.class)))
@@ -835,7 +835,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains(String.format("classes should not implement %s", Collection.class.getName()))
-                .containsPattern(String.format("Class <%s> implements %s in %s",
+                .containsPattern(String.format("Class <%s> does implement %s in %s",
                         quote(violated.getName()),
                         quote(Collection.class.getName()),
                         locationPattern(violated)))
@@ -1359,7 +1359,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be interfaces")
-                .containsPattern(String.format("Class <%s> is not an interface in %s",
+                .containsPattern(String.format("Class <%s> is no interface in %s",
                         quote(violated.getName()),
                         locationPattern(violated)))
                 .doesNotMatch(String.format(".*%s.* interface.*", quote(satisfied.getName())));
@@ -1399,7 +1399,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be enums")
-                .containsPattern(String.format("Class <%s> is not an enum in %s",
+                .containsPattern(String.format("Class <%s> is no enum in %s",
                         quote(violated.getName()),
                         locationPattern(violated)))
                 .doesNotMatch(String.format(".*%s.* enum.*", quote(satisfied.getName())));
@@ -1443,7 +1443,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be top level classes")
-                .containsPattern(String.format("Class <%s> is not a top level class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no top level class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* top level class.*", quote(satisfied.getName())));
     }
 
@@ -1487,7 +1487,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be nested classes")
-                .containsPattern(String.format("Class <%s> is not a nested class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no nested class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* nested class.*", quote(satisfied.getName())));
     }
 
@@ -1531,7 +1531,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be member classes")
-                .containsPattern(String.format("Class <%s> is not a member class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no member class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* member class.*", quote(satisfied.getName())));
     }
 
@@ -1575,7 +1575,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be inner classes")
-                .containsPattern(String.format("Class <%s> is not an inner class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no inner class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* inner class.*", quote(satisfied.getName())));
     }
 
@@ -1619,7 +1619,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be anonymous classes")
-                .containsPattern(String.format("Class <%s> is not an anonymous class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no anonymous class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* anonymous class.*", quote(satisfied.getName())));
     }
 
@@ -1663,7 +1663,7 @@ public class ClassesShouldTest {
 
         assertThat(singleLineFailureReportOf(result))
                 .contains("classes should be local classes")
-                .containsPattern(String.format("Class <%s> is not a local class", quote(violated.getName())))
+                .containsPattern(String.format("Class <%s> is no local class", quote(violated.getName())))
                 .doesNotMatch(String.format(".*%s.* local class.*", quote(satisfied.getName())));
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassShouldTest.java
@@ -190,7 +190,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), regex)
                 .haveFailingRuleText("the class %s should have name not matching '%s'",
                         SomeClass.class.getName(), regex)
-                .containFailureDetail(String.format("Class <%s> matches '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has name matching '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(regex),
                         locationPattern(SomeClass.class)))
@@ -222,7 +222,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), regex)
                 .haveFailingRuleText("no class %s should have name matching '%s'",
                         SomeClass.class.getName(), regex)
-                .containFailureDetail(String.format("Class <%s> matches '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has name matching '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(regex),
                         locationPattern(SomeClass.class)))
@@ -255,7 +255,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), prefix)
                 .haveFailingRuleText("the class %s should have simple name not starting with '%s'",
                         SomeClass.class.getName(), prefix)
-                .containFailureDetail(String.format("simple name of %s starts with '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name starting with '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(prefix),
                         locationPattern(SomeClass.class)))
@@ -289,7 +289,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), prefix)
                 .haveFailingRuleText("no class %s should have simple name starting with '%s'",
                         SomeClass.class.getName(), prefix)
-                .containFailureDetail(String.format("simple name of %s starts with '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name starting with '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(prefix),
                         locationPattern(SomeClass.class)))
@@ -323,7 +323,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), infix)
                 .haveFailingRuleText("the class %s should have simple name not containing '%s'",
                         SomeClass.class.getName(), infix)
-                .containFailureDetail(String.format("simple name of %s contains '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name containing '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(infix),
                         locationPattern(SomeClass.class)))
@@ -357,7 +357,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), infix)
                 .haveFailingRuleText("no class %s should have simple name containing '%s'",
                         SomeClass.class.getName(), infix)
-                .containFailureDetail(String.format("simple name of %s contains '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name containing '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(infix),
                         locationPattern(SomeClass.class)))
@@ -391,7 +391,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), suffix)
                 .haveFailingRuleText("the class %s should have simple name not ending with '%s'",
                         SomeClass.class.getName(), suffix)
-                .containFailureDetail(String.format("simple name of %s ends with '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name ending with '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(suffix),
                         locationPattern(SomeClass.class)))
@@ -425,7 +425,7 @@ public class GivenClassShouldTest {
                         SomeClass.class.getName(), suffix)
                 .haveFailingRuleText("no class %s should have simple name ending with '%s'",
                         SomeClass.class.getName(), suffix)
-                .containFailureDetail(String.format("simple name of %s ends with '%s' in %s",
+                .containFailureDetail(String.format("Class <%s> has simple name ending with '%s' in %s",
                         quote(SomeClass.class.getName()),
                         quote(suffix),
                         locationPattern(SomeClass.class)))
@@ -1035,7 +1035,7 @@ public class GivenClassShouldTest {
                         ArrayList.class.getName(), Collection.class.getName())
                 .haveFailingRuleText("the class %s should not implement %s",
                         ArrayList.class.getName(), Collection.class.getName())
-                .containFailureDetail(String.format("Class <%s> implements %s in %s",
+                .containFailureDetail(String.format("Class <%s> does implement %s in %s",
                         quote(ArrayList.class.getName()),
                         quote(Collection.class.getName()),
                         locationPattern(ArrayList.class)))
@@ -1064,7 +1064,7 @@ public class GivenClassShouldTest {
                         ArrayList.class.getName(), Collection.class.getName())
                 .haveFailingRuleText("no class %s should implement %s",
                         ArrayList.class.getName(), Collection.class.getName())
-                .containFailureDetail(String.format("Class <%s> implements %s in %s",
+                .containFailureDetail(String.format("Class <%s> does implement %s in %s",
                         quote(ArrayList.class.getName()),
                         quote(Collection.class.getName()),
                         locationPattern(ArrayList.class)))

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -419,7 +419,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name does not start with '%s' in %s",
+                .containsPattern(String.format(".*%s.* does not have name starting with '%s' in %s",
                         quote(violatingMember),
                         quote(prefix),
                         locationPattern(SimpleFieldAndMethod.class)));
@@ -447,7 +447,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name starts with '%s' in %s",
+                .containsPattern(String.format(".*%s.* has name starting with '%s' in %s",
                         quote(prefix),
                         quote(prefix),
                         locationPattern(SimpleFieldAndMethod.class)));
@@ -475,7 +475,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name does not contain '%s' in %s",
+                .containsPattern(String.format(".*%s.* does not have name containing '%s' in %s",
                         quote(violatingMember),
                         quote(infix),
                         locationPattern(SimpleFieldAndMethod.class)));
@@ -503,7 +503,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name contains '%s' in %s",
+                .containsPattern(String.format(".*%s.* has name containing '%s' in %s",
                         quote(infix),
                         quote(infix),
                         locationPattern(SimpleFieldAndMethod.class)));
@@ -531,7 +531,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name does not end with '%s' in %s",
+                .containsPattern(String.format(".*%s.* does not have name ending with '%s' in %s",
                         quote(violatingMember),
                         quote(suffix),
                         locationPattern(SimpleFieldAndMethod.class)));
@@ -559,7 +559,7 @@ public class MembersShouldTest {
         EvaluationResult result = rule.evaluate(importClasses(SimpleFieldAndMethod.class));
 
         assertThat(singleLineFailureReportOf(result))
-                .containsPattern(String.format(".*%s.* name ends with '%s' in %s",
+                .containsPattern(String.format(".*%s.* has name ending with '%s' in %s",
                         quote(suffix),
                         quote(suffix),
                         locationPattern(SimpleFieldAndMethod.class)));

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldTest.java
@@ -342,7 +342,7 @@ public class MembersShouldTest {
                 .evaluate(importClasses(ClassWithVariousMembers.class, A.class, B.class, C.class, MetaAnnotation.class));
 
         Set<String> actualMembers = parseMembers(result.getFailureReport().getDetails());
-        assertThat(actualMembers).containsOnlyElementsOf(expectedMembers);
+        assertThat(actualMembers).hasSameElementsAs(expectedMembers);
     }
 
     @DataProvider
@@ -394,7 +394,7 @@ public class MembersShouldTest {
                 .evaluate(importClasses(ClassWithVariousMembers.class, OtherClassWithMembers.class));
 
         Set<String> actualMembers = parseMembers(result.getFailureReport().getDetails());
-        assertThat(actualMembers).containsOnlyElementsOf(expectedMessages);
+        assertThat(actualMembers).hasSameElementsAs(expectedMessages);
     }
 
     @DataProvider


### PR DESCRIPTION
So far there has not been any straight forward way to turn a `DescribedPredicate` into an `ArchCondition`, even though the semantics are fairly similar (both determine if elements match a certain condition). The reason is, that `ArchCondition` needs more information than `DescribedPredicate`. While `DescribedPredicate` only needs to have some description to be displayed as part of the `ArchRule` text, `ArchCondition` additionally needs to describe each single event/violation that occurs. And the way how to do this depends on the predicate (take e.g. "does not *have* simple name 'Demo'" vs "is no enum" or "does not reside in a package 'com.demo'"). Thus, we have created a generic factory method `ArchCondition.from(predicate)` and two more convenient "sentence-like" factory methods `ArchConditions.{have/be}(predicate)` that can be used for most common cases. In any case if the event description does not fit it is possible to adjust it via `ConditionByPredicate.describeEventsBy(..)`.