### PR TITLE
Prepare Release `1.0.0-rc1`

### DIFF
--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -48,7 +48,9 @@ def updateVersion = { Closure<String> calculateNewVersion ->
 
 task prepareRelease() {
     doFirst {
-        String releaseVersion = withCurrentVersion { int oldMajor, int oldMinor, int oldPatch, String oldSuffix -> "$oldMajor.$oldMinor.$oldPatch" }
+        String releaseVersion = withCurrentVersion { int oldMajor, int oldMinor, int oldPatch, String oldSuffix ->
+            "$oldMajor.$oldMinor.$oldPatch${oldSuffix.replace('-SNAPSHOT', '')}"
+        }
 
         def releaseBranch = "release-$releaseVersion"
         executeCommand(['git', 'checkout', '-b', "$releaseBranch"])

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 archunit.group=com.tngtech.archunit
-archunit.version=0.24.0-SNAPSHOT
+archunit.version=1.0.0-rc1-SNAPSHOT
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED


### PR DESCRIPTION
We want to release a candidate for ArchUnit `1.0.0`. So, this change contains the version adjustment to `1.0.0-rc1-SNAPSHOT` and adjusts the release support code to accept an `-rc` suffix.