### PR TITLE
Add rule checking test and implementation class are in same package

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
@@ -1,0 +1,44 @@
+package com.tngtech.archunit.library;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.library.testclasses.packages.correct.ImplementationClassWithCorrectPackage;
+import com.tngtech.archunit.library.testclasses.packages.incorrect.ImplementationClassWithWrongTestClassPackage;
+import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.ImplementationClassWithWrongTestClassPackageTest;
+import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.ImplementationClassWithWrongTestClassPackageTestingScenario;
+import org.junit.Test;
+
+import static com.tngtech.archunit.library.GeneralCodingRules.testClassesShouldResideInTheSamePackageAsImplementation;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
+
+public class GeneralCodingRulesTest {
+
+    @Test
+    public void test_class_in_same_package_should_fail_when_test_class_reside_in_different_package_as_implementation() {
+        assertThatRule(testClassesShouldResideInTheSamePackageAsImplementation())
+                .checking(new ClassFileImporter().importPackagesOf(ImplementationClassWithWrongTestClassPackage.class))
+                .hasOnlyOneViolationWithStandardPattern(ImplementationClassWithWrongTestClassPackageTest.class,
+                        "does not reside in same package as implementation class <" + ImplementationClassWithWrongTestClassPackage.class.getName() + ">");
+    }
+
+    @Test
+    public void test_class_in_same_package_should_fail_when_test_class_reside_in_different_package_as_implementation_with_custom_suffix() {
+        assertThatRule(testClassesShouldResideInTheSamePackageAsImplementation("TestingScenario"))
+                .checking(new ClassFileImporter().importPackagesOf(ImplementationClassWithWrongTestClassPackage.class))
+                .hasOnlyOneViolationWithStandardPattern(ImplementationClassWithWrongTestClassPackageTestingScenario.class,
+                        "does not reside in same package as implementation class <" + ImplementationClassWithWrongTestClassPackage.class.getName() + ">");
+    }
+
+    @Test
+    public void test_class_in_same_package_should_pass_when_test_class_and_implementation_class_reside_in_the_same_package() {
+        assertThatRule(testClassesShouldResideInTheSamePackageAsImplementation())
+                .checking(new ClassFileImporter().importPackagesOf(ImplementationClassWithCorrectPackage.class))
+                .hasNoViolation();
+    }
+
+    @Test
+    public void test_class_in_same_package_should_pass_when_test_class_and_implementation_class_reside_in_the_same_package_with_custom_suffix() {
+        assertThatRule(testClassesShouldResideInTheSamePackageAsImplementation("TestingScenario"))
+                .checking(new ClassFileImporter().importPackagesOf(ImplementationClassWithCorrectPackage.class))
+                .hasNoViolation();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackage.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackage.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.correct;
+
+public class ImplementationClassWithCorrectPackage {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackageTest.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.correct;
+
+public class ImplementationClassWithCorrectPackageTest {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackageTestingScenario.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/ImplementationClassWithCorrectPackageTestingScenario.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.correct;
+
+public class ImplementationClassWithCorrectPackageTestingScenario {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/ImplementationClassWithWrongTestClassPackage.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/ImplementationClassWithWrongTestClassPackage.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.incorrect;
+
+public class ImplementationClassWithWrongTestClassPackage {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/wrongsubdir/ImplementationClassWithWrongTestClassPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/wrongsubdir/ImplementationClassWithWrongTestClassPackageTest.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir;
+
+public class ImplementationClassWithWrongTestClassPackageTest {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/wrongsubdir/ImplementationClassWithWrongTestClassPackageTestingScenario.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/wrongsubdir/ImplementationClassWithWrongTestClassPackageTestingScenario.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir;
+
+public class ImplementationClassWithWrongTestClassPackageTestingScenario {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
@@ -55,6 +55,11 @@ public class ArchRuleCheckAssertion {
         return this;
     }
 
+    public ArchRuleCheckAssertion hasOnlyOneViolationWithStandardPattern(Class<?> violatingClass, String violationDescription) {
+        String violationMessage = "Class <" + violatingClass.getName() + "> " + violationDescription + " in (" + violatingClass.getSimpleName() + ".java:0)";
+        return hasOnlyOneViolation(violationMessage);
+    }
+
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     public ArchRuleCheckAssertion hasOnlyOneViolationMatching(String regex) {
         assertThat(getOnlyElement(evaluationResult.getFailureReport().getDetails())).matches(regex);


### PR DESCRIPTION
This will add the library rule `GeneralCodingRules.testClassesShouldResideInTheSamePackageAsImplementation(..)` which will test that implementation and test class reside in the same package. The rule can e.g. detect mismatches like `com.myapp.correct.SomeClass` and `com.myapp.wrong.SomeClassTest`.

Resolves: #475 