### PR TITLE
Rename `JavaPackage.getAllClasses()` -> `getClassesInPackageTree()`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaPackage.java
@@ -303,7 +303,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     }
 
     /**
-     * @return all classes directly contained in this package, but not classes in the lower levels of the package tree (compare {@link #getAllClasses()})
+     * @return all classes directly contained in this package, but not classes in the lower levels of the package tree (compare {@link #getClassesInPackageTree()})
      */
     @PublicAPI(usage = ACCESS)
     public Set<JavaClass> getClasses() {
@@ -311,13 +311,14 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
     }
 
     /**
-     * @return all classes contained in this package tree (compare {@link #getClasses()})
+     * @return all classes contained in this {@link JavaPackage package tree}, i.e. all classes in this package,
+     *         subpackages, subpackages of subpackages, and so on (compare {@link #getClasses()})
      */
     @PublicAPI(usage = ACCESS)
-    public Set<JavaClass> getAllClasses() {
+    public Set<JavaClass> getClassesInPackageTree() {
         ImmutableSet.Builder<JavaClass> result = ImmutableSet.<JavaClass>builder().addAll(classes);
         for (JavaPackage subpackage : getSubpackages()) {
-            result.addAll(subpackage.getAllClasses());
+            result.addAll(subpackage.getClassesInPackageTree());
         }
         return result.build();
     }
@@ -512,7 +513,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
      */
     @PublicAPI(usage = ACCESS)
     public Set<Dependency> getClassDependenciesFromThisPackageTree() {
-        return getClassDependenciesFrom(getAllClasses());
+        return getClassDependenciesFrom(getClassesInPackageTree());
     }
 
     /**
@@ -541,7 +542,7 @@ public final class JavaPackage implements HasName, HasAnnotations<JavaPackage> {
      */
     @PublicAPI(usage = ACCESS)
     public Set<Dependency> getClassDependenciesToThisPackageTree() {
-        return getClassDependenciesTo(getAllClasses());
+        return getClassDependenciesTo(getClassesInPackageTree());
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
@@ -121,7 +121,7 @@ public final class MetricsComponents<T> extends ForwardingCollection<MetricsComp
     public static MetricsComponents<JavaClass> fromPackages(Collection<JavaPackage> packages) {
         ImmutableSet.Builder<MetricsComponent<JavaClass>> components = ImmutableSet.builder();
         for (JavaPackage javaPackage : packages) {
-            components.add(MetricsComponent.of(javaPackage.getName(), javaPackage.getAllClasses()));
+            components.add(MetricsComponent.of(javaPackage.getName(), javaPackage.getClassesInPackageTree()));
         }
         return MetricsComponents.of(components.build());
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
@@ -40,14 +40,14 @@ public class JavaClassesTest {
     public void creation_of_JavaClasses_from_existing_classes_should_keep_the_original_package_tree() {
         JavaClasses classes = JavaClasses.of(singletonList(ALL_CLASSES.get(SomeClass.class)));
 
-        assertThat(classes.getDefaultPackage().getAllClasses()).hasSameElementsAs(ALL_CLASSES.getDefaultPackage().getAllClasses());
+        assertThat(classes.getDefaultPackage().getClassesInPackageTree()).hasSameElementsAs(ALL_CLASSES.getDefaultPackage().getClassesInPackageTree());
     }
 
     @Test
     public void creation_of_JavaClasses_from_empty_classes_should_create_empty_default_package() {
         JavaClasses classes = JavaClasses.of(emptySet());
 
-        assertThat(classes.getDefaultPackage().getAllClasses()).isEmpty();
+        assertThat(classes.getDefaultPackage().getClassesInPackageTree()).isEmpty();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -221,7 +221,7 @@ public class JavaPackageTest {
 
         JavaPackage javaLang = defaultPackage.getPackage("java.lang");
 
-        assertThatTypes(javaLang.getAllClasses()).contain(Object.class, String.class, Annotation.class, Field.class);
+        assertThatTypes(javaLang.getClassesInPackageTree()).contain(Object.class, String.class, Annotation.class, Field.class);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterSlowTest.java
@@ -171,7 +171,7 @@ public class ClassFileImporterSlowTest {
 
         JavaPackage javaPackage = defaultPackage.getPackage("java.lang");
         assertThatTypes(javaPackage.getClasses()).contain(Object.class, String.class, Integer.class);
-        assertThatTypes(javaPackage.getAllClasses()).contain(Object.class, Annotation.class, Field.class);
+        assertThatTypes(javaPackage.getClassesInPackageTree()).contain(Object.class, Annotation.class, Field.class);
 
         assertThat(javaClasses.containPackage("java.util"))
                 .as("Classes contain package 'java.util'").isTrue();


### PR DESCRIPTION
In all other places we have replaced the fuzzy word "all" by "in package tree" to clarify the semantics. The Javadoc already hinted at the fact that this method name should be consolidated. Now with release 1.0.0 we can break the API and don't need to deprecate the old method. I decided to call the method `getClassesInPackageTree()`, even though the similar method `getSubpackagesInTree()` does not add the infix "package", because I think for the former it is worth it to clarify the context, while the latter already talks about packages, so "tree" is already clear from the context.