### PR TITLE
improve naming around `JavaPackage` dependencies

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -100,10 +100,9 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     @Override
     @PublicAPI(usage = ACCESS)
     public Set<? extends JavaAnnotation<JavaPackage>> getAnnotations() {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().getAnnotations().stream().map(withSelfAsOwner).collect(toSet());
-        }
-        return emptySet();
+        return packageInfo
+                .map(it -> it.getAnnotations().stream().map(withSelfAsOwner).collect(toSet()))
+                .orElse(emptySet());
     }
 
     @Override
@@ -134,64 +133,43 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     @Override
     @PublicAPI(usage = ACCESS)
     public Optional<JavaAnnotation<JavaPackage>> tryGetAnnotationOfType(String typeName) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().tryGetAnnotationOfType(typeName).map(withSelfAsOwner);
-        }
-        return Optional.empty();
+        return packageInfo.flatMap(it -> it.tryGetAnnotationOfType(typeName).map(withSelfAsOwner));
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isAnnotatedWith(Class<? extends Annotation> annotationType) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isAnnotatedWith(annotationType);
-        }
-        return false;
+        return packageInfo.map(it -> it.isAnnotatedWith(annotationType)).orElse(false);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isAnnotatedWith(String annotationTypeName) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isAnnotatedWith(annotationTypeName);
-        }
-        return false;
+        return packageInfo.map(it -> it.isAnnotatedWith(annotationTypeName)).orElse(false);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isAnnotatedWith(predicate);
-        }
-        return false;
+        return packageInfo.map(it -> it.isAnnotatedWith(predicate)).orElse(false);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isMetaAnnotatedWith(Class<? extends Annotation> annotationType) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isMetaAnnotatedWith(annotationType);
-        }
-        return false;
+        return packageInfo.map(it -> it.isMetaAnnotatedWith(annotationType)).orElse(false);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isMetaAnnotatedWith(String annotationTypeName) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isMetaAnnotatedWith(annotationTypeName);
-        }
-        return false;
+        return packageInfo.map(it -> it.isMetaAnnotatedWith(annotationTypeName)).orElse(false);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-        if (packageInfo.isPresent()) {
-            return packageInfo.get().isMetaAnnotatedWith(predicate);
-        }
-        return false;
+        return packageInfo.map(it -> it.isMetaAnnotatedWith(predicate)).orElse(false);
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -491,8 +491,11 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     @PublicAPI(usage = ACCESS)
     public Set<Dependency> getClassDependenciesFromSelf() {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
-        for (JavaClass javaClass : getAllClasses()) {
-            addAllNonSelfDependencies(result, javaClass.getDirectDependenciesFromSelf());
+        Set<JavaClass> allClasses = getAllClasses();
+        for (JavaClass javaClass : allClasses) {
+            javaClass.getDirectDependenciesFromSelf().stream()
+                    .filter(it -> !allClasses.contains(it.getTargetClass()))
+                    .forEach(result::add);
         }
         return result.build();
     }
@@ -504,18 +507,13 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     @PublicAPI(usage = ACCESS)
     public Set<Dependency> getClassDependenciesToSelf() {
         ImmutableSet.Builder<Dependency> result = ImmutableSet.builder();
-        for (JavaClass javaClass : getAllClasses()) {
-            addAllNonSelfDependencies(result, javaClass.getDirectDependenciesToSelf());
+        Set<JavaClass> allClasses = getAllClasses();
+        for (JavaClass javaClass : allClasses) {
+            javaClass.getDirectDependenciesToSelf().stream()
+                    .filter(it -> !allClasses.contains(it.getOriginClass()))
+                    .forEach(result::add);
         }
         return result.build();
-    }
-
-    private void addAllNonSelfDependencies(ImmutableSet.Builder<Dependency> result, Set<Dependency> dependencies) {
-        for (Dependency dependency : dependencies) {
-            if (!containsClass(dependency.getOriginClass()) || !containsClass(dependency.getTargetClass())) {
-                result.add(dependency);
-            }
-        }
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasAnnotations.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasAnnotations.java
@@ -30,15 +30,45 @@ public interface HasAnnotations<SELF extends HasAnnotations<SELF>> extends CanBe
     @PublicAPI(usage = ACCESS)
     Set<? extends JavaAnnotation<? extends SELF>> getAnnotations();
 
+    /**
+     * @param type The {@link Class} of the {@link Annotation} to retrieve.
+     * @return The {@link Annotation} of the given type.
+     *         Will throw an {@link IllegalArgumentException} if no matching {@link Annotation} is present.
+     * @param <A> The type of the {@link Annotation} to retrieve
+     * @see #tryGetAnnotationOfType(Class)
+     * @see #getAnnotationOfType(String)
+     */
     @PublicAPI(usage = ACCESS)
     <A extends Annotation> A getAnnotationOfType(Class<A> type);
 
+    /**
+     * @param typeName The fully qualified class name of the {@link Annotation} type to retrieve.
+     * @return The {@link JavaAnnotation} matching the given type.
+     *         Will throw an {@link IllegalArgumentException} if no matching {@link Annotation} is present.
+     * @see #tryGetAnnotationOfType(String)
+     * @see #getAnnotationOfType(Class)
+     */
     @PublicAPI(usage = ACCESS)
     JavaAnnotation<? extends SELF> getAnnotationOfType(String typeName);
 
+    /**
+     * @param type The {@link Class} of the {@link Annotation} to retrieve.
+     * @return The {@link Annotation} of the given type or {@link Optional#empty()}
+     *         if there is no {@link Annotation} with the respective annotation type.
+     * @param <A> The type of the {@link Annotation} to retrieve
+     * @see #getAnnotationOfType(Class)
+     * @see #tryGetAnnotationOfType(String)
+     */
     @PublicAPI(usage = ACCESS)
     <A extends Annotation> Optional<A> tryGetAnnotationOfType(Class<A> type);
 
+    /**
+     * @param typeName The fully qualified class name of the {@link Annotation} type to retrieve.
+     * @return The {@link JavaAnnotation} matching the given type or {@link Optional#empty()}
+     *         if there is no {@link Annotation} with the respective annotation type.
+     * @see #getAnnotationOfType(String)
+     * @see #tryGetAnnotationOfType(Class)
+     */
     @PublicAPI(usage = ACCESS)
     Optional<? extends JavaAnnotation<? extends SELF>> tryGetAnnotationOfType(String typeName);
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -117,48 +117,68 @@ public class JavaPackageTest {
     }
 
     @Test
-    public void retrieves_class_by_class_object() {
-        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+    public void retrieves_JavaClasses() {
+        JavaClasses classes = new ClassFileImporter().importClasses(Object.class, String.class);
+        JavaPackage defaultPackage = classes.getDefaultPackage();
+        JavaClass javaLangObject = classes.get(Object.class);
 
-        assertThat(defaultPackage.getPackage("java").containsClass(Object.class))
-                .as("package 'java' contains java.lang.Object").isFalse();
+        assertThat(defaultPackage.getPackage("java").containsClass(javaLangObject))
+                .as("package 'java' contains " + javaLangObject.getName()).isFalse();
 
         JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
 
-        assertThat(javaPackage.containsClass(Object.class))
-                .as("java.lang.Object is reported contained by class object").isTrue();
-        assertThat(javaPackage.getClass(Object.class).isEquivalentTo(Object.class))
-                .as("java.lang.Object is returned by class object").isTrue();
+        assertThat(javaPackage.containsClass(javaLangObject))
+                .as(javaLangObject.getName() + " is contained").isTrue();
+        assertThat(javaPackage.getClass(Object.class))
+                .as(javaLangObject.getName() + "is returned").isEqualTo(javaLangObject);
+    }
+
+    @Test
+    public void retrieves_class_by_class_object() {
+        Class<?> javaLangObject = Object.class;
+        JavaPackage defaultPackage = importDefaultPackage(javaLangObject, String.class);
+
+        assertThat(defaultPackage.getPackage("java").containsClass(javaLangObject))
+                .as("package 'java' contains " + javaLangObject.getName()).isFalse();
+
+        JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
+
+        assertThat(javaPackage.containsClass(javaLangObject))
+                .as(javaLangObject + " is reported contained by class object").isTrue();
+        assertThat(javaPackage.getClass(javaLangObject).isEquivalentTo(javaLangObject))
+                .as(javaLangObject + " is returned by class object").isTrue();
     }
 
     @Test
     public void retrieves_class_by_fully_qualified_name() {
-        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+        Class<Object> javaLangObject = Object.class;
+        JavaPackage defaultPackage = importDefaultPackage(javaLangObject, String.class);
 
-        assertThat(defaultPackage.getPackage("java").containsClassWithFullyQualifiedName(Object.class.getName()))
-                .as("package 'java' contains java.lang.Object").isFalse();
+        assertThat(defaultPackage.getPackage("java").containsClassWithFullyQualifiedName(javaLangObject.getName()))
+                .as("package 'java' contains " + javaLangObject.getName()).isFalse();
 
         JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
 
-        assertThat(javaPackage.containsClassWithFullyQualifiedName(Object.class.getName()))
-                .as("java.lang.Object is reported contained by fully qualified name").isTrue();
-        assertThat(javaPackage.getClassWithFullyQualifiedName(Object.class.getName()).isEquivalentTo(Object.class))
-                .as("java.lang.Object is returned by fully qualified name").isTrue();
+        assertThat(javaPackage.containsClassWithFullyQualifiedName(javaLangObject.getName()))
+                .as(javaLangObject.getName() + " is reported contained by fully qualified name").isTrue();
+        assertThat(javaPackage.getClassWithFullyQualifiedName(javaLangObject.getName()).isEquivalentTo(javaLangObject))
+                .as(javaLangObject.getName() + " is returned by fully qualified name").isTrue();
     }
 
     @Test
     public void retrieves_class_by_simple_class_name() {
-        JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class);
+        Class<Object> javaLangObject = Object.class;
+        JavaPackage defaultPackage = importDefaultPackage(javaLangObject, String.class);
 
-        assertThat(defaultPackage.getPackage("java").containsClassWithSimpleName(Object.class.getSimpleName()))
-                .as("package 'java' contains java.lang.Object").isFalse();
+        assertThat(defaultPackage.getPackage("java").containsClassWithSimpleName(javaLangObject.getSimpleName()))
+                .as("package 'java' contains " + javaLangObject.getName()).isFalse();
 
         JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
 
-        assertThat(javaPackage.containsClassWithSimpleName(Object.class.getSimpleName()))
-                .as("java.lang.Object is reported contained by simple name").isTrue();
-        assertThat(javaPackage.getClassWithSimpleName(Object.class.getSimpleName()).isEquivalentTo(Object.class))
-                .as("java.lang.Object is returned by simple name").isTrue();
+        assertThat(javaPackage.containsClassWithSimpleName(javaLangObject.getSimpleName()))
+                .as(javaLangObject + " is reported contained by simple name").isTrue();
+        assertThat(javaPackage.getClassWithSimpleName(javaLangObject.getSimpleName()).isEquivalentTo(javaLangObject))
+                .as(javaLangObject + " is returned by simple name").isTrue();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -17,6 +17,7 @@ import com.tngtech.archunit.core.domain.packageexamples.first.First1;
 import com.tngtech.archunit.core.domain.packageexamples.first.First2;
 import com.tngtech.archunit.core.domain.packageexamples.second.ClassDependingOnOtherSecondClass;
 import com.tngtech.archunit.core.domain.packageexamples.second.Second1;
+import com.tngtech.archunit.core.domain.packageexamples.second.Second2;
 import com.tngtech.archunit.core.domain.packageexamples.second.sub.SecondSub1;
 import com.tngtech.archunit.core.domain.packageexamples.third.sub.ThirdSub1;
 import com.tngtech.archunit.core.domain.packageexamples.unrelated.AnyClass;
@@ -267,7 +268,8 @@ public class JavaPackageTest {
         assertThatDependencies(examplePackage.getPackage("second").getClassDependenciesFromSelf())
                 .contain(Second1.class, First2.class)
                 .contain(SecondSub1.class, ThirdSub1.class)
-                .contain(SecondSub1.class, First1.class);
+                .contain(SecondSub1.class, First1.class)
+                .doesNotContain(Second2.class, SecondSub1.class);
 
         assertThatDependencies(examplePackage.getPackage("third").getClassDependenciesFromSelf())
                 .contain(ThirdSub1.class, First1.class);
@@ -292,7 +294,8 @@ public class JavaPackageTest {
                 .contain(SecondSub1.class, ThirdSub1.class);
 
         assertThatDependencies(examplePackage.getPackage("second").getClassDependenciesToSelf())
-                .doesNotContain(ClassDependingOnOtherSecondClass.class, Second1.class);
+                .doesNotContain(ClassDependingOnOtherSecondClass.class, Second1.class)
+                .doesNotContain(SecondSub1.class, Second2.class);
 
         assertThatDependencies(examplePackage.getPackage("unrelated").getClassDependenciesToSelf())
                 .isEmpty();

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second1.java
@@ -2,6 +2,7 @@ package com.tngtech.archunit.core.domain.packageexamples.second;
 
 import com.tngtech.archunit.core.domain.packageexamples.first.First2;
 
+@SuppressWarnings("unused")
 public class Second1 {
     First2 first2;
     // Since we meanwhile consider arrays to be within the package of their component type, we will always run into the problem

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second2.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/Second2.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.core.domain.packageexamples.second;
+
+import com.tngtech.archunit.core.domain.packageexamples.second.sub.SecondSub1;
+
+@SuppressWarnings("unused")
+public class Second2 {
+    SecondSub1 dependencyToSubpackage;
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/sub/SecondSub1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/second/sub/SecondSub1.java
@@ -1,9 +1,13 @@
 package com.tngtech.archunit.core.domain.packageexamples.second.sub;
 
 import com.tngtech.archunit.core.domain.packageexamples.first.First1;
+import com.tngtech.archunit.core.domain.packageexamples.second.Second2;
 import com.tngtech.archunit.core.domain.packageexamples.third.sub.ThirdSub1;
 
+@SuppressWarnings("unused")
 public class SecondSub1 extends ThirdSub1 {
+    Second2 second2;
+
     SecondSub1(First1 first1) {
     }
 }


### PR DESCRIPTION
This breaking change will clear up some semantic ambiguities around the methods of `JavaPackage` that deal with subpackages. In particular, we will now consider dependencies from/to a package only those where the origin/target class **directly** resides within the package. Subpackages are considered only those packages that reside **directly** within a package. Everything that considers all classes within the package and all subpackages recursively (i.e. subpackages of subpackages and so on) will now refer to the term "package tree".

Changes:
* Added `getClassDependencies{From/To}ThisPackage`
* Renamed `getClassDependencies{From/To}Self` to `getClassDependencies{From/To}ThisPackageTree`
* Added `getPackageDependencies{From/To}ThisPackage`
* Renamed `getPackageDependencies{From/To}Self` to `getPackageDependencies{From/To}ThisPackageTree`
* Renamed `getAllSubpackages` to `getSubpackagesInTree`
* Renamed `accept(..., ClassVisitor/PackageVisitor)` to `traversePackageTree(..., ClassVisitor/PackageVisitor)`

Resolves: #919