### PR TITLE
move package `library.plantuml` -> `library.plantuml.rules`

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/PlantUmlArchitectureTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/PlantUmlArchitectureTest.java
@@ -17,10 +17,10 @@ import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependency;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringAllDependencies;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.adhereToPlantUmlDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringAllDependencies;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.adhereToPlantUmlDiagram;
 
 @Category(Example.class)
 @RunWith(ArchUnitRunner.class)

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/PlantUmlArchitectureTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/PlantUmlArchitectureTest.java
@@ -15,10 +15,10 @@ import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependency;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringAllDependencies;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.adhereToPlantUmlDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringAllDependencies;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.adhereToPlantUmlDiagram;
 
 @ArchTag("example")
 @AnalyzeClasses(packages = "com.tngtech.archunit.example.plantuml")

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/PlantUmlArchitectureTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/PlantUmlArchitectureTest.java
@@ -15,10 +15,10 @@ import static com.tngtech.archunit.core.domain.Dependency.Predicates.dependency;
 import static com.tngtech.archunit.core.domain.JavaClass.Functions.GET_PACKAGE_NAME;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringAllDependencies;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.adhereToPlantUmlDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringAllDependencies;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.adhereToPlantUmlDiagram;
 
 @Category(Example.class)
 public class PlantUmlArchitectureTest {

--- a/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchTests.java
+++ b/archunit-junit/src/api/java/com/tngtech/archunit/junit/ArchTests.java
@@ -50,6 +50,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * }
  * </code></pre>
  */
+@PublicAPI(usage = ACCESS)
 public final class ArchTests {
     private final Class<?> definitionLocation;
 

--- a/archunit-junit/src/api/java/com/tngtech/archunit/junit/CacheMode.java
+++ b/archunit-junit/src/api/java/com/tngtech/archunit/junit/CacheMode.java
@@ -29,6 +29,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * will be reused for <code>BTest</code>. If this is not desired, the {@link CacheMode}.{@link #PER_CLASS}
  * can be used to completely deactivate caching between different test classes.
  */
+@PublicAPI(usage = ACCESS)
 public enum CacheMode {
     /**
      * Signals that imported Java classes should be cached for the current test class only, and discarded afterwards.

--- a/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/ArchConfiguration.java
@@ -43,6 +43,7 @@ import static com.tngtech.archunit.base.ClassLoaders.getCurrentClassLoader;
 /**
  * Allows access to configured properties in {@value ARCHUNIT_PROPERTIES_RESOURCE_NAME}.
  */
+@PublicAPI(usage = ACCESS)
 public final class ArchConfiguration {
     @Internal // {@value ...} does not work on non public constants outside of the package
     public static final String ARCHUNIT_PROPERTIES_RESOURCE_NAME = "archunit.properties";
@@ -405,6 +406,7 @@ public final class ArchConfiguration {
         }
     }
 
+    @PublicAPI(usage = ACCESS)
     public final class ExtensionProperties {
         private final String extensionIdentifier;
 

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedIterable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedIterable.java
@@ -24,6 +24,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
 @PublicAPI(usage = INHERITANCE)
 public interface DescribedIterable<T> extends Iterable<T>, HasDescription {
+    @PublicAPI(usage = ACCESS)
     final class From {
         private From() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/base/HasDescription.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/HasDescription.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface HasDescription {
     @PublicAPI(usage = ACCESS)
     String getDescription();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -82,6 +82,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
  *
  * @see #resolveMember()
  */
+@PublicAPI(usage = ACCESS)
 public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotated, HasOwner<JavaClass>, HasDescription {
     private final String name;
     private final JavaClass owner;
@@ -229,6 +230,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {
         }
@@ -248,6 +250,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents an {@link AccessTarget} where the target is a field. For further elaboration about the necessity to distinguish
      * {@link FieldAccessTarget FieldAccessTarget} from {@link JavaField}, refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class FieldAccessTarget extends AccessTarget implements HasType {
         private final JavaClass type;
 
@@ -317,6 +320,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link FieldAccessTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -336,6 +340,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents an {@link AccessTarget} where the target is a code unit. For further elaboration about the necessity to distinguish
      * {@link CodeUnitAccessTarget CodeUnitAccessTarget} from {@link JavaCodeUnit}, refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public abstract static class CodeUnitAccessTarget extends AccessTarget
             implements HasParameterTypes, HasReturnType, HasThrowsClause<CodeUnitAccessTarget> {
         private final ImmutableList<JavaClass> parameters;
@@ -399,6 +404,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link CodeUnitAccessTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -419,6 +425,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents an {@link AccessTarget} where the target is a code unit. For further elaboration about the necessity to distinguish
      * {@link CodeUnitCallTarget CodeUnitCallTarget} from {@link JavaCodeUnit} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public abstract static class CodeUnitCallTarget extends CodeUnitAccessTarget {
         CodeUnitCallTarget(CodeUnitAccessTargetBuilder<?, ?> builder) {
             super(builder);
@@ -436,6 +443,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents an {@link AccessTarget} where the target is a code unit. For further elaboration about the necessity to distinguish
      * {@link CodeUnitReferenceTarget CodeUnitReferenceTarget} from {@link JavaCodeUnit} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public abstract static class CodeUnitReferenceTarget extends CodeUnitAccessTarget {
         CodeUnitReferenceTarget(CodeUnitAccessTargetBuilder<?, ?> builder) {
             super(builder);
@@ -453,6 +461,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents a {@link CodeUnitCallTarget} where the target is a constructor. For further elaboration about the necessity to distinguish
      * {@link ConstructorCallTarget ConstructorCallTarget} from {@link JavaConstructor} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class ConstructorCallTarget extends CodeUnitCallTarget {
         ConstructorCallTarget(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorCallTarget> builder) {
             super(builder);
@@ -485,6 +494,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link ConstructorCallTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -504,6 +514,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents a {@link CodeUnitReferenceTarget} where the target is a constructor. For further elaboration about the necessity to distinguish
      * {@link ConstructorReferenceTarget ConstructorReferenceTarget} from {@link JavaConstructor} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class ConstructorReferenceTarget extends CodeUnitReferenceTarget {
         ConstructorReferenceTarget(CodeUnitAccessTargetBuilder<JavaConstructor, ConstructorReferenceTarget> builder) {
             super(builder);
@@ -536,6 +547,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link ConstructorReferenceTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -555,6 +567,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents a {@link CodeUnitCallTarget} where the target is a method. For further elaboration about the necessity to distinguish
      * {@link MethodCallTarget MethodCallTarget} from {@link JavaMethod} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class MethodCallTarget extends CodeUnitCallTarget {
         MethodCallTarget(CodeUnitAccessTargetBuilder<JavaMethod, MethodCallTarget> builder) {
             super(builder);
@@ -611,6 +624,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link MethodCallTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -630,6 +644,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      * Represents a {@link CodeUnitReferenceTarget} where the target is a method. For further elaboration about the necessity to distinguish
      * {@link MethodReferenceTarget MethodReferenceTarget} from {@link JavaMethod} refer to the documentation at {@link AccessTarget}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class MethodReferenceTarget extends CodeUnitReferenceTarget {
         MethodReferenceTarget(CodeUnitAccessTargetBuilder<JavaMethod, MethodReferenceTarget> builder) {
             super(builder);
@@ -664,6 +679,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         /**
          * Predefined {@link ChainableFunction functions} to transform {@link MethodReferenceTarget}.
          */
+        @PublicAPI(usage = ACCESS)
         public static final class Functions {
             private Functions() {
             }
@@ -689,6 +705,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      *     <li>{@link HasOwner.Predicates}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -54,7 +54,8 @@ import static com.tngtech.archunit.base.Optionals.asSet;
  * Note that a {@link Dependency} will by definition never be a self-reference,
  * i.e. <code>origin</code> will never be equal to <code>target</code>.
  */
-public class Dependency implements HasDescription, Comparable<Dependency>, HasSourceCodeLocation {
+@PublicAPI(usage = ACCESS)
+public final class Dependency implements HasDescription, Comparable<Dependency>, HasSourceCodeLocation {
     private final JavaClass originClass;
     private final JavaClass targetClass;
     private final int lineNumber;
@@ -336,6 +337,7 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
     /**
      * Predefined {@link DescribedPredicate predicates} targeting {@link Dependency}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }
@@ -393,6 +395,7 @@ public class Dependency implements HasDescription, Comparable<Dependency>, HasSo
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link Dependency}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Formatters.java
@@ -30,6 +30,7 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
+@PublicAPI(usage = ACCESS)
 public final class Formatters {
     private Formatters() {
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
@@ -24,6 +24,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
 
     private final JavaCodeUnit owner;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public abstract class JavaAccess<TARGET extends AccessTarget>
         implements HasName, HasDescription, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
 
@@ -133,6 +134,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
      *     <li>{@link HasOwner.Predicates}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }
@@ -202,6 +204,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
         private Functions() {
         }
 
+        @PublicAPI(usage = ACCESS)
         public static final class Get {
             private Get() {
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAnnotation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAnnotation.java
@@ -75,6 +75,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
  *                is annotated on a class or member, it is that class or member. If this
  *                annotation is a member of another annotation, it is that annotation.
  */
+@PublicAPI(usage = ACCESS)
 public final class JavaAnnotation<OWNER extends HasDescription> implements HasType, HasOwner<OWNER>, HasDescription {
     private final JavaClass type;
     private final OWNER owner;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUnitAccess<T> {
     JavaCall(JavaAccessBuilder<T, ?> builder) {
         super(builder);
@@ -32,6 +33,7 @@ public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUni
      * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCall}.
      * Further predicates to be used with {@link JavaCall} can be found at {@link JavaCodeUnitAccess.Predicates}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -69,7 +69,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toSet;
 
-public class JavaClass
+@PublicAPI(usage = ACCESS)
+public final class JavaClass
         implements JavaType, HasName.AndFullName, HasTypeParameters<JavaClass>, HasAnnotations<JavaClass>, HasModifiers, HasSourceCodeLocation {
 
     private final Optional<Source> source;
@@ -1757,6 +1758,7 @@ public class JavaClass
      *     <li>{@link JavaType.Functions}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {
         }
@@ -2054,6 +2056,7 @@ public class JavaClass
      *     <li>{@link CanBeAnnotated.Predicates}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClasses.java
@@ -33,6 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static java.util.stream.Collectors.toMap;
 
+@PublicAPI(usage = ACCESS)
 public final class JavaClasses extends ForwardingCollection<JavaClass> implements DescribedIterable<JavaClass>, CanOverrideDescription<JavaClasses> {
     private final ImmutableMap<String, JavaClass> classes;
     private final JavaPackage defaultPackage;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -54,6 +54,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
  * in particular every place, where Java code with behavior, like calling other methods or accessing fields, can
  * be defined.
  */
+@PublicAPI(usage = ACCESS)
 public abstract class JavaCodeUnit
         extends JavaMember
         implements HasParameterTypes, HasReturnType, HasTypeParameters<JavaCodeUnit>, HasThrowsClause<JavaCodeUnit> {
@@ -368,6 +369,7 @@ public abstract class JavaCodeUnit
      *     <li>{@link HasThrowsClause.Predicates}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }
@@ -408,6 +410,7 @@ public abstract class JavaCodeUnit
         private Functions() {
         }
 
+        @PublicAPI(usage = ACCESS)
         public static final class Get {
             private Get() {
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public abstract class JavaCodeUnitAccess<T extends CodeUnitAccessTarget> extends JavaAccess<T> {
     JavaCodeUnitAccess(JavaAccessBuilder<T, ?> builder) {
         super(builder);
@@ -32,6 +33,7 @@ public abstract class JavaCodeUnitAccess<T extends CodeUnitAccessTarget> extends
      * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCodeUnitAccess}.
      * Further predicates to be used with {@link JavaCodeUnitAccess} can be found at {@link JavaAccess.Predicates}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public abstract class JavaCodeUnitReference<T extends CodeUnitReferenceTarget> extends JavaCodeUnitAccess<T> {
     JavaCodeUnitReference(JavaAccessBuilder<T, ?> builder) {
         super(builder);
@@ -32,6 +33,7 @@ public abstract class JavaCodeUnitReference<T extends CodeUnitReferenceTarget> e
      * Predefined {@link DescribedPredicate predicates} targeting {@link JavaCodeUnitReference}.
      * Further predicates to be used with {@link JavaCodeUnitReference} can be found at {@link JavaCodeUnitAccess.Predicates}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructor.java
@@ -33,6 +33,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 
+@PublicAPI(usage = ACCESS)
 public final class JavaConstructor extends JavaCodeUnit {
     private final Supplier<Constructor<?>> constructorSupplier;
     private final ThrowsClause<JavaConstructor> throwsClause;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorCall.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorCall.java
@@ -15,10 +15,14 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorCallTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorCallBuilder;
 
-public class JavaConstructorCall extends JavaCall<ConstructorCallTarget> {
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class JavaConstructorCall extends JavaCall<ConstructorCallTarget> {
     JavaConstructorCall(JavaConstructorCallBuilder builder) {
         super(builder);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaConstructorReference.java
@@ -15,10 +15,14 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.AccessTarget.ConstructorReferenceTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaConstructorReferenceBuilder;
 
-public class JavaConstructorReference extends JavaCodeUnitReference<ConstructorReferenceTarget> {
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class JavaConstructorReference extends JavaCodeUnitReference<ConstructorReferenceTarget> {
     JavaConstructorReference(JavaConstructorReferenceBuilder builder) {
         super(builder);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaEnumConstant.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaEnumConstant.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaEnumConstantBuilder
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public final class JavaEnumConstant {
     private final JavaClass declaringClass;
     private final String name;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -30,7 +30,8 @@ import com.tngtech.archunit.core.importer.DomainBuilders;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
-public class JavaField extends JavaMember implements HasType {
+@PublicAPI(usage = ACCESS)
+public final class JavaField extends JavaMember implements HasType {
     private final JavaType type;
     private final Supplier<Field> fieldSupplier;
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
@@ -30,7 +30,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.GET;
 import static com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType.SET;
 
-public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
+@PublicAPI(usage = ACCESS)
+public final class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
     private static final Map<AccessType, String> MESSAGE_VERB = ImmutableMap.of(
             GET, "gets",
             SET, "sets");
@@ -57,6 +58,7 @@ public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
         return MESSAGE_VERB.get(accessType);
     }
 
+    @PublicAPI(usage = ACCESS)
     public enum AccessType {
         @PublicAPI(usage = ACCESS)
         GET(Opcodes.GETFIELD | Opcodes.GETSTATIC),
@@ -85,6 +87,7 @@ public class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
      * Predefined {@link DescribedPredicate predicates} targeting {@link JavaFieldAccess}.
      * Further predicates to be used with {@link JavaFieldAccess} can be found at {@link JavaAccess.Predicates}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -43,6 +43,7 @@ import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Utils.t
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 
+@PublicAPI(usage = ACCESS)
 public abstract class JavaMember implements
         HasName.AndFullName, HasDescriptor, HasAnnotations<JavaMember>, HasModifiers, HasOwner<JavaClass>, HasSourceCodeLocation {
 
@@ -208,6 +209,7 @@ public abstract class JavaMember implements
      *     <li>{@link HasOwner.Predicates}</li>
      * </ul>
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -34,7 +34,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 
-public class JavaMethod extends JavaCodeUnit {
+@PublicAPI(usage = ACCESS)
+public final class JavaMethod extends JavaCodeUnit {
     private final Supplier<Method> methodSupplier;
     private final ThrowsClause<JavaMethod> throwsClause;
     private final Optional<Object> annotationDefaultValue;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodCall.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodCall.java
@@ -15,10 +15,14 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodCallBuilder;
 
-public class JavaMethodCall extends JavaCall<MethodCallTarget> {
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class JavaMethodCall extends JavaCall<MethodCallTarget> {
     JavaMethodCall(JavaMethodCallBuilder builder) {
         super(builder);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethodReference.java
@@ -15,10 +15,14 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaMethodReferenceBuilder;
 
-public class JavaMethodReference extends JavaCodeUnitReference<MethodReferenceTarget> {
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class JavaMethodReference extends JavaCodeUnitReference<MethodReferenceTarget> {
     JavaMethodReference(JavaMethodReferenceBuilder builder) {
         super(builder);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
@@ -27,6 +27,7 @@ import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
+@PublicAPI(usage = ACCESS)
 public enum JavaModifier {
     @PublicAPI(usage = ACCESS)
     PUBLIC(EnumSet.allOf(ApplicableType.class), Opcodes.ACC_PUBLIC),

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -85,6 +85,7 @@ import static java.util.stream.Collectors.toSet;
  * {@code com.example.second.nested}
  * </code></pre>
  */
+@PublicAPI(usage = ACCESS)
 public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     private final String name;
     private final String relativeName;
@@ -747,6 +748,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link JavaPackage}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaStaticInitializer.java
@@ -39,7 +39,8 @@ import static java.util.Collections.emptySet;
  * }
  * </code></pre>
  */
-public class JavaStaticInitializer extends JavaCodeUnit {
+@PublicAPI(usage = ACCESS)
+public final class JavaStaticInitializer extends JavaCodeUnit {
     @PublicAPI(usage = ACCESS)
     public static final String STATIC_INITIALIZER_NAME = "<clinit>";
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -42,6 +42,7 @@ public interface JavaType extends HasName {
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link JavaType}.
      */
+    @PublicAPI(usage = ACCESS)
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -37,7 +37,8 @@ import static java.util.stream.Collectors.joining;
  * A lower bound denotes a common subtype that must be assignable to all substitutions
  * of this wildcard type. It is denoted by {@code ? super SomeType}.
  */
-public class JavaWildcardType implements JavaType, HasUpperBounds {
+@PublicAPI(usage = ACCESS)
+public final class JavaWildcardType implements JavaType, HasUpperBounds {
     private static final String WILDCARD_TYPE_NAME = "?";
 
     private final List<JavaType> upperBounds;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/PackageMatcher.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/PackageMatcher.java
@@ -61,6 +61,7 @@ import static java.util.stream.Collectors.toList;
  * </ul>
  * Create via {@link PackageMatcher#of(String) PackageMatcher.of(packageIdentifier)}
  */
+@PublicAPI(usage = ACCESS)
 public final class PackageMatcher {
     private static final String OPT_LETTERS_AT_START = "(?:^\\w*)?";
     private static final String OPT_LETTERS_AT_END = "(?:\\w*$)?";
@@ -190,6 +191,7 @@ public final class PackageMatcher {
         return "\\" + outerOpeningChar + "[^" + outerClosingChar + "]*\\" + nestedOpeningChar;
     }
 
+    @PublicAPI(usage = ACCESS)
     public static final class Result {
         private final Matcher matcher;
 
@@ -211,6 +213,6 @@ public final class PackageMatcher {
     @PublicAPI(usage = ACCESS)
     public static final Function<Result, List<String>> TO_GROUPS = input ->
             IntStream.rangeClosed(1, input.getNumberOfGroups())
-                    .mapToObj(i -> input.getGroup(i))
+                    .mapToObj(input::getGroup)
                     .collect(toList());
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
@@ -43,7 +43,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * to your <code>{@value com.tngtech.archunit.ArchConfiguration#ARCHUNIT_PROPERTIES_RESOURCE_NAME}</code>.
  * </p>
  */
-public class Source {
+@PublicAPI(usage = ACCESS)
+public final class Source {
     private final URI uri;
     private final Optional<String> fileName;
     private final Md5sum md5sum;
@@ -92,7 +93,8 @@ public class Source {
         return uri + " [md5='" + md5sum + "']";
     }
 
-    public static class Md5sum {
+    @PublicAPI(usage = ACCESS)
+    public static final class Md5sum {
         /**
          * We can't determine the md5 sum, because the platform is missing the digest algorithm
          */
@@ -173,7 +175,7 @@ public class Source {
             }
 
             Optional<byte[]> bytesFromUri = read(uri);
-            return bytesFromUri.isPresent() ? new Md5sum(bytesFromUri.get(), MD5_DIGEST) : UNDETERMINED;
+            return bytesFromUri.map(bytes -> new Md5sum(bytes, MD5_DIGEST)).orElse(UNDETERMINED);
         }
 
         private static Optional<byte[]> read(URI uri) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
@@ -38,6 +38,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 import static java.util.stream.Collectors.toList;
 
+@PublicAPI(usage = ACCESS)
 public final class ThrowsClause<LOCATION extends HasParameterTypes & HasReturnType & HasName.AndFullName & CanBeAnnotated & HasOwner<JavaClass>>
         extends ForwardingList<ThrowsDeclaration<LOCATION>>
         implements HasOwner<LOCATION> {
@@ -137,6 +138,7 @@ public final class ThrowsClause<LOCATION extends HasParameterTypes & HasReturnTy
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link ThrowsClause}.
      */
+    @PublicAPI(usage = ACCESS)
     public static final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
@@ -50,6 +50,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  *                   For further information about the resolution process of {@link AccessTarget AccessTargets} to
  *                   {@link JavaMember JavaMembers} consult the documentation at {@link AccessTarget}.
  */
+@PublicAPI(usage = ACCESS)
 public final class ThrowsDeclaration<LOCATION extends HasParameterTypes & HasReturnType & HasName.AndFullName & CanBeAnnotated & HasOwner<JavaClass>>
         implements HasType, HasOwner<ThrowsClause<LOCATION>> {
 
@@ -146,6 +147,7 @@ public final class ThrowsDeclaration<LOCATION extends HasParameterTypes & HasRet
         private Functions() {
         }
 
+        @PublicAPI(usage = ACCESS)
         public static final class Get {
             private Get() {
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
@@ -34,6 +34,7 @@ import static com.tngtech.archunit.core.domain.Formatters.ensureSimpleName;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 
+@PublicAPI(usage = ACCESS)
 public interface CanBeAnnotated {
 
     /**
@@ -95,6 +96,7 @@ public interface CanBeAnnotated {
     /**
      * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link CanBeAnnotated}
      */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }
@@ -215,6 +217,7 @@ public interface CanBeAnnotated {
         }
     }
 
+    @PublicAPI(usage = ACCESS)
     final class Utils {
         private Utils() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanOverrideDescription.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanOverrideDescription.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface CanOverrideDescription<SELF> {
     /**
      * Allows to adjust the description of this object. Note that this method will not modify the current object,

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
@@ -31,6 +31,7 @@ public interface HasModifiers {
     /**
      * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasModifiers}
      */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -26,10 +26,12 @@ import com.tngtech.archunit.base.DescribedPredicate;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 
+@PublicAPI(usage = ACCESS)
 public interface HasName {
     @PublicAPI(usage = ACCESS)
     String getName();
 
+    @PublicAPI(usage = ACCESS)
     interface AndFullName extends HasName {
         /**
          * @return The full name of the given object. Varies by context, for details consult Javadoc of the concrete subclass.
@@ -40,6 +42,7 @@ public interface HasName {
         /**
          * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasName.AndFullName}
          */
+        @PublicAPI(usage = ACCESS)
         final class Predicates {
             private Predicates() {
             }
@@ -86,6 +89,7 @@ public interface HasName {
             }
         }
 
+        @PublicAPI(usage = ACCESS)
         final class Functions {
             private Functions() {
             }
@@ -103,6 +107,7 @@ public interface HasName {
     /**
      * Predefined {@link DescribedPredicate predicates} targeting objects that implement {@link HasName}
      */
+    @PublicAPI(usage = ACCESS)
     final class Predicates {
         private Predicates() {
         }
@@ -210,6 +215,7 @@ public interface HasName {
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link HasName}.
      */
+    @PublicAPI(usage = ACCESS)
     final class Functions {
         private Functions() {
         }
@@ -231,6 +237,7 @@ public interface HasName {
         };
     }
 
+    @PublicAPI(usage = ACCESS)
     final class Utils {
         private Utils() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
@@ -32,6 +32,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * an annotation parameter is owned by the annotation that declares it, etc.
  * @param <T> The type of the "owner", e.g. a <code>{@link JavaClass}</code> as the owner of a <code>{@link JavaMember}</code>
  */
+@PublicAPI(usage = ACCESS)
 public interface HasOwner<T> {
     /**
      * @return The "owner" of this object, compare {@link HasOwner}
@@ -47,6 +48,7 @@ public interface HasOwner<T> {
         private Predicates() {
         }
 
+        @PublicAPI(usage = ACCESS)
         public static final class With {
             private With() {
             }
@@ -80,6 +82,7 @@ public interface HasOwner<T> {
         private Functions() {
         }
 
+        @PublicAPI(usage = ACCESS)
         public static final class Get {
             private Get() {
             }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -30,6 +30,7 @@ import static com.tngtech.archunit.core.domain.Formatters.formatMethodParameterT
 import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAMES;
 
+@PublicAPI(usage = ACCESS)
 public interface HasParameterTypes {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasReturnType.java
@@ -25,6 +25,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasReturnType.Functions.GET_RAW_RETURN_TYPE;
 
+@PublicAPI(usage = ACCESS)
 public interface HasReturnType {
 
     @PublicAPI(usage = ACCESS)
@@ -61,6 +62,7 @@ public interface HasReturnType {
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link HasReturnType}.
      */
+    @PublicAPI(usage = ACCESS)
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasSourceCodeLocation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasSourceCodeLocation.java
@@ -20,6 +20,7 @@ import com.tngtech.archunit.core.domain.SourceCodeLocation;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface HasSourceCodeLocation {
     /**
      * @return The {@link SourceCodeLocation} of this object, i.e. how to locate the respective object within the set of source files.

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
@@ -33,6 +33,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 
+@PublicAPI(usage = ACCESS)
 public interface HasThrowsClause<LOCATION extends HasParameterTypes & HasReturnType & HasName.AndFullName & CanBeAnnotated & HasOwner<JavaClass>> {
     @PublicAPI(usage = ACCESS)
     ThrowsClause<? extends LOCATION> getThrowsClause();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
@@ -26,6 +26,7 @@ import static com.tngtech.archunit.base.DescribedPredicate.equalTo;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 
+@PublicAPI(usage = ACCESS)
 public interface HasType {
 
     @PublicAPI(usage = ACCESS)
@@ -61,6 +62,7 @@ public interface HasType {
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link HasType}.
      */
+    @PublicAPI(usage = ACCESS)
     final class Functions {
         private Functions() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -78,6 +78,7 @@ import static java.util.stream.Collectors.toSet;
  *
  * @see ArchConfiguration
  */
+@PublicAPI(usage = ACCESS)
 public final class ClassFileImporter {
     private static final Logger LOG = LoggerFactory.getLogger(ClassFileImporter.class);
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -61,6 +61,7 @@ import static java.util.Collections.emptySet;
  *     <li><code>jar:file:///home/someuser/.m2/repository/myproject/foolib.jar!/myproject/Foo.class</code></li>
  * </ul>
  */
+@PublicAPI(usage = ACCESS)
 public abstract class Location {
     private static final InitialConfiguration<Set<Factory>> factories = new InitialConfiguration<>();
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Locations.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Locations.java
@@ -35,6 +35,7 @@ import static java.util.Collections.list;
  * Represents a set of {@link Location locations} of Java class files. Also offers methods to derive concrete locations (i.e. URIs) from
  * higher level concepts like packages or the classpath.
  */
+@PublicAPI(usage = ACCESS)
 public final class Locations {
     private static final InitialConfiguration<LocationResolver> locationResolver = new InitialConfiguration<>();
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspath.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspath.java
@@ -32,6 +32,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  *
  * @see ClassResolverFromClasspath
  */
+@PublicAPI(usage = ACCESS)
 public final class SelectedClassResolverFromClasspath implements ClassResolver {
     private final Set<String> packageRoots;
     private final ClassResolverFromClasspath classResolverFromClasspath = new ClassResolverFromClasspath();

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
@@ -52,6 +52,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  *
  * @see com.tngtech.archunit.library.dependencies.Slices.Transformer
  */
+@PublicAPI(usage = ACCESS)
 public interface ArchRule extends CanBeEvaluated, CanOverrideDescription<ArchRule> {
     @PublicAPI(usage = ACCESS)
     void check(JavaClasses classes);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/CanBeEvaluated.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/CanBeEvaluated.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface CanBeEvaluated extends HasDescription {
     @PublicAPI(usage = ACCESS)
     EvaluationResult evaluate(JavaClasses classes);

--- a/archunit/src/main/java/com/tngtech/archunit/lang/CompositeArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/CompositeArchRule.java
@@ -28,6 +28,7 @@ import static com.tngtech.archunit.lang.ArchRule.Factory.createBecauseDescriptio
 import static com.tngtech.archunit.lang.Priority.MEDIUM;
 import static java.util.Collections.singletonList;
 
+@PublicAPI(usage = ACCESS)
 public final class CompositeArchRule implements ArchRule {
     private final Priority priority;
     private final List<ArchRule> rules;
@@ -123,7 +124,7 @@ public final class CompositeArchRule implements ArchRule {
         }
 
         @PublicAPI(usage = ACCESS)
-        public final CompositeArchRule of(ArchRule rule) {
+        public CompositeArchRule of(ArchRule rule) {
             return new CompositeArchRule(priority, singletonList(rule), rule.getDescription());
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ConditionEvent.java
@@ -92,6 +92,7 @@ public interface ConditionEvent {
      * <i>'Method A.foo() calls method B.bar() in (A.java:123)'</i>
      * </p>
      */
+    @PublicAPI(usage = ACCESS, state = EXPERIMENTAL)
     interface Handler {
         /**
          * @param correspondingObjects The objects this event describes (e.g. method calls, field accesses, ...)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
@@ -53,6 +53,7 @@ import static java.util.stream.Collectors.toList;
  * });
  * </code></pre>
  */
+@PublicAPI(usage = ACCESS)
 public final class EvaluationResult {
     static final String ARCHUNIT_IGNORE_PATTERNS_FILE_NAME = "archunit_ignore_patterns.txt";
     private static final String COMMENT_LINE_PREFIX = "#";

--- a/archunit/src/main/java/com/tngtech/archunit/lang/FailureReport.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/FailureReport.java
@@ -16,7 +16,6 @@
 package com.tngtech.archunit.lang;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
@@ -24,6 +23,7 @@ import com.tngtech.archunit.base.HasDescription;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public final class FailureReport {
     private final FailureMessages failureMessages;
     private final HasDescription rule;
@@ -48,9 +48,5 @@ public final class FailureReport {
     @Override
     public String toString() {
         return FailureDisplayFormatFactory.create().formatFailure(rule, failureMessages, priority);
-    }
-
-    FailureReport filter(Predicate<String> predicate) {
-        return new FailureReport(rule, priority, failureMessages.filter(predicate));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/Priority.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/Priority.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public enum Priority {
     @PublicAPI(usage = ACCESS)
     HIGH,

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -131,6 +131,7 @@ import static java.util.Arrays.asList;
  * A collection of predefined {@link ArchCondition ArchConditions} that can be customized or joined together
  * via {@link ArchCondition#and(ArchCondition)} and {@link ArchCondition#or(ArchCondition)}.
  */
+@PublicAPI(usage = ACCESS)
 public final class ArchConditions {
     private ArchConditions() {
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchPredicates.java
@@ -29,7 +29,8 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * For example {@link DescribedPredicate predicates} targeting {@link JavaClass} can be found
  * within the class {@link JavaClass.Predicates}.
  */
-public class ArchPredicates {
+@PublicAPI(usage = ACCESS)
+public final class ArchPredicates {
     private ArchPredicates() {
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/TransitiveDependencyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/TransitiveDependencyCondition.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.lang.ArchCondition;
@@ -30,11 +31,13 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getLast;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.lang.ConditionEvent.createMessage;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
-public class TransitiveDependencyCondition extends ArchCondition<JavaClass> {
+@PublicAPI(usage = ACCESS)
+public final class TransitiveDependencyCondition extends ArchCondition<JavaClass> {
 
     private final DescribedPredicate<? super JavaClass> conditionPredicate;
     private final TransitiveDependencyPath transitiveDependencyPath = new TransitiveDependencyPath();

--- a/archunit/src/main/java/com/tngtech/archunit/lang/extension/EvaluatedRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/extension/EvaluatedRule.java
@@ -28,6 +28,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * respective {@link EvaluationResult}. To react to failures during evaluation of the rule,
  * see {@link EvaluationResult}.
  */
+@PublicAPI(usage = ACCESS, state = EXPERIMENTAL)
 public interface EvaluatedRule {
     @PublicAPI(usage = ACCESS, state = EXPERIMENTAL)
     ArchRule getRule();

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
@@ -44,6 +44,7 @@ import static com.tngtech.archunit.lang.Priority.MEDIUM;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.never;
 import static java.util.Collections.singleton;
 
+@PublicAPI(usage = ACCESS)
 public final class ArchRuleDefinition {
     private ArchRuleDefinition() {
     }
@@ -149,6 +150,7 @@ public final class ArchRuleDefinition {
         return priority(MEDIUM).noMethods();
     }
 
+    @PublicAPI(usage = ACCESS)
     public static final class Creator {
         private final Priority priority;
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShould.java
@@ -42,6 +42,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface ClassesShould {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldConjunction.java
@@ -51,6 +51,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * Note that inverting the rule, e.g. via {@link ArchRuleDefinition#noClasses()}, will also invert the join operator. I.e.
  * if you define {@code noClasses().should().a().orShould().b()} it will mean that all classes must satisfy {@code not(a) AND not(b)}.
  */
+@PublicAPI(usage = ACCESS)
 public interface ClassesShouldConjunction extends ArchRule {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -35,6 +35,7 @@ import com.tngtech.archunit.core.domain.properties.HasType;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface ClassesThat<CONJUNCTION> {
     /**
      * Matches classes by their fully qualified class name.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<?>> extends MembersShould<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShouldConjunction.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface CodeUnitsShouldConjunction<CODE_UNIT extends JavaCodeUnit> extends MembersShouldConjunction<CODE_UNIT> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsThat.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface CodeUnitsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface FieldsShould<CONJUNCTION extends FieldsShouldConjunction> extends MembersShould<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShouldConjunction.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface FieldsShouldConjunction extends MembersShouldConjunction<JavaField> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsThat.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface FieldsThat<CONJUNCTION> extends MembersThat<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClass.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenClass {
     /**
      * Like {@link GivenClasses#should()} but for a single class

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClasses.java
@@ -25,6 +25,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenClasses extends GivenObjects<JavaClass> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesConjunction.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenClassesConjunction extends GivenConjunction<JavaClass> {
     @Override
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnits.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnits.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenCodeUnits<CODE_UNIT extends JavaCodeUnit> extends GivenMembers<CODE_UNIT> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnitsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnitsConjunction.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenCodeUnitsConjunction<CODE_UNIT extends JavaCodeUnit> extends GivenMembersConjunction<CODE_UNIT> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConjunction.java
@@ -29,6 +29,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * or create a complete {@link ArchRule} via {@link #should(ArchCondition)}.
  * @param <OBJECTS> The type of the objects to be checked by the final {@link ArchRule}, e.g. {@link JavaClass}.
  */
+@PublicAPI(usage = ACCESS)
 public interface GivenConjunction<OBJECTS> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConstructors.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConstructors.java
@@ -15,7 +15,11 @@
  */
 package com.tngtech.archunit.lang.syntax.elements;
 
+import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
 public interface GivenConstructors extends GivenCodeUnits<JavaConstructor> {
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConstructorsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenConstructorsConjunction.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.core.domain.JavaConstructor;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenConstructorsConjunction extends GivenCodeUnitsConjunction<JavaConstructor> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFields.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFields.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenFields extends GivenMembers<JavaField> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFieldsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenFieldsConjunction.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenFieldsConjunction extends GivenMembersConjunction<JavaField> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembers.java
@@ -25,6 +25,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenMembers<MEMBER extends JavaMember> extends GivenObjects<MEMBER> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersConjunction.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenMembersConjunction<MEMBER extends JavaMember> extends GivenConjunction<MEMBER> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethods.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethods.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenMethods extends GivenCodeUnits<JavaMethod> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethodsConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenMethodsConjunction.java
@@ -22,6 +22,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenMethodsConjunction extends GivenCodeUnitsConjunction<JavaMethod> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenObjects.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/GivenObjects.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenObjects<T> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShould.java
@@ -31,6 +31,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface MembersShould<CONJUNCTION extends MembersShouldConjunction<?>> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersShouldConjunction.java
@@ -31,6 +31,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * hierarchy of classes.
  * @param <MEMBER> The concrete type of {@link JavaMember} this conjunction describes, e.g. {@link JavaMethod}.
  */
+@PublicAPI(usage = ACCESS)
 public interface MembersShouldConjunction<MEMBER extends JavaMember> extends ArchRule {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MembersThat.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface MembersThat<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsShould.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface MethodsShould<CONJUNCTION extends MethodsShouldConjunction> extends CodeUnitsShould<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsShouldConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsShouldConjunction.java
@@ -21,6 +21,7 @@ import com.tngtech.archunit.lang.ArchCondition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface MethodsShouldConjunction extends CodeUnitsShouldConjunction<JavaMethod> {
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/MethodsThat.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface MethodsThat<CONJUNCTION> extends CodeUnitsThat<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeAccessedSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeAccessedSpecification.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface OnlyBeAccessedSpecification<CONJUNCTION> {
     /**
      * Matches classes residing in a package matching any of the supplied package identifiers.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/OnlyBeCalledSpecification.java
@@ -26,6 +26,7 @@ import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface OnlyBeCalledSpecification<CONJUNCTION> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -78,6 +78,7 @@ import static java.util.stream.Collectors.toSet;
  * <li>{@link #onionArchitecture()}</li>
  * </ul>
  */
+@PublicAPI(usage = ACCESS)
 public final class Architectures {
     private Architectures() {
     }
@@ -113,6 +114,7 @@ public final class Architectures {
         return new DependencySettings();
     }
 
+    @PublicAPI(usage = ACCESS)
     public static final class LayeredArchitecture implements ArchRule {
         private final LayerDefinitions layerDefinitions;
         private final Set<LayerDependencySpecification> dependencySpecifications;
@@ -529,6 +531,7 @@ public final class Architectures {
             }
         }
 
+        @PublicAPI(usage = ACCESS)
         public final class LayerDefinition {
             private final String name;
             private final boolean optional;
@@ -581,6 +584,7 @@ public final class Architectures {
             TARGET
         }
 
+        @PublicAPI(usage = ACCESS)
         public final class LayerDependencySpecification {
             private final String layerName;
             private final Set<String> allowedLayers = new LinkedHashSet<>();
@@ -762,6 +766,7 @@ public final class Architectures {
         return new OnionArchitecture();
     }
 
+    @PublicAPI(usage = ACCESS)
     public static final class OnionArchitecture implements ArchRule {
         private static final String DOMAIN_MODEL_LAYER = "domain model";
         private static final String DOMAIN_SERVICE_LAYER = "domain service";

--- a/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
@@ -72,6 +72,7 @@ import static java.util.stream.Collectors.groupingBy;
  * For further information refer to {@link ClassFileImporter}.
  * </p>
  */
+@PublicAPI(usage = ACCESS)
 public final class GeneralCodingRules {
     private GeneralCodingRules() {
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
@@ -48,6 +48,7 @@ import static java.util.stream.Collectors.toList;
  * Thus there could be a slice 'Order' housing all the classes from the {@code order} package, a slice 'Customer'
  * housing all the classes from the {@code customer} package and so on.
  */
+@PublicAPI(usage = ACCESS)
 public final class Slice extends ForwardingSet<JavaClass> implements HasDescription, CanOverrideDescription<Slice> {
     private final SliceAssignment sliceAssignment;
     private final List<String> matchingGroups;

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceDependency.java
@@ -30,6 +30,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.StreamSupport.stream;
 
+@PublicAPI(usage = ACCESS)
 public final class SliceDependency implements HasDescription {
     private final Slice origin;
     private final SortedSet<Dependency> relevantDependencies;

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
@@ -35,6 +35,7 @@ import static java.util.Collections.emptyList;
  * be equal if and only if their parts are equal. The parts can also be referred to from
  * {@link Slices#namingSlices(String)} via '{@code $x}' where '{@code x}' is the number of the part.
  */
+@PublicAPI(usage = ACCESS)
 public final class SliceIdentifier {
     private final List<String> parts;
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceRule.java
@@ -40,6 +40,7 @@ import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nam
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.priority;
 import static java.util.Collections.emptyList;
 
+@PublicAPI(usage = ACCESS)
 public final class SliceRule implements ArchRule {
     private final Slices.Transformer inputTransformer;
     private final Priority priority;

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
@@ -50,6 +50,7 @@ import static java.util.stream.Collectors.toSet;
  * Basic collection of {@link Slice} for tests of dependencies between different domain packages, e.g. to avoid cycles.
  * Refer to {@link SlicesRuleDefinition} for further info on how to form an {@link ArchRule} to test slices.
  */
+@PublicAPI(usage = ACCESS)
 public final class Slices implements DescribedIterable<Slice>, CanOverrideDescription<Slices> {
     private final Iterable<Slice> slices;
     private final String description;
@@ -170,6 +171,7 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
      *
      * @see Slices
      */
+    @PublicAPI(usage = ACCESS)
     public static class Transformer implements ClassesTransformer<Slice> {
         private final SliceAssignment sliceAssignment;
         private final String description;

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SlicesRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SlicesRuleDefinition.java
@@ -41,6 +41,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
  * </code></pre>
  * Then this rule will assert, that the four slices of 'myapp' are free of cycles.
  */
+@PublicAPI(usage = ACCESS)
 public final class SlicesRuleDefinition {
     private SlicesRuleDefinition() {
     }
@@ -53,6 +54,7 @@ public final class SlicesRuleDefinition {
         return new Creator();
     }
 
+    @PublicAPI(usage = ACCESS)
     public static class Creator {
         private Creator() {
         }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenNamedSlices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenNamedSlices.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.library.dependencies.Slice;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenNamedSlices extends GivenObjects<Slice>, CanOverrideDescription<GivenNamedSlices> {
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlices.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenSlices extends GivenNamedSlices {
     @PublicAPI(usage = ACCESS)
     GivenNamedSlices namingSlices(String pattern);

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlicesConjunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/GivenSlicesConjunction.java
@@ -24,6 +24,7 @@ import com.tngtech.archunit.library.dependencies.Slice;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface GivenSlicesConjunction extends GivenConjunction<Slice> {
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/SlicesShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/syntax/SlicesShould.java
@@ -20,6 +20,7 @@ import com.tngtech.archunit.library.dependencies.SliceRule;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+@PublicAPI(usage = ACCESS)
 public interface SlicesShould {
     @PublicAPI(usage = ACCESS)
     SliceRule beFreeOfCycles();

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/PlantUmlArchCondition.java
@@ -88,7 +88,8 @@ import static java.util.Collections.singleton;
  *     <li>Dependencies must use arrows only consisting of dashes, pointing right, e.g. <code>--&gt;</code></li>
  * </ol>
  */
-public class PlantUmlArchCondition extends ArchCondition<JavaClass> {
+@PublicAPI(usage = ACCESS)
+public final class PlantUmlArchCondition extends ArchCondition<JavaClass> {
     private final DescribedPredicate<Dependency> ignorePredicate;
     private final JavaClassDiagramAssociation javaClassDiagramAssociation;
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Alias.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Alias.java
@@ -13,35 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
-import java.util.Optional;
 
-class ComponentIdentifier {
-    private final ComponentName componentName;
-    private final Optional<Alias> alias;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-    ComponentIdentifier(ComponentName componentName) {
-        this(componentName, Optional.empty());
+class Alias {
+    private final String value;
+
+    Alias(String value) {
+        if (value.contains("[") || value.contains("]") || value.contains("\"")) {
+            throw new IllegalDiagramException("Alias '%s' should not contain character(s): '[' or ']' or '\"'", value);
+        }
+        this.value = checkNotNull(value);
     }
 
-    ComponentIdentifier(ComponentName componentName, Alias alias) {
-        this(componentName, Optional.of(alias));
-    }
-
-    private ComponentIdentifier(ComponentName componentName, Optional<Alias> alias) {
-        this.componentName = componentName;
-        this.alias = alias;
-    }
-
-    ComponentName getComponentName() {
-        return componentName;
+    String asString() {
+        return value;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(componentName, alias);
+        return Objects.hash(value);
     }
 
     @Override
@@ -52,16 +46,14 @@ class ComponentIdentifier {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ComponentIdentifier other = (ComponentIdentifier) obj;
-        return Objects.equals(this.componentName, other.componentName)
-                && Objects.equals(this.alias, other.alias);
+        final Alias other = (Alias) obj;
+        return Objects.equals(this.value, other.value);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
-                "componentName=" + componentName +
-                ", alias=" + alias +
+                "value='" + value + '\'' +
                 '}';
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIdentifier.java
@@ -13,26 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
+import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+class ComponentIdentifier {
+    private final ComponentName componentName;
+    private final Optional<Alias> alias;
 
-class Stereotype {
-    private String value;
-
-    Stereotype(String value) {
-        this.value = checkNotNull(value);
+    ComponentIdentifier(ComponentName componentName) {
+        this(componentName, Optional.empty());
     }
 
-    String asString() {
-        return value;
+    ComponentIdentifier(ComponentName componentName, Alias alias) {
+        this(componentName, Optional.of(alias));
+    }
+
+    private ComponentIdentifier(ComponentName componentName, Optional<Alias> alias) {
+        this.componentName = componentName;
+        this.alias = alias;
+    }
+
+    ComponentName getComponentName() {
+        return componentName;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(componentName, alias);
     }
 
     @Override
@@ -43,14 +52,16 @@ class Stereotype {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Stereotype other = (Stereotype) obj;
-        return Objects.equals(this.value, other.value);
+        final ComponentIdentifier other = (ComponentIdentifier) obj;
+        return Objects.equals(this.componentName, other.componentName)
+                && Objects.equals(this.alias, other.alias);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
-                "value='" + value + '\'' +
+                "componentName=" + componentName +
+                ", alias=" + alias +
                 '}';
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIntersectionException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIntersectionException.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
-class IllegalDiagramException extends RuntimeException {
-    IllegalDiagramException(String message, Object... args) {
-        super(String.format(message, args));
+class ComponentIntersectionException extends RuntimeException {
+    ComponentIntersectionException(String format) {
+        super(format);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentName.java
@@ -13,32 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class PlantUmlComponentDependency {
-    private final PlantUmlComponent origin;
-    private final PlantUmlComponent target;
+class ComponentName {
+    private final String value;
 
-    PlantUmlComponentDependency(PlantUmlComponent origin, PlantUmlComponent target) {
-        this.origin = checkNotNull(origin);
-        this.target = checkNotNull(target);
+    ComponentName(String value) {
+        this.value = checkNotNull(value);
     }
 
-    PlantUmlComponent getOrigin() {
-        return origin;
-    }
-
-    PlantUmlComponent getTarget() {
-        return target;
+    String asString() {
+        return value;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(origin, target);
+        return Objects.hash(value);
     }
 
     @Override
@@ -49,16 +43,14 @@ class PlantUmlComponentDependency {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final PlantUmlComponentDependency other = (PlantUmlComponentDependency) obj;
-        return Objects.equals(this.origin, other.origin)
-                && Objects.equals(this.target, other.target);
+        final ComponentName other = (ComponentName) obj;
+        return Objects.equals(this.value, other.value);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
-                "origin=" + origin +
-                ", target=" + target +
+                "value='" + value + '\'' +
                 '}';
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/IllegalDiagramException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/IllegalDiagramException.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
-class ComponentIntersectionException extends RuntimeException {
-    ComponentIntersectionException(String format) {
-        super(format);
+class IllegalDiagramException extends RuntimeException {
+    IllegalDiagramException(String message, Object... args) {
+        super(String.format(message, args));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociation.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ParsedDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ParsedDependency.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Collection;
 import java.util.List;
@@ -62,9 +62,8 @@ class PlantUmlComponent {
     }
 
     ComponentIdentifier getIdentifier() {
-        return alias.isPresent()
-                ? new ComponentIdentifier(componentName, alias.get())
-                : new ComponentIdentifier(componentName);
+        return alias.map(it -> new ComponentIdentifier(componentName, it))
+                .orElseGet(() -> new ComponentIdentifier(componentName));
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponentDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponentDependency.java
@@ -13,29 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class Alias {
-    private String value;
+class PlantUmlComponentDependency {
+    private final PlantUmlComponent origin;
+    private final PlantUmlComponent target;
 
-    Alias(String value) {
-        if (value.contains("[") || value.contains("]") || value.contains("\"")) {
-            throw new IllegalDiagramException("Alias '%s' should not contain character(s): '[' or ']' or '\"'", value);
-        }
-        this.value = checkNotNull(value);
+    PlantUmlComponentDependency(PlantUmlComponent origin, PlantUmlComponent target) {
+        this.origin = checkNotNull(origin);
+        this.target = checkNotNull(target);
     }
 
-    String asString() {
-        return value;
+    PlantUmlComponent getTarget() {
+        return target;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return Objects.hash(origin, target);
     }
 
     @Override
@@ -46,14 +45,16 @@ class Alias {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Alias other = (Alias) obj;
-        return Objects.equals(this.value, other.value);
+        final PlantUmlComponentDependency other = (PlantUmlComponentDependency) obj;
+        return Objects.equals(this.origin, other.origin)
+                && Objects.equals(this.target, other.target);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
-                "value='" + value + '\'' +
+                "origin=" + origin +
+                ", target=" + target +
                 '}';
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponents.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Collection;
 import java.util.Map;
@@ -22,7 +22,7 @@ import java.util.function.Predicate;
 
 import com.google.common.collect.FluentIterable;
 
-import static com.tngtech.archunit.library.plantuml.PlantUmlComponent.Functions.TO_EXISTING_ALIAS;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlComponent.Functions.TO_EXISTING_ALIAS;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlDiagram.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlDiagram.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.List;
 import java.util.Set;

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParseException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParseException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 class PlantUmlParseException extends RuntimeException {
     PlantUmlParseException(Exception e) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParser.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParser.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -26,8 +26,8 @@ import java.util.regex.Pattern;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
-import com.tngtech.archunit.library.plantuml.PlantUmlPatterns.PlantUmlComponentMatcher;
-import com.tngtech.archunit.library.plantuml.PlantUmlPatterns.PlantUmlDependencyMatcher;
+import com.tngtech.archunit.library.plantuml.rules.PlantUmlPatterns.PlantUmlComponentMatcher;
+import com.tngtech.archunit.library.plantuml.rules.PlantUmlPatterns.PlantUmlDependencyMatcher;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -120,8 +120,8 @@ class PlantUmlPatterns {
         private static final Pattern DEPENDENCY_RIGHT_ARROW_PATTERN = Pattern.compile("\\s-+" + DEPENDENCY_ARROW_CENTER_REGEX + "-*>\\s");
         private static final Pattern DEPENDENCY_LEFT_ARROW_PATTERN = Pattern.compile("\\s<-*" + DEPENDENCY_ARROW_CENTER_REGEX + "-+\\s");
 
+        private final String origin;
         private final String target;
-        private String origin;
 
         PlantUmlDependencyMatcher(String origin, String target) {
             this.origin = checkNotNull(origin, "Origin must not be null");

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Stereotype.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Stereotype.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class ComponentName {
+class Stereotype {
     private final String value;
 
-    ComponentName(String value) {
+    Stereotype(String value) {
         this.value = checkNotNull(value);
     }
 
@@ -43,7 +43,7 @@ class ComponentName {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ComponentName other = (ComponentName) obj;
+        final Stereotype other = (Stereotype) obj;
         return Objects.equals(this.value, other.value);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -109,8 +109,6 @@ import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.quote;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(DataProviderRunner.class)
 @SuppressWarnings("SameParameterValue")
@@ -1797,11 +1795,9 @@ public class JavaClassTest {
 
     @Test
     public void predicate_reside_in_a_package() {
-        JavaClass clazz = fakeClassWithPackage("some.arbitrary.pkg");
+        JavaClass clazz = importClassWithContext(getClass());
 
-        assertThat(resideInAPackage("some..pkg")).accepts(clazz);
-
-        clazz = fakeClassWithPackage("wrong.arbitrary.pkg");
+        assertThat(resideInAPackage("com..domain")).accepts(clazz);
 
         assertThat(resideInAPackage("some..pkg")).rejects(clazz);
 
@@ -1810,11 +1806,9 @@ public class JavaClassTest {
 
     @Test
     public void predicate_reside_in_any_package() {
-        JavaClass clazz = fakeClassWithPackage("some.arbitrary.pkg");
+        JavaClass clazz = importClassWithContext(getClass());
 
-        assertThat(resideInAnyPackage("any.thing", "some..pkg")).accepts(clazz);
-
-        clazz = fakeClassWithPackage("wrong.arbitrary.pkg");
+        assertThat(resideInAnyPackage("any.thing", "com..domain")).accepts(clazz);
 
         assertThat(resideInAnyPackage("any.thing", "some..pkg")).rejects(clazz);
 
@@ -2161,12 +2155,6 @@ public class JavaClassTest {
                 return !value.getOwner().isEquivalentTo(Object.class);
             }
         };
-    }
-
-    private static JavaClass fakeClassWithPackage(String pkg) {
-        JavaClass javaClass = mock(JavaClass.class);
-        when(javaClass.getPackageName()).thenReturn(pkg);
-        return javaClass;
     }
 
     private static AssignableAssert assertThatAssignable() {

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociationTest.java
@@ -1,4 +1,4 @@
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchConditionTest.java
@@ -1,4 +1,4 @@
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,7 +16,7 @@ import com.tngtech.archunit.library.diagramtests.multipledependencies.origin.Som
 import com.tngtech.archunit.library.diagramtests.multipledependencies.target.SomeTarget;
 import com.tngtech.archunit.library.diagramtests.simpledependency.origin.SomeOriginClass;
 import com.tngtech.archunit.library.diagramtests.simpledependency.target.SomeTargetClass;
-import com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration;
+import com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.DataProviders;
@@ -35,10 +35,10 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.equivalentTo
 import static com.tngtech.archunit.core.domain.TestUtils.importClasses;
 import static com.tngtech.archunit.lang.ArchRule.Assertions.assertNoViolation;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringAllDependencies;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
-import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.adhereToPlantUmlDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringAllDependencies;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInAnyPackage;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.consideringOnlyDependenciesInDiagram;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.adhereToPlantUmlDiagram;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
@@ -1,4 +1,4 @@
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/TestDiagram.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/TestDiagram.java
@@ -1,4 +1,4 @@
-package com.tngtech.archunit.library.plantuml;
+package com.tngtech.archunit.library.plantuml.rules;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
... to free up the namespace for further possible enhancements around PlantUML. Our upcoming `1.0.0` release is the perfect point in time to do this breaking change. This will allow us to also add some infrastructure to create diagrams in the future within the `library.plantuml` package and make it clear that all existing code has the context of creating rules from PlantUML.

Signed-off-by: Peter Gafert <peter.gafert@tngtech.com>