### PR TITLE
Upgrade `actions/setup-java` from `1` to `3.6.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,4 +128,4 @@ jobs:
         env:
           JAVA_HOME: ${{ env.build_jdk_path }}
         with:
-          arguments: build -xtest -xspotbugsMain -xjavadoc runMavenTest -PtestJavaVersion=${{ matrix.test_java_version }} -Porg.gradle.java.installations.paths=${{ env.test_jdk_path }}
+          arguments: runMavenTest -PtestJavaVersion=${{ matrix.test_java_version }} -Porg.gradle.java.installations.paths=${{ env.test_jdk_path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
       - name: Build
         uses: gradle/gradle-build-action@v2
@@ -58,8 +59,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Build JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
       - name: Test
         uses: gradle/gradle-build-action@v2
@@ -91,12 +93,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Build JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
       - name: Set up Test JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.test_java_version }}
       - name: Provide installed JDKs
         uses: actions/github-script@v6

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Gradle JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.6.0
         with:
+          distribution: 'zulu'
           java-version: 14
 
       - name: Update Gradle Wrapper

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v3.6.0
         with:
           distribution: 'zulu'
-          java-version: 14
+          java-version: 17
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1.0.18


### PR DESCRIPTION
We now need to specify a distribution explicitly or the action will throw an error. We picked `zulu`, since that was the one we have used so far anyway with the `v1` and it offers the full range of Java versions so far.