### PR TITLE
Fix userguide regarding DescribedPredicate

### DIFF
--- a/docs/userguide/007_The_Lang_API.adoc
+++ b/docs/userguide/007_The_Lang_API.adoc
@@ -131,7 +131,7 @@ For example:
 DescribedPredicate<JavaClass> haveAFieldAnnotatedWithPayload =
     new DescribedPredicate<JavaClass>("have a field annotated with @Payload"){
         @Override
-        public boolean apply(JavaClass input) {
+        public boolean test(JavaClass input) {
             boolean someFieldAnnotatedWithPayload = // iterate fields and check for @Payload
             return someFieldAnnotatedWithPayload;
         }


### PR DESCRIPTION
DescribedPredicate had an `apply` method that was renamed to `test` in 1.0.

This PR renames the only mention of DescribedPredicate#apply() in the user guide.

Signed-off-by: Thomas Much <github@snailshell.de>