### PR TITLE
Fix referenced class objects and instanceof checks in lambdas

### DIFF
--- a/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/SlicesIsolationTest.java
+++ b/archunit-example/example-junit4/src/test/java/com/tngtech/archunit/exampletest/junit4/SlicesIsolationTest.java
@@ -38,7 +38,7 @@ public class SlicesIsolationTest {
                     .ignoreDependency(UseCaseOneTwoController.class, UseCaseTwoController.class)
                     .ignoreDependency(nameMatching(".*controller\\.three.*"), alwaysTrue());
 
-    private static DescribedPredicate<Slice> containDescription(final String descriptionPart) {
+    private static DescribedPredicate<Slice> containDescription(String descriptionPart) {
         return new DescribedPredicate<Slice>("contain description '%s'", descriptionPart) {
             @Override
             public boolean test(Slice input) {

--- a/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/SlicesIsolationTest.java
+++ b/archunit-example/example-junit5/src/test/java/com/tngtech/archunit/exampletest/junit5/SlicesIsolationTest.java
@@ -35,7 +35,7 @@ public class SlicesIsolationTest {
                     .ignoreDependency(UseCaseOneTwoController.class, UseCaseTwoController.class)
                     .ignoreDependency(nameMatching(".*controller\\.three.*"), alwaysTrue());
 
-    private static DescribedPredicate<Slice> containDescription(final String descriptionPart) {
+    private static DescribedPredicate<Slice> containDescription(String descriptionPart) {
         return new DescribedPredicate<Slice>("contain description '%s'", descriptionPart) {
             @Override
             public boolean test(Slice input) {

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/persistence/first/dao/domain/PersistentObject.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/persistence/first/dao/domain/PersistentObject.java
@@ -31,7 +31,7 @@ public class PersistentObject {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final PersistentObject other = (PersistentObject) obj;
+        PersistentObject other = (PersistentObject) obj;
         return Objects.equals(this.id, other.id);
     }
 }

--- a/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/persistence/second/dao/domain/OtherPersistentObject.java
+++ b/archunit-example/example-plain/src/main/java/com/tngtech/archunit/example/layers/persistence/second/dao/domain/OtherPersistentObject.java
@@ -38,7 +38,7 @@ public class OtherPersistentObject {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final OtherPersistentObject other = (OtherPersistentObject) obj;
+        OtherPersistentObject other = (OtherPersistentObject) obj;
         return Objects.equals(this.id, other.id);
     }
 }

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SlicesIsolationTest.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/SlicesIsolationTest.java
@@ -43,7 +43,7 @@ public class SlicesIsolationTest {
                 .check(classes);
     }
 
-    private static DescribedPredicate<Slice> containDescription(final String descriptionPart) {
+    private static DescribedPredicate<Slice> containDescription(String descriptionPart) {
         return new DescribedPredicate<Slice>("contain description '%s'", descriptionPart) {
             @Override
             public boolean test(Slice input) {

--- a/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/extension/NewConfigurationEvent.java
+++ b/archunit-example/example-plain/src/test/java/com/tngtech/archunit/exampletest/extension/NewConfigurationEvent.java
@@ -35,7 +35,7 @@ public class NewConfigurationEvent {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final NewConfigurationEvent other = (NewConfigurationEvent) obj;
+        NewConfigurationEvent other = (NewConfigurationEvent) obj;
         return Objects.equals(this.properties, other.properties);
     }
 

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/ArchUnitArchitectureTest.java
@@ -83,11 +83,11 @@ public class ArchUnitArchitectureTest {
         return classIsResolvedViaReflection().and(not(explicitlyAllowedUsage));
     }
 
-    private static DescribedPredicate<JavaAccess<?>> contextIsAnnotatedWith(final Class<? extends Annotation> annotationType) {
+    private static DescribedPredicate<JavaAccess<?>> contextIsAnnotatedWith(Class<? extends Annotation> annotationType) {
         return origin(With.owner(withAnnotation(annotationType)));
     }
 
-    private static DescribedPredicate<JavaClass> withAnnotation(final Class<? extends Annotation> annotationType) {
+    private static DescribedPredicate<JavaClass> withAnnotation(Class<? extends Annotation> annotationType) {
         return new DescribedPredicate<JavaClass>("annotated with @" + annotationType.getName()) {
             @Override
             public boolean test(JavaClass input) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -1263,8 +1263,8 @@ class ExamplesIntegrationTest {
 
     }
 
-    private static MessageAssertionChain.Link classesContaining(final Class<?>... classes) {
-        final String expectedLine = String.format("there is/are %d element(s) in %s", classes.length, formatNamesOf(classes));
+    private static MessageAssertionChain.Link classesContaining(Class<?>... classes) {
+        String expectedLine = String.format("there is/are %d element(s) in %s", classes.length, formatNamesOf(classes));
         return new MessageAssertionChain.Link() {
             @Override
             public Result filterMatching(List<String> lines) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExtensionIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExtensionIntegrationTest.java
@@ -65,7 +65,7 @@ class ExtensionIntegrationTest {
         assertThat(ExampleExtension.getEvaluatedRuleEvents()).isEmpty();
     }
 
-    private static Condition<Object> containingEntry(final String propKey, final String propValue) {
+    private static Condition<Object> containingEntry(String propKey, String propValue) {
         return new Condition<Object>(String.format("containing entry {%s=%s}", propKey, propValue)) {
             @Override
             public boolean matches(Object value) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/CyclicErrorMatcher.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/CyclicErrorMatcher.java
@@ -58,7 +58,7 @@ public class CyclicErrorMatcher implements MessageAssertionChain.Link {
 
     @Override
     public MessageAssertionChain.Link.Result filterMatching(List<String> lines) {
-        final Result.Builder builder = new Result.Builder()
+        Result.Builder builder = new Result.Builder()
                 .containsText(cycleText());
 
         for (String sliceName : details.asMap().keySet()) {

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/HandlingAssertion.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/HandlingAssertion.java
@@ -80,7 +80,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateFieldAccesses(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<>(this.expectedFieldAccesses);
+        Set<ExpectedRelation> left = new HashSet<>(this.expectedFieldAccesses);
         result.handleViolations((Collection<JavaFieldAccess> violatingObjects, String message) ->
                 errorMessages.addAll(removeExpectedAccesses(violatingObjects, left)));
         return union(errorMessages, errorMessagesFrom(left));
@@ -88,7 +88,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateMethodCalls(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<>(expectedMethodCalls);
+        Set<ExpectedRelation> left = new HashSet<>(expectedMethodCalls);
         result.handleViolations((Collection<JavaMethodCall> violatingObjects, String message) ->
                 errorMessages.addAll(removeExpectedAccesses(violatingObjects, left)));
         return union(errorMessages, errorMessagesFrom(left));
@@ -96,7 +96,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateConstructorCalls(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<>(expectedConstructorCalls);
+        Set<ExpectedRelation> left = new HashSet<>(expectedConstructorCalls);
         result.handleViolations((Collection<JavaConstructorCall> violatingObjects, String message) ->
                 errorMessages.addAll(removeExpectedAccesses(violatingObjects, left)));
         return union(errorMessages, errorMessagesFrom(left));
@@ -104,7 +104,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateCalls(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<>(Sets.union(expectedConstructorCalls, expectedMethodCalls));
+        Set<ExpectedRelation> left = new HashSet<>(Sets.union(expectedConstructorCalls, expectedMethodCalls));
         result.handleViolations((Collection<JavaCall<?>> violatingObjects, String message) ->
                 errorMessages.addAll(removeExpectedAccesses(violatingObjects, left)));
         return union(errorMessages, errorMessagesFrom(left));
@@ -112,7 +112,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateAccesses(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<ExpectedRelation>() {
+        Set<ExpectedRelation> left = new HashSet<ExpectedRelation>() {
             {
                 addAll(expectedConstructorCalls);
                 addAll(expectedMethodCalls);
@@ -126,7 +126,7 @@ class HandlingAssertion {
 
     private Set<String> evaluateDependencies(EvaluationResult result) {
         Set<String> errorMessages = new HashSet<>();
-        final Set<ExpectedRelation> left = new HashSet<>(expectedDependencies);
+        Set<ExpectedRelation> left = new HashSet<>(expectedDependencies);
         result.handleViolations((Collection<Dependency> violatingObjects, String message) ->
                 errorMessages.addAll(removeExpectedAccesses(violatingObjects, left)));
         return union(errorMessages, errorMessagesFrom(left));

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/MessageAssertionChain.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/MessageAssertionChain.java
@@ -38,8 +38,8 @@ public class MessageAssertionChain {
         return links.stream().map(Link::getDescription).collect(joining(lineSeparator()));
     }
 
-    static Link matchesLine(final String pattern) {
-        final Pattern p = Pattern.compile(pattern);
+    static Link matchesLine(String pattern) {
+        Pattern p = Pattern.compile(pattern);
         return new Link() {
             @Override
             public Result filterMatching(List<String> lines) {
@@ -61,7 +61,7 @@ public class MessageAssertionChain {
     }
 
     static Link containsLine(String text, Object... args) {
-        final String expectedLine = String.format(text, args);
+        String expectedLine = String.format(text, args);
         return new Link() {
             @Override
             public Result filterMatching(List<String> lines) {
@@ -79,7 +79,7 @@ public class MessageAssertionChain {
 
     static Link containsText(String text, Object... args) {
         String expectedText = String.format(text, args);
-        final List<String> expectedLines = Splitter.on(lineSeparator()).splitToList(expectedText);
+        List<String> expectedLines = Splitter.on(lineSeparator()).splitToList(expectedText);
         return new Link() {
             @Override
             public Result filterMatching(List<String> lines) {
@@ -115,10 +115,10 @@ public class MessageAssertionChain {
         return "Lines were >>>>>>>>" + lineSeparator() + Joiner.on(lineSeparator()).join(lines) + lineSeparator() + "<<<<<<<<";
     }
 
-    static Link containsConsecutiveLines(final List<String> expectedLines) {
+    static Link containsConsecutiveLines(List<String> expectedLines) {
         checkArgument(!expectedLines.isEmpty(), "Asserting zero consecutive lines makes no sense");
-        final String linesDescription = Joiner.on(lineSeparator()).join(expectedLines);
-        final String description = "Message contains consecutive lines " + lineSeparator() + linesDescription;
+        String linesDescription = Joiner.on(lineSeparator()).join(expectedLines);
+        String description = "Message contains consecutive lines " + lineSeparator() + linesDescription;
 
         return new Link() {
             @Override

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
@@ -64,7 +64,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
 
     @Override
     public Statement classBlock(RunNotifier notifier) {
-        final Statement statement = super.classBlock(notifier);
+        Statement statement = super.classBlock(notifier);
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
@@ -201,7 +201,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     }
 
     // extractingResultOf(..) only looks for public methods
-    private Extractor<Object, Object> resultOf(final String methodName) {
+    private Extractor<Object, Object> resultOf(String methodName) {
         return input -> {
             Collection<Method> candidates = getAllMethods(input.getClass(), method -> method.getName().equals(methodName));
             checkState(!candidates.isEmpty(),

--- a/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/engine_api/FieldSelector.java
+++ b/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/engine_api/FieldSelector.java
@@ -59,7 +59,7 @@ public final class FieldSelector implements DiscoverySelector {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final FieldSelector other = (FieldSelector) obj;
+        FieldSelector other = (FieldSelector) obj;
         return Objects.equals(this.clazz, other.clazz)
                 && Objects.equals(this.field, other.field);
     }

--- a/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/engine_api/FieldSource.java
+++ b/archunit-junit/junit5/engine-api/src/main/java/com/tngtech/archunit/junit/engine_api/FieldSource.java
@@ -62,7 +62,7 @@ public final class FieldSource implements TestSource {
 		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
-        final FieldSource other = (FieldSource) obj;
+        FieldSource other = (FieldSource) obj;
         return Objects.equals(this.javaClass, other.javaClass)
                 && Objects.equals(this.fieldName, other.fieldName);
     }

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ClassCache.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ClassCache.java
@@ -149,7 +149,7 @@ class ClassCache {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final LocationsKey other = (LocationsKey) obj;
+            LocationsKey other = (LocationsKey) obj;
             return Objects.equals(this.importOptionTypes, other.importOptionTypes)
                     && Objects.equals(this.locations, other.locations);
         }

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
@@ -121,7 +121,7 @@ class ReflectionUtils {
         throw (T) throwable;
     }
 
-    static Predicate<AnnotatedElement> withAnnotation(final Class<? extends Annotation> annotationType) {
+    static Predicate<AnnotatedElement> withAnnotation(Class<? extends Annotation> annotationType) {
         return input -> input.isAnnotationPresent(annotationType);
     }
 }

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheConcurrencyTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheConcurrencyTest.java
@@ -67,7 +67,7 @@ public class ClassCacheConcurrencyTest {
         verifyNoMoreInteractions(classFileImporter);
     }
 
-    private Runnable repeatGetClassesToAnalyze(final int times) {
+    private Runnable repeatGetClassesToAnalyze(int times) {
         return () -> {
             for (int j = 0; j < times; j++) {
                 cache.getClassesToAnalyzeFor(TEST_CLASSES.get(j % TEST_CLASSES.size()),

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ClassCacheTest.java
@@ -246,7 +246,7 @@ public class ClassCacheTest {
         verifyNoMoreInteractions(cacheClassFileImporter);
     }
 
-    private static Condition<Iterable<? extends Location>> locationContaining(final String part) {
+    private static Condition<Iterable<? extends Location>> locationContaining(String part) {
         return new Condition<Iterable<? extends Location>>() {
             @Override
             public boolean matches(Iterable<? extends Location> locations) {

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
@@ -62,7 +62,7 @@ public class ReflectionUtilsTest {
                         field(OtherInterface.class, "OTHER_CONSTANT"));
     }
 
-    private Predicate<Member> named(final String name) {
+    private Predicate<Member> named(String name) {
         return input -> input.getName().equals(name);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/base/ChainableFunction.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/ChainableFunction.java
@@ -23,7 +23,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
 
 @PublicAPI(usage = INHERITANCE)
 public abstract class ChainableFunction<F, T> implements Function<F, T> {
-    public <E> ChainableFunction<E, T> after(final Function<? super E, ? extends F> function) {
+    public <E> ChainableFunction<E, T> after(Function<? super E, ? extends F> function) {
         return new ChainableFunction<E, T>() {
             @Override
             public T apply(E input) {
@@ -32,7 +32,7 @@ public abstract class ChainableFunction<F, T> implements Function<F, T> {
         };
     }
 
-    public <U> ChainableFunction<F, U> then(final Function<? super T, ? extends U> function) {
+    public <U> ChainableFunction<F, U> then(Function<? super T, ? extends U> function) {
         return new ChainableFunction<F, U>() {
             @Override
             public U apply(F input) {

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedIterable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedIterable.java
@@ -30,7 +30,7 @@ public interface DescribedIterable<T> extends Iterable<T>, HasDescription {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static <T> DescribedIterable<T> iterable(final Iterable<T> iterable, final String description) {
+        public static <T> DescribedIterable<T> iterable(Iterable<T> iterable, String description) {
             return new DescribedIterable<T>() {
                 @Override
                 public String getDescription() {

--- a/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/base/DescribedPredicate.java
@@ -68,15 +68,15 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
         return new AsPredicate<>(this, description, params);
     }
 
-    public DescribedPredicate<T> and(final DescribedPredicate<? super T> other) {
+    public DescribedPredicate<T> and(DescribedPredicate<? super T> other) {
         return new AndPredicate<>(this, other);
     }
 
-    public DescribedPredicate<T> or(final DescribedPredicate<? super T> other) {
+    public DescribedPredicate<T> or(DescribedPredicate<? super T> other) {
         return new OrPredicate<>(this, other);
     }
 
-    public <F> DescribedPredicate<F> onResultOf(final Function<? super F, ? extends T> function) {
+    public <F> DescribedPredicate<F> onResultOf(Function<? super F, ? extends T> function) {
         return new OnResultOfPredicate<>(this, function);
     }
 
@@ -129,27 +129,27 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     };
 
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> equalTo(final T object) {
+    public static <T> DescribedPredicate<T> equalTo(T object) {
         return new EqualToPredicate<>(object);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <T extends Comparable<T>> DescribedPredicate<T> lessThan(final T value) {
+    public static <T extends Comparable<T>> DescribedPredicate<T> lessThan(T value) {
         return new LessThanPredicate<>(value);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThan(final T value) {
+    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThan(T value) {
         return new GreaterThanPredicate<>(value);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <T extends Comparable<T>> DescribedPredicate<T> lessThanOrEqualTo(final T value) {
+    public static <T extends Comparable<T>> DescribedPredicate<T> lessThanOrEqualTo(T value) {
         return new LessThanOrEqualToPredicate<>(value);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThanOrEqualTo(final T value) {
+    public static <T extends Comparable<T>> DescribedPredicate<T> greaterThanOrEqualTo(T value) {
         return new GreaterThanOrEqualToPredicate<>(value);
     }
 
@@ -162,7 +162,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * Same as {@link #not(DescribedPredicate)} but with a different description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> doesNot(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<T> doesNot(DescribedPredicate<? super T> predicate) {
         return not(predicate).as("does not %s", predicate.getDescription()).forSubtype();
     }
 
@@ -170,7 +170,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * Same as {@link #not(DescribedPredicate)} but with a different description
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> doNot(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<T> doNot(DescribedPredicate<? super T> predicate) {
         return not(predicate).as("do not %s", predicate.getDescription()).forSubtype();
     }
 
@@ -180,7 +180,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * @param <T> The type of object the {@link DescribedPredicate predicate} applies to
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<T> not(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<T> not(DescribedPredicate<? super T> predicate) {
         return new NotPredicate<>(predicate);
     }
 
@@ -253,7 +253,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<Optional<T>> optionalContains(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<Optional<T>> optionalContains(DescribedPredicate<? super T> predicate) {
         return new OptionalContainsPredicate<>(predicate);
     }
 
@@ -271,7 +271,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * @param <T> The type of object the {@link DescribedPredicate predicate} applies to
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<Iterable<? extends T>> anyElementThat(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<Iterable<? extends T>> anyElementThat(DescribedPredicate<? super T> predicate) {
         return new AnyElementPredicate<>(predicate);
     }
 
@@ -282,7 +282,7 @@ public abstract class DescribedPredicate<T> implements Predicate<T> {
      * @param <T> The type of object the {@link DescribedPredicate predicate} applies to
      */
     @PublicAPI(usage = ACCESS)
-    public static <T> DescribedPredicate<Iterable<T>> allElements(final DescribedPredicate<? super T> predicate) {
+    public static <T> DescribedPredicate<Iterable<T>> allElements(DescribedPredicate<? super T> predicate) {
         return new AllElementsPredicate<>(predicate);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AccessTarget.java
@@ -153,7 +153,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      */
     @Override
     @PublicAPI(usage = ACCESS)
-    public boolean isAnnotatedWith(final String annotationTypeName) {
+    public boolean isAnnotatedWith(String annotationTypeName) {
         return resolveMember().isPresent() && resolveMember().get().isAnnotatedWith(annotationTypeName);
     }
 
@@ -166,7 +166,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      */
     @Override
     @PublicAPI(usage = ACCESS)
-    public boolean isAnnotatedWith(final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+    public boolean isAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
         return resolveMember().isPresent() && resolveMember().get().isAnnotatedWith(predicate);
     }
 
@@ -188,7 +188,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      */
     @Override
     @PublicAPI(usage = ACCESS)
-    public boolean isMetaAnnotatedWith(final String annotationTypeName) {
+    public boolean isMetaAnnotatedWith(String annotationTypeName) {
         return resolveMember().isPresent() && resolveMember().get().isMetaAnnotatedWith(annotationTypeName);
     }
 
@@ -201,7 +201,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
      */
     @Override
     @PublicAPI(usage = ACCESS)
-    public boolean isMetaAnnotatedWith(final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+    public boolean isMetaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
         return resolveMember().isPresent() && resolveMember().get().isMetaAnnotatedWith(predicate);
     }
 
@@ -218,7 +218,7 @@ public abstract class AccessTarget implements HasName.AndFullName, CanBeAnnotate
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final AccessTarget other = (AccessTarget) obj;
+        AccessTarget other = (AccessTarget) obj;
         return Objects.equals(this.fullName, other.fullName);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/AnnotationProxy.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/AnnotationProxy.java
@@ -364,7 +364,7 @@ class AnnotationProxy {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final MethodKey other = (MethodKey) obj;
+            MethodKey other = (MethodKey) obj;
             return Objects.equals(this.name, other.name)
                     && Objects.equals(this.paramTypeNames, other.paramTypeNames);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -288,7 +288,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Dependency other = (Dependency) obj;
+        Dependency other = (Dependency) obj;
         return Objects.equals(this.originClass, other.originClass)
                 && Objects.equals(this.targetClass, other.targetClass)
                 && Objects.equals(this.lineNumber, other.lineNumber)
@@ -372,7 +372,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<Dependency> dependencyOrigin(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<Dependency> dependencyOrigin(DescribedPredicate<? super JavaClass> predicate) {
             return Functions.GET_ORIGIN_CLASS.is(predicate).as("origin " + predicate.getDescription());
         }
 
@@ -387,7 +387,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<Dependency> dependencyTarget(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<Dependency> dependencyTarget(DescribedPredicate<? super JavaClass> predicate) {
             return Functions.GET_TARGET_CLASS.is(predicate).as("target " + predicate.getDescription());
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -180,8 +180,8 @@ public class DomainObjectCreationContext {
         return ThrowsClause.from(codeUnit, types);
     }
 
-    public static InstanceofCheck createInstanceofCheck(JavaCodeUnit codeUnit, JavaClass target, int lineNumber) {
-        return InstanceofCheck.from(codeUnit, target, lineNumber);
+    public static InstanceofCheck createInstanceofCheck(JavaCodeUnit codeUnit, JavaClass type, int lineNumber, boolean declaredInLambda) {
+        return InstanceofCheck.from(codeUnit, type, lineNumber, declaredInLambda);
     }
 
     public static <OWNER extends HasDescription> JavaTypeVariable<OWNER> createTypeVariable(String name, OWNER owner, JavaClass erasure) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -172,8 +172,8 @@ public class DomainObjectCreationContext {
         return new Source(uri, sourceFileName, md5InClassSourcesEnabled);
     }
 
-    public static ReferencedClassObject createReferencedClassObject(JavaCodeUnit codeUnit, JavaClass javaClass, int lineNumber) {
-        return ReferencedClassObject.from(codeUnit, javaClass, lineNumber);
+    public static ReferencedClassObject createReferencedClassObject(JavaCodeUnit codeUnit, JavaClass javaClass, int lineNumber, boolean declaredInLambda) {
+        return ReferencedClassObject.from(codeUnit, javaClass, lineNumber, declaredInLambda);
     }
 
     public static <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> createThrowsClause(CODE_UNIT codeUnit, List<JavaClass> types) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -65,5 +65,7 @@ public interface ImportContext {
 
     Set<ReferencedClassObject> createReferencedClassObjectsFor(JavaCodeUnit codeUnit);
 
+    Set<InstanceofCheck> createInstanceofChecksFor(JavaCodeUnit codeUnit);
+
     JavaClass resolveClass(String fullyQualifiedClassName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -63,5 +63,7 @@ public interface ImportContext {
 
     Set<TryCatchBlockBuilder> createTryCatchBlockBuilders(JavaCodeUnit codeUnit);
 
+    Set<ReferencedClassObject> createReferencedClassObjectsFor(JavaCodeUnit codeUnit);
+
     JavaClass resolveClass(String fullyQualifiedClassName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
@@ -28,27 +28,29 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
 
     private final JavaCodeUnit owner;
-    private final JavaClass target;
+    private final JavaClass type;
     private final int lineNumber;
+    private final boolean declaredInLambda;
     private final SourceCodeLocation sourceCodeLocation;
 
-    private InstanceofCheck(JavaCodeUnit owner, JavaClass target, int lineNumber) {
+    private InstanceofCheck(JavaCodeUnit owner, JavaClass type, int lineNumber, boolean declaredInLambda) {
         this.owner = checkNotNull(owner);
-        this.target = checkNotNull(target);
+        this.type = checkNotNull(type);
         this.lineNumber = lineNumber;
+        this.declaredInLambda = declaredInLambda;
         sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaClass getRawType() {
-        return target;
+        return type;
     }
 
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaType getType() {
-        return target;
+        return type;
     }
 
     @Override
@@ -62,6 +64,11 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, H
         return lineNumber;
     }
 
+    @PublicAPI(usage = ACCESS)
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
+    }
+
     @Override
     public SourceCodeLocation getSourceCodeLocation() {
         return sourceCodeLocation;
@@ -71,12 +78,13 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, H
     public String toString() {
         return toStringHelper(this)
                 .add("owner", owner)
-                .add("target", target)
+                .add("type", type)
                 .add("lineNumber", lineNumber)
+                .add("declaredInLambda", declaredInLambda)
                 .toString();
     }
 
-    static InstanceofCheck from(JavaCodeUnit owner, JavaClass target, int lineNumber) {
-        return new InstanceofCheck(owner, target, lineNumber);
+    static InstanceofCheck from(JavaCodeUnit owner, JavaClass type, int lineNumber, boolean declaredInLambda) {
+        return new InstanceofCheck(owner, type, lineNumber, declaredInLambda);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -155,12 +155,12 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaAccess<?>> targetOwner(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<JavaAccess<?>> targetOwner(DescribedPredicate<? super JavaClass> predicate) {
             return target(Get.<JavaClass>owner().is(predicate));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaAccess<?>> target(final DescribedPredicate<? super AccessTarget> predicate) {
+        public static DescribedPredicate<JavaAccess<?>> target(DescribedPredicate<? super AccessTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCall.java
@@ -39,7 +39,7 @@ public abstract class JavaCall<T extends CodeUnitCallTarget> extends JavaCodeUni
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaCall<?>> target(final DescribedPredicate<? super CodeUnitCallTarget> predicate) {
+        public static DescribedPredicate<JavaCall<?>> target(DescribedPredicate<? super CodeUnitCallTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1388,7 +1388,7 @@ public final class JavaClass
     }
 
     @PublicAPI(usage = ACCESS)
-    public boolean isAssignableTo(final String typeName) {
+    public boolean isAssignableTo(String typeName) {
         return isAssignableTo(GET_NAME.is(equalTo(typeName)));
     }
 
@@ -1467,12 +1467,12 @@ public final class JavaClass
         completionProcess.markGenericInterfacesComplete();
     }
 
-    void completeMembers(final ImportContext context) {
+    void completeMembers(ImportContext context) {
         members = JavaClassMembers.create(this, context);
         completionProcess.markMembersComplete();
     }
 
-    void completeAnnotations(final ImportContext context) {
+    void completeAnnotations(ImportContext context) {
         annotations = context.createAnnotations(this);
         members.completeAnnotations(context);
         completionProcess.markAnnotationsComplete();
@@ -2142,27 +2142,27 @@ public final class JavaClass
         };
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> type(final Class<?> type) {
+        public static DescribedPredicate<JavaClass> type(Class<?> type) {
             return equalTo(type.getName()).<JavaClass>onResultOf(GET_NAME).as("type " + type.getName());
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> simpleName(final String name) {
+        public static DescribedPredicate<JavaClass> simpleName(String name) {
             return equalTo(name).onResultOf(GET_SIMPLE_NAME).as("simple name '%s'", name);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> simpleNameStartingWith(final String prefix) {
+        public static DescribedPredicate<JavaClass> simpleNameStartingWith(String prefix) {
             return new SimpleNameStartingWithPredicate(prefix);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> simpleNameContaining(final String infix) {
+        public static DescribedPredicate<JavaClass> simpleNameContaining(String infix) {
             return new SimpleNameContainingPredicate(infix);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> simpleNameEndingWith(final String suffix) {
+        public static DescribedPredicate<JavaClass> simpleNameEndingWith(String suffix) {
             return new SimpleNameEndingWithPredicate(suffix);
         }
 
@@ -2179,7 +2179,7 @@ public final class JavaClass
          * @see #assignableFrom(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableTo(final Class<?> type) {
+        public static DescribedPredicate<JavaClass> assignableTo(Class<?> type) {
             return assignableTo(type.getName());
         }
 
@@ -2196,7 +2196,7 @@ public final class JavaClass
          * @see #assignableTo(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableFrom(final Class<?> type) {
+        public static DescribedPredicate<JavaClass> assignableFrom(Class<?> type) {
             return assignableFrom(type.getName());
         }
 
@@ -2204,7 +2204,7 @@ public final class JavaClass
          * Same as {@link #assignableTo(Class)} but takes a fully qualified class name as an argument instead of a class object.
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableTo(final String typeName) {
+        public static DescribedPredicate<JavaClass> assignableTo(String typeName) {
             return assignableTo(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
@@ -2212,7 +2212,7 @@ public final class JavaClass
          * Same as {@link #assignableFrom(Class)} but takes a fully qualified class name as an argument instead of a class object.
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableFrom(final String typeName) {
+        public static DescribedPredicate<JavaClass> assignableFrom(String typeName) {
             return assignableFrom(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
@@ -2227,7 +2227,7 @@ public final class JavaClass
          * @see #assignableFrom(DescribedPredicate)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableTo(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<JavaClass> assignableTo(DescribedPredicate<? super JavaClass> predicate) {
             return new AssignableToPredicate(predicate);
         }
 
@@ -2242,7 +2242,7 @@ public final class JavaClass
          * @see #assignableTo(DescribedPredicate)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> assignableFrom(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<JavaClass> assignableFrom(DescribedPredicate<? super JavaClass> predicate) {
             return new AssignableFromPredicate(predicate);
         }
 
@@ -2259,7 +2259,7 @@ public final class JavaClass
          * @see #assignableTo(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> implement(final Class<?> type) {
+        public static DescribedPredicate<JavaClass> implement(Class<?> type) {
             if (!type.isInterface()) {
                 throw new InvalidSyntaxUsageException(String.format(
                         "implement(type) can only ever be true, if type is an interface, but type %s is not. "
@@ -2272,7 +2272,7 @@ public final class JavaClass
          * Same as {@link #implement(Class)} but takes a fully qualified class name as an argument instead of a class object.
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> implement(final String typeName) {
+        public static DescribedPredicate<JavaClass> implement(String typeName) {
             return implement(GET_NAME.is(equalTo(typeName)).as(typeName));
         }
 
@@ -2285,7 +2285,7 @@ public final class JavaClass
          * @see #assignableTo(DescribedPredicate)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> implement(final DescribedPredicate<? super JavaClass> predicate) {
+        public static DescribedPredicate<JavaClass> implement(DescribedPredicate<? super JavaClass> predicate) {
             DescribedPredicate<JavaClass> selfIsImplementation = not(INTERFACES);
             DescribedPredicate<JavaClass> interfacePredicate = predicate.<JavaClass>forSubtype().and(INTERFACES);
             return selfIsImplementation.and(assignableTo(interfacePredicate))
@@ -2302,7 +2302,7 @@ public final class JavaClass
          * tested {@link JavaClass} matches the identifier
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> resideInAPackage(final String packageIdentifier) {
+        public static DescribedPredicate<JavaClass> resideInAPackage(String packageIdentifier) {
             return resideInAnyPackage(new String[]{packageIdentifier},
                     String.format("reside in a package '%s'", packageIdentifier));
         }
@@ -2311,13 +2311,13 @@ public final class JavaClass
          * @see #resideInAPackage(String)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> resideInAnyPackage(final String... packageIdentifiers) {
+        public static DescribedPredicate<JavaClass> resideInAnyPackage(String... packageIdentifiers) {
             return resideInAnyPackage(packageIdentifiers,
                     String.format("reside in any package [%s]", joinSingleQuoted(packageIdentifiers)));
         }
 
-        private static DescribedPredicate<JavaClass> resideInAnyPackage(final String[] packageIdentifiers, final String description) {
-            final Set<PackageMatcher> packageMatchers = stream(packageIdentifiers).map(PackageMatcher::of).collect(toSet());
+        private static DescribedPredicate<JavaClass> resideInAnyPackage(String[] packageIdentifiers, String description) {
+            Set<PackageMatcher> packageMatchers = stream(packageIdentifiers).map(PackageMatcher::of).collect(toSet());
             return new PackageMatchesPredicate(packageMatchers, description);
         }
 
@@ -2337,7 +2337,7 @@ public final class JavaClass
          * @see JavaClass#isEquivalentTo(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaClass> equivalentTo(final Class<?> clazz) {
+        public static DescribedPredicate<JavaClass> equivalentTo(Class<?> clazz) {
             return new EquivalentToPredicate(clazz);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -1480,7 +1480,7 @@ public final class JavaClass
 
     JavaClassDependencies completeFrom(ImportContext context) {
         completeComponentType(context);
-        members.completeAccessesFrom(context);
+        members.completeFrom(context);
         javaClassDependencies = new JavaClassDependencies(this);
         return javaClassDependencies;
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -247,8 +247,8 @@ class JavaClassDependencies {
     }
 
     private <T extends HasDescription & HasAnnotations<?>> Stream<Dependency> annotationDependencies(T annotated) {
-        final Stream.Builder<Dependency> addToStream = Stream.builder();
-        for (final JavaAnnotation<?> annotation : annotated.getAnnotations()) {
+        Stream.Builder<Dependency> addToStream = Stream.builder();
+        for (JavaAnnotation<?> annotation : annotated.getAnnotations()) {
             Dependency.tryCreateFromAnnotation(annotation).forEach(addToStream);
             annotation.accept(new DefaultParameterVisitor() {
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDescriptor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDescriptor.java
@@ -200,7 +200,7 @@ public interface JavaClassDescriptor {
                 if (obj == null || getClass() != obj.getClass()) {
                     return false;
                 }
-                final JavaClassDescriptor other = (JavaClassDescriptor) obj;
+                JavaClassDescriptor other = (JavaClassDescriptor) obj;
                 return Objects.equals(this.getFullyQualifiedClassName(), other.getFullyQualifiedClassName());
             }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -318,9 +318,9 @@ class JavaClassMembers {
         }
     }
 
-    void completeAccessesFrom(ImportContext context) {
+    void completeFrom(ImportContext context) {
         for (JavaCodeUnit codeUnit : codeUnits) {
-            codeUnit.completeAccessesFrom(context);
+            codeUnit.completeFrom(context);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -55,7 +55,7 @@ class JavaClassMembers {
             .addAll(getAllConstructors())
             .build());
 
-    JavaClassMembers(final JavaClass owner, Set<JavaField> fields, Set<JavaMethod> methods, Set<JavaConstructor> constructors, Optional<JavaStaticInitializer> staticInitializer) {
+    JavaClassMembers(JavaClass owner, Set<JavaField> fields, Set<JavaMethod> methods, Set<JavaConstructor> constructors, Optional<JavaStaticInitializer> staticInitializer) {
         this.owner = owner;
         this.fields = fields;
         this.methods = methods;

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClasses.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClasses.java
@@ -164,7 +164,7 @@ public final class JavaClasses extends ForwardingCollection<JavaClass> implement
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final JavaClasses other = (JavaClasses) obj;
+        JavaClasses other = (JavaClasses) obj;
         return Objects.equals(this.classes.keySet(), other.classes.keySet())
                 && Objects.equals(this.description, other.description);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -63,7 +63,6 @@ public abstract class JavaCodeUnit
     private final Parameters parameters;
     private final String fullName;
     private final List<JavaTypeVariable<JavaCodeUnit>> typeParameters;
-    private final Set<InstanceofCheck> instanceofChecks;
 
     private Set<JavaFieldAccess> fieldAccesses = Collections.emptySet();
     private Set<JavaMethodCall> methodCalls = Collections.emptySet();
@@ -72,6 +71,7 @@ public abstract class JavaCodeUnit
     private Set<JavaConstructorReference> constructorReferences = Collections.emptySet();
     private Set<TryCatchBlock> tryCatchBlocks = Collections.emptySet();
     private Set<ReferencedClassObject> referencedClassObjects;
+    private Set<InstanceofCheck> instanceofChecks;
 
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
@@ -79,7 +79,6 @@ public abstract class JavaCodeUnit
         returnType = new ReturnType(this, builder);
         parameters = new Parameters(this, builder);
         fullName = formatMethod(getOwner().getName(), getName(), namesOf(getRawParameterTypes()));
-        instanceofChecks = ImmutableSet.copyOf(builder.getInstanceofChecks(this));
     }
 
     /**
@@ -281,6 +280,7 @@ public abstract class JavaCodeUnit
                 .map(builder -> builder.build(this, context))
                 .collect(toImmutableSet());
         referencedClassObjects = context.createReferencedClassObjectsFor(this);
+        instanceofChecks = context.createInstanceofChecksFor(this);
     }
 
     @ResolvesTypesViaReflection

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -63,7 +63,6 @@ public abstract class JavaCodeUnit
     private final Parameters parameters;
     private final String fullName;
     private final List<JavaTypeVariable<JavaCodeUnit>> typeParameters;
-    private final Set<ReferencedClassObject> referencedClassObjects;
     private final Set<InstanceofCheck> instanceofChecks;
 
     private Set<JavaFieldAccess> fieldAccesses = Collections.emptySet();
@@ -72,6 +71,7 @@ public abstract class JavaCodeUnit
     private Set<JavaMethodReference> methodReferences = Collections.emptySet();
     private Set<JavaConstructorReference> constructorReferences = Collections.emptySet();
     private Set<TryCatchBlock> tryCatchBlocks = Collections.emptySet();
+    private Set<ReferencedClassObject> referencedClassObjects;
 
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
@@ -79,7 +79,6 @@ public abstract class JavaCodeUnit
         returnType = new ReturnType(this, builder);
         parameters = new Parameters(this, builder);
         fullName = formatMethod(getOwner().getName(), getName(), namesOf(getRawParameterTypes()));
-        referencedClassObjects = ImmutableSet.copyOf(builder.getReferencedClassObjects(this));
         instanceofChecks = ImmutableSet.copyOf(builder.getInstanceofChecks(this));
     }
 
@@ -271,7 +270,7 @@ public abstract class JavaCodeUnit
         return parameters.getAnnotations();
     }
 
-    void completeAccessesFrom(ImportContext context) {
+    void completeFrom(ImportContext context) {
         Set<TryCatchBlockBuilder> tryCatchBlockBuilders = context.createTryCatchBlockBuilders(this);
         fieldAccesses = context.createFieldAccessesFor(this, tryCatchBlockBuilders);
         methodCalls = context.createMethodCallsFor(this, tryCatchBlockBuilders);
@@ -281,6 +280,7 @@ public abstract class JavaCodeUnit
         tryCatchBlocks = tryCatchBlockBuilders.stream()
                 .map(builder -> builder.build(this, context))
                 .collect(toImmutableSet());
+        referencedClassObjects = context.createReferencedClassObjectsFor(this);
     }
 
     @ResolvesTypesViaReflection

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitAccess.java
@@ -39,7 +39,7 @@ public abstract class JavaCodeUnitAccess<T extends CodeUnitAccessTarget> extends
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaCodeUnitAccess<?>> target(final DescribedPredicate<? super CodeUnitAccessTarget> predicate) {
+        public static DescribedPredicate<JavaCodeUnitAccess<?>> target(DescribedPredicate<? super CodeUnitAccessTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnitReference.java
@@ -39,7 +39,7 @@ public abstract class JavaCodeUnitReference<T extends CodeUnitReferenceTarget> e
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaCodeUnitReference<?>> target(final DescribedPredicate<? super CodeUnitReferenceTarget> predicate) {
+        public static DescribedPredicate<JavaCodeUnitReference<?>> target(DescribedPredicate<? super CodeUnitReferenceTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaEnumConstant.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaEnumConstant.java
@@ -60,7 +60,7 @@ public final class JavaEnumConstant {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final JavaEnumConstant other = (JavaEnumConstant) obj;
+        JavaEnumConstant other = (JavaEnumConstant) obj;
         return Objects.equals(this.declaringClass, other.declaringClass)
                 && Objects.equals(this.name, other.name);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaFieldAccess.java
@@ -93,12 +93,12 @@ public final class JavaFieldAccess extends JavaAccess<FieldAccessTarget> {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaFieldAccess> accessType(final AccessType accessType) {
+        public static DescribedPredicate<JavaFieldAccess> accessType(AccessType accessType) {
             return new AccessTypePredicate(accessType);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<JavaFieldAccess> target(final DescribedPredicate<? super FieldAccessTarget> predicate) {
+        public static DescribedPredicate<JavaFieldAccess> target(DescribedPredicate<? super FieldAccessTarget> predicate) {
             return new TargetPredicate<>(predicate);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
@@ -31,12 +31,14 @@ public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUn
     private final JavaClass value;
     private final int lineNumber;
     private final SourceCodeLocation sourceCodeLocation;
+    private final boolean declaredInLambda;
 
-    private ReferencedClassObject(JavaCodeUnit owner, JavaClass value, int lineNumber) {
+    private ReferencedClassObject(JavaCodeUnit owner, JavaClass value, int lineNumber, boolean declaredInLambda) {
         this.owner = checkNotNull(owner);
         this.value = checkNotNull(value);
         this.lineNumber = lineNumber;
         sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
+        this.declaredInLambda = declaredInLambda;
     }
 
     @Override
@@ -73,17 +75,23 @@ public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUn
         return sourceCodeLocation;
     }
 
+    @PublicAPI(usage = ACCESS)
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
+    }
+
     @Override
     public String toString() {
         return toStringHelper(this)
                 .add("owner", owner)
                 .add("value", value)
                 .add("sourceCodeLocation", sourceCodeLocation)
+                .add("declaredInLambda", declaredInLambda)
                 .toString();
     }
 
-    static ReferencedClassObject from(JavaCodeUnit owner, JavaClass javaClass, int lineNumber) {
-        return new ReferencedClassObject(owner, javaClass, lineNumber);
+    static ReferencedClassObject from(JavaCodeUnit owner, JavaClass javaClass, int lineNumber, boolean declaredInLambda) {
+        return new ReferencedClassObject(owner, javaClass, lineNumber, declaredInLambda);
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
@@ -66,7 +66,7 @@ final class ReverseDependencies {
         this.directDependenciesToClass = createDirectDependenciesToClassSupplier(creation.allDependencies);
     }
 
-    private static Supplier<SetMultimap<JavaClass, Dependency>> createDirectDependenciesToClassSupplier(final List<JavaClassDependencies> allDependencies) {
+    private static Supplier<SetMultimap<JavaClass, Dependency>> createDirectDependenciesToClassSupplier(List<JavaClassDependencies> allDependencies) {
         return Suppliers.memoize(() -> {
             ImmutableSetMultimap.Builder<JavaClass, Dependency> result = ImmutableSetMultimap.builder();
             for (JavaClassDependencies dependencies : allDependencies) {
@@ -221,7 +221,7 @@ final class ReverseDependencies {
         }
 
         private void registerAnnotations(JavaClass clazz) {
-            for (final JavaAnnotation<?> annotation : findAnnotations(clazz)) {
+            for (JavaAnnotation<?> annotation : findAnnotations(clazz)) {
                 annotationTypeDependencies.put(annotation.getRawType(), annotation);
                 annotation.accept(new JavaAnnotation.DefaultParameterVisitor() {
                     @Override
@@ -277,7 +277,7 @@ final class ReverseDependencies {
         @Override
         public Set<ACCESS> load(MEMBER member) {
             ImmutableSet.Builder<ACCESS> result = ImmutableSet.builder();
-            for (final JavaClass javaClass : getPossibleTargetClassesForAccess(member.getOwner())) {
+            for (JavaClass javaClass : getPossibleTargetClassesForAccess(member.getOwner())) {
                 for (ACCESS access : this.accessesToSelf.get(javaClass)) {
                     Optional<? extends JavaMember> target = access.getTarget().resolveMember();
                     if (target.isPresent() && target.get().equals(member)) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Source.java
@@ -83,7 +83,7 @@ public final class Source {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Source other = (Source) obj;
+        Source other = (Source) obj;
         return Objects.equals(this.uri, other.uri)
                 && Objects.equals(this.md5sum, other.md5sum);
     }
@@ -151,7 +151,7 @@ public final class Source {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final Md5sum other = (Md5sum) obj;
+            Md5sum other = (Md5sum) obj;
             return Arrays.equals(this.md5Bytes, other.md5Bytes)
                     && Objects.equals(this.text, other.text);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/SourceCodeLocation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/SourceCodeLocation.java
@@ -110,7 +110,7 @@ public final class SourceCodeLocation {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final SourceCodeLocation other = (SourceCodeLocation) obj;
+        SourceCodeLocation other = (SourceCodeLocation) obj;
         return Objects.equals(this.sourceClass, other.sourceClass)
                 && Objects.equals(this.lineNumber, other.lineNumber);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsClause.java
@@ -110,7 +110,7 @@ public final class ThrowsClause<LOCATION extends HasParameterTypes & HasReturnTy
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ThrowsClause<?> other = (ThrowsClause<?>) obj;
+        ThrowsClause<?> other = (ThrowsClause<?>) obj;
         return Objects.equals(this.location, other.location)
                 && Objects.equals(this.getTypes(), other.getTypes());
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ThrowsDeclaration.java
@@ -124,7 +124,7 @@ public final class ThrowsDeclaration<LOCATION extends HasParameterTypes & HasRet
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ThrowsDeclaration<?> other = (ThrowsDeclaration<?>) obj;
+        ThrowsDeclaration<?> other = (ThrowsDeclaration<?>) obj;
         return Objects.equals(this.getLocation(), other.getLocation())
                 && Objects.equals(this.type, other.type);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/CanBeAnnotated.java
@@ -107,7 +107,7 @@ public interface CanBeAnnotated {
          * @param annotationType The type of the annotation to check for
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> annotatedWith(final Class<? extends Annotation> annotationType) {
+        public static DescribedPredicate<CanBeAnnotated> annotatedWith(Class<? extends Annotation> annotationType) {
             checkAnnotationHasReasonableRetention(annotationType);
 
             return annotatedWith(annotationType.getName());
@@ -132,7 +132,7 @@ public interface CanBeAnnotated {
          * @see #annotatedWith(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> annotatedWith(final String annotationTypeName) {
+        public static DescribedPredicate<CanBeAnnotated> annotatedWith(String annotationTypeName) {
             DescribedPredicate<HasType> typeNameMatches = GET_RAW_TYPE.then(GET_NAME).is(equalTo(annotationTypeName));
             return annotatedWith(typeNameMatches.as("@" + ensureSimpleName(annotationTypeName)));
         }
@@ -143,7 +143,7 @@ public interface CanBeAnnotated {
          * @param predicate Qualifies matching annotations
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> annotatedWith(final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+        public static DescribedPredicate<CanBeAnnotated> annotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
             return new AnnotatedPredicate(predicate);
         }
 
@@ -172,7 +172,7 @@ public interface CanBeAnnotated {
          * @param annotationType The type of the annotation to check for
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(final Class<? extends Annotation> annotationType) {
+        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(Class<? extends Annotation> annotationType) {
             checkAnnotationHasReasonableRetention(annotationType);
 
             return metaAnnotatedWith(annotationType.getName());
@@ -182,7 +182,7 @@ public interface CanBeAnnotated {
          * @see #metaAnnotatedWith(Class)
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(final String annotationTypeName) {
+        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(String annotationTypeName) {
             DescribedPredicate<HasType> typeNameMatches = GET_RAW_TYPE.then(GET_NAME).is(equalTo(annotationTypeName));
             return metaAnnotatedWith(typeNameMatches.as("@" + ensureSimpleName(annotationTypeName)));
         }
@@ -198,7 +198,7 @@ public interface CanBeAnnotated {
          * @param predicate Qualifies matching annotations
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+        public static DescribedPredicate<CanBeAnnotated> metaAnnotatedWith(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
             return new MetaAnnotatedPredicate(predicate);
         }
 
@@ -256,7 +256,7 @@ public interface CanBeAnnotated {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static <A extends Annotation> Function<JavaAnnotation<?>, A> toAnnotationOfType(final Class<A> type) {
+        public static <A extends Annotation> Function<JavaAnnotation<?>, A> toAnnotationOfType(Class<A> type) {
             return input -> input.as(type);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasModifiers.java
@@ -37,7 +37,7 @@ public interface HasModifiers {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasModifiers> modifier(final JavaModifier modifier) {
+        public static DescribedPredicate<HasModifiers> modifier(JavaModifier modifier) {
             return new ModifierPredicate(modifier);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -113,7 +113,7 @@ public interface HasName {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> name(final String name) {
+        public static DescribedPredicate<HasName> name(String name) {
             return new NameEqualsPredicate(name);
         }
 
@@ -121,22 +121,22 @@ public interface HasName {
          * Matches names against a regular expression.
          */
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameMatching(final String regex) {
+        public static DescribedPredicate<HasName> nameMatching(String regex) {
             return new NameMatchingPredicate(regex);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameStartingWith(final String prefix) {
+        public static DescribedPredicate<HasName> nameStartingWith(String prefix) {
             return new NameStartingWithPredicate(prefix);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameContaining(final String infix) {
+        public static DescribedPredicate<HasName> nameContaining(String infix) {
             return new NameContainingPredicate(infix);
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasName> nameEndingWith(final String postfix) {
+        public static DescribedPredicate<HasName> nameEndingWith(String postfix) {
             return new NameEndingWithPredicate(postfix);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasOwner.java
@@ -54,7 +54,7 @@ public interface HasOwner<T> {
             }
 
             @PublicAPI(usage = ACCESS)
-            public static <T> DescribedPredicate<HasOwner<T>> owner(final DescribedPredicate<? super T> predicate) {
+            public static <T> DescribedPredicate<HasOwner<T>> owner(DescribedPredicate<? super T> predicate) {
                 return new OwnerPredicate<>(predicate);
             }
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasParameterTypes.java
@@ -69,23 +69,23 @@ public interface HasParameterTypes {
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final Class<?>... types) {
+        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(Class<?>... types) {
             return rawParameterTypes(formatNamesOf(types));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final String... types) {
+        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(String... types) {
             return rawParameterTypes(ImmutableList.copyOf(types));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final List<String> typeNames) {
+        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(List<String> typeNames) {
             return new RawParameterTypesPredicate(equalTo(typeNames).onResultOf(GET_NAMES)
                     .as("[%s]", formatMethodParameterTypeNames(typeNames)));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(final DescribedPredicate<? super List<JavaClass>> predicate) {
+        public static DescribedPredicate<HasParameterTypes> rawParameterTypes(DescribedPredicate<? super List<JavaClass>> predicate) {
             return new RawParameterTypesPredicate(predicate);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasThrowsClause.java
@@ -48,28 +48,28 @@ public interface HasThrowsClause<LOCATION extends HasParameterTypes & HasReturnT
 
         @PublicAPI(usage = ACCESS)
         @SafeVarargs
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(final Class<? extends Throwable>... types) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(Class<? extends Throwable>... types) {
             return throwsClauseWithTypes(formatNamesOf(types));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(final String... typeNames) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(String... typeNames) {
             return throwsClauseWithTypes(ImmutableList.copyOf(typeNames));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(final List<String> typeNames) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseWithTypes(List<String> typeNames) {
             return throwsClause(equalTo(typeNames).onResultOf(ThrowsClause.Functions.GET_TYPES.then(GET_NAMES))
                     .as("[%s]", formatThrowsDeclarationTypeNames(typeNames)));
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseContainingType(final Class<? extends Throwable> type) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseContainingType(Class<? extends Throwable> type) {
             return throwsClauseContainingType(type.getName());
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseContainingType(final String typeName) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClauseContainingType(String typeName) {
             return throwsClauseContainingType(name(typeName).as(typeName));
         }
 
@@ -80,7 +80,7 @@ public interface HasThrowsClause<LOCATION extends HasParameterTypes & HasReturnT
         }
 
         @PublicAPI(usage = ACCESS)
-        public static DescribedPredicate<HasThrowsClause<?>> throwsClause(final DescribedPredicate<? super ThrowsClause<?>> predicate) {
+        public static DescribedPredicate<HasThrowsClause<?>> throwsClause(DescribedPredicate<? super ThrowsClause<?>> predicate) {
             return new ThrowsTypesPredicate(predicate);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -245,9 +245,9 @@ interface AccessRecord<TARGET extends AccessTarget> {
             RawAccessRecordProcessed(RawAccessRecord record, ImportedClasses classes, AccessTargetFactory<TARGET> accessTargetFactory) {
                 this.record = record;
                 this.classes = classes;
-                targetOwner = this.classes.getOrResolve(record.target.owner.getFullyQualifiedClassName());
+                targetOwner = this.classes.getOrResolve(record.getTarget().owner.getFullyQualifiedClassName());
                 this.accessTargetFactory = accessTargetFactory;
-                originSupplier = createOriginSupplier(record.caller, classes);
+                originSupplier = createOriginSupplier(record.getOrigin(), classes);
             }
 
             @Override
@@ -257,17 +257,17 @@ interface AccessRecord<TARGET extends AccessTarget> {
 
             @Override
             public TARGET getTarget() {
-                return accessTargetFactory.create(targetOwner, record.target, classes);
+                return accessTargetFactory.create(targetOwner, record.getTarget(), classes);
             }
 
             @Override
             public int getLineNumber() {
-                return record.lineNumber;
+                return record.getLineNumber();
             }
 
             @Override
             public boolean isDeclaredInLambda() {
-                return record.declaredInLambda;
+                return record.isDeclaredInLambda();
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -291,17 +291,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
         }
 
         private static Supplier<JavaCodeUnit> createOriginSupplier(CodeUnit origin, ImportedClasses classes) {
-            return Suppliers.memoize(() -> Factory.getOrigin(origin, classes));
-        }
-
-        private static JavaCodeUnit getOrigin(CodeUnit rawOrigin, ImportedClasses classes) {
-            for (JavaCodeUnit method : classes.getOrResolve(rawOrigin.getDeclaringClassName()).getCodeUnits()) {
-                if (rawOrigin.is(method)) {
-                    return method;
-                }
-            }
-            throw new IllegalStateException("Never found a " + JavaCodeUnit.class.getSimpleName() +
-                    " that matches supposed origin " + rawOrigin);
+            return Suppliers.memoize(() -> origin.resolveFrom(classes));
         }
 
         private static List<JavaClass> getArgumentTypesFrom(String descriptor, ImportedClasses classes) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/AccessRecord.java
@@ -290,7 +290,7 @@ interface AccessRecord<TARGET extends AccessTarget> {
             }
         }
 
-        private static Supplier<JavaCodeUnit> createOriginSupplier(final CodeUnit origin, final ImportedClasses classes) {
+        private static Supplier<JavaCodeUnit> createOriginSupplier(CodeUnit origin, ImportedClasses classes) {
             return Suppliers.memoize(() -> Factory.getOrigin(origin, classes));
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -85,6 +85,7 @@ class ClassFileImportRecord {
     private final Set<RawAccessRecord> rawMethodReferenceRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawConstructorReferenceRecords = new HashSet<>();
     private final Set<RawReferencedClassObject> rawReferencedClassObjects = new HashSet<>();
+    private final Set<RawInstanceofCheck> rawInstanceofChecks = new HashSet<>();
     private final SyntheticAccessRecorder syntheticLambdaAccessRecorder = createSyntheticLambdaAccessRecorder();
     private final SyntheticAccessRecorder syntheticPrivateAccessRecorder = createSyntheticPrivateAccessRecorder();
 
@@ -251,6 +252,10 @@ class ClassFileImportRecord {
         rawReferencedClassObjects.add(referencedClassObject);
     }
 
+    void registerInstanceofCheck(RawInstanceofCheck instanceofCheck) {
+        rawInstanceofChecks.add(instanceofCheck);
+    }
+
     void forEachRawFieldAccessRecord(Consumer<RawAccessRecord.ForField> doWithRecord) {
         fixSyntheticOrigins(
                 rawFieldAccessRecords, COPY_RAW_FIELD_ACCESS_RECORD,
@@ -293,6 +298,13 @@ class ClassFileImportRecord {
         ).forEach(doWithReferencedClassObject);
     }
 
+    void forEachRawInstanceofCheck(Consumer<RawInstanceofCheck> doWithInstanceofCheck) {
+        fixSyntheticOrigins(
+                rawInstanceofChecks, COPY_RAW_INSTANCEOF_CHECK,
+                syntheticLambdaAccessRecorder
+        ).forEach(doWithInstanceofCheck);
+    }
+
     private <ACCESS extends RawCodeUnitDependency<?>> Stream<ACCESS> fixSyntheticOrigins(
             Set<ACCESS> rawAccessRecordsIncludingSyntheticAccesses,
             Function<ACCESS, ? extends RawCodeUnitDependencyBuilder<ACCESS, ?>> createAccessWithNewOrigin,
@@ -323,6 +335,9 @@ class ClassFileImportRecord {
 
     private static final Function<RawReferencedClassObject, RawReferencedClassObject.Builder> COPY_RAW_REFERENCED_CLASS_OBJECT =
             referencedClassObject -> copyInto(new RawReferencedClassObject.Builder(), referencedClassObject);
+
+    private static final Function<RawInstanceofCheck, RawInstanceofCheck.Builder> COPY_RAW_INSTANCEOF_CHECK =
+            instanceofCheck -> copyInto(new RawInstanceofCheck.Builder(), instanceofCheck);
 
     private static <TARGET, BUILDER extends RawCodeUnitDependencyBuilder<?, TARGET>> BUILDER copyInto(BUILDER builder, RawCodeUnitDependency<TARGET> referencedClassObject) {
         builder

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -84,6 +84,7 @@ class ClassFileImportRecord {
     private final Set<RawAccessRecord> rawConstructorCallRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawMethodReferenceRecords = new HashSet<>();
     private final Set<RawAccessRecord> rawConstructorReferenceRecords = new HashSet<>();
+    private final Set<RawReferencedClassObject> rawReferencedClassObjects = new HashSet<>();
     private final SyntheticAccessRecorder syntheticLambdaAccessRecorder = createSyntheticLambdaAccessRecorder();
     private final SyntheticAccessRecorder syntheticPrivateAccessRecorder = createSyntheticPrivateAccessRecorder();
 
@@ -246,6 +247,10 @@ class ClassFileImportRecord {
         syntheticLambdaAccessRecorder.registerSyntheticMethodInvocation(record);
     }
 
+    void registerReferencedClassObject(RawReferencedClassObject referencedClassObject) {
+        rawReferencedClassObjects.add(referencedClassObject);
+    }
+
     void forEachRawFieldAccessRecord(Consumer<RawAccessRecord.ForField> doWithRecord) {
         fixSyntheticOrigins(
                 rawFieldAccessRecords, COPY_RAW_FIELD_ACCESS_RECORD,
@@ -281,6 +286,13 @@ class ClassFileImportRecord {
         ).forEach(doWithRecord);
     }
 
+    void forEachRawReferencedClassObject(Consumer<RawReferencedClassObject> doWithReferencedClassObject) {
+        fixSyntheticOrigins(
+                rawReferencedClassObjects, COPY_RAW_REFERENCED_CLASS_OBJECT,
+                syntheticLambdaAccessRecorder
+        ).forEach(doWithReferencedClassObject);
+    }
+
     private <ACCESS extends RawCodeUnitDependency<?>> Stream<ACCESS> fixSyntheticOrigins(
             Set<ACCESS> rawAccessRecordsIncludingSyntheticAccesses,
             Function<ACCESS, ? extends RawCodeUnitDependencyBuilder<ACCESS, ?>> createAccessWithNewOrigin,
@@ -308,6 +320,9 @@ class ClassFileImportRecord {
     private static final Function<RawAccessRecord.ForField, RawAccessRecord.ForField.Builder> COPY_RAW_FIELD_ACCESS_RECORD =
             access -> copyInto(new RawAccessRecord.ForField.Builder(), access)
                     .withAccessType(access.accessType);
+
+    private static final Function<RawReferencedClassObject, RawReferencedClassObject.Builder> COPY_RAW_REFERENCED_CLASS_OBJECT =
+            referencedClassObject -> copyInto(new RawReferencedClassObject.Builder(), referencedClassObject);
 
     private static <TARGET, BUILDER extends RawCodeUnitDependencyBuilder<?, TARGET>> BUILDER copyInto(BUILDER builder, RawCodeUnitDependency<TARGET> referencedClassObject) {
         builder

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -217,13 +217,13 @@ class ClassFileImportRecord {
     }
 
     void registerFieldAccess(RawAccessRecord.ForField record) {
-        if (!isSyntheticEnumSwitchMapFieldName(record.target.name)) {
+        if (!isSyntheticEnumSwitchMapFieldName(record.getTarget().name)) {
             rawFieldAccessRecords.add(record);
         }
     }
 
     void registerMethodCall(RawAccessRecord record) {
-        if (isSyntheticAccessMethodName(record.target.name)) {
+        if (isSyntheticAccessMethodName(record.getTarget().name)) {
             syntheticPrivateAccessRecorder.registerSyntheticMethodInvocation(record);
         } else {
             rawMethodCallRecords.add(record);
@@ -281,9 +281,9 @@ class ClassFileImportRecord {
         ).forEach(doWithRecord);
     }
 
-    private <ACCESS extends RawAccessRecord> Stream<ACCESS> fixSyntheticOrigins(
+    private <ACCESS extends RawCodeUnitDependency<?>> Stream<ACCESS> fixSyntheticOrigins(
             Set<ACCESS> rawAccessRecordsIncludingSyntheticAccesses,
-            Function<ACCESS, ? extends RawAccessRecord.BaseBuilder<ACCESS, ?>> createAccessWithNewOrigin,
+            Function<ACCESS, ? extends RawCodeUnitDependencyBuilder<ACCESS, ?>> createAccessWithNewOrigin,
             SyntheticAccessRecorder... syntheticAccessRecorders
     ) {
 
@@ -303,25 +303,26 @@ class ClassFileImportRecord {
     }
 
     private static final Function<RawAccessRecord, RawAccessRecord.Builder> COPY_RAW_ACCESS_RECORD =
-            access -> new RawAccessRecord.Builder()
-                    .withCaller(access.caller)
-                    .withTarget(access.target)
-                    .withLineNumber(access.lineNumber)
-                    .withDeclaredInLambda(access.declaredInLambda);
+            access -> copyInto(new RawAccessRecord.Builder(), access);
 
     private static final Function<RawAccessRecord.ForField, RawAccessRecord.ForField.Builder> COPY_RAW_FIELD_ACCESS_RECORD =
-            access -> new RawAccessRecord.ForField.Builder()
-                    .withCaller(access.caller)
-                    .withAccessType(access.accessType)
-                    .withTarget(access.target)
-                    .withLineNumber(access.lineNumber)
-                    .withDeclaredInLambda(access.declaredInLambda);
+            access -> copyInto(new RawAccessRecord.ForField.Builder(), access)
+                    .withAccessType(access.accessType);
+
+    private static <TARGET, BUILDER extends RawCodeUnitDependencyBuilder<?, TARGET>> BUILDER copyInto(BUILDER builder, RawCodeUnitDependency<TARGET> referencedClassObject) {
+        builder
+                .withOrigin(referencedClassObject.getOrigin())
+                .withTarget(referencedClassObject.getTarget())
+                .withLineNumber(referencedClassObject.getLineNumber())
+                .withDeclaredInLambda(referencedClassObject.isDeclaredInLambda());
+        return builder;
+    }
 
     private static SyntheticAccessRecorder createSyntheticLambdaAccessRecorder() {
         return new SyntheticAccessRecorder(
                 codeUnit -> isLambdaMethodName(codeUnit.getName()),
                 (accessBuilder, newOrigin) -> accessBuilder
-                        .withCaller(newOrigin)
+                        .withOrigin(newOrigin)
                         .withDeclaredInLambda(true)
         );
     }
@@ -329,7 +330,7 @@ class ClassFileImportRecord {
     private static SyntheticAccessRecorder createSyntheticPrivateAccessRecorder() {
         return new SyntheticAccessRecorder(
                 codeUnit -> isSyntheticAccessMethodName(codeUnit.getName()),
-                RawAccessRecord.BaseBuilder::withCaller
+                RawCodeUnitDependencyBuilder::withOrigin
         );
     }
 
@@ -377,54 +378,51 @@ class ClassFileImportRecord {
     private static class SyntheticAccessRecorder {
         private final SetMultimap<String, RawAccessRecord> rawSyntheticMethodInvocationRecordsByTarget = HashMultimap.create();
         private final Predicate<CodeUnit> isSyntheticOrigin;
-        private final BiConsumer<RawAccessRecord.BaseBuilder<?, ?>, CodeUnit> fixOrigin;
+        private final BiConsumer<RawCodeUnitDependencyBuilder<?, ?>, CodeUnit> fixOrigin;
 
         SyntheticAccessRecorder(
                 Predicate<CodeUnit> isSyntheticOrigin,
-                BiConsumer<RawAccessRecord.BaseBuilder<?, ?>, CodeUnit> fixOrigin
+                BiConsumer<RawCodeUnitDependencyBuilder<?, ?>, CodeUnit> fixOrigin
         ) {
             this.isSyntheticOrigin = isSyntheticOrigin;
             this.fixOrigin = fixOrigin;
         }
 
         void registerSyntheticMethodInvocation(RawAccessRecord record) {
-            rawSyntheticMethodInvocationRecordsByTarget.put(getMemberKey(record.target), record);
+            rawSyntheticMethodInvocationRecordsByTarget.put(getMemberKey(record.getTarget()), record);
         }
 
-        <ACCESS extends RawAccessRecord> Set<ACCESS> fixSyntheticAccess(
+        <ACCESS extends RawCodeUnitDependency<?>> Set<ACCESS> fixSyntheticAccess(
                 ACCESS access,
-                Function<ACCESS, ? extends RawAccessRecord.BaseBuilder<ACCESS, ?>> copyAccess
+                Function<ACCESS, ? extends RawCodeUnitDependencyBuilder<ACCESS, ?>> copyAccess
         ) {
-            return isSyntheticOrigin.test(access.caller)
+            return isSyntheticOrigin.test(access.getOrigin())
                     ? replaceOriginByFixedOrigin(access, copyAccess)
                     : singleton(access);
         }
 
-        private <ACCESS extends RawAccessRecord> Set<ACCESS> replaceOriginByFixedOrigin(
+        private <ACCESS extends RawCodeUnitDependency<?>> Set<ACCESS> replaceOriginByFixedOrigin(
                 ACCESS accessFromSyntheticMethod,
-                Function<ACCESS, ? extends RawAccessRecord.BaseBuilder<ACCESS, ?>> copyAccess
+                Function<ACCESS, ? extends RawCodeUnitDependencyBuilder<ACCESS, ?>> copyAccess
         ) {
             Set<ACCESS> result = findNonSyntheticOriginOf(accessFromSyntheticMethod)
                     .map(accessWithCorrectOrigin -> {
-                        RawAccessRecord.BaseBuilder<ACCESS, ?> copiedBuilder = copyAccess.apply(accessFromSyntheticMethod);
-                        fixOrigin.accept(copiedBuilder, accessWithCorrectOrigin.caller);
+                        RawCodeUnitDependencyBuilder<ACCESS, ?> copiedBuilder = copyAccess.apply(accessFromSyntheticMethod);
+                        fixOrigin.accept(copiedBuilder, accessWithCorrectOrigin.getOrigin());
                         return copiedBuilder.build();
                     })
                     .collect(toSet());
 
             if (result.isEmpty()) {
-                log.warn("Could not find matching origin for synthetic method {}.{}|{}",
-                        accessFromSyntheticMethod.target.getDeclaringClassName(),
-                        accessFromSyntheticMethod.target.name,
-                        accessFromSyntheticMethod.target.getDescriptor());
+                log.warn("Could not find matching origin for synthetic method {}", accessFromSyntheticMethod);
             }
 
             return result;
         }
 
-        private <ACCESS extends RawAccessRecord> Stream<RawAccessRecord> findNonSyntheticOriginOf(ACCESS access) {
-            return isSyntheticOrigin.test(access.caller)
-                    ? rawSyntheticMethodInvocationRecordsByTarget.get(getMemberKey(access.caller)).stream().flatMap(this::findNonSyntheticOriginOf)
+        private <ACCESS extends RawCodeUnitDependency<?>> Stream<RawCodeUnitDependency<?>> findNonSyntheticOriginOf(ACCESS access) {
+            return isSyntheticOrigin.test(access.getOrigin())
+                    ? rawSyntheticMethodInvocationRecordsByTarget.get(getMemberKey(access.getOrigin())).stream().flatMap(this::findNonSyntheticOriginOf)
                     : Stream.of(access);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImporter.java
@@ -334,7 +334,7 @@ public final class ClassFileImporter {
         }
     }
 
-    private ClassFileSource unify(final List<ClassFileSource> sources) {
+    private ClassFileSource unify(List<ClassFileSource> sources) {
         return Iterables.concat(sources)::iterator;
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -301,7 +301,7 @@ class ClassFileProcessor {
 
         private <BUILDER extends RawAccessRecord.BaseBuilder<?, BUILDER>> BUILDER filled(BUILDER builder, TargetInfo target) {
             return builder
-                    .withCaller(codeUnit)
+                    .withOrigin(codeUnit)
                     .withTarget(target)
                     .withLineNumber(lineNumber);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -288,6 +288,16 @@ class ClassFileProcessor {
         }
 
         @Override
+        public void handleInstanceofCheck(JavaClassDescriptor instanceOfCheckType, int lineNumber) {
+            importRecord.registerInstanceofCheck(new RawInstanceofCheck.Builder()
+                    .withOrigin(codeUnit)
+                    .withTarget(instanceOfCheckType)
+                    .withLineNumber(lineNumber)
+                    .withDeclaredInLambda(false)
+                    .build());
+        }
+
+        @Override
         public void handleTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType) {
             LOG.trace("Found try/catch block between {} and {} for throwable {}", start, end, throwableType);
             tryCatchRecorder.registerTryCatchBlock(start, end, handler, throwableType);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -278,6 +278,16 @@ class ClassFileProcessor {
         }
 
         @Override
+        public void handleReferencedClassObject(JavaClassDescriptor type, int lineNumber) {
+            importRecord.registerReferencedClassObject(new RawReferencedClassObject.Builder()
+                    .withOrigin(codeUnit)
+                    .withTarget(type)
+                    .withLineNumber(lineNumber)
+                    .withDeclaredInLambda(false)
+                    .build());
+        }
+
+        @Override
         public void handleTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType) {
             LOG.trace("Found try/catch block between {} and {} for throwable {}", start, end, throwableType);
             tryCatchRecorder.registerTryCatchBlock(start, end, handler, throwableType);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileSource.java
@@ -76,7 +76,7 @@ interface ClassFileSource extends Iterable<ClassFileLocation> {
                     && importOptions.include(Location.of(file));
         }
 
-        private Supplier<InputStream> newInputStreamSupplierFor(final Path file) {
+        private Supplier<InputStream> newInputStreamSupplierFor(Path file) {
             return new InputStreamSupplier() {
                 @Override
                 InputStream getInputStream() throws IOException {
@@ -108,16 +108,16 @@ interface ClassFileSource extends Iterable<ClassFileLocation> {
             }
         }
 
-        private Predicate<JarEntry> classFilesBeneath(final NormalizedResourceName prefix) {
+        private Predicate<JarEntry> classFilesBeneath(NormalizedResourceName prefix) {
             return input -> input.getName().startsWith(prefix.toEntryName())
                     && FileToImport.isRelevant(input.getName());
         }
 
-        private Function<JarEntry, ClassFileInJar> toClassFilesInJarOf(final JarURLConnection connection) {
+        private Function<JarEntry, ClassFileInJar> toClassFilesInJarOf(JarURLConnection connection) {
             return input -> new ClassFileInJar(connection, input);
         }
 
-        private Predicate<ClassFileInJar> by(final ImportOptions importOptions) {
+        private Predicate<ClassFileInJar> by(ImportOptions importOptions) {
             return input -> input.isIncludedIn(importOptions);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -68,7 +68,6 @@ import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.JavaWildcardType;
-import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.Source;
 import com.tngtech.archunit.core.domain.SourceCodeLocation;
 import com.tngtech.archunit.core.domain.ThrowsClause;
@@ -82,7 +81,6 @@ import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeVariable;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createGenericArrayType;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createInstanceofCheck;
-import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createReferencedClassObject;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createSource;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createThrowsClause;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createTryCatchBlock;
@@ -250,7 +248,6 @@ public final class DomainBuilders {
         private SetMultimap<Integer, JavaAnnotationBuilder> parameterAnnotationsByIndex;
         private JavaCodeUnitTypeParametersBuilder typeParametersBuilder;
         private List<JavaClassDescriptor> throwsDeclarations;
-        private final Set<RawReferencedClassObject> rawReferencedClassObjects = new HashSet<>();
         private final List<RawInstanceofCheck> instanceOfChecks = new ArrayList<>();
 
         private JavaCodeUnitBuilder() {
@@ -280,11 +277,6 @@ public final class DomainBuilders {
 
         SELF withThrowsClause(List<JavaClassDescriptor> throwsDeclarations) {
             this.throwsDeclarations = throwsDeclarations;
-            return self();
-        }
-
-        SELF addReferencedClassObject(RawReferencedClassObject rawReferencedClassObject) {
-            rawReferencedClassObjects.add(rawReferencedClassObject);
             return self();
         }
 
@@ -337,14 +329,6 @@ public final class DomainBuilders {
 
         public <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> getThrowsClause(CODE_UNIT codeUnit) {
             return createThrowsClause(codeUnit, asJavaClasses(this.throwsDeclarations));
-        }
-
-        public Set<ReferencedClassObject> getReferencedClassObjects(JavaCodeUnit codeUnit) {
-            ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
-            for (RawReferencedClassObject rawReferencedClassObject : this.rawReferencedClassObjects) {
-                result.add(createReferencedClassObject(codeUnit, get(rawReferencedClassObject.getClassName()), rawReferencedClassObject.getLineNumber()));
-            }
-            return result.build();
         }
 
         public Set<InstanceofCheck> getInstanceofChecks(JavaCodeUnit codeUnit) {
@@ -733,7 +717,7 @@ public final class DomainBuilders {
         }
     }
 
-    private static abstract class AbstractTypeParametersBuilder<OWNER extends HasDescription> {
+    private abstract static class AbstractTypeParametersBuilder<OWNER extends HasDescription> {
         private final List<JavaTypeParameterBuilder<OWNER>> typeParameterBuilders;
 
         AbstractTypeParametersBuilder(List<JavaTypeParameterBuilder<OWNER>> typeParameterBuilders) {
@@ -1096,7 +1080,7 @@ public final class DomainBuilders {
     }
 
     @Internal
-    public static abstract class AccessTargetBuilder<MEMBER extends JavaMember, TARGET extends AccessTarget, SELF extends AccessTargetBuilder<MEMBER, TARGET, SELF>> {
+    public abstract static class AccessTargetBuilder<MEMBER extends JavaMember, TARGET extends AccessTarget, SELF extends AccessTargetBuilder<MEMBER, TARGET, SELF>> {
         private final Function<SELF, TARGET> createTarget;
 
         private JavaClass owner;

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -44,7 +44,6 @@ import com.tngtech.archunit.core.domain.AccessTarget.MethodReferenceTarget;
 import com.tngtech.archunit.core.domain.DomainObjectCreationContext;
 import com.tngtech.archunit.core.domain.Formatters;
 import com.tngtech.archunit.core.domain.ImportContext;
-import com.tngtech.archunit.core.domain.InstanceofCheck;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -80,7 +79,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeVariable;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createGenericArrayType;
-import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createInstanceofCheck;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createSource;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createThrowsClause;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createTryCatchBlock;
@@ -248,7 +246,6 @@ public final class DomainBuilders {
         private SetMultimap<Integer, JavaAnnotationBuilder> parameterAnnotationsByIndex;
         private JavaCodeUnitTypeParametersBuilder typeParametersBuilder;
         private List<JavaClassDescriptor> throwsDeclarations;
-        private final List<RawInstanceofCheck> instanceOfChecks = new ArrayList<>();
 
         private JavaCodeUnitBuilder() {
         }
@@ -277,11 +274,6 @@ public final class DomainBuilders {
 
         SELF withThrowsClause(List<JavaClassDescriptor> throwsDeclarations) {
             this.throwsDeclarations = throwsDeclarations;
-            return self();
-        }
-
-        SELF addInstanceOfCheck(RawInstanceofCheck rawInstanceOfChecks) {
-            this.instanceOfChecks.add(rawInstanceOfChecks);
             return self();
         }
 
@@ -329,14 +321,6 @@ public final class DomainBuilders {
 
         public <CODE_UNIT extends JavaCodeUnit> ThrowsClause<CODE_UNIT> getThrowsClause(CODE_UNIT codeUnit) {
             return createThrowsClause(codeUnit, asJavaClasses(this.throwsDeclarations));
-        }
-
-        public Set<InstanceofCheck> getInstanceofChecks(JavaCodeUnit codeUnit) {
-            ImmutableSet.Builder<InstanceofCheck> result = ImmutableSet.builder();
-            for (RawInstanceofCheck instanceOfCheck : this.instanceOfChecks) {
-                result.add(createInstanceofCheck(codeUnit, get(instanceOfCheck.getTarget().getFullyQualifiedClassName()), instanceOfCheck.getLineNumber()));
-            }
-            return result.build();
         }
 
         private List<JavaClass> asJavaClasses(List<JavaClassDescriptor> descriptors) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -116,12 +116,12 @@ public final class DomainBuilders {
         JavaEnumConstantBuilder() {
         }
 
-        JavaEnumConstantBuilder withDeclaringClass(final JavaClass declaringClass) {
+        JavaEnumConstantBuilder withDeclaringClass(JavaClass declaringClass) {
             this.declaringClass = declaringClass;
             return this;
         }
 
-        JavaEnumConstantBuilder withName(final String name) {
+        JavaEnumConstantBuilder withName(String name) {
             this.name = name;
             return this;
         }
@@ -401,7 +401,7 @@ public final class DomainBuilders {
         }
 
         @Override
-        JavaMethod construct(JavaMethodBuilder builder, final ImportedClasses importedClasses) {
+        JavaMethod construct(JavaMethodBuilder builder, ImportedClasses importedClasses) {
             return DomainObjectCreationContext.createJavaMethod(builder, createAnnotationDefaultValue);
         }
     }
@@ -586,7 +586,7 @@ public final class DomainBuilders {
         abstract static class ValueBuilder {
             abstract <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses);
 
-            static ValueBuilder fromPrimitiveProperty(final Object value) {
+            static ValueBuilder fromPrimitiveProperty(Object value) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses unused) {
@@ -595,7 +595,7 @@ public final class DomainBuilders {
                 };
             }
 
-            public static ValueBuilder fromEnumProperty(final JavaClassDescriptor enumType, final String value) {
+            public static ValueBuilder fromEnumProperty(JavaClassDescriptor enumType, String value) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {
@@ -608,7 +608,7 @@ public final class DomainBuilders {
                 };
             }
 
-            static ValueBuilder fromClassProperty(final JavaClassDescriptor value) {
+            static ValueBuilder fromClassProperty(JavaClassDescriptor value) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {
@@ -617,7 +617,7 @@ public final class DomainBuilders {
                 };
             }
 
-            static ValueBuilder fromAnnotationProperty(final JavaAnnotationBuilder builder) {
+            static ValueBuilder fromAnnotationProperty(JavaAnnotationBuilder builder) {
                 return new ValueBuilder() {
                     @Override
                     <T extends HasDescription> Optional<Object> build(T owner, ImportedClasses importedClasses) {
@@ -656,7 +656,7 @@ public final class DomainBuilders {
 
             abstract String getFinishedName(String name);
 
-            JavaTypeFinisher after(final JavaTypeFinisher other) {
+            JavaTypeFinisher after(JavaTypeFinisher other) {
                 return new JavaTypeFinisher() {
                     @Override
                     JavaType finish(JavaType input, ImportedClasses classes) {
@@ -992,17 +992,17 @@ public final class DomainBuilders {
         private JavaAccessBuilder() {
         }
 
-        SELF withOrigin(final JavaCodeUnit origin) {
+        SELF withOrigin(JavaCodeUnit origin) {
             this.origin = origin;
             return self();
         }
 
-        SELF withTarget(final TARGET target) {
+        SELF withTarget(TARGET target) {
             this.target = target;
             return self();
         }
 
-        SELF withLineNumber(final int lineNumber) {
+        SELF withLineNumber(int lineNumber) {
             this.lineNumber = lineNumber;
             return self();
         }
@@ -1041,7 +1041,7 @@ public final class DomainBuilders {
         JavaFieldAccessBuilder() {
         }
 
-        JavaFieldAccessBuilder withAccessType(final AccessType accessType) {
+        JavaFieldAccessBuilder withAccessType(AccessType accessType) {
             this.accessType = accessType;
             return this;
         }
@@ -1107,12 +1107,12 @@ public final class DomainBuilders {
             this.createTarget = createTarget;
         }
 
-        SELF withOwner(final JavaClass owner) {
+        SELF withOwner(JavaClass owner) {
             this.owner = owner;
             return self();
         }
 
-        SELF withName(final String name) {
+        SELF withName(String name) {
             this.name = name;
             return self();
         }
@@ -1154,7 +1154,7 @@ public final class DomainBuilders {
             super(DomainObjectCreationContext::createFieldAccessTarget);
         }
 
-        FieldAccessTargetBuilder withType(final JavaClass type) {
+        FieldAccessTargetBuilder withType(JavaClass type) {
             this.type = type;
             return this;
         }
@@ -1179,12 +1179,12 @@ public final class DomainBuilders {
             super(createTarget);
         }
 
-        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withParameters(final List<JavaClass> parameters) {
+        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withParameters(List<JavaClass> parameters) {
             this.parameters = parameters;
             return self();
         }
 
-        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withReturnType(final JavaClass returnType) {
+        CodeUnitAccessTargetBuilder<CODE_UNIT, ACCESS_TARGET> withReturnType(JavaClass returnType) {
             this.returnType = returnType;
             return self();
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -71,7 +71,6 @@ import static com.tngtech.archunit.core.importer.ClassFileProcessor.ASM_API_VERS
 import static com.tngtech.archunit.core.importer.JavaClassDescriptorImporter.isAsmMethodHandle;
 import static com.tngtech.archunit.core.importer.JavaClassDescriptorImporter.isLambdaMetafactory;
 import static com.tngtech.archunit.core.importer.JavaClassDescriptorImporter.isLambdaMethod;
-import static com.tngtech.archunit.core.importer.RawInstanceofCheck.from;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 
@@ -401,7 +400,7 @@ class JavaClassProcessor extends ClassVisitor {
         public void visitTypeInsn(int opcode, String type) {
             if (opcode == Opcodes.INSTANCEOF) {
                 JavaClassDescriptor instanceOfCheckType = JavaClassDescriptorImporter.createFromAsmObjectTypeName(type);
-                codeUnitBuilder.addInstanceOfCheck(from(instanceOfCheckType, actualLineNumber));
+                accessHandler.handleInstanceofCheck(instanceOfCheckType, actualLineNumber);
                 declarationHandler.onDeclaredInstanceofCheck(instanceOfCheckType.getFullyQualifiedClassName());
             }
         }
@@ -537,6 +536,8 @@ class JavaClassProcessor extends ClassVisitor {
 
         void handleReferencedClassObject(JavaClassDescriptor type, int lineNumber);
 
+        void handleInstanceofCheck(JavaClassDescriptor instanceOfCheckType, int lineNumber);
+
         void handleTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType);
 
         void handleTryFinallyBlock(Label start, Label end, Label handler);
@@ -575,6 +576,10 @@ class JavaClassProcessor extends ClassVisitor {
 
             @Override
             public void handleReferencedClassObject(JavaClassDescriptor type, int lineNumber) {
+            }
+
+            @Override
+            public void handleInstanceofCheck(JavaClassDescriptor instanceOfCheckType, int lineNumber) {
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -373,7 +373,7 @@ class JavaClassProcessor extends ClassVisitor {
         public void visitLdcInsn(Object value) {
             if (JavaClassDescriptorImporter.isAsmType(value)) {
                 JavaClassDescriptor type = JavaClassDescriptorImporter.importAsmType(value);
-                codeUnitBuilder.addReferencedClassObject(RawReferencedClassObject.from(type, actualLineNumber));
+                accessHandler.handleReferencedClassObject(type, actualLineNumber);
                 declarationHandler.onDeclaredClassObject(type.getFullyQualifiedClassName());
             }
         }
@@ -535,6 +535,8 @@ class JavaClassProcessor extends ClassVisitor {
 
         void handleLambdaInstruction(String owner, String name, String desc);
 
+        void handleReferencedClassObject(JavaClassDescriptor type, int lineNumber);
+
         void handleTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType);
 
         void handleTryFinallyBlock(Label start, Label end, Label handler);
@@ -569,6 +571,10 @@ class JavaClassProcessor extends ClassVisitor {
 
             @Override
             public void handleLambdaInstruction(String owner, String name, String desc) {
+            }
+
+            @Override
+            public void handleReferencedClassObject(JavaClassDescriptor type, int lineNumber) {
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -417,12 +417,7 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         @Override
-        public void visitInvokeDynamicInsn(
-                final String name,
-                final String descriptor,
-                final Handle bootstrapMethodHandle,
-                final Object... bootstrapMethodArguments
-        ) {
+        public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
             if (isLambdaMetafactory(bootstrapMethodHandle.getOwner())) {
                 Object methodHandleCandidate = bootstrapMethodArguments[1];
                 if (isAsmMethodHandle(methodHandleCandidate)) {
@@ -640,12 +635,12 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         @Override
-        public AnnotationVisitor visitAnnotation(final String name, String desc) {
+        public AnnotationVisitor visitAnnotation(String name, String desc) {
             return new AnnotationProcessor(addAnnotationAsProperty(name, this.annotationBuilder), declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
         }
 
         @Override
-        public AnnotationVisitor visitArray(final String name) {
+        public AnnotationVisitor visitArray(String name) {
             return new AnnotationArrayProcessor(new AnnotationArrayContext() {
                 @Override
                 public String getDeclaringAnnotationTypeName() {
@@ -670,11 +665,11 @@ class JavaClassProcessor extends ClassVisitor {
         }
     }
 
-    private static TakesAnnotationBuilder addAnnotationAtIndex(final SetMultimap<Integer, JavaAnnotationBuilder> annotations, final int index) {
+    private static TakesAnnotationBuilder addAnnotationAtIndex(SetMultimap<Integer, JavaAnnotationBuilder> annotations, int index) {
         return annotation -> annotations.put(index, annotation);
     }
 
-    private static TakesAnnotationBuilder addAnnotationAsProperty(final String name, final JavaAnnotationBuilder annotationBuilder) {
+    private static TakesAnnotationBuilder addAnnotationAsProperty(String name, JavaAnnotationBuilder annotationBuilder) {
         return builder -> annotationBuilder.addProperty(name, ValueBuilder.fromAnnotationProperty(builder));
     }
 
@@ -716,7 +711,7 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         @Override
-        public void visitEnum(String name, final String desc, final String value) {
+        public void visitEnum(String name, String desc, String value) {
             setDerivedComponentType(JavaEnumConstant.class);
             values.add(handleAnnotationEnumProperty(desc, value, declarationHandler));
         }
@@ -856,7 +851,7 @@ class JavaClassProcessor extends ClassVisitor {
 
         @Override
         public final void visit(String name, Object input) {
-            final Object value = JavaClassDescriptorImporter.importAsmTypeIfPossible(input);
+            Object value = JavaClassDescriptorImporter.importAsmTypeIfPossible(input);
             if (value instanceof JavaClassDescriptor) {
                 visitClass(name, (JavaClassDescriptor) value);
             } else {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -168,7 +168,7 @@ public abstract class Location {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Location other = (Location) obj;
+        Location other = (Location) obj;
         return Objects.equals(this.uri, other.uri);
     }
 
@@ -375,8 +375,8 @@ public abstract class Location {
             return getAllFilesBeneath(rootFile.toPath());
         }
 
-        private List<NormalizedResourceName> getAllFilesBeneath(final Path root) throws IOException {
-            final ImmutableList.Builder<NormalizedResourceName> result = ImmutableList.builder();
+        private List<NormalizedResourceName> getAllFilesBeneath(Path root) throws IOException {
+            ImmutableList.Builder<NormalizedResourceName> result = ImmutableList.builder();
             Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
@@ -80,7 +80,7 @@ class NormalizedResourceName {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final NormalizedResourceName other = (NormalizedResourceName) obj;
+        NormalizedResourceName other = (NormalizedResourceName) obj;
         return Objects.equals(this.resourceName, other.resourceName);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedUri.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedUri.java
@@ -66,7 +66,7 @@ class NormalizedUri {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final NormalizedUri other = (NormalizedUri) obj;
+        NormalizedUri other = (NormalizedUri) obj;
         return Objects.equals(this.uri, other.uri);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
@@ -25,17 +25,37 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class RawAccessRecord {
-    final CodeUnit caller;
-    final TargetInfo target;
-    final int lineNumber;
-    final boolean declaredInLambda;
+class RawAccessRecord implements RawCodeUnitDependency<RawAccessRecord.TargetInfo> {
+    private final CodeUnit origin;
+    private final TargetInfo target;
+    private final int lineNumber;
+    private final boolean declaredInLambda;
 
-    RawAccessRecord(CodeUnit caller, TargetInfo target, int lineNumber, boolean declaredInLambda) {
-        this.caller = checkNotNull(caller);
+    RawAccessRecord(CodeUnit origin, TargetInfo target, int lineNumber, boolean declaredInLambda) {
+        this.origin = checkNotNull(origin);
         this.target = checkNotNull(target);
         this.lineNumber = lineNumber;
         this.declaredInLambda = declaredInLambda;
+    }
+
+    @Override
+    public CodeUnit getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public TargetInfo getTarget() {
+        return target;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
     }
 
     @Override
@@ -44,7 +64,7 @@ class RawAccessRecord {
     }
 
     private String fieldsAsString() {
-        return "caller=" + caller + ", target=" + target + ", lineNumber=" + lineNumber;
+        return "origin=" + origin + ", target=" + target + ", lineNumber=" + lineNumber + ", declaredInLambda=" + declaredInLambda;
     }
 
     interface MemberSignature {
@@ -195,33 +215,37 @@ class RawAccessRecord {
 
     static class Builder extends BaseBuilder<RawAccessRecord, Builder> {
         @Override
-        RawAccessRecord build() {
-            return new RawAccessRecord(caller, target, lineNumber, declaredInLambda);
+        public RawAccessRecord build() {
+            return new RawAccessRecord(origin, target, lineNumber, declaredInLambda);
         }
     }
 
-    abstract static class BaseBuilder<ACCESS extends RawAccessRecord, SELF extends BaseBuilder<ACCESS, SELF>> {
-        CodeUnit caller;
+    abstract static class BaseBuilder<ACCESS extends RawAccessRecord, SELF extends BaseBuilder<ACCESS, SELF>> implements RawCodeUnitDependencyBuilder<ACCESS, TargetInfo> {
+        CodeUnit origin;
         TargetInfo target;
         int lineNumber = -1;
         boolean declaredInLambda = false;
 
-        SELF withCaller(CodeUnit caller) {
-            this.caller = caller;
+        @Override
+        public SELF withOrigin(CodeUnit origin) {
+            this.origin = origin;
             return self();
         }
 
-        SELF withTarget(TargetInfo target) {
+        @Override
+        public SELF withTarget(TargetInfo target) {
             this.target = target;
             return self();
         }
 
-        SELF withLineNumber(int lineNumber) {
+        @Override
+        public SELF withLineNumber(int lineNumber) {
             this.lineNumber = lineNumber;
             return self();
         }
 
-        SELF withDeclaredInLambda(boolean declaredInLambda) {
+        @Override
+        public SELF withDeclaredInLambda(boolean declaredInLambda) {
             this.declaredInLambda = declaredInLambda;
             return self();
         }
@@ -230,15 +254,13 @@ class RawAccessRecord {
         SELF self() {
             return (SELF) this;
         }
-
-        abstract ACCESS build();
     }
 
     static class ForField extends RawAccessRecord {
         final AccessType accessType;
 
-        private ForField(CodeUnit caller, TargetInfo target, int lineNumber, AccessType accessType, boolean declaredInLambda) {
-            super(caller, target, lineNumber, declaredInLambda);
+        private ForField(CodeUnit origin, TargetInfo target, int lineNumber, AccessType accessType, boolean declaredInLambda) {
+            super(origin, target, lineNumber, declaredInLambda);
             this.accessType = accessType;
         }
 
@@ -251,8 +273,8 @@ class RawAccessRecord {
             }
 
             @Override
-            ForField build() {
-                return new ForField(super.caller, super.target, super.lineNumber, accessType, declaredInLambda);
+            public ForField build() {
+                return new ForField(super.origin, super.target, super.lineNumber, accessType, declaredInLambda);
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
@@ -181,7 +181,7 @@ class RawAccessRecord {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final TargetInfo other = (TargetInfo) obj;
+            TargetInfo other = (TargetInfo) obj;
             return Objects.equals(this.owner, other.owner) &&
                     Objects.equals(this.name, other.name) &&
                     Objects.equals(this.desc, other.desc);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawAccessRecord.java
@@ -123,7 +123,17 @@ class RawAccessRecord implements RawCodeUnitDependency<RawAccessRecord.TargetInf
             return declaringClassName;
         }
 
-        boolean is(JavaCodeUnit method) {
+        JavaCodeUnit resolveFrom(ImportedClasses classes) {
+            for (JavaCodeUnit method : classes.getOrResolve(getDeclaringClassName()).getCodeUnits()) {
+                if (is(method)) {
+                    return method;
+                }
+            }
+            throw new IllegalStateException("Never found a " + JavaCodeUnit.class.getSimpleName() +
+                    " that matches supposed origin " + this);
+        }
+
+        private boolean is(JavaCodeUnit method) {
             return getName().equals(method.getName())
                     && descriptor.equals(method.getDescriptor())
                     && getDeclaringClassName().equals(method.getOwner().getName());

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawCodeUnitDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawCodeUnitDependency.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+interface RawCodeUnitDependency<TARGET> {
+    RawAccessRecord.CodeUnit getOrigin();
+
+    TARGET getTarget();
+
+    int getLineNumber();
+
+    boolean isDeclaredInLambda();
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawCodeUnitDependencyBuilder.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawCodeUnitDependencyBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2022 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
+
+interface RawCodeUnitDependencyBuilder<CODE_UNIT_DEPENDENCY extends RawCodeUnitDependency<TARGET>, TARGET> {
+    RawCodeUnitDependencyBuilder<CODE_UNIT_DEPENDENCY, TARGET> withOrigin(CodeUnit origin);
+
+    RawCodeUnitDependencyBuilder<CODE_UNIT_DEPENDENCY, TARGET> withTarget(TARGET target);
+
+    RawCodeUnitDependencyBuilder<CODE_UNIT_DEPENDENCY, TARGET> withLineNumber(int lineNumber);
+
+    RawCodeUnitDependencyBuilder<CODE_UNIT_DEPENDENCY, TARGET> withDeclaredInLambda(boolean declaredInLambda);
+
+    CODE_UNIT_DEPENDENCY build();
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawInstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawInstanceofCheck.java
@@ -20,32 +20,82 @@ import com.tngtech.archunit.core.domain.JavaClassDescriptor;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class RawInstanceofCheck {
+class RawInstanceofCheck implements RawCodeUnitDependency<JavaClassDescriptor> {
+    private final RawAccessRecord.CodeUnit origin;
     private final JavaClassDescriptor target;
     private final int lineNumber;
+    private final boolean declaredInLambda;
 
-    private RawInstanceofCheck(JavaClassDescriptor target, int lineNumber) {
+    private RawInstanceofCheck(RawAccessRecord.CodeUnit origin, JavaClassDescriptor target, int lineNumber, boolean declaredInLambda) {
+        this.origin = checkNotNull(origin);
         this.target = checkNotNull(target);
         this.lineNumber = lineNumber;
+        this.declaredInLambda = declaredInLambda;
     }
 
-    static RawInstanceofCheck from(JavaClassDescriptor target, int lineNumber) {
-        return new RawInstanceofCheck(target, lineNumber);
+    @Override
+    public RawAccessRecord.CodeUnit getOrigin() {
+        return origin;
     }
 
-    JavaClassDescriptor getTarget() {
+    @Override
+    public JavaClassDescriptor getTarget() {
         return target;
     }
 
-    int getLineNumber() {
+    @Override
+    public int getLineNumber() {
         return lineNumber;
+    }
+
+    @Override
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
     }
 
     @Override
     public String toString() {
         return toStringHelper(this)
+                .add("origin", origin)
                 .add("target", target)
                 .add("lineNumber", lineNumber)
+                .add("declaredInLambda", declaredInLambda)
                 .toString();
+    }
+
+    static class Builder implements RawCodeUnitDependencyBuilder<RawInstanceofCheck, JavaClassDescriptor> {
+        private RawAccessRecord.CodeUnit origin;
+        private JavaClassDescriptor target;
+        private int lineNumber;
+        private boolean declaredInLambda;
+
+        @Override
+        public RawInstanceofCheck.Builder withOrigin(RawAccessRecord.CodeUnit origin) {
+            this.origin = origin;
+            return this;
+        }
+
+        @Override
+        public RawInstanceofCheck.Builder withTarget(JavaClassDescriptor target) {
+            this.target = target;
+            return this;
+        }
+
+        @Override
+        public RawInstanceofCheck.Builder withLineNumber(int lineNumber) {
+            this.lineNumber = lineNumber;
+            return this;
+        }
+
+        @Override
+        public RawInstanceofCheck.Builder withDeclaredInLambda(boolean declaredInLambda) {
+            this.declaredInLambda = declaredInLambda;
+            return this;
+        }
+
+        @Override
+        public RawInstanceofCheck build() {
+            return new RawInstanceofCheck(origin, target, lineNumber, declaredInLambda);
+        }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawReferencedClassObject.java
@@ -16,36 +16,89 @@
 package com.tngtech.archunit.core.importer;
 
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
+import com.tngtech.archunit.core.importer.RawAccessRecord.CodeUnit;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-class RawReferencedClassObject {
-    private final JavaClassDescriptor type;
+class RawReferencedClassObject implements RawCodeUnitDependency<JavaClassDescriptor> {
+    private final CodeUnit origin;
+    private final JavaClassDescriptor target;
     private final int lineNumber;
+    private final boolean declaredInLambda;
 
-    private RawReferencedClassObject(JavaClassDescriptor type, int lineNumber) {
-        this.type = checkNotNull(type);
+    private RawReferencedClassObject(CodeUnit origin, JavaClassDescriptor target, int lineNumber, boolean declaredInLambda) {
+        this.origin = checkNotNull(origin);
+        this.target = checkNotNull(target);
         this.lineNumber = lineNumber;
+        this.declaredInLambda = declaredInLambda;
     }
 
-    static RawReferencedClassObject from(JavaClassDescriptor target, int lineNumber) {
-        return new RawReferencedClassObject(target, lineNumber);
+    @Override
+    public CodeUnit getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public JavaClassDescriptor getTarget() {
+        return target;
     }
 
     String getClassName() {
-        return type.getFullyQualifiedClassName();
+        return target.getFullyQualifiedClassName();
     }
 
-    int getLineNumber() {
+    public int getLineNumber() {
         return lineNumber;
+    }
+
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
     }
 
     @Override
     public String toString() {
         return toStringHelper(this)
-                .add("type", type)
+                .add("origin", origin)
+                .add("target", target)
                 .add("lineNumber", lineNumber)
+                .add("declaredInLambda", declaredInLambda)
                 .toString();
+    }
+
+    static class Builder implements RawCodeUnitDependencyBuilder<RawReferencedClassObject, JavaClassDescriptor> {
+        private CodeUnit origin;
+        private JavaClassDescriptor target;
+        private int lineNumber;
+        private boolean declaredInLambda;
+
+        @Override
+        public Builder withOrigin(CodeUnit origin) {
+            this.origin = origin;
+            return this;
+        }
+
+        @Override
+        public Builder withTarget(JavaClassDescriptor target) {
+            this.target = target;
+            return this;
+        }
+
+        @Override
+        public Builder withLineNumber(int lineNumber) {
+            this.lineNumber = lineNumber;
+            return this;
+        }
+
+        @Override
+        public Builder withDeclaredInLambda(boolean declaredInLambda) {
+            this.declaredInLambda = declaredInLambda;
+            return this;
+        }
+
+        @Override
+        public RawReferencedClassObject build() {
+            return new RawReferencedClassObject(origin, target, lineNumber, declaredInLambda);
+        }
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/UrlSource.java
@@ -59,7 +59,7 @@ interface UrlSource extends Iterable<URL> {
         private static final String BOOT_CLASS_PATH_PROPERTY_NAME = "sun.boot.class.path";
 
         static UrlSource iterable(Iterable<URL> urls) {
-            final Iterable<URL> uniqueUrls = unique(urls);
+            Iterable<URL> uniqueUrls = unique(urls);
             return new UrlSource() {
                 @Override
                 public Iterator<URL> iterator() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/resolvers/ClassResolver.java
@@ -122,8 +122,8 @@ public interface ClassResolver {
             }
         }
 
-        private ClassResolverProvider createProvider(final Class<?> resolverClass, final List<String> args) {
-            final Optional<Constructor<?>> listConstructor = tryGetListConstructor(resolverClass);
+        private ClassResolverProvider createProvider(Class<?> resolverClass, List<String> args) {
+            Optional<Constructor<?>> listConstructor = tryGetListConstructor(resolverClass);
             if (listConstructor.isPresent()) {
                 return new ClassResolverProvider(instantiationException(listConstructor.get(), args)) {
                     @Override
@@ -139,7 +139,7 @@ public interface ClassResolver {
         }
 
         private Function<Exception, ClassResolverConfigurationException> instantiationException(
-                final Constructor<?> constructor, final List<String> args) {
+                Constructor<?> constructor, List<String> args) {
 
             return cause -> ClassResolverConfigurationException.onInstantiation(constructor, args, cause);
         }
@@ -152,8 +152,8 @@ public interface ClassResolver {
             }
         }
 
-        private ClassResolverProvider tryCreateResolverProviderForDefaultConstructor(final Class<?> resolverClass, final List<String> args) {
-            final Constructor<?> defaultConstructor;
+        private ClassResolverProvider tryCreateResolverProviderForDefaultConstructor(Class<?> resolverClass, List<String> args) {
+            Constructor<?> defaultConstructor;
             try {
                 defaultConstructor = accessibleConstructor(resolverClass);
             } catch (NoSuchMethodException e) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/AbstractClassesTransformer.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/AbstractClassesTransformer.java
@@ -44,7 +44,7 @@ public abstract class AbstractClassesTransformer<T> implements ClassesTransforme
     public abstract Iterable<T> doTransform(JavaClasses collection);
 
     @Override
-    public final ClassesTransformer<T> that(final DescribedPredicate<? super T> predicate) {
+    public final ClassesTransformer<T> that(DescribedPredicate<? super T> predicate) {
         return new AbstractClassesTransformer<T>(description + " that " + predicate.getDescription()) {
             @Override
             public Iterable<T> doTransform(JavaClasses collection) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/ArchRule.java
@@ -125,7 +125,7 @@ public interface ArchRule extends CanBeEvaluated, CanOverrideDescription<ArchRul
 
     @Internal
     class Factory {
-        public static <T> ArchRule create(final ClassesTransformer<T> classesTransformer, final ArchCondition<T> condition, final Priority priority) {
+        public static <T> ArchRule create(ClassesTransformer<T> classesTransformer, ArchCondition<T> condition, Priority priority) {
             return new SimpleArchRule<>(priority, classesTransformer, condition, Optional.empty(), AllowEmptyShould.AS_CONFIGURED);
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/EvaluationResult.java
@@ -129,7 +129,7 @@ public final class EvaluationResult {
     public final <T> void handleViolations(ViolationHandler<T> violationHandler, T... __ignored_parameter_to_reify_type__) {
         Class<T> correspondingObjectType = componentTypeOf(__ignored_parameter_to_reify_type__);
         ConditionEvent.Handler eventHandler = convertToEventHandler(correspondingObjectType, violationHandler);
-        for (final ConditionEvent event : violations) {
+        for (ConditionEvent event : violations) {
             event.handleWith(eventHandler);
         }
     }
@@ -189,7 +189,7 @@ public final class EvaluationResult {
         return patterns.isEmpty() ? violations : filterEvents(violations, notMatchedByAny(patterns));
     }
 
-    private static Predicate<String> notMatchedByAny(final Set<Pattern> patterns) {
+    private static Predicate<String> notMatchedByAny(Set<Pattern> patterns) {
         return message -> {
             String normalizedMessage = message.replaceAll("\r*\n", " ");
             return patterns.stream().noneMatch(pattern -> pattern.matcher(normalizedMessage).matches());

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AllDependenciesCondition.java
@@ -36,7 +36,7 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
 
     AllDependenciesCondition(
             String description,
-            final DescribedPredicate<? super Dependency> predicate,
+            DescribedPredicate<? super Dependency> predicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies) {
 
         this(description, predicate, javaClassToRelevantDependencies, alwaysFalse());
@@ -44,7 +44,7 @@ public final class AllDependenciesCondition extends AllAttributesMatchCondition<
 
     private AllDependenciesCondition(
             String description,
-            final DescribedPredicate<? super Dependency> conditionPredicate,
+            DescribedPredicate<? super Dependency> conditionPredicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies,
             DescribedPredicate<Dependency> ignorePredicate) {
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AndCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AndCondition.java
@@ -54,7 +54,7 @@ class AndCondition<T> extends JoinCondition<T> {
         }
 
         @Override
-        public void handleWith(final ConditionEvent.Handler handler) {
+        public void handleWith(ConditionEvent.Handler handler) {
             for (ConditionWithEvents<T> condition : evaluatedConditions) {
                 condition.getEvents().getViolating().forEach(event -> event.handleWith(handler));
             }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/AnyDependencyCondition.java
@@ -36,7 +36,7 @@ public final class AnyDependencyCondition extends AnyAttributeMatchesCondition<D
 
     AnyDependencyCondition(
             String description,
-            final DescribedPredicate<? super Dependency> predicate,
+            DescribedPredicate<? super Dependency> predicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies) {
 
         this(description, predicate, javaClassToRelevantDependencies, alwaysFalse());
@@ -44,7 +44,7 @@ public final class AnyDependencyCondition extends AnyAttributeMatchesCondition<D
 
     private AnyDependencyCondition(
             String description,
-            final DescribedPredicate<? super Dependency> conditionPredicate,
+            DescribedPredicate<? super Dependency> conditionPredicate,
             Function<JavaClass, ? extends Collection<Dependency>> javaClassToRelevantDependencies,
             DescribedPredicate<Dependency> ignorePredicate) {
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -137,12 +137,12 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> getField(final Class<?> owner, final String fieldName) {
+    public static ArchCondition<JavaClass> getField(Class<?> owner, String fieldName) {
         return getField(owner.getName(), fieldName);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> getField(final String ownerName, final String fieldName) {
+    public static ArchCondition<JavaClass> getField(String ownerName, String fieldName) {
         return getFieldWhere(ownerAndNameAre(ownerName, fieldName))
                 .as("get field %s.%s", ensureSimpleName(ownerName), fieldName);
     }
@@ -154,12 +154,12 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> setField(final Class<?> owner, final String fieldName) {
+    public static ArchCondition<JavaClass> setField(Class<?> owner, String fieldName) {
         return setField(owner.getName(), fieldName);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> setField(final String ownerName, final String fieldName) {
+    public static ArchCondition<JavaClass> setField(String ownerName, String fieldName) {
         return setFieldWhere(ownerAndNameAre(ownerName, fieldName))
                 .as("set field %s.%s", ensureSimpleName(ownerName), fieldName);
     }
@@ -171,12 +171,12 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> accessField(final Class<?> owner, final String fieldName) {
+    public static ArchCondition<JavaClass> accessField(Class<?> owner, String fieldName) {
         return accessField(owner.getName(), fieldName);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> accessField(final String ownerName, final String fieldName) {
+    public static ArchCondition<JavaClass> accessField(String ownerName, String fieldName) {
         return accessFieldWhere(ownerAndNameAre(ownerName, fieldName))
                 .as("access field %s.%s", ensureSimpleName(ownerName), fieldName);
     }
@@ -188,7 +188,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyAccessFieldsThat(final DescribedPredicate<? super JavaField> predicate) {
+    public static ArchCondition<JavaClass> onlyAccessFieldsThat(DescribedPredicate<? super JavaField> predicate) {
         ChainableFunction<JavaFieldAccess, FieldAccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaFieldAccess> accessPredicate = getTarget.then(FieldAccessTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaField>forSubtype()).or(optionalEmpty()));
@@ -215,13 +215,13 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> callMethodWhere(final DescribedPredicate<? super JavaMethodCall> predicate) {
+    public static ArchCondition<JavaClass> callMethodWhere(DescribedPredicate<? super JavaMethodCall> predicate) {
         return new ClassAccessesCondition<>(predicate, GET_METHOD_CALLS_FROM_SELF)
                 .as("call method where " + predicate.getDescription());
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyCallMethodsThat(final DescribedPredicate<? super JavaMethod> predicate) {
+    public static ArchCondition<JavaClass> onlyCallMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
         ChainableFunction<JavaMethodCall, MethodCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaMethodCall> callPredicate = getTarget.then(MethodCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaMethod>forSubtype()).or(optionalEmpty()));
@@ -248,13 +248,13 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> callConstructorWhere(final DescribedPredicate<? super JavaConstructorCall> predicate) {
+    public static ArchCondition<JavaClass> callConstructorWhere(DescribedPredicate<? super JavaConstructorCall> predicate) {
         return new ClassAccessesCondition<>(predicate, GET_CONSTRUCTOR_CALLS_FROM_SELF)
                 .as("call constructor where " + predicate.getDescription());
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyCallConstructorsThat(final DescribedPredicate<? super JavaConstructor> predicate) {
+    public static ArchCondition<JavaClass> onlyCallConstructorsThat(DescribedPredicate<? super JavaConstructor> predicate) {
         ChainableFunction<JavaConstructorCall, ConstructorCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaConstructorCall> callPredicate = getTarget.then(ConstructorCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaConstructor>forSubtype()).or(optionalEmpty()));
@@ -269,7 +269,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyCallCodeUnitsThat(final DescribedPredicate<? super JavaCodeUnit> predicate) {
+    public static ArchCondition<JavaClass> onlyCallCodeUnitsThat(DescribedPredicate<? super JavaCodeUnit> predicate) {
         ChainableFunction<JavaCall<?>, CodeUnitCallTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaCall<?>> callPredicate = getTarget.then(CodeUnitCallTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaCodeUnit>forSubtype()).or(optionalEmpty()));
@@ -278,7 +278,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyAccessMembersThat(final DescribedPredicate<? super JavaMember> predicate) {
+    public static ArchCondition<JavaClass> onlyAccessMembersThat(DescribedPredicate<? super JavaMember> predicate) {
         ChainableFunction<JavaAccess<?>, AccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(AccessTarget.Functions.RESOLVE_MEMBER)
                 .is(optionalContains(predicate.<JavaMember>forSubtype()).or(optionalEmpty()));
@@ -292,7 +292,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> accessClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+    public static ArchCondition<JavaClass> accessClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         ChainableFunction<JavaAccess<?>, AccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(Get.owner()).is(predicate);
         return new ClassAccessesCondition<>(accessPredicate, GET_ACCESSES_FROM_SELF)
@@ -300,14 +300,14 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyAccessClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+    public static ArchCondition<JavaClass> onlyAccessClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         ChainableFunction<JavaAccess<?>, AccessTarget> getTarget = JavaAccess.Functions.Get.target();
         DescribedPredicate<JavaAccess<?>> accessPredicate = getTarget.then(Get.owner()).is(predicate);
         return new AllAccessesCondition("only access classes that", accessPredicate, GET_ACCESSES_FROM_SELF);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> dependOnClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+    public static ArchCondition<JavaClass> dependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         return new AnyDependencyCondition(
                 "depend on classes that " + predicate.getDescription(),
                 GET_TARGET_CLASS.is(predicate),
@@ -315,12 +315,12 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> transitivelyDependOnClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+    public static ArchCondition<JavaClass> transitivelyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         return new TransitiveDependencyCondition(predicate);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> onlyDependOnClassesThat(final DescribedPredicate<? super JavaClass> predicate) {
+    public static ArchCondition<JavaClass> onlyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         return new AllDependenciesCondition(
                 "only depend on classes that " + predicate.getDescription(),
                 GET_TARGET_CLASS.is(predicate),
@@ -452,36 +452,36 @@ public final class ArchConditions {
         return new ContainsOnlyCondition<>(condition);
     }
 
-    private static DescribedPredicate<? super JavaFieldAccess> ownerAndNameAre(String ownerName, final String fieldName) {
+    private static DescribedPredicate<? super JavaFieldAccess> ownerAndNameAre(String ownerName, String fieldName) {
         return JavaFieldAccess.Predicates.target(With.owner(name(ownerName)))
                 .and(JavaFieldAccess.Predicates.target(name(fieldName)))
                 .as(ownerName + "." + fieldName);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> be(final Class<?> clazz) {
+    public static ArchCondition<JavaClass> be(Class<?> clazz) {
         return be(clazz.getName());
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> notBe(final Class<?> clazz) {
+    public static ArchCondition<JavaClass> notBe(Class<?> clazz) {
         return not(be(clazz));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> be(final String className) {
+    public static ArchCondition<JavaClass> be(String className) {
         return be(fullyQualifiedName(className).as(className))
                 .describeEventsBy((__, satisfied) -> (satisfied ? "is " : "is not ") + className)
                 .forSubtype();
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> notBe(final String className) {
+    public static ArchCondition<JavaClass> notBe(String className) {
         return not(be(className));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveName(final String name) {
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveName(String name) {
         return have(name(name));
     }
 
@@ -503,7 +503,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveFullyQualifiedName(final String name) {
+    public static ArchCondition<JavaClass> haveFullyQualifiedName(String name) {
         return have(fullyQualifiedName(name));
     }
 
@@ -519,7 +519,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveSimpleName(final String name) {
+    public static ArchCondition<JavaClass> haveSimpleName(String name) {
         return have(simpleName(name));
     }
 
@@ -529,7 +529,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveSimpleNameStartingWith(final String prefix) {
+    public static ArchCondition<JavaClass> haveSimpleNameStartingWith(String prefix) {
         return have(simpleNameStartingWith(prefix));
     }
 
@@ -539,17 +539,17 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveSimpleNameContaining(final String infix) {
+    public static ArchCondition<JavaClass> haveSimpleNameContaining(String infix) {
         return have(simpleNameContaining(infix));
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveSimpleNameNotContaining(final String infix) {
+    public static ArchCondition<JavaClass> haveSimpleNameNotContaining(String infix) {
         return not(haveSimpleNameContaining(infix)).as("have simple name not containing '%s'", infix);
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> haveSimpleNameEndingWith(final String suffix) {
+    public static ArchCondition<JavaClass> haveSimpleNameEndingWith(String suffix) {
         return have(simpleNameEndingWith(suffix));
     }
 
@@ -559,7 +559,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameMatching(final String regex) {
+    public static <HAS_NAME extends HasName & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_NAME> haveNameMatching(String regex) {
         return have(nameMatching(regex));
     }
 
@@ -611,7 +611,7 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> resideInAPackage(final String packageIdentifier) {
+    public static ArchCondition<JavaClass> resideInAPackage(String packageIdentifier) {
         return does(JavaClass.Predicates.resideInAPackage(packageIdentifier));
     }
 
@@ -632,13 +632,13 @@ public final class ArchConditions {
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_MODIFIERS extends HasModifiers & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_MODIFIERS> haveModifier(
-            final JavaModifier modifier) {
+            JavaModifier modifier) {
         return have(modifier(modifier));
     }
 
     @PublicAPI(usage = ACCESS)
     public static <HAS_MODIFIERS extends HasModifiers & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_MODIFIERS> notHaveModifier(
-            final JavaModifier modifier) {
+            JavaModifier modifier) {
         return not(ArchConditions.haveModifier(modifier));
     }
 
@@ -756,7 +756,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beAnnotatedWith(
-            final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+            DescribedPredicate<? super JavaAnnotation<?>> predicate) {
         return be(annotatedWith(predicate));
     }
 
@@ -810,7 +810,7 @@ public final class ArchConditions {
      */
     @PublicAPI(usage = ACCESS)
     public static <HAS_ANNOTATIONS extends HasAnnotations<?> & HasDescription & HasSourceCodeLocation> ArchCondition<HAS_ANNOTATIONS> beMetaAnnotatedWith(
-            final DescribedPredicate<? super JavaAnnotation<?>> predicate) {
+            DescribedPredicate<? super JavaAnnotation<?>> predicate) {
         return be(metaAnnotatedWith(predicate));
     }
 
@@ -1337,7 +1337,7 @@ public final class ArchConditions {
 
         private final Function<JavaClass, ? extends Collection<T>> getHasModifiers;
 
-        HaveOnlyModifiersCondition(String description, final JavaModifier modifier, Function<JavaClass, ? extends Collection<T>> getHasModifiers) {
+        HaveOnlyModifiersCondition(String description, JavaModifier modifier, Function<JavaClass, ? extends Collection<T>> getHasModifiers) {
             super("have only " + description, be(modifier(modifier).as(modifier.toString().toLowerCase())));
             this.getHasModifiers = getHasModifiers;
         }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JavaAccessPackagePredicate.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JavaAccessPackagePredicate.java
@@ -53,7 +53,7 @@ class JavaAccessPackagePredicate extends DescribedPredicate<JavaAccess<?>> {
             this.getPackageName = getPackageName;
         }
 
-        JavaAccessPackagePredicate matching(final String... packageIdentifiers) {
+        JavaAccessPackagePredicate matching(String... packageIdentifiers) {
             return new JavaAccessPackagePredicate(packageIdentifiers, getPackageName);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JoinCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/JoinCondition.java
@@ -107,7 +107,7 @@ abstract class JoinCondition<T> extends ArchCondition<T> {
         }
 
         List<String> getUniqueLinesOfViolations() {
-            final Set<String> result = new TreeSet<>();
+            Set<String> result = new TreeSet<>();
             for (ConditionWithEvents<T> evaluation : evaluatedConditions) {
                 for (ConditionEvent event : evaluation.events.getViolating()) {
                     result.addAll(event.getDescriptionLines());

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/OrCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/OrCondition.java
@@ -61,7 +61,7 @@ class OrCondition<T> extends JoinCondition<T> {
         }
 
         @Override
-        public void handleWith(final Handler handler) {
+        public void handleWith(Handler handler) {
             handler.handle(singleton(correspondingObject), createMessage());
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ArchRuleDefinition.java
@@ -262,28 +262,28 @@ public final class ArchRuleDefinition {
         }
 
         @PublicAPI(usage = ACCESS)
-        public GivenClass theClass(final Class<?> clazz) {
+        public GivenClass theClass(Class<?> clazz) {
             return theClass(clazz.getName());
         }
 
         @PublicAPI(usage = ACCESS)
-        public GivenClass theClass(final String className) {
+        public GivenClass theClass(String className) {
             ClassesTransformer<JavaClass> theClass = theClassTransformer(className);
             return new GivenClassInternal(priority, theClass, Function.identity());
         }
 
         @PublicAPI(usage = ACCESS)
-        public GivenClass noClass(final Class<?> clazz) {
+        public GivenClass noClass(Class<?> clazz) {
             return noClass(clazz.getName());
         }
 
         @PublicAPI(usage = ACCESS)
-        public GivenClass noClass(final String className) {
+        public GivenClass noClass(String className) {
             ClassesTransformer<JavaClass> noClass = theClassTransformer(className).as("no class " + className);
             return new GivenClassInternal(priority, noClass, ArchRuleDefinition.negateCondition());
         }
 
-        private ClassesTransformer<JavaClass> theClassTransformer(final String className) {
+        private ClassesTransformer<JavaClass> theClassTransformer(String className) {
             return new AbstractClassesTransformer<JavaClass>("the class " + className) {
                 @Override
                 public Iterable<JavaClass> doTransform(JavaClasses classes) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesShouldInternal.java
@@ -65,12 +65,12 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
-    public ClassesShouldConjunction be(final Class<?> clazz) {
+    public ClassesShouldConjunction be(Class<?> clazz) {
         return addCondition(ArchConditions.be(clazz));
     }
 
     @Override
-    public ClassesShouldConjunction notBe(final Class<?> clazz) {
+    public ClassesShouldConjunction notBe(Class<?> clazz) {
         return addCondition(ArchConditions.notBe(clazz));
     }
 
@@ -85,7 +85,7 @@ class ClassesShouldInternal extends ObjectsShouldInternal<JavaClass>
     }
 
     @Override
-    public ClassesShouldConjunction haveFullyQualifiedName(final String name) {
+    public ClassesShouldConjunction haveFullyQualifiedName(String name) {
         return addCondition(ArchConditions.haveFullyQualifiedName(name));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -443,7 +443,7 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
     }
 
     @Override
-    public CONJUNCTION belongToAnyOf(final Class<?>... classes) {
+    public CONJUNCTION belongToAnyOf(Class<?>... classes) {
         return givenWith(JavaClass.Predicates.belongToAnyOf(classes));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ObjectsShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ObjectsShouldInternal.java
@@ -153,7 +153,7 @@ class ObjectsShouldInternal<T> implements ArchRule {
             return and(Function.identity());
         }
 
-        static <T> AddMode<T> and(final Function<ArchCondition<T>, ArchCondition<T>> prepareCondition) {
+        static <T> AddMode<T> and(Function<ArchCondition<T>, ArchCondition<T>> prepareCondition) {
             return new AddMode<T>() {
                 @Override
                 ArchCondition<T> apply(Optional<ArchCondition<T>> first, ArchCondition<? super T> other) {
@@ -163,7 +163,7 @@ class ObjectsShouldInternal<T> implements ArchRule {
             };
         }
 
-        static <T> AddMode<T> or(final Function<ArchCondition<T>, ArchCondition<T>> prepareCondition) {
+        static <T> AddMode<T> or(Function<ArchCondition<T>, ArchCondition<T>> prepareCondition) {
             return new AddMode<T>() {
                 @Override
                 ArchCondition<T> apply(Optional<ArchCondition<T>> first, ArchCondition<? super T> other) {
@@ -176,7 +176,7 @@ class ObjectsShouldInternal<T> implements ArchRule {
         abstract ArchCondition<T> apply(Optional<ArchCondition<T>> first, ArchCondition<? super T> other);
     }
 
-    static <T> Function<ArchCondition<T>, ArchCondition<T>> prependDescription(final String prefix) {
+    static <T> Function<ArchCondition<T>, ArchCondition<T>> prependDescription(String prefix) {
         return input -> input.as(prefix + " " + input.getDescription());
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -435,7 +435,7 @@ public final class Architectures {
         }
 
         private abstract static class AllClassesAreContainedInArchitectureCheck {
-            abstract Optional<EvaluationResult> evaluate(final JavaClasses classes, final LayerDefinitions layerDefinitions);
+            abstract Optional<EvaluationResult> evaluate(JavaClasses classes, LayerDefinitions layerDefinitions);
 
             static class Enabled extends AllClassesAreContainedInArchitectureCheck {
                 private final DescribedPredicate<? super JavaClass> ignorePredicate;
@@ -444,7 +444,7 @@ public final class Architectures {
                     this.ignorePredicate = ignorePredicate;
                 }
 
-                Optional<EvaluationResult> evaluate(final JavaClasses classes, final LayerDefinitions layerDefinitions) {
+                Optional<EvaluationResult> evaluate(JavaClasses classes, LayerDefinitions layerDefinitions) {
                     return Optional.of(classes().should(beContainedInLayers(layerDefinitions)).evaluate(classes));
                 }
 
@@ -469,7 +469,7 @@ public final class Architectures {
             }
         }
 
-        private static ArchCondition<JavaClass> notBeEmptyFor(final LayeredArchitecture.LayerDefinition layerDefinition) {
+        private static ArchCondition<JavaClass> notBeEmptyFor(LayeredArchitecture.LayerDefinition layerDefinition) {
             return new LayerShouldNotBeEmptyCondition(layerDefinition);
         }
 
@@ -477,7 +477,7 @@ public final class Architectures {
             private final LayeredArchitecture.LayerDefinition layerDefinition;
             private boolean empty = true;
 
-            LayerShouldNotBeEmptyCondition(final LayeredArchitecture.LayerDefinition layerDefinition) {
+            LayerShouldNotBeEmptyCondition(LayeredArchitecture.LayerDefinition layerDefinition) {
                 super("not be empty");
                 this.layerDefinition = layerDefinition;
             }
@@ -514,7 +514,7 @@ public final class Architectures {
                 return containsPredicateFor(layerDefinitions.keySet());
             }
 
-            DescribedPredicate<JavaClass> containsPredicateFor(final Collection<String> layerNames) {
+            DescribedPredicate<JavaClass> containsPredicateFor(Collection<String> layerNames) {
                 DescribedPredicate<JavaClass> result = alwaysFalse();
                 for (LayerDefinition definition : get(layerNames)) {
                     result = result.or(definition.containsPredicate());
@@ -705,7 +705,7 @@ public final class Architectures {
              * @return {@link DependencySettings dependency settings} to be used when checking for violations of the layered architecture
              */
             @PublicAPI(usage = ACCESS)
-            public LayeredArchitecture consideringOnlyDependenciesInAnyPackage(String packageIdentifier, final String... furtherPackageIdentifiers) {
+            public LayeredArchitecture consideringOnlyDependenciesInAnyPackage(String packageIdentifier, String... furtherPackageIdentifiers) {
                 String[] packageIdentifiers = Stream.concat(Stream.of(packageIdentifier), Stream.of(furtherPackageIdentifiers)).toArray(String[]::new);
                 return new LayeredArchitecture(setToConsideringOnlyDependenciesInAnyPackage(packageIdentifiers));
             }

--- a/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/DependencyRules.java
@@ -123,7 +123,7 @@ public final class DependencyRules {
         }
 
         @Override
-        public void check(final JavaClass clazz, final ConditionEvents events) {
+        public void check(JavaClass clazz, ConditionEvents events) {
             for (Dependency dependency : clazz.getDirectDependenciesFromSelf()) {
                 boolean dependencyOnUpperPackage = isDependencyOnUpperPackage(dependency.getOriginClass(), dependency.getTargetClass());
                 events.add(new SimpleConditionEvent(dependency, dependencyOnUpperPackage, dependency.getDescription()));

--- a/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/ProxyRules.java
@@ -162,7 +162,7 @@ public final class ProxyRules {
      * </p>
      */
     @PublicAPI(usage = ACCESS)
-    public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that(final DescribedPredicate<? super MethodCallTarget> predicate) {
+    public static ArchCondition<JavaClass> directly_call_other_methods_declared_in_the_same_class_that(DescribedPredicate<? super MethodCallTarget> predicate) {
         return new ArchCondition<JavaClass>("directly call other methods declared in the same class that " + predicate.getDescription()) {
             @Override
             public void check(JavaClass javaClass, ConditionEvents events) {

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Cycle.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Cycle.java
@@ -70,7 +70,7 @@ class Cycle<T, ATTACHMENT> {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Cycle<?, ?> other = (Cycle<?, ?>) obj;
+        Cycle<?, ?> other = (Cycle<?, ?>) obj;
         return Objects.equals(this.path.getSetOfEdges(), other.path.getSetOfEdges());
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Edge.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Edge.java
@@ -59,7 +59,7 @@ final class Edge<T, ATTACHMENT> {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Edge<?, ?> other = (Edge<?, ?>) obj;
+        Edge<?, ?> other = (Edge<?, ?>) obj;
         return Objects.equals(this.from, other.from)
                 && Objects.equals(this.to, other.to);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Path.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Path.java
@@ -111,7 +111,7 @@ class Path<T, ATTACHMENT> {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Path<?, ?> other = (Path<?, ?>) obj;
+        Path<?, ?> other = (Path<?, ?>) obj;
         return Objects.equals(this.edges, other.edges);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slice.java
@@ -169,7 +169,7 @@ public final class Slice extends ForwardingSet<JavaClass> implements HasDescript
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Slice other = (Slice) obj;
+        Slice other = (Slice) obj;
         return Objects.equals(this.matchingGroups, other.matchingGroups);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceDependency.java
@@ -46,7 +46,7 @@ public final class SliceDependency implements HasDescription {
         this.target = target;
     }
 
-    private SortedSet<Dependency> filterTarget(Iterable<Dependency> dependenciesToConsider, final Slice target) {
+    private SortedSet<Dependency> filterTarget(Iterable<Dependency> dependenciesToConsider, Slice target) {
         return stream(dependenciesToConsider.spliterator(), false)
                 .filter(input -> target.contains(input.getTargetClass()))
                 .collect(toCollection(TreeSet::new));
@@ -92,7 +92,7 @@ public final class SliceDependency implements HasDescription {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final SliceDependency other = (SliceDependency) obj;
+        SliceDependency other = (SliceDependency) obj;
         return Objects.equals(this.origin, other.origin)
                 && Objects.equals(this.target, other.target);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceIdentifier.java
@@ -60,7 +60,7 @@ public final class SliceIdentifier {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final SliceIdentifier other = (SliceIdentifier) obj;
+        SliceIdentifier other = (SliceIdentifier) obj;
         return Objects.equals(this.parts, other.parts);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/Slices.java
@@ -242,7 +242,7 @@ public final class Slices implements DescribedIterable<Slice>, CanOverrideDescri
         }
 
         @Override
-        public Slices.Transformer that(final DescribedPredicate<? super Slice> predicate) {
+        public Slices.Transformer that(DescribedPredicate<? super Slice> predicate) {
             String newDescription = this.predicate.joinDescription(getDescription(), predicate.getDescription());
             return new Transformer(sliceAssignment, newDescription, namingPattern, this.predicate.add(predicate));
         }

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
@@ -141,7 +141,7 @@ public final class FreezingArchRule implements ArchRule {
 
     private EvaluationResult removeObsoleteViolationsFromStoreAndReturnNewViolations(EvaluationResultLineBreakAdapter result) {
         log.debug("Found frozen result for rule '{}'", delegate.getDescription());
-        final List<String> knownViolations = store.getViolations(delegate);
+        List<String> knownViolations = store.getViolations(delegate);
         CategorizedViolations categorizedViolations = new CategorizedViolations(matcher, result, knownViolations);
         removeObsoleteViolationsFromStore(categorizedViolations);
         return filterOutKnownViolations(result, categorizedViolations.getKnownActualViolations());
@@ -155,7 +155,7 @@ public final class FreezingArchRule implements ArchRule {
         }
     }
 
-    private EvaluationResult filterOutKnownViolations(EvaluationResultLineBreakAdapter result, final Set<String> knownActualViolations) {
+    private EvaluationResult filterOutKnownViolations(EvaluationResultLineBreakAdapter result, Set<String> knownActualViolations) {
         log.debug("Filtering out known violations: {}", knownActualViolations);
         return result.filterDescriptionsMatching(violation -> !knownActualViolations.contains(violation));
     }
@@ -293,7 +293,7 @@ public final class FreezingArchRule implements ArchRule {
             return result.getPriority();
         }
 
-        EvaluationResult filterDescriptionsMatching(final Predicate<String> predicate) {
+        EvaluationResult filterDescriptionsMatching(Predicate<String> predicate) {
             return result.filterDescriptionsMatching(input -> predicate.test(ensureUnixLineBreaks(input)));
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactory.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationLineMatcherFactory.java
@@ -97,7 +97,7 @@ class ViolationLineMatcherFactory {
             }
 
             private int findStartIndexOfNextRelevantPart() {
-                final int startOfIgnoredPart = end + 1;
+                int startOfIgnoredPart = end + 1;
                 int indexOfNonDigit = findIndexOfNextNonDigitChar(startOfIgnoredPart);
                 if (str.charAt(end) == ':') {
                     boolean foundNumber = indexOfNonDigit > startOfIgnoredPart;

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Alias.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Alias.java
@@ -46,7 +46,7 @@ class Alias {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Alias other = (Alias) obj;
+        Alias other = (Alias) obj;
         return Objects.equals(this.value, other.value);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIdentifier.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentIdentifier.java
@@ -52,7 +52,7 @@ class ComponentIdentifier {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ComponentIdentifier other = (ComponentIdentifier) obj;
+        ComponentIdentifier other = (ComponentIdentifier) obj;
         return Objects.equals(this.componentName, other.componentName)
                 && Objects.equals(this.alias, other.alias);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ComponentName.java
@@ -43,7 +43,7 @@ class ComponentName {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ComponentName other = (ComponentName) obj;
+        ComponentName other = (ComponentName) obj;
         return Objects.equals(this.value, other.value);
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociation.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/JavaClassDiagramAssociation.java
@@ -48,7 +48,7 @@ class JavaClassDiagramAssociation {
         }
     }
 
-    Set<String> getTargetPackageIdentifiers(final JavaClass javaClass) {
+    Set<String> getTargetPackageIdentifiers(JavaClass javaClass) {
         ImmutableSet.Builder<String> result = ImmutableSet.builder();
         for (PlantUmlComponent target : getComponentOf(javaClass).getDependencies()) {
             result.addAll(getPackageIdentifiersFromComponentOf(target));
@@ -68,7 +68,7 @@ class JavaClassDiagramAssociation {
         return result.build();
     }
 
-    private PlantUmlComponent getComponentOf(final JavaClass javaClass) {
+    private PlantUmlComponent getComponentOf(JavaClass javaClass) {
         return getOnlyElement(getAssociatedComponents(javaClass));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ParsedDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/ParsedDependency.java
@@ -47,7 +47,7 @@ class ParsedDependency {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final ParsedDependency other = (ParsedDependency) obj;
+        ParsedDependency other = (ParsedDependency) obj;
         return Objects.equals(this.origin, other.origin)
                 && Objects.equals(this.target, other.target);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
@@ -135,12 +135,12 @@ public final class PlantUmlArchCondition extends ArchCondition<JavaClass> {
     }
 
     @PublicAPI(usage = ACCESS)
-    public PlantUmlArchCondition ignoreDependencies(final Class<?> origin, final Class<?> target) {
+    public PlantUmlArchCondition ignoreDependencies(Class<?> origin, Class<?> target) {
         return ignoreDependencies(origin.getName(), target.getName());
     }
 
     @PublicAPI(usage = ACCESS)
-    public PlantUmlArchCondition ignoreDependencies(final String origin, final String target) {
+    public PlantUmlArchCondition ignoreDependencies(String origin, String target) {
         return ignoreDependencies(
                 GET_ORIGIN_CLASS.is(name(origin)).and(GET_TARGET_CLASS.is(name(target)))
                         .as("ignoring dependencies from %s to %s", origin, target));
@@ -307,8 +307,8 @@ public final class PlantUmlArchCondition extends ArchCondition<JavaClass> {
          * e.g. '<code>com.myapp..</code>'.
          */
         @PublicAPI(usage = ACCESS)
-        public static Configuration consideringOnlyDependenciesInAnyPackage(String packageIdentifier, final String... furtherPackageIdentifiers) {
-            final List<String> packageIdentifiers = FluentIterable.from(singleton(packageIdentifier))
+        public static Configuration consideringOnlyDependenciesInAnyPackage(String packageIdentifier, String... furtherPackageIdentifiers) {
+            List<String> packageIdentifiers = FluentIterable.from(singleton(packageIdentifier))
                     .append(furtherPackageIdentifiers)
                     .toList();
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
@@ -79,7 +79,7 @@ class PlantUmlComponent {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final PlantUmlComponent other = (PlantUmlComponent) obj;
+        PlantUmlComponent other = (PlantUmlComponent) obj;
         return Objects.equals(this.componentName, other.componentName)
                 && Objects.equals(this.stereotypes, other.stereotypes)
                 && Objects.equals(this.alias, other.alias);

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponentDependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponentDependency.java
@@ -45,7 +45,7 @@ class PlantUmlComponentDependency {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final PlantUmlComponentDependency other = (PlantUmlComponentDependency) obj;
+        PlantUmlComponentDependency other = (PlantUmlComponentDependency) obj;
         return Objects.equals(this.origin, other.origin)
                 && Objects.equals(this.target, other.target);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
@@ -73,7 +73,7 @@ class PlantUmlPatterns {
         return new PlantUmlComponentMatcher(input);
     }
 
-    private Predicate<String> matches(final Pattern pattern) {
+    private Predicate<String> matches(Pattern pattern) {
         return input -> pattern.matcher(input).matches();
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Stereotype.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/Stereotype.java
@@ -43,7 +43,7 @@ class Stereotype {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final Stereotype other = (Stereotype) obj;
+        Stereotype other = (Stereotype) obj;
         return Objects.equals(this.value, other.value);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/base/ChainableFunctionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/ChainableFunctionTest.java
@@ -26,7 +26,7 @@ public class ChainableFunctionTest {
                 .accepts("8");
     }
 
-    private DescribedPredicate<Integer> greaterThan(final int number) {
+    private DescribedPredicate<Integer> greaterThan(int number) {
         return new DescribedPredicate<Integer>("greater than " + number) {
             @Override
             public boolean test(Integer input) {
@@ -44,7 +44,7 @@ public class ChainableFunctionTest {
         };
     }
 
-    private ChainableFunction<Integer, Integer> plus(final int number) {
+    private ChainableFunction<Integer, Integer> plus(int number) {
         return new ChainableFunction<Integer, Integer>() {
             @Override
             public Integer apply(Integer input) {

--- a/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/base/DescribedPredicateTest.java
@@ -273,7 +273,7 @@ public class DescribedPredicateTest {
                 .accepts(ImmutableList.of());
     }
 
-    private Function<Object, Integer> constant(final int integer) {
+    private Function<Object, Integer> constant(int integer) {
         return input -> integer;
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/AnnotationProxyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/AnnotationProxyTest.java
@@ -294,7 +294,7 @@ public class AnnotationProxyTest {
     }
 
     // NOTE: We do not want this value to be treated as a string by the formatter, and e.g. quoted -> Object
-    private Object subAnnotationFormatter(final AnnotationPropertiesFormatter formatter, final String value) {
+    private Object subAnnotationFormatter(AnnotationPropertiesFormatter formatter, String value) {
         return new Object() {
             @Override
             public String toString() {
@@ -396,7 +396,7 @@ public class AnnotationProxyTest {
         return stream(subAnnotations).map(SubAnnotation::value).collect(toList());
     }
 
-    private Condition<String> matching(final Class<?> annotationType, final Map<String, String> properties) {
+    private Condition<String> matching(Class<?> annotationType, Map<String, String> properties) {
         return new Condition<String>("matching " + properties) {
             @Override
             public boolean matches(String value) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -142,7 +142,7 @@ public class JavaClassTest {
         }
 
         JavaMethod method = importClassWithContext(IsArrayTestClass.class).getMethod("notAnArray");
-        final JavaClass nonArrayType = method.getRawReturnType();
+        JavaClass nonArrayType = method.getRawReturnType();
 
         assertThat(nonArrayType.isArray()).isFalse();
         assertThat(nonArrayType.tryGetComponentType()).isEmpty();
@@ -428,7 +428,7 @@ public class JavaClassTest {
 
     @Test
     public void getCodeUnitWithParameterTypes() {
-        final JavaClass clazz = importClasses(ChildWithFieldAndMethod.class).get(ChildWithFieldAndMethod.class);
+        JavaClass clazz = importClasses(ChildWithFieldAndMethod.class).get(ChildWithFieldAndMethod.class);
 
         assertIllegalArgumentException("childMethod", () -> clazz.getCodeUnitWithParameterTypes("childMethod"));
         assertIllegalArgumentException("childMethod", () -> clazz.getCodeUnitWithParameterTypes("childMethod", Object.class));
@@ -446,7 +446,7 @@ public class JavaClassTest {
 
     @Test
     public void tryGetCodeUnitWithParameterTypes() {
-        final JavaClass clazz = importClasses(ChildWithFieldAndMethod.class).get(ChildWithFieldAndMethod.class);
+        JavaClass clazz = importClasses(ChildWithFieldAndMethod.class).get(ChildWithFieldAndMethod.class);
 
         assertThatCodeUnit(clazz.tryGetCodeUnitWithParameterTypes("childMethod", Collections.singletonList(String.class)).get())
                 .matchesMethod(ChildWithFieldAndMethod.class, "childMethod", String.class);
@@ -1976,7 +1976,7 @@ public class JavaClassTest {
         return members.stream().filter(it -> !it.getOwner().isEquivalentTo(Object.class)).collect(toSet());
     }
 
-    private JavaClass getOnlyClassSettingField(JavaClasses classes, final String fieldName) {
+    private JavaClass getOnlyClassSettingField(JavaClasses classes, String fieldName) {
         return getOnlyElement(classes.that(new DescribedPredicate<JavaClass>("") {
             @Override
             public boolean test(JavaClass input) {
@@ -2053,7 +2053,7 @@ public class JavaClassTest {
             };
         }
 
-        Condition<Dependency> toClassEquivalentTo(final Class<?> clazz) {
+        Condition<Dependency> toClassEquivalentTo(Class<?> clazz) {
             return new Condition<Dependency>("any dependency to class " + clazz.getName()) {
                 @Override
                 public boolean matches(Dependency value) {
@@ -2062,7 +2062,7 @@ public class JavaClassTest {
             };
         }
 
-        Condition<Dependency> fromClassEquivalentTo(final Class<?> clazz) {
+        Condition<Dependency> fromClassEquivalentTo(Class<?> clazz) {
             return new Condition<Dependency>("any dependency from class " + clazz.getName()) {
                 @Override
                 public boolean matches(Dependency value) {
@@ -2114,7 +2114,7 @@ public class JavaClassTest {
                     targetDescription = target.getSimpleName() + "." + targetName;
                 }
 
-                Condition<Dependency> inLineNumber(final int lineNumber) {
+                Condition<Dependency> inLineNumber(int lineNumber) {
                     return new Condition<Dependency>(String.format(
                             "%s %s %s in line %d", originDescription, descriptionPart, targetDescription, lineNumber)) {
                         @Override
@@ -2163,7 +2163,7 @@ public class JavaClassTest {
         private Set<DescribedPredicate<JavaClass>> assignable = new HashSet<>();
         private Class<?> firstType;
 
-        public FromEvaluation from(final Class<?> type) {
+        public FromEvaluation from(Class<?> type) {
             firstType = type;
             message = String.format("assignableFrom(%s) matches ", type.getSimpleName());
             assignable = ImmutableSet.of(new DescribedPredicate<JavaClass>("direct assignable from") {
@@ -2175,7 +2175,7 @@ public class JavaClassTest {
             return new FromEvaluation();
         }
 
-        public ToEvaluation to(final Class<?> type) {
+        public ToEvaluation to(Class<?> type) {
             firstType = type;
             message = String.format("assignableTo(%s) matches ", type.getSimpleName());
             assignable = ImmutableSet.of(new DescribedPredicate<JavaClass>("direct assignable to") {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassesTest.java
@@ -112,7 +112,7 @@ public class JavaClassesTest {
                 .hasMessage("JavaClasses do not contain JavaClass of type %s", String.class.getName());
     }
 
-    private DescribedPredicate<JavaClass> haveTheNameOf(final Class<?> clazz) {
+    private DescribedPredicate<JavaClass> haveTheNameOf(Class<?> clazz) {
         return new DescribedPredicate<JavaClass>("have the name " + clazz.getSimpleName()) {
             @Override
             public boolean test(JavaClass input) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
@@ -116,7 +116,7 @@ public class JavaCodeUnitTest {
 
     @Test
     public void falls_back_to_creating_parameters_with_only_generic_types_if_match_between_raw_types_and_generic_types_cannot_be_made() {
-        final List<String> nonConstant = newArrayList(getClass().getName());
+        List<String> nonConstant = newArrayList(getClass().getName());
         class LocalClassReferencingNonConstantFromOuterScope {
             @SuppressWarnings("unused")
             LocalClassReferencingNonConstantFromOuterScope(List<String> someParameterizedType) {
@@ -262,7 +262,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        final JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         SomeParameterAnnotation annotation = parameter.getAnnotationOfType(SomeParameterAnnotation.class);
@@ -284,7 +284,7 @@ public class JavaCodeUnitTest {
             }
         }
 
-        final JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
+        JavaParameter parameter = new ClassFileImporter().importClass(SomeClass.class)
                 .getMethod("method", String.class).getParameters().get(0);
 
         assertThat(parameter.tryGetAnnotationOfType(SomeParameterAnnotation.class).get()).isInstanceOf(SomeParameterAnnotation.class);

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -239,7 +239,7 @@ public class JavaPackageTest {
     public void visits_classes() {
         JavaPackage defaultPackage = importDefaultPackage(Object.class, String.class, File.class, Serializable.class, Security.class);
 
-        final List<JavaClass> visitedClasses = new ArrayList<>();
+        List<JavaClass> visitedClasses = new ArrayList<>();
         defaultPackage.traversePackageTree(startsWith("S"), visitedClasses::add);
 
         assertThatTypes(visitedClasses).contain(String.class, Serializable.class, Security.class);
@@ -252,7 +252,7 @@ public class JavaPackageTest {
     public void visits_packages() {
         JavaPackage defaultPackage = importDefaultPackage(Object.class, Annotation.class, File.class, Security.class);
 
-        final List<JavaPackage> visitedPackages = new ArrayList<>();
+        List<JavaPackage> visitedPackages = new ArrayList<>();
         defaultPackage.traversePackageTree(nameContains(".lang"), visitedPackages::add);
 
         assertThatPackages(visitedPackages).containPackagesOf(Object.class, Annotation.class);
@@ -420,7 +420,7 @@ public class JavaPackageTest {
     @Test
     public void test_getPackageInfo() {
         JavaPackage annotatedPackage = importPackage("packageexamples.annotated");
-        final JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
+        JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
 
         assertThat(annotatedPackage.getPackageInfo()).isNotNull();
 
@@ -452,8 +452,8 @@ public class JavaPackageTest {
 
     @Test
     public void test_getAnnotationOfType_type() {
-        final JavaPackage annotatedPackage = importPackage("packageexamples.annotated");
-        final JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
+        JavaPackage annotatedPackage = importPackage("packageexamples.annotated");
+        JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
 
         assertThat(annotatedPackage.getAnnotationOfType(PackageLevelAnnotation.class)).isInstanceOf(PackageLevelAnnotation.class);
 
@@ -466,8 +466,8 @@ public class JavaPackageTest {
 
     @Test
     public void test_getAnnotationOfType_typeName() {
-        final JavaPackage annotatedPackage = importPackage("packageexamples.annotated");
-        final JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
+        JavaPackage annotatedPackage = importPackage("packageexamples.annotated");
+        JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
 
         assertThatType(annotatedPackage.getAnnotationOfType(PackageLevelAnnotation.class.getName())
                 .getRawType()).matches(PackageLevelAnnotation.class);
@@ -577,7 +577,7 @@ public class JavaPackageTest {
         return HasName.Predicates.nameMatching(".*" + quote(infix) + ".*");
     }
 
-    private DescribedPredicate<JavaClass> startsWith(final String prefix) {
+    private DescribedPredicate<JavaClass> startsWith(String prefix) {
         return GET_SIMPLE_NAME.is(new DescribedPredicate<String>("starts with '%s'", prefix) {
             @Override
             public boolean test(String input) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -85,7 +85,7 @@ public class TestUtils {
 
     public static JavaClasses importClassesWithContext(Class<?>... classes) {
         JavaClasses importedHierarchy = importHierarchies(classes);
-        final List<String> classNames = formatNamesOf(classes);
+        List<String> classNames = formatNamesOf(classes);
         return importedHierarchy.that(new DescribedPredicate<JavaClass>("") {
             @Override
             public boolean test(JavaClass input) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -166,7 +166,7 @@ public class TestUtils {
             ImportContext context = mock(ImportContext.class);
             Set<JavaMethodCall> calls = targets.stream().map(target -> newMethodCall(method, target, lineNumber)).collect(toSet());
             when(context.createMethodCallsFor(eq(method), anySet())).thenReturn(ImmutableSet.copyOf(calls));
-            method.completeAccessesFrom(context);
+            method.completeFrom(context);
             return getCallToTarget(methodCallTarget);
         }
 
@@ -190,7 +190,7 @@ public class TestUtils {
                     .thenReturn(ImmutableSet.of(
                             newFieldAccess(method, target, lineNumber, accessType)
                     ));
-            method.completeAccessesFrom(context);
+            method.completeFrom(context);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasModifiersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasModifiersTest.java
@@ -16,7 +16,7 @@ public class HasModifiersTest {
                 .hasDescription("modifier PRIVATE");
     }
 
-    private static HasModifiers hasModifiers(final JavaModifier... modifiers) {
+    private static HasModifiers hasModifiers(JavaModifier... modifiers) {
         return () -> ImmutableSet.copyOf(modifiers);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasNameTest.java
@@ -74,11 +74,11 @@ public class HasNameTest {
                 .as(input + " =~ " + regex);
     }
 
-    private HasName newHasName(final String name) {
+    private HasName newHasName(String name) {
         return newHasNameAndFullName(name, "full " + name);
     }
 
-    private HasName.AndFullName newHasNameAndFullName(final String name, final String fullName) {
+    private HasName.AndFullName newHasNameAndFullName(String name, String fullName) {
         return new HasName.AndFullName() {
             @Override
             public String getName() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasOwnerTest.java
@@ -25,7 +25,7 @@ public class HasOwnerTest {
         assertThat(Get.<String>owner().apply(hasOwner)).isEqualTo("owner");
     }
 
-    private DescribedPredicate<String> startsWith(final String prefix) {
+    private DescribedPredicate<String> startsWith(String prefix) {
         return new DescribedPredicate<String>("starts with " + prefix) {
             @Override
             public boolean test(String input) {
@@ -34,7 +34,7 @@ public class HasOwnerTest {
         };
     }
 
-    private <T> HasOwner<T> hasOwner(final T owner) {
+    private <T> HasOwner<T> hasOwner(T owner) {
         return () -> owner;
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasParameterTypesTest.java
@@ -50,7 +50,7 @@ public class HasParameterTypesTest {
                 .hasDescription("raw parameter types some text");
     }
 
-    private HasParameterTypes newHasParameterTypes(final Class<?>... parameters) {
+    private HasParameterTypes newHasParameterTypes(Class<?>... parameters) {
         return new HasParameterTypes() {
 
             @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasReturnTypeTest.java
@@ -70,11 +70,11 @@ public class HasReturnTypeTest {
                 .as("result of GET_RAW_RETURN_TYPE").isEqualTo(expectedType);
     }
 
-    private HasReturnType newHasReturnType(final JavaClass rawReturnType) {
+    private HasReturnType newHasReturnType(JavaClass rawReturnType) {
         return newHasReturnType(rawReturnType, rawReturnType);
     }
 
-    private HasReturnType newHasReturnType(final JavaType genericReturnType, final JavaClass rawReturnType) {
+    private HasReturnType newHasReturnType(JavaType genericReturnType, JavaClass rawReturnType) {
         return new HasReturnType() {
 
             @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasThrowsClauseTest.java
@@ -74,7 +74,7 @@ public class HasThrowsClauseTest {
     }
 
     @SafeVarargs
-    private final HasThrowsClause<?> newHasThrowsClause(final Class<? extends Throwable>... throwsDeclarations) {
+    private final HasThrowsClause<?> newHasThrowsClause(Class<? extends Throwable>... throwsDeclarations) {
         return new HasThrowsClause() {
             @Override
             public ThrowsClause<?> getThrowsClause() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/properties/HasTypeTest.java
@@ -50,7 +50,7 @@ public class HasTypeTest {
         assertThatType(GET_RAW_TYPE.apply(newHasType(String.class))).matches(String.class);
     }
 
-    private HasType newHasType(final Class<?> owner) {
+    private HasType newHasType(Class<?> owner) {
         return new HasType() {
 
             @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
@@ -830,7 +830,7 @@ public class ClassFileImporterAccessesTest {
         // we test that the second recorded block is not cleared out by accident when the first block is closed
         @SuppressWarnings({"unused", "ConstantConditions", "TryFinallyCanBeTryWithResources", "UnnecessaryReturnStatement"})
         class SomeClass {
-            private void method(final int first, final boolean second) {
+            private void method(int first, boolean second) {
                 try {
                     Socket client = new Socket("", 0);
                     BufferedReader reader = new BufferedReader(null);
@@ -1291,7 +1291,7 @@ public class ClassFileImporterAccessesTest {
         return getOnlyElement(getByCaller(calls, caller));
     }
 
-    private <T extends JavaAccess<?>> Set<T> getByTarget(Set<T> calls, final JavaConstructor target) {
+    private <T extends JavaAccess<?>> Set<T> getByTarget(Set<T> calls, JavaConstructor target) {
         return getBy(calls, (Predicate<JavaAccess<?>>) input -> targetFrom(target).getFullName().equals(input.getTarget().getFullName()));
     }
 
@@ -1299,19 +1299,19 @@ public class ClassFileImporterAccessesTest {
         return getByTargetOwner(calls, targetOwner.getName());
     }
 
-    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final String targetOwnerName) {
+    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, String targetOwnerName) {
         return getBy(calls, targetOwnerNameEquals(targetOwnerName));
     }
 
-    private Predicate<JavaAccess<?>> targetOwnerNameEquals(final String targetFqn) {
+    private Predicate<JavaAccess<?>> targetOwnerNameEquals(String targetFqn) {
         return input -> targetFqn.equals(input.getTarget().getOwner().getName());
     }
 
-    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, final JavaClass targetOwner) {
+    private <T extends JavaAccess<?>> Set<T> getByTargetOwner(Set<T> calls, JavaClass targetOwner) {
         return getBy(calls, input -> targetOwner.equals(input.getTarget().getOwner()));
     }
 
-    private <T extends HasOwner<JavaCodeUnit>> Set<T> getByCaller(Set<T> calls, final JavaCodeUnit caller) {
+    private <T extends HasOwner<JavaCodeUnit>> Set<T> getByCaller(Set<T> calls, JavaCodeUnit caller) {
         return getBy(calls, input -> caller.equals(input.getOwner()));
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
@@ -1,5 +1,7 @@
 package com.tngtech.archunit.core.importer;
 
+import java.io.File;
+import java.io.FilterInputStream;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -16,6 +18,8 @@ import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
+import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjectsFromLambda;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -28,17 +32,19 @@ import static com.tngtech.archunit.core.domain.Formatters.formatNamesOf;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 import static com.tngtech.archunit.core.importer.JavaClassDescriptorImporterTestUtils.isLambdaMethodName;
-import static com.tngtech.archunit.testutil.assertion.AccessesAssertion.access;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAccesses;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
+import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
+import static com.tngtech.archunit.testutil.assertion.AccessesAssertion.access;
+import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
 import static java.util.stream.Collectors.toSet;
 
 @RunWith(DataProviderRunner.class)
-public class ClassFileImporterLambdaAccessesTest {
+public class ClassFileImporterLambdaDependenciesTest {
     @Test
     public void imports_method_call_from_lambda_without_parameter() {
         class Target {
@@ -508,6 +514,17 @@ public class ClassFileImporterLambdaAccessesTest {
         assertThat(accesses.stream().filter(a -> a.getOrigin().getName().contains("Direct")))
                 .isNotEmpty()
                 .allMatch(javaAccess -> !javaAccess.isDeclaredInLambda());
+    }
+
+    @Test
+    public void imports_referenced_class_object_in_lambda() {
+        JavaClasses classes = new ClassFileImporter().importClasses(ReferencingClassObjectsFromLambda.class);
+        Set<ReferencedClassObject> referencedClassObjects = classes.get(ReferencingClassObjectsFromLambda.class).getReferencedClassObjects();
+
+        assertThatReferencedClassObjects(referencedClassObjects).containReferencedClassObjects(
+                referencedClassObject(FilterInputStream.class, 10).declaredInLambda(),
+                referencedClassObject(File.class, 14).declaredInLambda()
+        );
     }
 
     private Condition<JavaMethod> syntheticLambdaMethods() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
@@ -9,6 +9,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -19,6 +20,7 @@ import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
+import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.CheckingInstanceofFromLambda;
 import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjectsFromLambda;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -36,8 +38,10 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAccess;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAccesses;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
+import static com.tngtech.archunit.testutil.Assertions.assertThatInstanceofChecks;
 import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
 import static com.tngtech.archunit.testutil.assertion.AccessesAssertion.access;
+import static com.tngtech.archunit.testutil.assertion.InstanceofChecksAssertion.instanceofCheck;
 import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$$;
@@ -524,6 +528,17 @@ public class ClassFileImporterLambdaDependenciesTest {
         assertThatReferencedClassObjects(referencedClassObjects).containReferencedClassObjects(
                 referencedClassObject(FilterInputStream.class, 10).declaredInLambda(),
                 referencedClassObject(File.class, 14).declaredInLambda()
+        );
+    }
+
+    @Test
+    public void imports_instanceof_checks_in_lambda() {
+        JavaClasses classes = new ClassFileImporter().importClasses(CheckingInstanceofFromLambda.class);
+        Set<InstanceofCheck> instanceofChecks = classes.get(CheckingInstanceofFromLambda.class).getInstanceofChecks();
+
+        assertThatInstanceofChecks(instanceofChecks).containInstanceofChecks(
+                instanceofCheck(FilterInputStream.class, 11).declaredInLambda(),
+                instanceofCheck(File.class, 15).declaredInLambda()
         );
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterTest.java
@@ -921,7 +921,7 @@ public class ClassFileImporterTest {
         Files.copy(Paths.get(uriOf(clazz)), new File(targetFolder, clazz.getSimpleName() + ".class").toPath());
     }
 
-    private Condition<CodeUnitAccessTarget> targetWithFullName(final String name) {
+    private Condition<CodeUnitAccessTarget> targetWithFullName(String name) {
         return new Condition<CodeUnitAccessTarget>(String.format("target with name '%s'", name)) {
             @Override
             public boolean matches(CodeUnitAccessTarget value) {
@@ -930,7 +930,7 @@ public class ClassFileImporterTest {
         };
     }
 
-    private static ImportOption importOnly(final Class<?>... classes) {
+    private static ImportOption importOnly(Class<?>... classes) {
         return location -> stream(classes).anyMatch(c -> location.contains(urlOf(c).getFile()));
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileSourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileSourceTest.java
@@ -59,7 +59,7 @@ public class ClassFileSourceTest {
 
     @Test
     @UseDataProvider("expected_classes")
-    public void classes_in_JAR_are_filtered(Set<String> givenEntries, ImportOptions importOptions, final Set<String> expectedIncluded) {
+    public void classes_in_JAR_are_filtered(Set<String> givenEntries, ImportOptions importOptions, Set<String> expectedIncluded) {
         TestJarFile testJarFile = new TestJarFile();
         for (String entry : givenEntries) {
             testJarFile.withEntry(entry);
@@ -74,7 +74,7 @@ public class ClassFileSourceTest {
     @Test
     @UseDataProvider("expected_classes")
     public void classes_from_file_path_are_filtered(
-            Set<String> givenFiles, ImportOptions importOptions, final Set<String> expectedIncluded) throws IOException {
+            Set<String> givenFiles, ImportOptions importOptions, Set<String> expectedIncluded) throws IOException {
 
         File dir = tempDir.newFolder();
         for (String file : givenFiles) {
@@ -172,7 +172,7 @@ public class ClassFileSourceTest {
                 .hasSameElementsAs(expectedIncluded);
     }
 
-    private static ImportOptions locationContains(final String part) {
+    private static ImportOptions locationContains(String part) {
         return new ImportOptions().with(location -> location.contains(part));
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/DependencyResolutionProcessTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/DependencyResolutionProcessTestUtils.java
@@ -23,13 +23,13 @@ import static java.util.Collections.singleton;
 
 public class DependencyResolutionProcessTestUtils {
 
-    static JavaClasses importClassesWithOnlyGenericTypeResolution(final Class<?>... classes) {
+    static JavaClasses importClassesWithOnlyGenericTypeResolution(Class<?>... classes) {
         return ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(
                 MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE
         ).importClasses(classes);
     }
 
-    static JavaClass importClassWithOnlyGenericTypeResolution(final Class<?> clazz) {
+    static JavaClass importClassWithOnlyGenericTypeResolution(Class<?> clazz) {
         return importClassesWithOnlyGenericTypeResolution(clazz).get(clazz);
     }
 
@@ -50,11 +50,11 @@ public class DependencyResolutionProcessTestUtils {
             return new ImporterWithAdjustedResolutionRuns(singleton(propertyName), Optional.of(number));
         }
 
-        JavaClass importClass(final Class<?> clazz) {
+        JavaClass importClass(Class<?> clazz) {
             return importClasses(clazz).get(clazz);
         }
 
-        public JavaClasses importClasses(final Class<?>... classes) {
+        public JavaClasses importClasses(Class<?>... classes) {
             return resetConfigurationAround(() -> {
                 ImporterWithAdjustedResolutionRuns.this.setAllIterationsToZeroExcept(propertyNames);
                 return new ClassFileImporter().importClasses(classes);

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -34,6 +34,7 @@ import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
+import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.importer.DomainBuilders.BuilderWithBuildParameter;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder.ValueBuilder;
@@ -426,6 +427,11 @@ public class ImportTestUtils {
 
         @Override
         public Set<TryCatchBlockBuilder> createTryCatchBlockBuilders(JavaCodeUnit codeUnit) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<ReferencedClassObject> createReferencedClassObjectsFor(JavaCodeUnit codeUnit) {
             return Collections.emptySet();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -16,6 +16,7 @@ import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.domain.DomainObjectCreationContext;
 import com.tngtech.archunit.core.domain.ImportContext;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClassDescriptor;
@@ -432,6 +433,11 @@ public class ImportTestUtils {
 
         @Override
         public Set<ReferencedClassObject> createReferencedClassObjectsFor(JavaCodeUnit codeUnit) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InstanceofCheck> createInstanceofChecksFor(JavaCodeUnit codeUnit) {
             return Collections.emptySet();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -266,7 +266,7 @@ public class ImportTestUtils {
         return javaClass;
     }
 
-    private static ImportContext simulateImportContext(final Class<?> inputClass, final ImportedTestClasses importedClasses) {
+    private static ImportContext simulateImportContext(Class<?> inputClass, ImportedTestClasses importedClasses) {
         return new ImportContextStub() {
             @Override
             public Set<JavaField> createFields(JavaClass owner) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationTest.java
@@ -160,7 +160,7 @@ public class LocationTest {
         return NormalizedResourceName.from(parentFolder.relativize(absolutePath).toString());
     }
 
-    private Condition<Object> elementWithSubstring(final String substring) {
+    private Condition<Object> elementWithSubstring(String substring) {
         return new Condition<Object>(String.format("element with substring '%s'", substring)) {
             @Override
             public boolean matches(Object value) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/UrlSourceTest.java
@@ -167,7 +167,7 @@ public class UrlSourceTest {
         return Joiner.on(File.separator).join(parts);
     }
 
-    private WrittenJarFile writeJarWithManifestClasspathAttribute(final File folder, String identifier, ManifestClasspathEntry... additionalClasspathManifestClasspathEntries) {
+    private WrittenJarFile writeJarWithManifestClasspathAttribute(File folder, String identifier, ManifestClasspathEntry... additionalClasspathManifestClasspathEntries) {
         Set<ManifestClasspathEntry> classpathManifestEntries = union(createManifestClasspathEntries(identifier), ImmutableSet.copyOf(additionalClasspathManifestClasspathEntries));
         String jarFileName = new TestJarFile()
                 .withManifestAttribute(CLASS_PATH, Joiner.on(" ").join(classpathManifestEntries.stream().map(resolveTo(folder)).collect(toSet())))
@@ -175,7 +175,7 @@ public class UrlSourceTest {
         return new WrittenJarFile(Paths.get(jarFileName), classpathManifestEntries);
     }
 
-    private Function<ManifestClasspathEntry, String> resolveTo(final File folder) {
+    private Function<ManifestClasspathEntry, String> resolveTo(File folder) {
         return manifestClasspathEntry -> manifestClasspathEntry.create(folder);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFromClassPathTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/ClassResolverFromClassPathTest.java
@@ -73,12 +73,12 @@ public class ClassResolverFromClassPathTest {
 
     @Test
     @UseDataProvider("urls_with_spaces")
-    public void is_resilient_against_wrongly_encoded_ClassLoader_resource_URLs(final URL urlReturnedByClassLoader, URI expectedUriDerivedFromUrl) {
+    public void is_resilient_against_wrongly_encoded_ClassLoader_resource_URLs(URL urlReturnedByClassLoader, URI expectedUriDerivedFromUrl) {
         // it seems like some OSGI ClassLoaders incorrectly return URLs with unencoded spaces.
         // This lead to `url.toURI()` throwing an exception -> https://github.com/TNG/ArchUnit/issues/683
         verifyUrlCannotBeConvertedToUriInTheCurrentForm(urlReturnedByClassLoader);
 
-        final JavaClass expectedJavaClass = importClassWithContext(Object.class);
+        JavaClass expectedJavaClass = importClassWithContext(Object.class);
         when(uriImporter.tryImport(expectedUriDerivedFromUrl)).thenReturn(Optional.of(expectedJavaClass));
 
         Optional<JavaClass> resolvedClass = withMockedContextClassLoader(classLoaderMock -> {
@@ -103,7 +103,7 @@ public class ClassResolverFromClassPathTest {
         }
     }
 
-    private void verifyUrlCannotBeConvertedToUriInTheCurrentForm(final URL url) {
+    private void verifyUrlCannotBeConvertedToUriInTheCurrentForm(URL url) {
         assertThatThrownBy(url::toURI).isInstanceOf(URISyntaxException.class);
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspathTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/resolvers/SelectedClassResolverFromClasspathTest.java
@@ -58,7 +58,7 @@ public class SelectedClassResolverFromClasspathTest {
                 .isTrue();
     }
 
-    private URI uriFor(final Class<?> clazz) {
+    private URI uriFor(Class<?> clazz) {
         return argThat(argument -> argument.toString().contains(clazz.getSimpleName()));
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/innerclassimport/ClassWithInnerClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/innerclassimport/ClassWithInnerClass.java
@@ -3,7 +3,7 @@ package com.tngtech.archunit.core.importer.testexamples.innerclassimport;
 @SuppressWarnings("unused")
 public class ClassWithInnerClass {
     void callInsideOfAnonymous() {
-        final CalledClass calledClass = null;
+        CalledClass calledClass = null;
 
         new CanBeCalled() {
             @Override
@@ -14,7 +14,7 @@ public class ClassWithInnerClass {
     }
 
     void callInsideOfLocalClass() {
-        final CalledClass calledClass = null;
+        CalledClass calledClass = null;
 
         class LocalCaller {
             void call() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/instanceofcheck/CheckingInstanceofFromLambda.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/instanceofcheck/CheckingInstanceofFromLambda.java
@@ -1,0 +1,17 @@
+package com.tngtech.archunit.core.importer.testexamples.instanceofcheck;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+@SuppressWarnings("unused")
+public class CheckingInstanceofFromLambda {
+    Predicate<?> reference() {
+        return (object) -> object instanceof FilterInputStream;
+    }
+
+    Supplier<Predicate<?>> nestedReference() {
+        return () -> (object) -> object instanceof File;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/instanceofcheck/ChecksMultipleInstanceofs.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/instanceofcheck/ChecksMultipleInstanceofs.java
@@ -1,0 +1,17 @@
+package com.tngtech.archunit.core.importer.testexamples.instanceofcheck;
+
+@SuppressWarnings({"StatementWithEmptyBody", "unused", "ConstantConditions"})
+public class ChecksMultipleInstanceofs {
+    static {
+        boolean foo = ((Object) null) instanceof InstanceofChecked;
+    }
+
+    public ChecksMultipleInstanceofs(Object param) {
+        if (param instanceof InstanceofChecked) {
+        }
+    }
+
+    boolean method(Object param) {
+        return param instanceof InstanceofChecked;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/referencedclassobjects/ReferencingClassObjectsFromLambda.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/referencedclassobjects/ReferencingClassObjectsFromLambda.java
@@ -1,0 +1,16 @@
+package com.tngtech.archunit.core.importer.testexamples.referencedclassobjects;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.util.function.Supplier;
+
+@SuppressWarnings("unused")
+public class ReferencingClassObjectsFromLambda {
+    Supplier<Class<?>> reference() {
+        return () -> FilterInputStream.class;
+    }
+
+    Supplier<Supplier<Class<?>>> nestedReference() {
+        return () -> () -> File.class;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchConditionTest.java
@@ -76,7 +76,7 @@ public class ArchConditionTest {
 
         ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(2, events);
-        final List<HandledViolation> handledViolations = new ArrayList<>();
+        List<HandledViolation> handledViolations = new ArrayList<>();
         evaluationResultOf(events).handleViolations((Collection<Integer> violatingObjects, String message) ->
                 handledViolations.add(new HandledViolation(violatingObjects, message)));
 
@@ -120,7 +120,7 @@ public class ArchConditionTest {
 
         ConditionEvents events = ConditionEvents.Factory.create();
         condition.check(1, events);
-        final List<HandledViolation> handledViolations = new ArrayList<>();
+        List<HandledViolation> handledViolations = new ArrayList<>();
         evaluationResultOf(events).handleViolations((Collection<Integer> violatingObjects, String message) ->
                 handledViolations.add(new HandledViolation(violatingObjects, message)));
 
@@ -269,10 +269,10 @@ public class ArchConditionTest {
                 .haveOneViolationMessageContaining(String.format("Class <%s> true some description", Object.class.getName()));
     }
 
-    private ArchCondition<Integer> greaterThan(final int... numbers) {
+    private ArchCondition<Integer> greaterThan(int... numbers) {
         return new ArchCondition<Integer>("greater than " + Arrays.toString(numbers)) {
             @Override
-            public void check(final Integer item, ConditionEvents events) {
+            public void check(Integer item, ConditionEvents events) {
                 for (int number : numbers) {
                     events.add(greaterThanEvent(item, number));
                 }
@@ -284,10 +284,10 @@ public class ArchConditionTest {
         return new EvaluationResult(() -> "irrelevant", events, MEDIUM);
     }
 
-    private ArchCondition<Integer> endsWith(final int number) {
+    private ArchCondition<Integer> endsWith(int number) {
         return new ArchCondition<Integer>("ends with " + number) {
             @Override
-            public void check(final Integer item, ConditionEvents events) {
+            public void check(Integer item, ConditionEvents events) {
                 boolean matches = item.toString().endsWith(Integer.toString(number));
                 events.add(new SimpleConditionEvent(item, matches,
                         item + (matches ? " ends with " : " does not end with ") + number));
@@ -364,7 +364,7 @@ public class ArchConditionTest {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final HandledViolation other = (HandledViolation) obj;
+            HandledViolation other = (HandledViolation) obj;
             return Objects.equals(this.objects, other.objects)
                     && Objects.equals(this.message, other.message);
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/ArchRuleTest.java
@@ -200,7 +200,7 @@ public class ArchRuleTest {
         };
     }
 
-    private ArchCondition<JavaClass> conditionThatReportsErrors(final String... messages) {
+    private ArchCondition<JavaClass> conditionThatReportsErrors(String... messages) {
         return new ArchCondition<JavaClass>("not have errors " + Joiner.on(", ").join(messages)) {
             @Override
             public void check(JavaClass item, ConditionEvents events) {
@@ -211,7 +211,7 @@ public class ArchRuleTest {
         };
     }
 
-    private static ArchCondition<JavaClass> addFixedNumberOfViolations(final int number) {
+    private static ArchCondition<JavaClass> addFixedNumberOfViolations(int number) {
         return new ArchCondition<JavaClass>("be violated exactly %d times", number) {
             @Override
             public void check(JavaClass item, ConditionEvents events) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/CompositeArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/CompositeArchRuleTest.java
@@ -130,7 +130,7 @@ public class CompositeArchRuleTest {
         return createArchRuleWithSatisfied(false);
     }
 
-    private static ArchRule createArchRuleWithSatisfied(final boolean satisfied) {
+    private static ArchRule createArchRuleWithSatisfied(boolean satisfied) {
         return ArchRule.Factory.create(new AbstractClassesTransformer<JavaClass>("irrelevant") {
             @Override
             public Iterable<JavaClass> doTransform(JavaClasses collection) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/EvaluationResultTest.java
@@ -75,7 +75,7 @@ public class EvaluationResultTest {
                 new SimpleConditionEvent(ImmutableList.of("yet another message"), false, "not expected"),
                 new SimpleConditionEvent(ImmutableSet.of("second message"), false, "also expected"));
 
-        final Set<String> actual = new HashSet<>();
+        Set<String> actual = new HashSet<>();
         result.handleViolations((Collection<Set<String>> violatingObject, String message) ->
                 actual.add(getOnlyElement(getOnlyElement(violatingObject)) + ": " + message));
 
@@ -119,7 +119,7 @@ public class EvaluationResultTest {
                 SimpleConditionEvent.violated(new CorrectType("handle type"), "I'm violated and correct type"),
                 SimpleConditionEvent.violated(new CorrectSubtype("handle sub type"), "I'm violated and correct sub type"));
 
-        final Set<String> handledFailures = new HashSet<>();
+        Set<String> handledFailures = new HashSet<>();
         result.handleViolations((Collection<CorrectType> violatingObjects, String message) ->
                 handledFailures.add(Joiner.on(", ").join(violatingObjects) + ": " + message));
 
@@ -204,7 +204,7 @@ public class EvaluationResultTest {
         return result;
     }
 
-    private HasDescription hasDescription(final String description) {
+    private HasDescription hasDescription(String description) {
         return () -> description;
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/FailureDisplayFormatFactoryTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/FailureDisplayFormatFactoryTest.java
@@ -40,7 +40,7 @@ public class FailureDisplayFormatFactoryTest {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private HasDescription hasDescription(final String description) {
+    private HasDescription hasDescription(String description) {
         return () -> description;
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/SimpleConditionEventTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/SimpleConditionEventTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SimpleConditionEventTest {
     @Test
     public void passes_corresponding_object_as_single_element_collection_with_message() {
-        final List<String> messages = new ArrayList<>();
+        List<String> messages = new ArrayList<>();
         ConditionEvent.Handler handler = (correspondingObjects, message) ->
                 messages.add(getOnlyElement(correspondingObjects) + ": " + message);
 

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassAccessesFieldConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ClassAccessesFieldConditionTest.java
@@ -110,7 +110,7 @@ public class ClassAccessesFieldConditionTest {
             return parts;
         }
 
-        SELF accessInfo(final AccessInfo accessInfo) {
+        SELF accessInfo(AccessInfo accessInfo) {
             this.accessInfo = accessInfo;
             return self();
         }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/extension/ArchUnitExtensionLoaderTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/extension/ArchUnitExtensionLoaderTest.java
@@ -114,8 +114,8 @@ public class ArchUnitExtensionLoaderTest {
         return "Loaded " + ArchUnitExtension.class.getSimpleName() + " with id '" + identifier + "'";
     }
 
-    private Condition<Throwable> containingWord(final String word) {
-        final Pattern wordPattern = Pattern.compile(" " + quote(word) + "[: ]");
+    private Condition<Throwable> containingWord(String word) {
+        Pattern wordPattern = Pattern.compile(" " + quote(word) + "[: ]");
         return new Condition<Throwable>(String.format("containing word '%s'", word)) {
             @Override
             public boolean matches(Throwable value) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ClassesShouldTest.java
@@ -1802,7 +1802,7 @@ public class ClassesShouldTest {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private static DescribedPredicate<JavaAnnotation<?>> annotation(final Class<? extends Annotation> type) {
+    private static DescribedPredicate<JavaAnnotation<?>> annotation(Class<? extends Annotation> type) {
         return new DescribedPredicate<JavaAnnotation<?>>("@" + type.getSimpleName()) {
             @Override
             public boolean test(JavaAnnotation<?> input) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShouldTest.java
@@ -624,7 +624,7 @@ public class CodeUnitsShouldTest {
                         quote(CONSTRUCTOR_ONE_ARG)));
     }
 
-    private static DescribedPredicate<JavaCodeUnit> doNotHaveParametersOfType(final Class<?> type) {
+    private static DescribedPredicate<JavaCodeUnit> doNotHaveParametersOfType(Class<?> type) {
         return new DescribedPredicate<JavaCodeUnit>("do not have parameters of type " + type.getSimpleName()) {
             @Override
             public boolean test(JavaCodeUnit codeUnit) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -932,7 +932,7 @@ public class GivenClassesThatTest {
         }
 
         public List<T> on(Class<?>... toCheck) {
-            final List<T> result = new ArrayList<>();
+            List<T> result = new ArrayList<>();
             JavaClasses classes = importClassesWithContext(toCheck);
             ArchCondition<T> condition = new ArchCondition<T>("ignored") {
                 @Override

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnitsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenCodeUnitsTest.java
@@ -278,7 +278,7 @@ public class GivenCodeUnitsTest {
         assertThat(result.getFailureReport().getDetails()).hasSameElementsAs(expectedMembers);
     }
 
-    static DescribedPredicate<List<JavaClass>> oneParameterOfType(final Class<?> type) {
+    static DescribedPredicate<List<JavaClass>> oneParameterOfType(Class<?> type) {
         return new DescribedPredicate<List<JavaClass>>("one parameter of type " + type.getName()) {
             @Override
             public boolean test(List<JavaClass> input) {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersTest.java
@@ -448,7 +448,7 @@ public class GivenMembersTest {
         };
     }
 
-    static DescribedPredicate<JavaMember> areNoFieldsWithType(final Class<?> type) {
+    static DescribedPredicate<JavaMember> areNoFieldsWithType(Class<?> type) {
         return new DescribedPredicate<JavaMember>("are no fields with type " + type.getSimpleName()) {
             @Override
             public boolean test(JavaMember member) {
@@ -457,7 +457,7 @@ public class GivenMembersTest {
         };
     }
 
-    static ArchCondition<JavaMember> beAnnotatedWith(final Class<? extends Annotation> annotationType) {
+    static ArchCondition<JavaMember> beAnnotatedWith(Class<? extends Annotation> annotationType) {
         return new ArchCondition<JavaMember>("be annotated with @%s", annotationType.getSimpleName()) {
             @Override
             public void check(JavaMember member, ConditionEvents events) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/GivenSlicesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/GivenSlicesTest.java
@@ -75,7 +75,7 @@ public class GivenSlicesTest {
         return slices().matching(TEST_CLASSES_PACKAGE + ".(*)..");
     }
 
-    private DescribedPredicate<Slice> descriptionMatching(final String regex) {
+    private DescribedPredicate<Slice> descriptionMatching(String regex) {
         return new DescribedPredicate<Slice>("description matching '%s'", regex) {
             @Override
             public boolean test(Slice input) {
@@ -85,7 +85,7 @@ public class GivenSlicesTest {
     }
 
     private Set<Slice> getSlicesMatchedByFilter(GivenConjunction<Slice> givenSlices) {
-        final Set<Slice> matched = new HashSet<>();
+        Set<Slice> matched = new HashSet<>();
         givenSlices.should(new ArchCondition<Slice>("") {
             @Override
             public void check(Slice item, ConditionEvents events) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceRuleTest.java
@@ -39,8 +39,8 @@ public class SliceRuleTest {
 
     @DataProvider
     public static Object[][] cycle_limits() {
-        final int totalNumberOfCycles = getNumberOfCyclesInCompleteGraph(7);
-        final int halfOfTotal = totalNumberOfCycles / 2;
+        int totalNumberOfCycles = getNumberOfCyclesInCompleteGraph(7);
+        int halfOfTotal = totalNumberOfCycles / 2;
         return $$(
                 $(new Runnable() {
                     @Override
@@ -178,13 +178,13 @@ public class SliceRuleTest {
         return slices().matching("nothing_because_there_is_no_capture_group").should().beFreeOfCycles();
     }
 
-    private List<String> filterLinesMatching(String text, final String regex) {
+    private List<String> filterLinesMatching(String text, String regex) {
         return Splitter.on(lineSeparator()).splitToList(text).stream()
                 .filter(input -> input.matches(".*(" + regex + ").*"))
                 .collect(toList());
     }
 
-    private Condition<List<? extends String>> subStringsPerLine(final String... substrings) {
+    private Condition<List<? extends String>> subStringsPerLine(String... substrings) {
         return new Condition<List<? extends String>>("substrings per line " + Arrays.asList(substrings)) {
             @Override
             public boolean matches(List<? extends String> lines) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesShouldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesShouldTest.java
@@ -110,7 +110,7 @@ public class SlicesShouldTest {
         return new ViolationsAssertion(rule.evaluate(classes));
     }
 
-    private DescribedPredicate<JavaClass> classIn(final String packageRegex) {
+    private DescribedPredicate<JavaClass> classIn(String packageRegex) {
         return new DescribedPredicate<JavaClass>("class in " + packageRegex) {
             @Override
             public boolean test(JavaClass input) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SlicesTest.java
@@ -122,7 +122,7 @@ public class SlicesTest {
         return Optional.empty();
     }
 
-    private SliceAssignment assignmentOfJavaLangAndUtil(final String description) {
+    private SliceAssignment assignmentOfJavaLangAndUtil(String description) {
         return new SliceAssignment() {
             @Override
             public String getDescription() {

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/FreezingArchRuleTest.java
@@ -544,16 +544,16 @@ public class FreezingArchRuleTest {
             return new RuleCreator(description, new ArrayList<>(), textModifier);
         }
 
-        RuleCreator withViolations(final String... messages) {
+        RuleCreator withViolations(String... messages) {
             List<ViolatedEvent> newEvents = Arrays.stream(messages).map(ViolatedEvent::new).collect(toList());
             return new RuleCreator(description, newEvents, textModifier);
         }
 
-        RuleCreator withViolations(final ViolatedEvent... events) {
+        RuleCreator withViolations(ViolatedEvent... events) {
             return new RuleCreator(description, ImmutableList.copyOf(events), textModifier);
         }
 
-        RuleCreator withStringReplace(final String toReplace, final String replaceWith) {
+        RuleCreator withStringReplace(String toReplace, String replaceWith) {
             return new RuleCreator(description, events, input -> input.replace(toReplace, replaceWith));
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/metrics/ComponentDependencyMetricsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/metrics/ComponentDependencyMetricsTest.java
@@ -129,7 +129,7 @@ public class ComponentDependencyMetricsTest {
 
     @Test
     public void rejects_requesting_metrics_of_unknown_component() {
-        final ComponentDependencyMetrics metrics = ArchitectureMetrics.componentDependencyMetrics(MetricsComponents.of());
+        ComponentDependencyMetrics metrics = ArchitectureMetrics.componentDependencyMetrics(MetricsComponents.of());
 
         List<ThrowingCallable> callables = ImmutableList.of(
                 () -> metrics.getEfferentCoupling("unknown"),

--- a/archunit/src/test/java/com/tngtech/archunit/library/metrics/LakosMetricsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/metrics/LakosMetricsTest.java
@@ -198,17 +198,17 @@ public class LakosMetricsTest {
                 this.ccd = ccd;
             }
 
-            Builder acd(final double acd) {
+            Builder acd(double acd) {
                 this.acd = acd;
                 return this;
             }
 
-            Builder racd(final double racd) {
+            Builder racd(double racd) {
                 this.racd = racd;
                 return this;
             }
 
-            ExpectedMetrics nccd(final double nccd) {
+            ExpectedMetrics nccd(double nccd) {
                 this.nccd = nccd;
                 return new ExpectedMetrics(this);
             }

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchConditionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchConditionTest.java
@@ -259,7 +259,7 @@ public class PlantUmlArchConditionTest {
         return assertThat(result.getFailureReport().getDetails());
     }
 
-    private Condition<List<? extends String>> lineMatching(final String pattern) {
+    private Condition<List<? extends String>> lineMatching(String pattern) {
         return new Condition<List<? extends String>>(String.format("line matching '%s'", pattern)) {
             @Override
             public boolean matches(List<? extends String> lines) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
@@ -167,7 +167,7 @@ public class PlantUmlParserTest {
     @Test
     @UseDataProvider("color_testcases")
     public void parses_various_colored_components(String color) {
-        final File diagramFile = TestDiagram.in(temporaryFolder)
+        File diagramFile = TestDiagram.in(temporaryFolder)
                 .component("SomeComponent").withColor(color).withStereoTypes("..stereotype..")
                 .write();
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/ArchConfigurationRule.java
@@ -13,12 +13,12 @@ public class ArchConfigurationRule extends ExternalResource {
     private boolean beforeHasBeenExecuted = false;
     private final List<Runnable> configurationInitializers = new ArrayList<>();
 
-    public ArchConfigurationRule resolveAdditionalDependenciesFromClassPath(final boolean enabled) {
+    public ArchConfigurationRule resolveAdditionalDependenciesFromClassPath(boolean enabled) {
         addConfigurationInitializer(() -> ArchConfiguration.get().setResolveMissingDependenciesFromClassPath(enabled));
         return this;
     }
 
-    public ArchConfigurationRule setFailOnEmptyShould(final boolean allowEmptyShould) {
+    public ArchConfigurationRule setFailOnEmptyShould(boolean allowEmptyShould) {
         addConfigurationInitializer(() -> ArchConfiguration.get().setProperty(FAIL_ON_EMPTY_SHOULD_PROPERTY_NAME, String.valueOf(allowEmptyShould)));
         return this;
     }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.FieldAccessTarget;
 import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
@@ -41,6 +42,7 @@ import com.tngtech.archunit.testutil.assertion.DependenciesAssertion;
 import com.tngtech.archunit.testutil.assertion.DependencyAssertion;
 import com.tngtech.archunit.testutil.assertion.DescribedPredicateAssertion;
 import com.tngtech.archunit.testutil.assertion.ExpectedAccessCreation;
+import com.tngtech.archunit.testutil.assertion.InstanceofChecksAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaAnnotationAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaAnnotationsAssertion;
 import com.tngtech.archunit.testutil.assertion.JavaClassAssertion;
@@ -156,6 +158,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static ReferencedClassObjectsAssertion assertThatReferencedClassObjects(Set<ReferencedClassObject> referencedClassObjects) {
         return new ReferencedClassObjectsAssertion(referencedClassObjects);
+    }
+
+    public static InstanceofChecksAssertion assertThatInstanceofChecks(Set<InstanceofCheck> instanceofChecks) {
+        return new InstanceofChecksAssertion(instanceofChecks);
     }
 
     public static JavaEnumConstantAssertion assertThat(JavaEnumConstant enumConstant) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Conditions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Conditions.java
@@ -10,7 +10,7 @@ public final class Conditions {
     private Conditions() {
     }
 
-    public static <T> Condition<Iterable<? extends T>> containing(final Condition<T> condition) {
+    public static <T> Condition<Iterable<? extends T>> containing(Condition<T> condition) {
         return new Condition<Iterable<? extends T>>() {
             @Override
             public boolean matches(Iterable<? extends T> value) {
@@ -23,7 +23,7 @@ public final class Conditions {
         }.as("containing an element that " + condition.description());
     }
 
-    public static Condition<JavaCodeUnit> codeUnitWithSignature(final String name, final Class<?>... parameters) {
+    public static Condition<JavaCodeUnit> codeUnitWithSignature(String name, Class<?>... parameters) {
         return new Condition<JavaCodeUnit>() {
             @Override
             public boolean matches(JavaCodeUnit value) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/JavaCallQuery.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/JavaCallQuery.java
@@ -22,7 +22,7 @@ public class JavaCallQuery {
         return that(hasOrigin(source));
     }
 
-    public JavaMethodCall inLineNumber(final int lineNumber) {
+    public JavaMethodCall inLineNumber(int lineNumber) {
         Set<JavaMethodCall> matchingCalls = that(hasLine(lineNumber)).calls;
         assertThat(matchingCalls).as("matching calls in line number " + lineNumber).isNotEmpty();
         return matchingCalls.iterator().next();
@@ -32,15 +32,15 @@ public class JavaCallQuery {
         return new JavaCallQuery(calls.stream().filter(predicate).collect(toSet()));
     }
 
-    public static JavaCallQuery methodCallTo(final JavaMethod method) {
+    public static JavaCallQuery methodCallTo(JavaMethod method) {
         return new JavaCallQuery(method.getCallsOfSelf());
     }
 
-    private static Predicate<JavaMethodCall> hasLine(final int lineNumber) {
+    private static Predicate<JavaMethodCall> hasLine(int lineNumber) {
         return input -> input.getLineNumber() == lineNumber;
     }
 
-    private static Predicate<JavaMethodCall> hasOrigin(final JavaCodeUnit origin) {
+    private static Predicate<JavaMethodCall> hasOrigin(JavaCodeUnit origin) {
         return input -> origin.equals(input.getOrigin());
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/TestLogRecorder.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/TestLogRecorder.java
@@ -32,7 +32,7 @@ public class TestLogRecorder {
             }
         };
         appender.start();
-        final LoggerContext ctx = getLoggerContext();
+        LoggerContext ctx = getLoggerContext();
         LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
         oldLevel = loggerConfig.getLevel();
         loggerConfig.setLevel(level);
@@ -49,7 +49,7 @@ public class TestLogRecorder {
             return;
         }
 
-        final LoggerContext ctx = getLoggerContext();
+        LoggerContext ctx = getLoggerContext();
         LoggerConfig loggerConfig = ctx.getConfiguration().getLoggerConfig(loggerClass.getName());
         loggerConfig.setLevel(oldLevel);
         loggerConfig.removeAppender(APPENDER_NAME);

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessToFieldAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessToFieldAssertion.java
@@ -18,7 +18,7 @@ public class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAss
         return new AccessToFieldAssertion(access);
     }
 
-    public AccessToFieldAssertion isTo(final String name) {
+    public AccessToFieldAssertion isTo(String name) {
         return isTo(new Condition<FieldAccessTarget>("field with name '" + name + "'") {
             @Override
             public boolean matches(FieldAccessTarget fieldAccessTarget) {
@@ -27,7 +27,7 @@ public class AccessToFieldAssertion extends BaseAccessAssertion<AccessToFieldAss
         });
     }
 
-    public AccessToFieldAssertion isTo(final Class<?> owner, final String name) {
+    public AccessToFieldAssertion isTo(Class<?> owner, String name) {
         return isTo(new Condition<FieldAccessTarget>("field " + owner.getName() + "." + name) {
             @Override
             public boolean matches(FieldAccessTarget fieldAccessTarget) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/CodeUnitAccessAssertion.java
@@ -17,7 +17,7 @@ public class CodeUnitAccessAssertion
         super((JavaCodeUnitAccess) call);
     }
 
-    public CodeUnitAccessAssertion isTo(final JavaCodeUnit target) {
+    public CodeUnitAccessAssertion isTo(JavaCodeUnit target) {
         return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>("method " + target.getFullName()) {
             @Override
             public boolean matches(AccessTarget.CodeUnitAccessTarget codeUnitAccessTarget) {
@@ -28,7 +28,7 @@ public class CodeUnitAccessAssertion
         });
     }
 
-    public CodeUnitAccessAssertion isTo(final Class<?> codeUnitOwner) {
+    public CodeUnitAccessAssertion isTo(Class<?> codeUnitOwner) {
         return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>() {
             @Override
             public boolean matches(AccessTarget.CodeUnitAccessTarget target) {
@@ -37,7 +37,7 @@ public class CodeUnitAccessAssertion
         });
     }
 
-    public CodeUnitAccessAssertion isTo(final String codeUnitName, final Class<?>... parameterTypes) {
+    public CodeUnitAccessAssertion isTo(String codeUnitName, Class<?>... parameterTypes) {
         return isTo(new Condition<AccessTarget.CodeUnitAccessTarget>("code unit " + codeUnitName + "(" + formatNamesOf(parameterTypes) + ")") {
             @Override
             public boolean matches(AccessTarget.CodeUnitAccessTarget target) {
@@ -47,7 +47,7 @@ public class CodeUnitAccessAssertion
         });
     }
 
-    public CodeUnitAccessAssertion isTo(Class<?> targetClass, String codeUnitName, final Class<?>... parameterTypes) {
+    public CodeUnitAccessAssertion isTo(Class<?> targetClass, String codeUnitName, Class<?>... parameterTypes) {
         return isTo(targetClass).isTo(codeUnitName, parameterTypes);
     }
 
@@ -65,7 +65,7 @@ public class CodeUnitAccessAssertion
         return this;
     }
 
-    private Condition<TryCatchBlock> caughtThrowableOfType(final Class<? extends Throwable> expectedThrowable) {
+    private Condition<TryCatchBlock> caughtThrowableOfType(Class<? extends Throwable> expectedThrowable) {
         return new Condition<TryCatchBlock>("caught throwable of type " + expectedThrowable.getSimpleName()) {
             @Override
             public boolean matches(TryCatchBlock tryCatchBlock) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/DependenciesAssertion.java
@@ -68,13 +68,13 @@ public class DependenciesAssertion extends AbstractIterableAssert<
         return this;
     }
 
-    public DependenciesAssertion contain(final ExpectedDependencies expectedDependencies) {
+    public DependenciesAssertion contain(ExpectedDependencies expectedDependencies) {
         matchExpectedDependencies(expectedDependencies)
                 .assertNoMissingDependencies();
         return this;
     }
 
-    public DependenciesAssertion containOnly(final ExpectedDependencies expectedDependencies) {
+    public DependenciesAssertion containOnly(ExpectedDependencies expectedDependencies) {
         ExpectedDependenciesMatchResult result = matchExpectedDependencies(expectedDependencies);
         result.assertNoMissingDependencies();
         result.assertAllDependenciesMatched();
@@ -84,7 +84,7 @@ public class DependenciesAssertion extends AbstractIterableAssert<
     private ExpectedDependenciesMatchResult matchExpectedDependencies(ExpectedDependencies expectedDependencies) {
         List<Dependency> rest = newArrayList(actual);
         List<ExpectedDependency> missingDependencies = new ArrayList<>();
-        for (final ExpectedDependency expectedDependency : expectedDependencies) {
+        for (ExpectedDependency expectedDependency : expectedDependencies) {
             if (rest.stream().noneMatch(expectedDependency::matches)) {
                 missingDependencies.add(expectedDependency);
             }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedAccessCreation.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/ExpectedAccessCreation.java
@@ -31,15 +31,15 @@ public class ExpectedAccessCreation {
             this.originCodeUnitName = originCodeUnitName;
         }
 
-        public ExpectedAccessCondition to(final Class<?> targetClass, final String targetName) {
+        public ExpectedAccessCondition to(Class<?> targetClass, String targetName) {
             return new ExpectedAccessCondition(originClass, originCodeUnitName, targetClass, targetName);
         }
 
-        public ExpectedFieldAccessCondition toField(AccessType accessType, final Class<?> targetClass, final String targetName) {
+        public ExpectedFieldAccessCondition toField(AccessType accessType, Class<?> targetClass, String targetName) {
             return new ExpectedFieldAccessCondition(originClass, originCodeUnitName, accessType, targetClass, targetName);
         }
 
-        public ExpectedConstructorCallCondition toConstructor(final Class<?> targetClass, final Class<?>... paramTypes) {
+        public ExpectedConstructorCallCondition toConstructor(Class<?> targetClass, Class<?>... paramTypes) {
             return new ExpectedConstructorCallCondition(originClass, originCodeUnitName, targetClass, formatNamesOf(paramTypes));
         }
     }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/InstanceofChecksAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/InstanceofChecksAssertion.java
@@ -1,0 +1,86 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.InstanceofCheck;
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstanceofChecksAssertion extends AbstractIterableAssert<InstanceofChecksAssertion, Set<InstanceofCheck>, InstanceofCheck, InstanceofChecksAssertion.InstanceofCheckAssertion> {
+    public InstanceofChecksAssertion(Set<InstanceofCheck> instanceofChecks) {
+        super(instanceofChecks, InstanceofChecksAssertion.class);
+    }
+
+    @Override
+    protected InstanceofCheckAssertion toAssert(InstanceofCheck value, String description) {
+        return new InstanceofCheckAssertion(value).as(description);
+    }
+
+    @Override
+    protected InstanceofChecksAssertion newAbstractIterableAssert(Iterable<? extends InstanceofCheck> iterable) {
+        return new InstanceofChecksAssertion(ImmutableSet.copyOf(iterable));
+    }
+
+    public void containInstanceofChecks(ExpectedInstanceofCheck... expectedInstanceofChecks) {
+        containInstanceofChecks(ImmutableList.copyOf(expectedInstanceofChecks));
+    }
+
+    public void containInstanceofChecks(Iterable<ExpectedInstanceofCheck> expectedInstanceofChecks) {
+        Set<ExpectedInstanceofCheck> unmatchedClassObjects = stream(expectedInstanceofChecks.spliterator(), false)
+                .filter(expected -> actual.stream().noneMatch(expected))
+                .collect(toSet());
+        assertThat(unmatchedClassObjects).as("Instanceof checks not contained in " + actual).isEmpty();
+    }
+
+    static class InstanceofCheckAssertion extends AbstractObjectAssert<InstanceofCheckAssertion, InstanceofCheck> {
+        InstanceofCheckAssertion(InstanceofCheck instanceofCheck) {
+            super(instanceofCheck, InstanceofCheckAssertion.class);
+        }
+    }
+
+    public static ExpectedInstanceofCheck instanceofCheck(Class<?> type, int lineNumber) {
+        return new ExpectedInstanceofCheck(type, lineNumber);
+    }
+
+    public static class ExpectedInstanceofCheck implements Predicate<InstanceofCheck> {
+        private final Class<?> type;
+        private final int lineNumber;
+        private final boolean declaredInLambda;
+
+        private ExpectedInstanceofCheck(Class<?> type, int lineNumber) {
+            this(type, lineNumber, false);
+        }
+
+        private ExpectedInstanceofCheck(Class<?> type, int lineNumber, boolean declaredInLambda) {
+            this.type = type;
+            this.lineNumber = lineNumber;
+            this.declaredInLambda = declaredInLambda;
+        }
+
+        public ExpectedInstanceofCheck declaredInLambda() {
+            return new ExpectedInstanceofCheck(type, lineNumber, true);
+        }
+
+        @Override
+        public boolean test(InstanceofCheck input) {
+            return input.getRawType().isEquivalentTo(type) && input.getLineNumber() == lineNumber && input.isDeclaredInLambda() == declaredInLambda;
+        }
+
+        @Override
+        public String toString() {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .add("lineNumber", lineNumber)
+                    .add("declaredInLambda", declaredInLambda)
+                    .toString();
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaAnnotationAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaAnnotationAssertion.java
@@ -85,7 +85,7 @@ public class JavaAnnotationAssertion extends AbstractObjectAssert<JavaAnnotation
         return this;
     }
 
-    public JavaAnnotationAssertion hasNoExplicitlyDeclaredProperty(final String propertyName) {
+    public JavaAnnotationAssertion hasNoExplicitlyDeclaredProperty(String propertyName) {
         String description = annotationPropertyDescription("String", propertyName);
         assertThat(actual.hasExplicitlyDeclaredProperty(propertyName))
                 .as(description + " has explicitly declared value")
@@ -204,7 +204,7 @@ public class JavaAnnotationAssertion extends AbstractObjectAssert<JavaAnnotation
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final SimpleTypeReference other = (SimpleTypeReference) obj;
+            SimpleTypeReference other = (SimpleTypeReference) obj;
             return Objects.equals(this.typeName, other.typeName);
         }
 
@@ -244,7 +244,7 @@ public class JavaAnnotationAssertion extends AbstractObjectAssert<JavaAnnotation
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final SimpleEnumConstantReference other = (SimpleEnumConstantReference) obj;
+            SimpleEnumConstantReference other = (SimpleEnumConstantReference) obj;
             return Objects.equals(this.type, other.type)
                     && Objects.equals(this.name, other.name);
         }
@@ -266,12 +266,12 @@ public class JavaAnnotationAssertion extends AbstractObjectAssert<JavaAnnotation
     public static class AnnotationPropertyAssertion {
         private final List<Consumer<JavaAnnotationAssertion>> executeAssertions = new ArrayList<>();
 
-        public AnnotationPropertyAssertion withAnnotationType(final Class<? extends Annotation> annotationType) {
+        public AnnotationPropertyAssertion withAnnotationType(Class<? extends Annotation> annotationType) {
             executeAssertions.add(assertion -> assertion.hasType(annotationType));
             return this;
         }
 
-        public AnnotationPropertyAssertion withClassProperty(final String propertyName, final Class<?> propertyValue) {
+        public AnnotationPropertyAssertion withClassProperty(String propertyName, Class<?> propertyValue) {
             executeAssertions.add(assertion -> assertion.hasClassProperty(propertyName, propertyValue));
             return this;
         }

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/syntax/MethodChoiceStrategy.java
@@ -37,7 +37,7 @@ public class MethodChoiceStrategy {
         return new MethodChoiceStrategy(ignorePredicate.or(methodWithName(string)));
     }
 
-    private Predicate<Method> methodWithName(final String methodName) {
+    private Predicate<Method> methodWithName(String methodName) {
         return input -> input.getName().equals(methodName);
     }
 
@@ -137,7 +137,7 @@ public class MethodChoiceStrategy {
             if (obj == null || getClass() != obj.getClass()) {
                 return false;
             }
-            final MethodKey other = (MethodKey) obj;
+            MethodKey other = (MethodKey) obj;
             return Objects.equals(this.name, other.name)
                     && Objects.equals(this.parameterTypes, other.parameterTypes);
         }


### PR DESCRIPTION
When we improved importing lambdas in a404fb4b we overlooked that there can also other dependencies than regular accesses be declared within the body of a lambda, namely references to class objects and instanceof checks. Since we completely removed the synthetic methods from the import but didn't resolve the origin of those dependencies against the correct (lambda-declaring) method these dependencies were now missing completely from the import.
We now fix this by applying the same origin resolution mechanism to those dependencies and associate them with the method that originally declares the lambda.

Resolves: #992