### PR TITLE
Fixing Javadoc code for layeredArchitecture()

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -90,6 +90,7 @@ public final class Architectures {
      * <br><br>
      * A layered architecture can for example be defined like this:
      * <pre><code>layeredArchitecture()
+     * .consideringAllDependencies()
      * .layer("UI").definedBy("my.application.ui..")
      * .layer("Business Logic").definedBy("my.application.domain..")
      * .layer("Persistence").definedBy("my.application.persistence..")


### PR DESCRIPTION
The existing Javadoc example code is broken in version 1.0.0. Fixing it.