### PR TITLE
recognize empty records

### DIFF
--- a/archunit/src/jdk16test/java/com/tngtech/archunit/core/importer/ClassFileImporterRecordsTest.java
+++ b/archunit/src/jdk16test/java/com/tngtech/archunit/core/importer/ClassFileImporterRecordsTest.java
@@ -4,21 +4,33 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 
+@RunWith(DataProviderRunner.class)
 public class ClassFileImporterRecordsTest {
+    @DataProvider
+    public static Object[][] imports_record() {
+        record SimpleRecord(String component1, int component2) {
+        }
+        record EmptyRecord() {
+        }
+        return testForEach(SimpleRecord.class, EmptyRecord.class);
+    }
 
     @Test
-    public void imports_simple_record() {
-        record RecordToImport(String component1, int component2) {
-        }
-
-        JavaClass javaClass = new ClassFileImporter().importClasses(RecordToImport.class, Record.class).get(RecordToImport.class);
+    @UseDataProvider
+    public void imports_record(Class<?> recordToImport) {
+        JavaClass javaClass = new ClassFileImporter().importClasses(recordToImport, Record.class).get(recordToImport);
 
         assertThat(javaClass)
-                .matches(RecordToImport.class)
+                .matches(recordToImport)
                 .hasRawSuperclassMatching(Record.class)
                 .hasNoInterfaces()
                 .isInterface(false)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.core.domain;
 import java.util.EnumSet;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.tngtech.archunit.PublicAPI;
 import org.objectweb.asm.Opcodes;
@@ -73,7 +74,17 @@ public enum JavaModifier {
     @Deprecated
     @PublicAPI(usage = ACCESS)
     public static Set<JavaModifier> getModifiersForClass(int asmAccess) {
-        return getModifiersFor(ApplicableType.CLASS, asmAccess);
+        Set<JavaModifier> modifiers = getModifiersFor(ApplicableType.CLASS, asmAccess);
+        boolean opCodeForRecordIsPresent = (asmAccess & Opcodes.ACC_RECORD) != 0;
+        if (opCodeForRecordIsPresent) {
+            // As records are implicitly static and final (compare JLS 8.10 Record Declarations),
+            // we ensure that those modifiers are always present. (asmAccess does not contain STATIC.)
+            return ImmutableSet.<JavaModifier>builder()
+                    .addAll(modifiers)
+                    .add(JavaModifier.STATIC, JavaModifier.FINAL)
+                    .build();
+        }
+        return modifiers;
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaModifier.java
@@ -64,16 +64,37 @@ public enum JavaModifier {
         this.asmAccessFlag = asmAccessFlag;
     }
 
+    /**
+     * @deprecated This seems like an unnecessary API for users of ArchUnit, but limits us to do internal refactorings.
+     * If you think you need this API, please reach out to us on GitHub by creating an issue at
+     * <a href="https://github.com/TNG/ArchUnit/issues">https://github.com/TNG/ArchUnit/issues</a>.
+     * Otherwise, at some point in the future we will remove this API without any replacement.
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static Set<JavaModifier> getModifiersForClass(int asmAccess) {
         return getModifiersFor(ApplicableType.CLASS, asmAccess);
     }
 
+    /**
+     * @deprecated This seems like an unnecessary API for users of ArchUnit, but limits us to do internal refactorings.
+     * If you think you need this API, please reach out to us on GitHub by creating an issue at
+     * <a href="https://github.com/TNG/ArchUnit/issues">https://github.com/TNG/ArchUnit/issues</a>.
+     * Otherwise, at some point in the future we will remove this API without any replacement.
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static Set<JavaModifier> getModifiersForField(int asmAccess) {
         return getModifiersFor(ApplicableType.FIELD, asmAccess);
     }
 
+    /**
+     * @deprecated This seems like an unnecessary API for users of ArchUnit, but limits us to do internal refactorings.
+     * If you think you need this API, please reach out to us on GitHub by creating an issue at
+     * <a href="https://github.com/TNG/ArchUnit/issues">https://github.com/TNG/ArchUnit/issues</a>.
+     * Otherwise, at some point in the future we will remove this API without any replacement.
+     */
+    @Deprecated
     @PublicAPI(usage = ACCESS)
     public static Set<JavaModifier> getModifiersForMethod(int asmAccess) {
         return getModifiersFor(ApplicableType.METHOD, asmAccess);


### PR DESCRIPTION
As `ClassVisitor#visitRecordComponent` is not invoked for empty records (without components), we better rely on the access flags provided to `ClassVisitor#visit`.

resolves #998