### PR TITLE
Reduce allocations in NormalizedResourceName

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/NormalizedResourceName.java
@@ -21,13 +21,36 @@ class NormalizedResourceName {
     private final String resourceName;
 
     private NormalizedResourceName(String resourceName) {
-        this.resourceName = resourceName
-                // normalize Windows backslashes
-                .replace('\\', '/')
-                // remove leading slashes
-                .replaceAll("^/*", "")
-                // remove trailing slashes
-                .replaceAll("/*$", "");
+        this.resourceName = normalizeName(resourceName);
+    }
+
+    private String normalizeName(String resourceName) {
+        // normalize Windows backslashes
+        resourceName = resourceName.replace('\\', '/');
+        // remove leading slashes
+        resourceName = removeLeadingSlashes(resourceName);
+        // remove trailing slashes
+        return removeTrailingSlashes(resourceName);
+    }
+
+    private String removeLeadingSlashes(String s) {
+        int index;
+        for (index = 0; index < s.length(); index++) {
+            if (s.charAt(index) != '/') {
+                break;
+            }
+        }
+        return s.substring(index);
+    }
+
+    private String removeTrailingSlashes(String s) {
+        int index;
+        for (index = s.length() - 1; index >= 0; index--) {
+            if (s.charAt(index) != '/') {
+                break;
+            }
+        }
+        return s.substring(0, index + 1);
     }
 
     static NormalizedResourceName from(String resourceName) {
@@ -44,7 +67,7 @@ class NormalizedResourceName {
 
     private boolean isAncestorPath(NormalizedResourceName prefix) {
         return resourceName.startsWith(prefix.resourceName) &&
-                resourceName.substring(prefix.resourceName.length()).startsWith("/");
+                resourceName.startsWith("/", prefix.resourceName.length());
     }
 
     /**


### PR DESCRIPTION
Hi,

I've been doing some profiling of some test suites lately that use ArchUnit. While the majority of allocations are done in the processing of classes (unsurprisingly), there are also some caused by `NormalizedResourceName` (mostly from actually normalizing the name) that seem avoidable.

I've put together a little benchmark comparison of the current approach (old), one with precompiled patterns and the approach proposed in this PR (new).
```
Benchmark                                                          (input)  Mode  Cnt     Score     Error   Units
MyBenchmark.testNew                                                com/foo  avgt   10     8,530 ±   0,115   ns/op
MyBenchmark.testNew:·gc.alloc.rate.norm                            com/foo  avgt   10    ≈ 10⁻⁶              B/op

MyBenchmark.testNew                                              /com/foo/  avgt   10    35,633 ±   0,537   ns/op
MyBenchmark.testNew:·gc.alloc.rate.norm                          /com/foo/  avgt   10    96,000 ±   0,001    B/op

MyBenchmark.testOld                                                com/foo  avgt   10   573,092 ±   9,175   ns/op
MyBenchmark.testOld:·gc.alloc.rate.norm                            com/foo  avgt   10  1752,000 ±   0,001    B/op

MyBenchmark.testOld                                              /com/foo/  avgt   10   580,875 ±  18,804   ns/op
MyBenchmark.testOld:·gc.alloc.rate.norm                          /com/foo/  avgt   10  1784,000 ±  38,247    B/op

MyBenchmark.testPrecompiledPattern                                 com/foo  avgt   10   305,113 ±   5,875   ns/op
MyBenchmark.testPrecompiledPattern:·gc.alloc.rate.norm             com/foo  avgt   10   720,000 ±   0,001    B/op

MyBenchmark.testPrecompiledPattern                               /com/foo/  avgt   10   330,982 ±  19,807   ns/op
MyBenchmark.testPrecompiledPattern:·gc.alloc.rate.norm           /com/foo/  avgt   10   752,000 ±  38,247    B/op
```

As you can see, the provided approach in this PR avoids allocations completely in case no stripping of trailing and leading slashes needs to be done, but is also considerably faster when it is done.

Let me know what you think.
Cheers,
Christoph