### PR TITLE
Consolidate `ClassFileImporter.importClasspath(..)` with other APIs

### DIFF
--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
@@ -2,12 +2,13 @@ package com.tngtech.archunit.exampletest;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-import com.tngtech.archunit.core.importer.ImportOptions;
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static java.util.Collections.singleton;
 
 @Category(Example.class)
 public class SecurityTest {
@@ -27,15 +28,15 @@ public class SecurityTest {
         ArchRule rule = classes().that().resideInAPackage("java.security.cert..")
                 .should().onlyBeAccessed().byAnyPackage("..example.layers.security..", "java..", "..sun..", "javax..", "apple.security..", "org.jcp..");
 
-        JavaClasses classes = new ClassFileImporter().importClasspath(onlyAppAndRuntime());
+        JavaClasses classes = new ClassFileImporter().importClasspath(singleton(onlyAppAndRuntime()));
 
         rule.check(classes);
     }
 
-    private ImportOptions onlyAppAndRuntime() {
-        return new ImportOptions().with(location ->
+    private ImportOption onlyAppAndRuntime() {
+        return location ->
                 location.contains("archunit")
                         || location.contains("/rt.jar")
-                        || location.contains("java.base"));
+                        || location.contains("java.base");
     }
 }

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SecurityTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static java.util.Collections.singleton;
 
 @Category(Example.class)
 public class SecurityTest {
@@ -28,7 +27,7 @@ public class SecurityTest {
         ArchRule rule = classes().that().resideInAPackage("java.security.cert..")
                 .should().onlyBeAccessed().byAnyPackage("..example.layers.security..", "java..", "..sun..", "javax..", "apple.security..", "org.jcp..");
 
-        JavaClasses classes = new ClassFileImporter().importClasspath(singleton(onlyAppAndRuntime()));
+        JavaClasses classes = new ClassFileImporter().withImportOption(onlyAppAndRuntime()).importClasspath();
 
         rule.check(classes);
     }

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -23,7 +23,6 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
-import com.tngtech.archunit.core.importer.ImportOptions;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -70,7 +69,7 @@ public @interface AnalyzeClasses {
 
     /**
      * Allows to filter the class import. The supplied types will be instantiated and used to create the
-     * {@link ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
+     * {@link ImportOption ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
      * {@link ImportOption}.
      *
      * @return The types of {@link ImportOption} to use for the import

--- a/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
+++ b/archunit-junit/junit5/api/src/main/java/com/tngtech/archunit/junit/AnalyzeClasses.java
@@ -24,7 +24,6 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
-import com.tngtech.archunit.core.importer.ImportOptions;
 import org.junit.platform.commons.annotation.Testable;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -74,7 +73,7 @@ public @interface AnalyzeClasses {
 
     /**
      * Allows to filter the class import. The supplied types will be instantiated and used to create the
-     * {@link ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
+     * {@link ImportOption ImportOptions} passed to the {@link ClassFileImporter}. Considering caching, compare the notes on
      * {@link ImportOption}.
      *
      * @return The types of {@link ImportOption} to use for the import

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ClassCache.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ClassCache.java
@@ -16,6 +16,7 @@
 package com.tngtech.archunit.junit.internal;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -29,7 +30,6 @@ import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
-import com.tngtech.archunit.core.importer.ImportOptions;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.core.importer.Locations;
 import com.tngtech.archunit.junit.CacheMode;
@@ -110,9 +110,9 @@ class ClassCache {
 
         private synchronized void initialize() {
             if (javaClasses == null) {
-                ImportOptions importOptions = new ImportOptions();
+                Set<ImportOption> importOptions = new HashSet<>();
                 for (Class<? extends ImportOption> optionClass : importOptionTypes) {
-                    importOptions = importOptions.with(newInstanceOf(optionClass));
+                    importOptions.add(newInstanceOf(optionClass));
                 }
                 javaClasses = cacheClassFileImporter.importClasses(importOptions, locations);
             }
@@ -121,7 +121,7 @@ class ClassCache {
 
     // Used for testing -> that's also the reason it's declared top level
     static class CacheClassFileImporter {
-        JavaClasses importClasses(ImportOptions importOptions, Collection<Location> locations) {
+        JavaClasses importClasses(Set<ImportOption> importOptions, Collection<Location> locations) {
             return new ClassFileImporter(importOptions).importLocations(locations);
         }
     }

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheConcurrencyTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheConcurrencyTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 
 import com.tngtech.archunit.Slow;
-import com.tngtech.archunit.core.importer.ImportOptions;
 import com.tngtech.archunit.junit.internal.ClassCache.CacheClassFileImporter;
 import org.junit.After;
 import org.junit.Before;
@@ -23,7 +22,7 @@ import org.mockito.junit.MockitoRule;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -64,7 +63,7 @@ public class ClassCacheConcurrencyTest {
         for (Future<?> future : futures) {
             future.get(1, MINUTES);
         }
-        verify(classFileImporter, atMost(TEST_CLASSES.size())).importClasses(any(ImportOptions.class), anyCollection());
+        verify(classFileImporter, atMost(TEST_CLASSES.size())).importClasses(anySet(), anyCollection());
         verifyNoMoreInteractions(classFileImporter);
     }
 

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheTest.java
@@ -8,7 +8,6 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
-import com.tngtech.archunit.core.importer.ImportOptions;
 import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.core.importer.Locations;
 import com.tngtech.archunit.junit.LocationProvider;
@@ -33,8 +32,8 @@ import static com.tngtech.archunit.junit.CacheMode.PER_CLASS;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -152,12 +151,12 @@ public class ClassCacheTest {
         TestAnalysisRequest defaultOptions = new TestAnalysisRequest().withWholeClasspath(true);
         Class<?>[] expectedImportResult = new Class[]{getClass()};
         doReturn(new ClassFileImporter().importClasses(expectedImportResult))
-                .when(cacheClassFileImporter).importClasses(any(ImportOptions.class), anyCollection());
+                .when(cacheClassFileImporter).importClasses(anySet(), anyCollection());
 
         JavaClasses classes = cache.getClassesToAnalyzeFor(TestClass.class, defaultOptions);
 
         assertThatTypes(classes).matchExactly(expectedImportResult);
-        verify(cacheClassFileImporter).importClasses(any(ImportOptions.class), locationCaptor.capture());
+        verify(cacheClassFileImporter).importClasses(anySet(), locationCaptor.capture());
         assertThat(locationCaptor.getValue())
                 .has(locationContaining("archunit"))
                 .has(locationContaining("asm"))
@@ -203,7 +202,7 @@ public class ClassCacheTest {
 
         assertThat(classes).isEmpty();
 
-        verify(cacheClassFileImporter).importClasses(any(ImportOptions.class), locationCaptor.capture());
+        verify(cacheClassFileImporter).importClasses(anySet(), locationCaptor.capture());
         assertThat(locationCaptor.getValue()).isEmpty();
     }
 
@@ -245,7 +244,7 @@ public class ClassCacheTest {
     }
 
     private void verifyNumberOfImports(int number) {
-        verify(cacheClassFileImporter, times(number)).importClasses(any(ImportOptions.class), anyCollection());
+        verify(cacheClassFileImporter, times(number)).importClasses(anySet(), anyCollection());
         verifyNoMoreInteractions(cacheClassFileImporter);
     }
 
@@ -281,7 +280,7 @@ public class ClassCacheTest {
     }
 
     public static class AnotherTestFilterForJUnitJars implements ImportOption {
-        private TestFilterForJUnitJars filter = new TestFilterForJUnitJars();
+        private final TestFilterForJUnitJars filter = new TestFilterForJUnitJars();
 
         @Override
         public boolean includes(Location location) {

--- a/archunit/src/jdk9main/java/com/tngtech/archunit/core/importer/ModuleLocationFactory.java
+++ b/archunit/src/jdk9main/java/com/tngtech/archunit/core/importer/ModuleLocationFactory.java
@@ -26,10 +26,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -129,7 +129,7 @@ class ModuleLocationFactory implements Location.Factory {
             locations = entries.stream()
                     .map(entry -> new ModuleClassFileLocation(moduleReference, entry))
                     .filter(classFileLocation -> classFileLocation.isIncludedBy(importOptions))
-                    .map(Function.identity()); // thanks Java type system :-(
+                    .map(identity());
         }
 
         private Set<String> loadEntries(ModuleReference moduleReference, NormalizedResourceName resourceName) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -48,8 +48,7 @@ import static java.util.stream.Collectors.toSet;
  * The central API to import {@link JavaClasses} from compiled Java class files.
  * Supports various types of {@link Location}, e.g. {@link Path},
  * {@link JarFile} or {@link URL}. The {@link Location Locations} that are scanned can be filtered by passing any number of
- * {@link ImportOption} to {@link #withImportOption(ImportOption)}, which will then be <b>AND</b>ed (compare
- * {@link ImportOptions}).
+ * {@link ImportOption} to {@link #withImportOption(ImportOption)}, which will then be <b>AND</b>ed.
  * <br><br>
  * Note that information about a class is only complete, if all necessary classes are imported.
  * For example, if class A is imported, and A accesses class B,
@@ -89,7 +88,11 @@ public final class ClassFileImporter {
     }
 
     @PublicAPI(usage = ACCESS)
-    public ClassFileImporter(ImportOptions importOptions) {
+    public ClassFileImporter(Collection<ImportOption> importOptions) {
+        this(new ImportOptions().with(importOptions));
+    }
+
+    private ClassFileImporter(ImportOptions importOptions) {
         this.importOptions = importOptions;
     }
 
@@ -236,11 +239,12 @@ public final class ClassFileImporter {
      */
     @PublicAPI(usage = ACCESS)
     public JavaClasses importClasspath() {
-        return importClasspath(importOptions.with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES));
+        return new ClassFileImporter(importOptions.with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES))
+                .importLocations(Locations.inClassPath());
     }
 
     /**
-     * Imports classes from the whole classpath considering the supplied {@link ImportOptions}.<br>
+     * Imports classes from the whole classpath considering the supplied {@link ImportOption ImportOptions}.<br>
      * Note that ArchUnit does not distinguish between the classpath and the modulepath for Java &gt;= 9,
      * thus all classes from the classpath or the modulepath will be considered.
      * <br><br>
@@ -248,7 +252,7 @@ public final class ClassFileImporter {
      * as well as configuration and details, refer to {@link ClassFileImporter}.
      */
     @PublicAPI(usage = ACCESS)
-    public JavaClasses importClasspath(ImportOptions options) {
+    public JavaClasses importClasspath(Collection<ImportOption> options) {
         return new ClassFileImporter(options).importLocations(Locations.inClassPath());
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -47,8 +47,9 @@ import static java.util.stream.Collectors.toSet;
 /**
  * The central API to import {@link JavaClasses} from compiled Java class files.
  * Supports various types of {@link Location}, e.g. {@link Path},
- * {@link JarFile} or {@link URL}. The {@link Location Locations} that are scanned can be filtered by passing any number of
- * {@link ImportOption} to {@link #withImportOption(ImportOption)}, which will then be <b>AND</b>ed.
+ * {@link JarFile} or {@link URL}. The {@link Location Locations} that are scanned can be filtered by
+ * {@link #withImportOption(ImportOption)} or {@link #withImportOptions(Collection)},
+ * which will then join the {@link ImportOption ImportOptions} using <b>AND</b> semantics.
  * <br><br>
  * Note that information about a class is only complete, if all necessary classes are imported.
  * For example, if class A is imported, and A accesses class B,
@@ -106,6 +107,14 @@ public final class ClassFileImporter {
     @PublicAPI(usage = ACCESS)
     public ClassFileImporter withImportOption(ImportOption option) {
         return new ClassFileImporter(importOptions.with(option));
+    }
+
+    /**
+     * Same as {@link #withImportOption(ImportOption)} but takes multiple {@link ImportOption ImportOptions}.
+     */
+    @PublicAPI(usage = ACCESS)
+    public ClassFileImporter withImportOptions(Collection<ImportOption> options) {
+        return new ClassFileImporter(importOptions.with(options));
     }
 
     /**
@@ -232,19 +241,7 @@ public final class ClassFileImporter {
     }
 
     /**
-     * Imports classes from the whole classpath without archives (JARs or JRTs).
-     * <br><br>
-     * For information about the impact of the imported classes on the evaluation of rules,
-     * as well as configuration and details, refer to {@link ClassFileImporter}.
-     */
-    @PublicAPI(usage = ACCESS)
-    public JavaClasses importClasspath() {
-        return new ClassFileImporter(importOptions.with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES))
-                .importLocations(Locations.inClassPath());
-    }
-
-    /**
-     * Imports classes from the whole classpath considering the supplied {@link ImportOption ImportOptions}.<br>
+     * Imports classes from the whole classpath.<br>
      * Note that ArchUnit does not distinguish between the classpath and the modulepath for Java &gt;= 9,
      * thus all classes from the classpath or the modulepath will be considered.
      * <br><br>
@@ -252,8 +249,8 @@ public final class ClassFileImporter {
      * as well as configuration and details, refer to {@link ClassFileImporter}.
      */
     @PublicAPI(usage = ACCESS)
-    public JavaClasses importClasspath(Collection<ImportOption> options) {
-        return new ClassFileImporter(options).importLocations(Locations.inClassPath());
+    public JavaClasses importClasspath() {
+        return importLocations(Locations.inClassPath());
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOptions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOptions.java
@@ -15,25 +15,19 @@
  */
 package com.tngtech.archunit.core.importer;
 
+import java.util.Collection;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import com.tngtech.archunit.PublicAPI;
+import com.google.common.collect.Sets;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static java.util.Collections.emptySet;
 
-/**
- * A collection of {@link ImportOption} to filter class locations. All supplied {@link ImportOption}s will be joined
- * with <b>AND</b>, i.e. only {@link Location}s that are accepted by <b>all</b> {@link ImportOption}s
- * will be imported.
- */
-public final class ImportOptions {
+final class ImportOptions {
     private final Set<ImportOption> options;
 
-    @PublicAPI(usage = ACCESS)
-    public ImportOptions() {
+    ImportOptions() {
         this(emptySet());
     }
 
@@ -41,13 +35,12 @@ public final class ImportOptions {
         this.options = checkNotNull(options);
     }
 
-    /**
-     * @param option An {@link ImportOption} to evaluate on {@link Location}s of class files
-     * @return self to add further {@link ImportOption}s in a fluent way
-     */
-    @PublicAPI(usage = ACCESS)
-    public ImportOptions with(ImportOption option) {
+    ImportOptions with(ImportOption option) {
         return new ImportOptions(ImmutableSet.<ImportOption>builder().addAll(options).add(option).build());
+    }
+
+    ImportOptions with(Collection<ImportOption> options) {
+        return new ImportOptions(Sets.union(this.options, ImmutableSet.copyOf(options)));
     }
 
     boolean include(Location location) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -29,6 +29,7 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.archunit.testutil.TestUtils.urlOf;
+import static java.util.Collections.singleton;
 import static java.util.jar.Attributes.Name.CLASS_PATH;
 import static java.util.stream.Collectors.toSet;
 
@@ -51,7 +52,7 @@ public class ClassFileImporterSlowTest {
         assertThatTypes(classes).doNotContain(Rule.class); // Default does not import jars
         assertThatTypes(classes).doNotContain(File.class); // Default does not import JDK classes
 
-        classes = new ClassFileImporter().importClasspath(new ImportOptions().with(importJavaBaseOrRtAndJUnitJarAndFilesOnTheClasspath()));
+        classes = new ClassFileImporter().importClasspath(singleton(importJavaBaseOrRtAndJUnitJarAndFilesOnTheClasspath()));
 
         assertThatTypes(classes).contain(ClassFileImporter.class, getClass(), Rule.class, File.class);
     }
@@ -62,7 +63,7 @@ public class ClassFileImporterSlowTest {
                 .importPackages("")
                 .stream().map(JavaClass::getName).collect(toSet());
         Set<String> classNamesOfClasspathImport = new ClassFileImporter()
-                .importClasspath(new ImportOptions().with(importJavaBaseOrRtAndJUnitJarAndFilesOnTheClasspath()))
+                .importClasspath(singleton(importJavaBaseOrRtAndJUnitJarAndFilesOnTheClasspath()))
                 .stream().map(JavaClass::getName).collect(toSet());
 
         Set<String> classNamesOnlyInDefaultPackageImport = Sets.difference(classNamesOfDefaultPackageImport, classNamesOfClasspathImport);
@@ -171,7 +172,7 @@ public class ClassFileImporterSlowTest {
     }
 
     private JavaClasses importJavaBase() {
-        return new ClassFileImporter().importClasspath(new ImportOptions().with(location -> {
+        return new ClassFileImporter().importClasspath(singleton(location -> {
             return
                     // before Java 9 package like java.lang were in rt.jar
                     location.contains("rt.jar") ||

--- a/docs/userguide/006_The_Core_API.adoc
+++ b/docs/userguide/006_The_Core_API.adoc
@@ -26,7 +26,7 @@ specified as URLs or as JAR files.
 
 Furthermore specific locations can be filtered out, if they are contained in the source of classes,
 but should not be imported. A typical use case would be to ignore test classes, when the classpath
-is imported. This can be achieved by specifying `ImportOptions`:
+is imported. This can be achieved by specifying `ImportOption`﻿s:
 
 [source,java,options="nowrap"]
 ----
@@ -47,7 +47,7 @@ A `Location` is principally an URI, i.e. ArchUnit considers sources as File or J
 
 For the two common cases to skip importing JAR files and to skip importing test files
 (for typical setups, like a Maven or Gradle build),
-there already exist predefined `ImportOptions`:
+there already exist predefined `ImportOption`﻿s:
 
 [source,java,options="nowrap"]
 ----
@@ -284,7 +284,7 @@ object from the Reflection API. For example:
 
 [source,java,options="nowrap"]
 ----
-JavaClasses classes = new ClassFileImporter().importClasspath(new ImportOptions());
+JavaClasses classes = new ClassFileImporter().importClasspath();
 
 // ArchUnit's java.lang.String
 JavaClass javaClass = classes.get(String.class);

--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -104,7 +104,7 @@ public class MyLocationProvider implements LocationProvider {
 @AnalyzeClasses(locations = MyLocationProvider.class)
 ----
 
-Furthermore to choose specific classes beneath those locations, `ImportOptions` can be
+Furthermore, to choose specific classes beneath those locations, `ImportOption`﻿s can be
 specified (compare <<The Core API>>). For example, to import the classpath, but only consider
 production code, and only consider code that is directly supplied and does not come from JARs:
 
@@ -118,7 +118,7 @@ and then supply the type to `@AnalyzeClasses`.
 
 ==== Controlling the Cache
 
-By default all classes will be cached by location. This means that between different
+By default, all classes will be cached by location. This means that between different
 test class runs imported Java classes will be reused, if the exact combination of locations has already
 been imported.
 


### PR DESCRIPTION
All other import methods behave consistently by taking into account all the `ImportOptions` that have been added via `withImportOption(..)` and then only controlling where to look for class files by the final `import...()` method. Only `importClasspath()` transparently adds an `ImportOption` to exclude archives from the import. This creates a surprising API, also that the only way to really import the whole classpath then is to use `importClasspath(emptySet())` with an empty set of `ImportOptions` passed to the `importClasspath(..)` method.
We now consolidate these APIs to make `importClasspath()` behave exactly like the other methods. We remove the version `importClasspath(Collection<ImportOption> options)` as there is no advantage now over using `withImportOptions(options).importClasspath()` like with all other import methods. Right now is the best moment to do this breaking change, since we are about to release version `1.0.0`.