### PR TITLE
Make AnalyzeClasses inherited

### DIFF
--- a/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit.junit;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.lang.annotation.Inherited;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -49,6 +50,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(TYPE)
 @Retention(RUNTIME)
 @PublicAPI(usage = ACCESS)
+@Inherited
 public @interface AnalyzeClasses {
     /**
      * @return Packages to look for within the classpath / modulepath


### PR DESCRIPTION
I'd propose this change so a common configuration for the AnalyzeClasses annotation can be set in a common superclass for ArchUnit test classes within a project:
```
@AnalyzeClasses(packages = "com.example.service", importOptions = {DoNotIncludeTests.class, DoNotIncludeSomething.class})
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@Inherited
public @interface ArchRulesTest {
    ...
}

@ArchRulesTest
public class SecurityArchitecturePolicies {
    ...
}

@ArchRulesTest
public class MappingFrameworkPolicies {
    ...
}

@ArchRulesTest
public class LayeredArchitecturePolicies {
    ...
}
```
I haven't actually tested this, so this is just a recommendation - if you'd like me to fork the repo, create tests, etc. please let me know and I'll see when I'll be able to get to it.