### PR TITLE
Improve Javadoc of predicates and functions

### DIFF
--- a/archunit/src/jdk16test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldNewerJavaVersionTest.java
+++ b/archunit/src/jdk16test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldNewerJavaVersionTest.java
@@ -1,0 +1,64 @@
+package com.tngtech.archunit.lang.syntax.elements;
+
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
+import com.tngtech.archunit.lang.syntax.elements.testobjects.SomeRecord;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.locationPattern;
+import static com.tngtech.archunit.lang.syntax.elements.ClassesShouldTest.singleLineFailureReportOf;
+import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$;
+import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
+import static java.util.regex.Pattern.quote;
+
+@RunWith(DataProviderRunner.class)
+public class ClassesShouldNewerJavaVersionTest {
+
+    @DataProvider
+    public static Object[][] data_beRecords() {
+        return $$(
+                $(classes().should().beRecords(), SomeRecord.class, String.class),
+                $(classes().should(ArchConditions.beRecords()), SomeRecord.class, String.class));
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_beRecords(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should be records")
+                .containsPattern(String.format("Class <%s> is no record in %s",
+                        quote(violated.getName()),
+                        locationPattern(violated)))
+                .doesNotMatch(String.format(".*%s.* record.*", quote(satisfied.getName())));
+    }
+
+    @DataProvider
+    public static Object[][] data_notBeRecords() {
+        return $$(
+                $(classes().should().notBeRecords(), String.class, SomeRecord.class),
+                $(classes().should(ArchConditions.notBeRecords()), String.class, SomeRecord.class));
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_notBeRecords(ArchRule rule, Class<?> satisfied, Class<?> violated) {
+        EvaluationResult result = rule.evaluate(importClasses(satisfied, violated));
+
+        assertThat(singleLineFailureReportOf(result))
+                .contains("classes should not be records")
+                .containsPattern(String.format("Class <%s> is a record in %s",
+                        quote(violated.getName()),
+                        locationPattern(violated)))
+                .doesNotMatch(String.format(".*%s.* record.*", quote(satisfied.getName())));
+    }
+}

--- a/archunit/src/jdk16test/java/com/tngtech/archunit/lang/syntax/elements/testobjects/SomeRecord.java
+++ b/archunit/src/jdk16test/java/com/tngtech/archunit/lang/syntax/elements/testobjects/SomeRecord.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.lang.syntax.elements.testobjects;
+
+public record SomeRecord(int attribute) {
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -658,6 +658,16 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         }
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link AccessTarget}.
+     * Note that due to inheritance further predicates for {@link AccessTarget} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Predicates}</li>
+     *     <li>{@link HasName.AndFullName.Predicates}</li>
+     *     <li>{@link CanBeAnnotated.Predicates}</li>
+     *     <li>{@link HasOwner.Predicates}</li>
+     * </ul>
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -226,6 +226,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         return "target{" + fullName + '}';
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link AccessTarget}.
+     */
     public static final class Functions {
         private Functions() {
         }
@@ -311,6 +314,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return "field <" + getFullName() + ">";
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link FieldAccessTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }
@@ -390,6 +396,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return (Optional<? extends JavaCodeUnit>) super.resolveMember();
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link CodeUnitAccessTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }
@@ -473,6 +482,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return "constructor <" + getFullName() + ">";
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link ConstructorCallTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }
@@ -521,6 +533,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return "constructor <" + getFullName() + ">";
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link ConstructorReferenceTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }
@@ -593,6 +608,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return "method <" + getFullName() + ">";
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link MethodCallTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }
@@ -643,6 +661,9 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
             return "method <" + getFullName() + ">";
         }
 
+        /**
+         * Predefined {@link ChainableFunction functions} to transform {@link MethodReferenceTarget}.
+         */
         public static final class Functions {
             private Functions() {
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -333,6 +333,9 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         }
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link Dependency}.
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -390,6 +390,9 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link Dependency}.
+     */
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -188,6 +188,15 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link JavaAccess}.
+     * Note that due to inheritance further functions for {@link JavaAccess} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Functions}</li>
+     *     <li>{@link HasName.AndFullName.Functions}</li>
+     *     <li>{@link HasOwner.Functions}</li>
+     * </ul>
+     */
     @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -125,6 +125,14 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
                 .collect(toImmutableSet());
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaAccess}.
+     * Note that due to inheritance further predicates for {@link JavaAccess} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Predicates}</li>
+     *     <li>{@link HasOwner.Predicates}</li>
+     * </ul>
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
@@ -28,6 +28,10 @@ public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUni
         super(builder);
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCall}.
+     * Further predicates to be used with {@link JavaCall} can be found at {@link JavaCodeUnitAccess.Predicates}.
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1748,6 +1748,15 @@ public class JavaClass
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link JavaClass}.
+     * Note that due to inheritance further functions for {@link JavaClass} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Functions}</li>
+     *     <li>{@link HasName.AndFullName.Functions}</li>
+     *     <li>{@link JavaType.Functions}</li>
+     * </ul>
+     */
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -2035,6 +2035,16 @@ public class JavaClass
                 };
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaClass}.
+     * Note that due to inheritance further predicates for {@link JavaClass} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Predicates}</li>
+     *     <li>{@link HasName.AndFullName.Predicates}</li>
+     *     <li>{@link HasModifiers.Predicates}</li>
+     *     <li>{@link CanBeAnnotated.Predicates}</li>
+     * </ul>
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -356,6 +356,16 @@ public abstract class JavaCodeUnit
         }
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCodeUnit}.
+     * Note that due to inheritance further predicates for {@link JavaCodeUnit} can be found in the following locations:
+     * <ul>
+     *     <li>{@link JavaMember.Predicates}</li>
+     *     <li>{@link HasParameterTypes.Predicates}</li>
+     *     <li>{@link HasReturnType.Predicates}</li>
+     *     <li>{@link HasThrowsClause.Predicates}</li>
+     * </ul>
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -29,6 +29,8 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.ForwardingList;
 import com.tngtech.archunit.base.MayResolveTypesViaReflection;
 import com.tngtech.archunit.base.ResolvesTypesViaReflection;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasParameterTypes;
 import com.tngtech.archunit.core.domain.properties.HasReturnType;
 import com.tngtech.archunit.core.domain.properties.HasThrowsClause;
@@ -391,6 +393,16 @@ public abstract class JavaCodeUnit
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link JavaCodeUnit}.
+     * Note that due to inheritance further functions for {@link JavaCodeUnit} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Functions}</li>
+     *     <li>{@link HasName.AndFullName.Functions}</li>
+     *     <li>{@link HasReturnType.Functions}</li>
+     *     <li>{@link HasOwner.Functions}</li>
+     * </ul>
+     */
     @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
@@ -28,6 +28,10 @@ public abstract class JavaCodeUnitAccess<T extends CodeUnitAccessTarget> extends
         super(builder);
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCodeUnitAccess}.
+     * Further predicates to be used with {@link JavaCodeUnitAccess} can be found at {@link JavaAccess.Predicates}.
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
@@ -28,6 +28,10 @@ public abstract class JavaCodeUnitReference<T extends CodeUnitReferenceTarget> e
         super(builder);
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCodeUnitReference}.
+     * Further predicates to be used with {@link JavaCodeUnitReference} can be found at {@link JavaCodeUnitAccess.Predicates}.
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
@@ -81,6 +81,10 @@ public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
         }
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaFieldAccess}.
+     * Further predicates to be used with {@link JavaFieldAccess} can be found at {@link JavaAccess.Predicates}.
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -197,6 +197,17 @@ public abstract class JavaMember implements
         return getClass().getSimpleName() + '{' + getFullName() + '}';
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting {@link JavaMember}.
+     * Note that due to inheritance further predicates for {@link JavaMember} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasName.Predicates}</li>
+     *     <li>{@link HasName.AndFullName.Predicates}</li>
+     *     <li>{@link HasModifiers.Predicates}</li>
+     *     <li>{@link CanBeAnnotated.Predicates}</li>
+     *     <li>{@link HasOwner.Predicates}</li>
+     * </ul>
+     */
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -576,6 +576,9 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
         void visit(JavaPackage javaPackage);
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link JavaPackage}.
+     */
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -39,6 +39,9 @@ public interface JavaType extends HasName {
     @PublicAPI(usage = ACCESS)
     JavaClass toErasure();
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link JavaType}.
+     */
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
@@ -86,6 +86,9 @@ public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUn
         return new ReferencedClassObject(owner, javaClass, lineNumber);
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link ReferencedClassObject}.
+     */
     @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
@@ -134,6 +134,9 @@ public final class ThrowsClause<LOCATION extends HasParameterTypes & HasReturnTy
         return throwsDeclarations;
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link ThrowsClause}.
+     */
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
@@ -133,6 +133,14 @@ public final class ThrowsDeclaration<LOCATION extends HasParameterTypes & HasRet
         return getClass().getSimpleName() + "{location=" + getLocation() + ", type=" + type + '}';
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link ThrowsDeclaration}.
+     * Note that due to inheritance further functions for {@link ThrowsDeclaration} can be found in the following locations:
+     * <ul>
+     *     <li>{@link HasType.Functions}</li>
+     *     <li>{@link HasOwner.Functions}</li>
+     * </ul>
+     */
     @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
@@ -92,6 +92,9 @@ public interface CanBeAnnotated {
     @PublicAPI(usage = ACCESS)
     boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate);
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link CanBeAnnotated}
+     */
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
@@ -28,6 +28,9 @@ public interface HasModifiers {
     @PublicAPI(usage = ACCESS)
     Set<JavaModifier> getModifiers();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasModifiers}
+     */
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -207,6 +207,9 @@ public interface HasName {
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link HasName}.
+     */
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -37,6 +37,9 @@ public interface HasName {
         @PublicAPI(usage = ACCESS)
         String getFullName();
 
+        /**
+         * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasName.AndFullName}
+         */
         final class Predicates {
             private Predicates() {
             }
@@ -97,6 +100,9 @@ public interface HasName {
         }
     }
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasName}
+     */
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
@@ -72,6 +72,9 @@ public interface HasOwner<T> {
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link HasOwner}.
+     */
     @PublicAPI(usage = ACCESS)
     final class Functions {
         private Functions() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
@@ -39,6 +39,9 @@ public interface HasOwner<T> {
     @PublicAPI(usage = ACCESS)
     T getOwner();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasOwner}
+     */
     @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -59,6 +59,10 @@ public interface HasParameterTypes {
     @PublicAPI(usage = ACCESS)
     List<JavaClass> getRawParameterTypes();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasParameterTypes}
+     */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
@@ -33,6 +33,10 @@ public interface HasReturnType {
     @PublicAPI(usage = ACCESS)
     JavaClass getRawReturnType();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasReturnType}
+     */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
@@ -58,6 +58,9 @@ public interface HasReturnType {
 
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link HasReturnType}.
+     */
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
@@ -37,6 +37,10 @@ public interface HasThrowsClause<LOCATION extends HasParameterTypes & HasReturnT
     @PublicAPI(usage = ACCESS)
     ThrowsClause<? extends LOCATION> getThrowsClause();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasThrowsClause}
+     */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
@@ -34,6 +34,10 @@ public interface HasType {
     @PublicAPI(usage = ACCESS)
     JavaClass getRawType();
 
+    /**
+     * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasType}
+     */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
@@ -58,6 +58,9 @@ public interface HasType {
         }
     }
 
+    /**
+     * Predefined {@link ChainableFunction functions} to transform {@link HasType}.
+     */
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -127,6 +127,10 @@ import static com.tngtech.archunit.core.domain.properties.HasThrowsClause.Predic
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
 import static java.util.Arrays.asList;
 
+/**
+ * A collection of predefined {@link ArchCondition ArchConditions} that can be customized or joined together
+ * via {@link ArchCondition#and(ArchCondition)} and {@link ArchCondition#or(ArchCondition)}.
+ */
 public final class ArchConditions {
     private ArchConditions() {
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
@@ -17,9 +17,18 @@ package com.tngtech.archunit.lang.conditions;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Predefined {@link DescribedPredicate predicates} that offer syntactic sugar.
+ * <br><br>
+ * Note that there are nested classes {@code DomainObject.Predicates} with predefined {@link DescribedPredicate predicates}
+ * for many domain objects by convention<br>
+ * For example {@link DescribedPredicate predicates} targeting {@link JavaClass} can be found
+ * within the class {@link JavaClass.Predicates}.
+ */
 public class ArchPredicates {
     private ArchPredicates() {
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/OnlyBeCalledSpecificationInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/OnlyBeCalledSpecificationInternal.java
@@ -18,7 +18,8 @@ package com.tngtech.archunit.lang.syntax;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
-import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.elements.ClassesThat;
 import com.tngtech.archunit.lang.syntax.elements.OnlyBeCalledSpecification;
@@ -41,17 +42,17 @@ class OnlyBeCalledSpecificationInternal<SHOULD extends AbstractMembersShouldInte
     }
 
     @Override
-    public SHOULD byCodeUnitsThat(DescribedPredicate<? super JavaMember> predicate) {
+    public SHOULD byCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate) {
         return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByCodeUnitsThat(predicate));
     }
 
     @Override
-    public SHOULD byMethodsThat(DescribedPredicate<? super JavaMember> predicate) {
+    public SHOULD byMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
         return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByMethodsThat(predicate));
     }
 
     @Override
-    public SHOULD byConstructorsThat(DescribedPredicate<? super JavaMember> predicate) {
+    public SHOULD byConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate) {
         return codeUnitsShould.addCondition(ArchConditions.onlyBeCalledByConstructorsThat(predicate));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -34,7 +34,9 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.PackageMatcher;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasName.Predicates;
+import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
@@ -321,6 +323,11 @@ public interface ClassesShould {
     /**
      * Asserts that classes are annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -331,6 +338,11 @@ public interface ClassesShould {
     /**
      * Asserts that classes are not annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -402,6 +414,12 @@ public interface ClassesShould {
      * The assertion is also successful if classes are directly annotated with an annotation matching the supplied predicate.
      * </p>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
+     *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
@@ -415,6 +433,12 @@ public interface ClassesShould {
      * <p>
      * The assertion also fails if classes are directly annotated with an annotation matching the supplied predicate.
      * </p>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -482,6 +506,10 @@ public interface ClassesShould {
      * Note that this only matches non-interface {@link JavaClass classes} that implement an interface matching the {@code predicate}
      * (compare {@link JavaClass.Predicates#implement(Class)}.
      * For general assignability see {@link #beAssignableTo(DescribedPredicate)}
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an interface imported classes should implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -494,6 +522,10 @@ public interface ClassesShould {
     /**
      * Asserts that classes do not implement a certain interface matching the given predicate.
      * This is the negation of {@link #implement(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an interface imported classes should NOT implement
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -560,6 +592,10 @@ public interface ClassesShould {
      * Asserts that classes are assignable to a certain type matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #beAssignableTo(String)}, but the approach is a lot more generic.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an upper type bound to match imported classes against
      *                  (imported subtypes will match)
@@ -573,6 +609,10 @@ public interface ClassesShould {
     /**
      * Asserts that classes are not assignable to a certain type matching the given predicate.
      * This is the negation of {@link #beAssignableTo(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an upper type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -643,6 +683,10 @@ public interface ClassesShould {
      * Asserts that classes are assignable from a certain type matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #beAssignableFrom(String)}, but the approach is a lot more generic.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying a lower type bound to match imported classes against
      *                  (imported supertypes will match)
@@ -656,6 +700,10 @@ public interface ClassesShould {
     /**
      * Asserts that classes are not assignable from a certain type matching the given predicate.
      * This is the negation of {@link #beAssignableFrom(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying a lower type bound imported classes should NOT have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -688,6 +736,11 @@ public interface ClassesShould {
     /**
      * Matches against accessing fields, where origin (a method or constructor) and target (a field)
      * can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaFieldAccess} can be found within {@link JavaFieldAccess.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaFieldAccess JavaFieldAccesses} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -697,6 +750,11 @@ public interface ClassesShould {
 
     /**
      * Matches all field accesses against the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaField} can be found within {@link JavaMember.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaField JavaFields} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -727,6 +785,11 @@ public interface ClassesShould {
     /**
      * Matches against getting of fields, where origin (a method or constructor) and target (a field)
      * can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaFieldAccess} can be found within {@link JavaFieldAccess.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaFieldAccess JavaFieldAccesses} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -757,6 +820,11 @@ public interface ClassesShould {
     /**
      * Matches against setting of fields, where origin (a method or constructor) and target (a field)
      * can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaFieldAccess} can be found within {@link JavaFieldAccess.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaFieldAccess JavaFieldAccesses} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -789,6 +857,11 @@ public interface ClassesShould {
     /**
      * Matches against method calls where origin (a method or constructor) and target (a method)
      * can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMethodCall} can be found within {@link JavaCall.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaMethodCall JavaMethodCalls} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -798,6 +871,11 @@ public interface ClassesShould {
 
     /**
      * Matches all method calls against the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMethod} can be found within {@link JavaMethod.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate Determines which {@link JavaMethod JavaMethods} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -828,6 +906,11 @@ public interface ClassesShould {
     /**
      * Matches against constructor calls where origin (a method or constructor) and target (a constructor)
      * can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaConstructorCall} can be found within {@link JavaCall.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaConstructorCall JavaConstructorCalls} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -837,6 +920,11 @@ public interface ClassesShould {
 
     /**
      * Matches all constructor calls against the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaConstructor} can be found within {@link JavaConstructor.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate Determines which {@link JavaConstructor JavaConstructors} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -848,6 +936,11 @@ public interface ClassesShould {
      * Matches against access of arbitrary targets (compare {@link AccessTarget})
      * where origin (a method or constructor) and target (a field, method or constructor) can be freely restricted
      * by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAccess} can be found within {@link JavaAccess.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaAccess JavaAccesses} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -857,6 +950,11 @@ public interface ClassesShould {
 
     /**
      * Matches all members calls against the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMember} can be found within {@link JavaMember.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaMember JavaMembers} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -867,6 +965,11 @@ public interface ClassesShould {
     /**
      * Matches against code unit calls (compare {@link JavaCodeUnit}) where origin (a code unit)
      * and target (a code unit) can be freely restricted by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaCall} can be found within {@link JavaCall.Predicates} or one of the respective ancestors
+     * like {@link JavaAccess.Predicates}.
      *
      * @param predicate Determines which {@link JavaCall JavaCalls} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -876,6 +979,11 @@ public interface ClassesShould {
 
     /**
      * Matches all code unit calls against the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaCodeUnit} can be found within {@link JavaCodeUnit.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate Determines which {@link JavaCodeUnit JavaCodeUnits} match the rule
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -909,6 +1017,10 @@ public interface ClassesShould {
      *
      * NOTE: 'access' refers only to violations by real accesses, i.e. accessing a field, and calling a method.
      * Compare with {@link #dependOnClassesThat(DescribedPredicate)} that catches a wider variety of violations.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the access target
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -942,6 +1054,10 @@ public interface ClassesShould {
      *
      * NOTE: 'access' refers only to violations by real accesses, i.e. accessing a field, and calling a method.
      * Compare with {@link #onlyDependOnClassesThat(DescribedPredicate)} that catches a wider variety of violations.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the access target
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -975,6 +1091,10 @@ public interface ClassesShould {
      *
      * NOTE: 'dependOn' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
      * Compare with {@link #accessClassesThat(DescribedPredicate)} that catches violations only by real accesses.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency target
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -1008,6 +1128,10 @@ public interface ClassesShould {
      *
      * NOTE: 'dependOn' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
      * Compare with {@link #onlyAccessClassesThat(DescribedPredicate)} that catches violations only by real accesses.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency target
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -1045,6 +1169,10 @@ public interface ClassesShould {
      * </code></pre>
      *
      * NOTE: 'dependOn' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency target
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -1092,6 +1220,10 @@ public interface ClassesShould {
      * NOTE: 'depends' catches wide variety of violations, e.g. having fields of type, having method parameters of type, extending type etc...
      * Compare with {@link #onlyBeAccessed()}.{@link OnlyBeAccessedSpecification#byClassesThat(DescribedPredicate) byClassesThat(DescribedPredicate)}
      * that catches violations only by real accesses.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate Determines which {@link JavaClass JavaClasses} match the dependency origin
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldConjunction.java
@@ -19,19 +19,73 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Allows to join together any existing {@link ArchCondition} of this rule with another {@link ArchCondition}
+ * via {@link #andShould() and} or {@link #orShould() or}. Note that the behavior is always fully left-associative, i.e. there is no
+ * "operator precedence" as for {@code &&} or {@code ||}. Take for example
+ *
+ * <pre><code>
+ * classes()...should().bePublic().orShould().bePrivate().andShould().haveNameMatching(pattern)
+ * </code></pre>
+ *
+ * The semantics of the new condition will be {@code (public OR private) AND haveNameMatching}
+ * – and not {@code public || (private && haveNameMatching)}.
+ * <br><br>
+ * Thus, for more complex conditions please consider explicitly joining {@link ArchConditions preconfigured conditions}
+ * or custom {@link ArchCondition conditions} via {@link ArchCondition#and(ArchCondition)} and {@link ArchCondition#or(ArchCondition)}
+ * where you can freely control the precedence via nesting. E.g.
+ *
+ * <pre><code>
+ * classes()...should(
+ *   bePublic().or(
+ *     bePrivate().and(haveNameMatching(pattern))
+ *   )
+ * )
+ * </code></pre>
+ *
+ * Note that inverting the rule, e.g. via {@link ArchRuleDefinition#noClasses()}, will also invert the join operator. I.e.
+ * if you define {@code noClasses().should().a().orShould().b()} it will mean that all classes must satisfy {@code not(a) AND not(b)}.
+ */
 public interface ClassesShouldConjunction extends ArchRule {
+
+    /**
+     * Joins another condition to this rule with {@code and} semantics. That is, all classes under test
+     * now needs to satisfy the existing condition and this new one.<br>
+     * Note that this is always left-associative and does not support any operator
+     * precedence, see {@link ClassesShouldConjunction}.
+     *
+     * @param condition Another condition to be 'and'-ed to the current condition of this rule
+     * @return A syntax element, which can be used to further restrict the classes under consideration
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction andShould(ArchCondition<? super JavaClass> condition);
 
+    /**
+     * Like {@link #andShould(ArchCondition)} but offers a fluent API to pick the condition to join.
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShould andShould();
 
+    /**
+     * Joins another condition to this rule with {@code or} semantics. That is, all classes under test
+     * now needs to satisfy the existing condition or this given one.<br>
+     * Note that this is always left-associative and does not support any operator
+     * precedence, see {@link ClassesShouldConjunction}.
+     *
+     * @param condition Another condition to be 'and'-ed to the current condition of this rule
+     * @return A syntax element, which can be used to further restrict the classes under consideration
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction orShould(ArchCondition<? super JavaClass> condition);
 
+    /**
+     * Like {@link #orShould(ArchCondition)} but offers a fluent API to pick the condition to join.
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShould orShould();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -29,7 +29,9 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.PackageMatcher;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasName.Predicates;
+import com.tngtech.archunit.core.domain.properties.HasType;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
@@ -297,6 +299,11 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -307,6 +314,11 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes not annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -379,6 +391,12 @@ public interface ClassesThat<CONJUNCTION> {
      * This also matches classes where a direct annotation matches the supplied predicate.
      * </p>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
+     *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -393,6 +411,12 @@ public interface ClassesThat<CONJUNCTION> {
      * <p>
      * Matching classes may also not be annotated with a direct annotation matching the supplied predicate.
      * </p>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -452,6 +476,10 @@ public interface ClassesThat<CONJUNCTION> {
      * Note that this only matches non-interface {@link JavaClass classes} that implement an interface matching the {@code predicate}
      * (compare {@link JavaClass.Predicates#implement(Class)}.
      * For general assignability see {@link #areAssignableTo(DescribedPredicate)}
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying interfaces matching classes must implement
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -462,6 +490,10 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes that do not implement a certain interface matching the given predicate.
      * This is the negation of {@link #implement(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying interfaces matching classes must not implement
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -518,6 +550,10 @@ public interface ClassesThat<CONJUNCTION> {
      * Matches classes assignable to a certain type matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #areAssignableTo(String)}, but the approach is a lot more generic.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an upper type bound to match imported classes against
      *                  (imported subtypes will match)
@@ -529,6 +565,10 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes not assignable to a certain type matching the given predicate.
      * This is the negation of {@link #areAssignableTo(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying an upper type bound imported classes should NOT have
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -589,6 +629,10 @@ public interface ClassesThat<CONJUNCTION> {
      * Matches classes assignable from a certain type matching the given predicate. For example, a call with
      * {@link Predicates#name(String)} would be equivalent to
      * {@link #areAssignableFrom(String)}, but the approach is a lot more generic.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying a lower type bound to match imported classes against
      *                  (imported supertypes will match)
@@ -600,6 +644,10 @@ public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes not assignable from a certain type matching the given predicate.
      * This is the negation of {@link #areAssignableFrom(DescribedPredicate)}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate identifying a lower type bound imported classes should NOT have
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -743,6 +791,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain any {@link JavaMember member} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMember} can be found within {@link JavaMember.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaMember JavaMembers}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -752,6 +805,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain any {@link JavaField field} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaField} can be found within {@link JavaMember.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaField JavaFields}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -761,6 +819,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain any {@link JavaCodeUnit code unit} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaCodeUnit} can be found within {@link JavaCodeUnit.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaCodeUnit JavaCodeUnits}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -770,6 +833,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain any {@link JavaMethod method} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMethod} can be found within {@link JavaMethod.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaMethod JavaMethods}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -779,6 +847,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain any {@link JavaConstructor constructor} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaConstructor} can be found within {@link JavaConstructor.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaConstructor JavaConstructors}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -788,6 +861,11 @@ public interface ClassesThat<CONJUNCTION> {
 
     /**
      * Matches classes that contain a {@link JavaStaticInitializer static initializer} matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaStaticInitializer} can be found within {@link JavaCodeUnit.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaStaticInitializer JavaStaticInitializers}
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -139,6 +140,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * }
      * </code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their raw parameter types
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -159,6 +165,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      *     void someMethod(String stringParam, int intParam) {...}
      * }
      * </code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their raw parameter types
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -265,6 +276,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * }
      * </code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their raw return types
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -285,6 +301,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      *     String someMethod() {...}
      * }
      * </code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their raw return types
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -391,6 +412,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      * }
      * </code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their declared {@link Throwable}
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -411,6 +437,11 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
      *     void someMethod() throws SomeException {...}
      * }
      * </code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their declared {@link Throwable}
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -116,6 +117,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#haveRawParameterTypes(DescribedPredicate) haveRawParameterTypes(whereFirstTypeIs(String.class))}</code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their raw parameter types
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -134,6 +140,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      * Then <code>someMethod</code> would be matched by
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#doNotHaveRawParameterTypes(DescribedPredicate) doNotHaveRawParameterTypes(whereFirstTypeIs(int.class))}</code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their raw parameter types
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -230,6 +241,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#haveRawReturnType(DescribedPredicate) haveRawReturnType(assignableTo(Serializable.class))}</code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their raw return types
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -248,6 +264,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      * Then <code>someMethod</code> would be matched by
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#doNotHaveRawReturnType(DescribedPredicate) doNotHaveRawReturnType(assignableTo(List.class))}</code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their raw return types
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -344,6 +365,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#declareThrowableOfType(DescribedPredicate) declareThrowableOfType(nameStartingWith("First"))}</code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} match by their declared {@link Throwable}
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -362,6 +388,11 @@ public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      * Then <code>someMethod</code> would be matched by
      *
      * <pre><code>{@link ArchRuleDefinition#codeUnits() codeUnits()}.{@link GivenCodeUnits#that() that()}.{@link CodeUnitsThat#doNotDeclareThrowableOfType(DescribedPredicate) doNotDeclareThrowableOfType(nameStartingWith("Second"))}</code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A {@link DescribedPredicate} that determines, which {@link JavaCodeUnit JavaCodeUnits} do not match by their declared {@link Throwable}
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -118,6 +119,11 @@ public interface FieldsShould<CONJUNCTION extends FieldsShouldConjunction> exten
      *     Object someField;
      * }</code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A predicate determining which sort of types fields should have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
@@ -137,6 +143,11 @@ public interface FieldsShould<CONJUNCTION extends FieldsShouldConjunction> exten
      * class Example {
      *     String someField;
      * }</code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate determining which sort of types fields should not have
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -113,6 +114,11 @@ public interface FieldsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      *
      * <pre><code>{@link ArchRuleDefinition#fields() fields()}.{@link GivenFields#that() that()}.{@link FieldsThat#haveRawType(DescribedPredicate) haveRawType(assignableTo(Serializable.class))}</code></pre>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate A predicate determining which types of fields match
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -131,6 +137,11 @@ public interface FieldsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
      * Then <code>someField</code> would be matched by
      *
      * <pre><code>{@link ArchRuleDefinition#fields() fields()}.{@link GivenFields#that() that()}.{@link FieldsThat#doNotHaveRawType(DescribedPredicate) doNotHaveRawType(assignableTo(List.class))}</code></pre>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate determining which types of fields do not match
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
@@ -22,9 +22,15 @@ import com.tngtech.archunit.lang.ArchCondition;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public interface GivenClass {
+    /**
+     * Like {@link GivenClasses#should()} but for a single class
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShould should();
 
+    /**
+     * Like {@link GivenClasses#should(ArchCondition)} but for a single class
+     */
     @PublicAPI(usage = ACCESS)
     ClassesShouldConjunction should(ArchCondition<? super JavaClass> condition);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -57,6 +58,8 @@ public interface GivenClasses extends GivenObjects<JavaClass> {
      * {@link ArchRuleDefinition#classes() classes()}.{@link GivenClasses#should() should()}.{@link ClassesShould#haveSimpleName(String) haveSimpleName("Example")}
      * </code>
      *
+     * Use {@link #should(ArchCondition)} to freely customize the condition against which the classes should be checked.
+     *
      * @return A syntax element, which can be used to restrict the classes under consideration
      */
     @PublicAPI(usage = ACCESS)
@@ -68,6 +71,9 @@ public interface GivenClasses extends GivenObjects<JavaClass> {
      * <code>
      * {@link ArchRuleDefinition#classes() classes()}.{@link GivenClasses#should(ArchCondition) should(haveSimpleName("Example"))}
      * </code>
+     *
+     * {@link #should()} is a fluent version of this API that allows your IDE to make suggestions.<br>
+     * Predefined conditions to customize and join can be found within {@link ArchConditions}.
      *
      * @return A syntax element, which can be used to restrict the classes under consideration
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
@@ -44,6 +45,10 @@ public interface GivenClasses extends GivenObjects<JavaClass> {
      * <code>
      * {@link ArchRuleDefinition#classes() classes()}.{@link GivenClasses#that(DescribedPredicate) that(haveSimpleName("Example"))}
      * </code>
+     *
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @return A syntax conjunction element, which can be completed to form a full rule
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConjunction.java
@@ -17,13 +17,27 @@ package com.tngtech.archunit.lang.syntax.elements;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClass.Predicates;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Allows to further filter the set of all objects via {@link #and(DescribedPredicate)} or {@link #or(DescribedPredicate)}
+ * or create a complete {@link ArchRule} via {@link #should(ArchCondition)}.
+ * @param <OBJECTS> The type of the objects to be checked by the final {@link ArchRule}, e.g. {@link JavaClass}.
+ */
 public interface GivenConjunction<OBJECTS> {
+
+    /**
+     * Creates an {@link ArchRule} that will evaluate all {@code OBJECTS} under test against the supplied
+     * {@link ArchCondition}.
+     *
+     * @param condition The {@link ArchCondition} to check objects against
+     * @return An {@link ArchRule} that can be checked against a set of {@code OBJECTS}
+     */
     @PublicAPI(usage = ACCESS)
     ArchRule should(ArchCondition<? super OBJECTS> condition);
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
@@ -29,9 +30,9 @@ public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<ME
     /**
      * Allows to restrict the set of members under consideration. E.g.
      * <br><br>
-     * <code>
+     * <pre><code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#that() that()}.{@link MembersThat#haveName(String) haveName("foo")}
-     * </code>
+     * </code></pre>
      *
      * @return A syntax element, which can be used to restrict the members under consideration
      */
@@ -41,9 +42,14 @@ public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<ME
     /**
      * Allows to restrict the set of members under consideration. E.g.
      * <br><br>
-     * <code>
+     * <pre><code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#that(DescribedPredicate) that(haveName("foo"))}
-     * </code>
+     * </code></pre>
+     *
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMember} can be found within {@link JavaMember.Predicates} or one of the respective ancestors
+     * like {@link HasName.Predicates}.
      *
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -54,9 +60,9 @@ public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<ME
     /**
      * Allows to specify assertions for the set of members under consideration. E.g.
      * <br><br>
-     * <code>
+     * <pre><code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#should() should()}.{@link MembersShould#haveName(String) haveName("foo")}
-     * </code>
+     * </code></pre>
      *
      * @return A syntax element, which can be used to restrict the members under consideration
      */
@@ -66,9 +72,9 @@ public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<ME
     /**
      * Allows to specify assertions for the set of members under consideration. E.g.
      * <br><br>
-     * <code>
+     * <pre><code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#should(ArchCondition) should(haveName("foo"))}
-     * </code>
+     * </code></pre>
      *
      * Predefined conditions to customize and join can be found within {@link ArchConditions}.
      *

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -68,6 +69,8 @@ public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<ME
      * <code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#should(ArchCondition) should(haveName("foo"))}
      * </code>
+     *
+     * Predefined conditions to customize and join can be found within {@link ArchConditions}.
      *
      * @return A syntax element, which can be used to restrict the members under consideration
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersConjunction.java
@@ -32,9 +32,15 @@ public interface GivenMembersConjunction<MEMBER extends JavaMember> extends Give
     @PublicAPI(usage = ACCESS)
     GivenMembersConjunction<MEMBER> or(DescribedPredicate<? super MEMBER> predicate);
 
+    /**
+     * Like {@link #and(DescribedPredicate)} but allows to pick the predicate to join by a fluent API.
+     */
     @PublicAPI(usage = ACCESS)
     MembersThat<? extends GivenMembersConjunction<MEMBER>> and();
 
+    /**
+     * Like {@link #or(DescribedPredicate)} but allows to pick the predicate to join by a fluent API.
+     */
     @PublicAPI(usage = ACCESS)
     MembersThat<? extends GivenMembersConjunction<MEMBER>> or();
 
@@ -42,6 +48,9 @@ public interface GivenMembersConjunction<MEMBER extends JavaMember> extends Give
     @PublicAPI(usage = ACCESS)
     MembersShouldConjunction<MEMBER> should(ArchCondition<? super MEMBER> condition);
 
+    /**
+     * Like {@link #should(ArchCondition)} but allows to pick the condition to join by a fluent API.
+     */
     @PublicAPI(usage = ACCESS)
     MembersShould<? extends MembersShouldConjunction<MEMBER>> should();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenObjects.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenObjects.java
@@ -17,7 +17,9 @@ package com.tngtech.archunit.lang.syntax.elements;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ClassesTransformer;
@@ -45,6 +47,10 @@ public interface GivenObjects<T> {
      * <code>
      * {@link ArchRuleDefinition#all(ClassesTransformer) all(customObjects)}.{@link GivenObjects#that(DescribedPredicate) that(predicate)}
      * </code>
+     *
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @return A syntax conjunction element, which can be completed to form a full rule
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
@@ -25,6 +25,8 @@ import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -279,6 +281,11 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
 
     /**
      * Asserts that members are annotated with an annotation matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -288,6 +295,11 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
 
     /**
      * Asserts that members are not annotated with an annotation matching the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -359,6 +371,12 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
      * The assertion is also successful if members are directly annotated with an annotation matching the supplied predicate.
      * </p>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
+     *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
      */
@@ -372,6 +390,12 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
      * <p>
      * The assertion also fails if members are directly annotated with an annotation matching the supplied predicate.
      * </p>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
@@ -472,6 +496,10 @@ public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> 
      * class AnyOther {
      *     Object someField;
      * }</code></pre>
+     *
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate which matches classes where members have to be declared in
      * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldConjunction.java
@@ -17,21 +17,43 @@ package com.tngtech.archunit.lang.syntax.elements;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Same as {@link ClassesShouldConjunction} but for rules about {@link JavaMember members}.
+ * In particular, the explanation about associativity of joining further {@link ArchCondition conditions}
+ * via {@link #andShould(ArchCondition)} and {@link #orShould(ArchCondition)}
+ * as explained within {@link ClassesShouldConjunction} also holds for the methods defined in this
+ * hierarchy of classes.
+ * @param <MEMBER> The concrete type of {@link JavaMember} this conjunction describes, e.g. {@link JavaMethod}.
+ */
 public interface MembersShouldConjunction<MEMBER extends JavaMember> extends ArchRule {
+
+    /**
+     * Same as {@link ClassesShouldConjunction#andShould(ArchCondition)} but for {@link JavaMember}
+     */
     @PublicAPI(usage = ACCESS)
     MembersShouldConjunction<MEMBER> andShould(ArchCondition<? super MEMBER> condition);
 
+    /**
+     * Same as {@link ClassesShouldConjunction#andShould()} but for {@link JavaMember}
+     */
     @PublicAPI(usage = ACCESS)
     MembersShould<? extends MembersShouldConjunction<MEMBER>> andShould();
 
+    /**
+     * Same as {@link ClassesShouldConjunction#orShould(ArchCondition)} but for {@link JavaMember}
+     */
     @PublicAPI(usage = ACCESS)
     MembersShouldConjunction<MEMBER> orShould(ArchCondition<? super MEMBER> condition);
 
+    /**
+     * Same as {@link ClassesShouldConjunction#orShould()} but for {@link JavaMember}
+     */
     @PublicAPI(usage = ACCESS)
     MembersShould<? extends MembersShouldConjunction<MEMBER>> orShould();
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
@@ -23,6 +23,8 @@ import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.domain.properties.HasType;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -276,6 +278,11 @@ public interface MembersThat<CONJUNCTION> {
     /**
      * Matches members annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -286,6 +293,11 @@ public interface MembersThat<CONJUNCTION> {
     /**
      * Matches members not annotated with a certain annotation, where matching annotations are
      * determined by the supplied predicate.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -358,6 +370,12 @@ public interface MembersThat<CONJUNCTION> {
      * This also matches members where a direct annotation matches the supplied predicate.
      * </p>
      *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
+     *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -372,6 +390,12 @@ public interface MembersThat<CONJUNCTION> {
      * <p>
      * Matching members may also not be annotated with a direct annotation matching the supplied predicate.
      * </p>
+     *
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaAnnotation} can be found within one of the respective ancestors
+     * like {@link HasType.Predicates}.
      *
      * @param predicate A predicate defining matching {@link JavaAnnotation JavaAnnotations}
      * @return A syntax conjunction element, which can be completed to form a full rule
@@ -477,6 +501,10 @@ public interface MembersThat<CONJUNCTION> {
      * <pre><code>
      * {@link ArchRuleDefinition#members() members()}.{@link GivenMembers#that() that()}.{@link MembersThat#areDeclaredInClassesThat(DescribedPredicate) areDeclaredInClassesThat(are(assignableTo(Serializable.class)))}
      * </code></pre>
+     *
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
      *
      * @param predicate A predicate which matches classes where members have to be declared in
      * @return A syntax conjunction element, which can be completed to form a full rule

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeAccessedSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeAccessedSpecification.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.PackageMatcher;
+import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
@@ -39,6 +40,12 @@ public interface OnlyBeAccessedSpecification<CONJUNCTION> {
     ClassesThat<ClassesShouldConjunction> byClassesThat();
 
     /**
+     * Allows to restrict the access origins by matching them against the supplied {@link DescribedPredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate Restricts which classes the access should be from
      * @return A syntax conjunction element, which can be completed to form a full rule
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
@@ -20,13 +20,21 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public interface OnlyBeCalledSpecification<CONJUNCTION> {
 
     /**
+     * Restricts allowed origins of calls to classes matching the supplied {@link DescribedPredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     *
      * @param predicate Restricts which classes the call should originate from. Every class that calls the respective {@link JavaCodeUnit} must match the predicate.
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -40,6 +48,13 @@ public interface OnlyBeCalledSpecification<CONJUNCTION> {
     ClassesThat<CONJUNCTION> byClassesThat();
 
     /**
+     * Restricts allowed origins of calls to code units matching the supplied {@link DescribedPredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaCodeUnit} can be found within {@link JavaCodeUnit.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
+     *
      * @param predicate Restricts which code units the call should originate from
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -47,6 +62,13 @@ public interface OnlyBeCalledSpecification<CONJUNCTION> {
     CONJUNCTION byCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate);
 
     /**
+     * Restricts allowed origins of calls to methods matching the supplied {@link DescribedPredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaMethod} can be found within {@link JavaMethod.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
+     *
      * @param predicate Restricts which methods the call should originate from. Calls from constructors are treated as mismatch.
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
@@ -54,6 +76,13 @@ public interface OnlyBeCalledSpecification<CONJUNCTION> {
     CONJUNCTION byMethodsThat(DescribedPredicate<? super JavaMethod> predicate);
 
     /**
+     * Restricts allowed origins of calls to constructors matching the supplied {@link DescribedPredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaConstructor} can be found within {@link JavaConstructor.Predicates} or one of the respective ancestors
+     * like {@link JavaMember.Predicates}.
+     *
      * @param predicate Restricts which constructors the call should originate from. Calls from methods are treated as mismatch.
      * @return A syntax conjunction element, which can be completed to form a full rule
      */

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
@@ -19,7 +19,8 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
-import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaMethod;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
@@ -43,19 +44,19 @@ public interface OnlyBeCalledSpecification<CONJUNCTION> {
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION byCodeUnitsThat(DescribedPredicate<? super JavaMember> predicate);
+    CONJUNCTION byCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate);
 
     /**
      * @param predicate Restricts which methods the call should originate from. Calls from constructors are treated as mismatch.
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION byMethodsThat(DescribedPredicate<? super JavaMember> predicate);
+    CONJUNCTION byMethodsThat(DescribedPredicate<? super JavaMethod> predicate);
 
     /**
      * @param predicate Restricts which constructors the call should originate from. Calls from methods are treated as mismatch.
      * @return A syntax conjunction element, which can be completed to form a full rule
      */
     @PublicAPI(usage = ACCESS)
-    CONJUNCTION byConstructorsThat(DescribedPredicate<? super JavaMember> predicate);
+    CONJUNCTION byConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -34,6 +34,7 @@ import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.PackageMatcher;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
@@ -275,6 +276,10 @@ public final class Architectures {
         /**
          * Like {@link #ensureAllClassesAreContainedInArchitecture()} but will ignore classes in packages matching
          * the specified {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
          *
          * @param predicate {@link DescribedPredicate predicate} specifying which classes may live outside the architecture
          *
@@ -537,6 +542,10 @@ public final class Architectures {
 
             /**
              * Defines a layer by a predicate, i.e. any {@link JavaClass} that will match the predicate will belong to this layer.
+             * <br><br>
+             * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+             * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+             * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
              */
             @PublicAPI(usage = ACCESS)
             public LayeredArchitecture definedBy(DescribedPredicate<? super JavaClass> predicate) {
@@ -787,44 +796,106 @@ public final class Architectures {
             this.overriddenDescription = overriddenDescription;
         }
 
+        /**
+         * Defines which classes belong to domain models by matching them against {@link PackageMatcher package identifiers}.
+         * @param packageIdentifiers {@link PackageMatcher package identifiers} defining which classes belong to domain models
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture domainModels(String... packageIdentifiers) {
             return domainModels(byPackagePredicate(packageIdentifiers));
         }
 
+        /**
+         * Defines which classes belong to domain models by matching them against the supplied {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+         * @param predicate A {@link DescribedPredicate} defining which classes belong to domain models
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture domainModels(DescribedPredicate<? super JavaClass> predicate) {
             domainModelPredicate = Optional.of(predicate);
             return this;
         }
 
+        /**
+         * Defines which classes belong to domain services by matching them against {@link PackageMatcher package identifiers}.
+         *
+         * @param packageIdentifiers {@link PackageMatcher package identifiers} defining which classes belong to domain services
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture domainServices(String... packageIdentifiers) {
             return domainServices(byPackagePredicate(packageIdentifiers));
         }
 
+        /**
+         * Defines which classes belong to domain services by matching them against the supplied {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+         * @param predicate A {@link DescribedPredicate} defining which classes belong to domain services
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture domainServices(DescribedPredicate<? super JavaClass> predicate) {
             domainServicePredicate = Optional.of(predicate);
             return this;
         }
 
+        /**
+         * Defines which classes belong to application services by matching them against {@link PackageMatcher package identifiers}.
+         *
+         * @param packageIdentifiers {@link PackageMatcher package identifiers} defining which classes belong to application services
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture applicationServices(String... packageIdentifiers) {
             return applicationServices(byPackagePredicate(packageIdentifiers));
         }
 
+        /**
+         * Defines which classes belong to application services by matching them against the supplied {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+         * @param predicate A {@link DescribedPredicate} defining which classes belong to application services
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture applicationServices(DescribedPredicate<? super JavaClass> predicate) {
             applicationPredicate = Optional.of(predicate);
             return this;
         }
 
+        /**
+         * Defines which classes belong to a specific adapter by matching them against {@link PackageMatcher package identifiers}.
+         *
+         * @param name The name of the adapter
+         * @param packageIdentifiers {@link PackageMatcher package identifiers} defining which classes belong to the adapter
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture adapter(String name, String... packageIdentifiers) {
             return adapter(name, byPackagePredicate(packageIdentifiers));
         }
 
+        /**
+         * Defines which classes belong to a specific adapter by matching them against the supplied {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+         *
+         * @param name The name of the adapter
+         * @param predicate A {@link DescribedPredicate} defining which classes belong to the adapter
+         * @return The {@link OnionArchitecture} to be checked against classes or further customized
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture adapter(String name, DescribedPredicate<? super JavaClass> predicate) {
             adapterPredicates.put(name, predicate);
@@ -841,16 +912,35 @@ public final class Architectures {
             return this;
         }
 
+        /**
+         * Ignores all {@link Dependency dependencies} that have an {@link Dependency#getOriginClass() origin class}
+         * {@link JavaClass#isEquivalentTo(Class) equivalent to} the supplied {@code origin} and {@link Dependency#getTargetClass() target class}
+         * {@link JavaClass#isEquivalentTo(Class) equivalent to} the supplied {@code target}.
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture ignoreDependency(Class<?> origin, Class<?> target) {
             return ignoreDependency(equivalentTo(origin), equivalentTo(target));
         }
 
+        /**
+         * Ignores all {@link Dependency dependencies} that have an {@link Dependency#getOriginClass() origin class}
+         * with fully qualified class name {@code origin} and {@link Dependency#getTargetClass() target class}
+         * with fully qualified class name {@code target}.
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture ignoreDependency(String origin, String target) {
             return ignoreDependency(name(origin), name(target));
         }
 
+        /**
+         * Ignores all {@link Dependency dependencies} that have an {@link Dependency#getOriginClass() origin class}
+         * matching the supplied {@code origin} {@link DescribedPredicate predicate} and {@link Dependency#getTargetClass() target class}
+         * matching the supplied {@code target} {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+         */
         @PublicAPI(usage = ACCESS)
         public OnionArchitecture ignoreDependency(DescribedPredicate<? super JavaClass> origin, DescribedPredicate<? super JavaClass> target) {
             this.ignoredDependencies.add(new IgnoredDependency(origin, target));
@@ -885,6 +975,10 @@ public final class Architectures {
         /**
          * Like {@link #ensureAllClassesAreContainedInArchitecture()} but will ignore classes in packages matching
          * the specified {@link DescribedPredicate predicate}.
+         * <br><br>
+         * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+         * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+         * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
          *
          * @param predicate {@link DescribedPredicate predicate} specifying which classes may live outside the architecture
          *

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlicesConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlicesConjunction.java
@@ -17,6 +17,8 @@ package com.tngtech.archunit.library.dependencies.syntax;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.elements.GivenConjunction;
 import com.tngtech.archunit.library.dependencies.Slice;
 
@@ -24,6 +26,9 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
 public interface GivenSlicesConjunction extends GivenConjunction<Slice> {
 
+    /**
+     * Like {@link #should(ArchCondition)} but allows to pick the {@link ArchCondition} by a fluent API.
+     */
     @PublicAPI(usage = ACCESS)
     SlicesShould should();
 
@@ -35,6 +40,20 @@ public interface GivenSlicesConjunction extends GivenConjunction<Slice> {
     @PublicAPI(usage = ACCESS)
     GivenSlicesConjunction or(DescribedPredicate<? super Slice> predicate);
 
+    /**
+     * Customizes the description of the slices under test, i.e. the part before the
+     * 'should' of the {@link ArchRule}. E.g.
+     *
+     * <pre><code>
+     * slices().matching("..some.pattern.(*)..").as("My specific components").should()...
+     * </code></pre>
+     *
+     * yields the rule text {@code My specific components should...}
+     *
+     * @param description The description of the slices within the slice rule
+     * @return A syntax element, which can be used to restrict the classes under consideration
+     *         or form a complete {@link ArchRule}
+     */
     @PublicAPI(usage = ACCESS)
     GivenSlicesConjunction as(String description);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
@@ -31,6 +31,7 @@ import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.PackageMatcher;
 import com.tngtech.archunit.core.domain.PackageMatchers;
+import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 
@@ -101,12 +102,28 @@ public class PlantUmlArchCondition extends ArchCondition<JavaClass> {
         this.javaClassDiagramAssociation = javaClassDiagramAssociation;
     }
 
+    /**
+     * Ignores all {@link Dependency dependencies} that have an {@link Dependency#getOriginClass() origin class}
+     * matching the supplied {@link DescribedPredicate ignorePredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     */
     @PublicAPI(usage = ACCESS)
     public PlantUmlArchCondition ignoreDependenciesWithOrigin(DescribedPredicate<? super JavaClass> ignorePredicate) {
         return ignoreDependencies(GET_ORIGIN_CLASS.is(ignorePredicate)
                 .as("ignoring dependencies with origin " + ignorePredicate.getDescription()));
     }
 
+    /**
+     * Ignores all {@link Dependency dependencies} that have an {@link Dependency#getTargetClass() target class}
+     * matching the supplied {@link DescribedPredicate ignorePredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link JavaClass} can be found within {@link JavaClass.Predicates} or one of the respective ancestors like {@link HasName.Predicates}.
+     */
     @PublicAPI(usage = ACCESS)
     public PlantUmlArchCondition ignoreDependenciesWithTarget(DescribedPredicate<? super JavaClass> ignorePredicate) {
         return ignoreDependencies(GET_TARGET_CLASS.is(ignorePredicate)
@@ -125,6 +142,13 @@ public class PlantUmlArchCondition extends ArchCondition<JavaClass> {
                         .as("ignoring dependencies from %s to %s", origin, target));
     }
 
+    /**
+     * Ignores all {@link Dependency dependencies} matching the supplied {@link DescribedPredicate ignorePredicate}.
+     * <br><br>
+     * Note that many predefined {@link DescribedPredicate predicates} can be found within a subclass {@code Predicates} of the
+     * respective domain object or a common ancestor. For example, {@link DescribedPredicate predicates} targeting
+     * {@link Dependency} can be found within {@link Dependency.Predicates}.
+     */
     @PublicAPI(usage = ACCESS)
     public PlantUmlArchCondition ignoreDependencies(DescribedPredicate<? super Dependency> ignorePredicate) {
         String description = getDescription() + ", " + ignorePredicate.getDescription();


### PR DESCRIPTION
At the moment it is quite challenging to find a certain predicate or function, because users might need to know the domain model very well to find the necessary location (e.g. predicates like `nameMatching(..)` are defined within `HasName.Predicates` to be reused for everything that has a name, but at the same time users now need to know that `JavaClass` implements `HasName` to use these predicates).

While in the long term it might make sense to implement a better entry point API to improve discoverability, for now we can at least improve the documentation to link from more specific predicates to more generic ones. I.e. that I have some chance to discover

1) Javadoc on some method `...That(DescribedPredicate<? super JavaClass>)` -> "you can find predefined predicates in `JavaClass.Predicates`
2) Javadoc on `JavaClass.Predicates` -> "due to inheritance you can find further applicable predicates in `HasName.Predicates`, `HasModifiers.Predicates`, ..."