### PR TITLE
add general coding rules for assertion messages and deprecated APIs

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
@@ -480,4 +480,22 @@ public final class GeneralCodingRules {
             }
         };
     }
+
+    /**
+     * A rule that checks that all {@link AssertionError AssertionErrors} (e.g. from the {@code assert} keyword) have a detail message.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * assert x > 0;  // violation
+     * throw new AssertionError();  // violation
+     *
+     * assert x > 0 : "x is not positive";  // no violation
+     * throw new AssertionError("x is not positive");  // no violation
+     * }</pre>
+     * </p>
+     */
+    @PublicAPI(usage = ACCESS)
+    public static final ArchRule ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE =
+            noClasses().should().callConstructor(AssertionError.class /* without detailMessage */)
+                    .because("assertions should have a detail message");
 }

--- a/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
@@ -12,10 +12,11 @@ import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.d
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.defaultsuffix.subdir.ImplementationClassWithWrongTestClassPackageTest;
 import org.junit.Test;
 
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.library.GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE;
+import static com.tngtech.archunit.library.GeneralCodingRules.DEPRECATED_API_SHOULD_NOT_BE_USED;
 import static com.tngtech.archunit.library.GeneralCodingRules.testClassesShouldResideInTheSamePackageAsImplementation;
 import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
-import static java.util.regex.Pattern.quote;
 
 public class GeneralCodingRulesTest {
 
@@ -118,5 +119,65 @@ public class GeneralCodingRulesTest {
         assertThatRule(ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE)
                 .checking(new ClassFileImporter().importClasses(ValidAssertions.class))
                 .hasNoViolation();
+    }
+
+    @Test
+    public void DEPRECATED_API_SHOULD_NOT_BE_USED_should_fail_on_call_to_deprecated_method() {
+        @SuppressWarnings("DeprecatedIsStillUsed")
+        class ClassWithDeprecatedMembers {
+            @Deprecated
+            int target;
+
+            @Deprecated
+            ClassWithDeprecatedMembers() {
+            }
+
+            @Deprecated
+            void target() {
+            }
+        }
+        @SuppressWarnings("DeprecatedIsStillUsed")
+        @Deprecated
+        class DeprecatedClass {
+            int target;
+
+            void target() {
+            }
+        }
+        @SuppressWarnings("unused")
+        class Origin {
+            @DeprecatedAnnotation
+            void origin() {
+                ClassWithDeprecatedMembers instanceOfClassWithDeprecatedMembers = new ClassWithDeprecatedMembers();
+                instanceOfClassWithDeprecatedMembers.target++;
+                instanceOfClassWithDeprecatedMembers.target();
+                DeprecatedClass instanceOfDeprecatedClass = new DeprecatedClass();
+                instanceOfDeprecatedClass.target++;
+                instanceOfDeprecatedClass.target();
+                Class<?> deprecatedClass = DeprecatedClass.class;
+            }
+        }
+
+        String innerClassConstructor = CONSTRUCTOR_NAME + "(" + GeneralCodingRulesTest.class.getName() + ")";
+        String violatingMethod = "Method <" + Origin.class.getName() + ".origin()>";
+        assertThatRule(DEPRECATED_API_SHOULD_NOT_BE_USED)
+                .hasDescriptionContaining("no classes should access @Deprecated members or should depend on @Deprecated classes, because there should be a better alternative")
+                .checking(new ClassFileImporter().importClasses(Origin.class, ClassWithDeprecatedMembers.class, DeprecatedClass.class))
+                .hasViolations(10)
+                .hasViolationContaining("%s calls constructor <%s.%s>", violatingMethod, ClassWithDeprecatedMembers.class.getName(), innerClassConstructor)
+                .hasViolationContaining("%s gets field <%s.target>", violatingMethod, ClassWithDeprecatedMembers.class.getName())
+                .hasViolationContaining("%s sets field <%s.target>", violatingMethod, ClassWithDeprecatedMembers.class.getName())
+                .hasViolationContaining("%s calls method <%s.target()>", violatingMethod, ClassWithDeprecatedMembers.class.getName())
+                .hasViolationContaining("%s calls constructor <%s.%s>", violatingMethod, DeprecatedClass.class.getName(), innerClassConstructor)
+                .hasViolationContaining("%s gets field <%s.target>", violatingMethod, DeprecatedClass.class.getName())
+                .hasViolationContaining("%s sets field <%s.target>", violatingMethod, DeprecatedClass.class.getName())
+                .hasViolationContaining("%s calls method <%s.target()>", violatingMethod, DeprecatedClass.class.getName())
+                .hasViolationContaining("%s is annotated with <%s>", violatingMethod, DeprecatedAnnotation.class.getName())
+                .hasViolationContaining("%s references class object <%s>", violatingMethod, DeprecatedClass.class.getName());
+    }
+
+    @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    private @interface DeprecatedAnnotation {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ArchRuleCheckAssertion.java
@@ -29,21 +29,25 @@ public class ArchRuleCheckAssertion {
         }
     }
 
+    public ArchRuleCheckAssertion hasViolationContaining(String part, Object... args) {
+        String expectedPart = String.format(part, args);
+        assertThat(evaluationResult.getFailureReport().getDetails())
+                .as("violation details (should have some detail containing '%s')", expectedPart)
+                .anyMatch(detail -> detail.contains(expectedPart));
+        return this;
+    }
+
     public ArchRuleCheckAssertion hasViolationMatching(String regex) {
-        for (String detail : evaluationResult.getFailureReport().getDetails()) {
-            if (detail.matches(regex)) {
-                return this;
-            }
-        }
-        throw new AssertionError(String.format("No violation matches '%s'", regex));
+        assertThat(evaluationResult.getFailureReport().getDetails())
+                .as("violation details (should have some detail matching '%s')", regex)
+                .anyMatch(detail -> detail.matches(regex));
+        return this;
     }
 
     public ArchRuleCheckAssertion hasNoViolationMatching(String regex) {
-        for (String detail : evaluationResult.getFailureReport().getDetails()) {
-            if (detail.matches(regex)) {
-                throw new AssertionError(String.format("Violation matches '%s'", regex));
-            }
-        }
+        assertThat(evaluationResult.getFailureReport().getDetails())
+                .as("violation details (should not have any detail matching '%s')", regex)
+                .noneMatch(detail -> detail.matches(regex));
         return this;
     }
 


### PR DESCRIPTION
This PR adds two more `GeneralCodingRules`:
* `ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE` resolves #963
* `DEPRECATED_API_SHOULD_NOT_BE_USED` checks that no class accesses members (i.e. calls methods or constructors, or accesses fields) that are either `@Deprecated` themselves or declared in `@Deprecated` classes, or references `@Deprecated` class objects.