### PR TITLE
Add `ImportOption` `DoNotIncludeGradleTestFixtures`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
@@ -56,6 +56,17 @@ public interface ImportOption {
                 return onlyIncludeTests.includes(location);
             }
         },
+        /**
+         * @see DoNotIncludeGradleTestFixtures
+         */
+        DO_NOT_INCLUDE_TEST_FIXTURES {
+            private final DoNotIncludeGradleTestFixtures doNotIncludeGradleTestFixtures = new DoNotIncludeGradleTestFixtures();
+
+            @Override
+            public boolean includes(Location location) {
+                return doNotIncludeGradleTestFixtures.includes(location);
+            }
+        },
         DO_NOT_INCLUDE_JARS {
             private final DoNotIncludeJars doNotIncludeJars = new DoNotIncludeJars();
 
@@ -129,6 +140,23 @@ public interface ImportOption {
         @Override
         public boolean includes(Location location) {
             return TEST_LOCATION.test(location);
+        }
+    }
+
+    /**
+     * Best effort {@link ImportOption} to omit checking test fixtures defined by the
+     * <a href="https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures">Gradle Test Fixtures Plugin</a>.<br>
+     * NOTE: This excludes all class files residing in some directory
+     * ../build/classes/../testFixtures/.. or some JAR matching ../build/libs/..-test-fixtures.jar
+     * (the former as it would be added from the file system to the classpath, the latter as it would be added as a JAR library to the classpath)
+     */
+    final class DoNotIncludeGradleTestFixtures implements ImportOption {
+        private static final Pattern TEST_FIXTURES_FILE_PATH_PATTERN = Pattern.compile(".*/build/classes/.*/testFixtures/.*");
+        private static final Pattern TEST_FIXTURES_JAR_PATH_PATTERN = Pattern.compile(".*/build/libs/.*-test-fixtures.jar!.*");
+
+        @Override
+        public boolean includes(Location location) {
+            return !location.matches(TEST_FIXTURES_FILE_PATH_PATTERN) && !location.matches(TEST_FIXTURES_JAR_PATH_PATTERN);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
@@ -2,6 +2,7 @@ package com.tngtech.archunit.core.importer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeArchives;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludePackageInfos;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeGradleTestFixtures;
 import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
 import com.tngtech.archunit.core.importer.ImportOption.OnlyIncludeTests;
 import com.tngtech.java.junit.dataprovider.DataProvider;
@@ -27,6 +29,7 @@ import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_JARS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_PACKAGE_INFOS;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TESTS;
+import static com.tngtech.archunit.core.importer.ImportOption.Predefined.DO_NOT_INCLUDE_TEST_FIXTURES;
 import static com.tngtech.archunit.core.importer.ImportOption.Predefined.ONLY_INCLUDE_TESTS;
 import static com.tngtech.archunit.testutil.TestUtils.relativeResourceUri;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
@@ -121,6 +124,25 @@ public class ImportOptionsTest {
 
         assertThat(doNotIncludeTests.includes(Location.of(targetFile.toPath())))
                 .as("includes location %s", targetFile.getAbsolutePath()).isEqualTo(expectedInclude);
+    }
+
+    @DataProvider
+    public static Object[][] data_excludes_test_fixtures() {
+        return testForEach(new DoNotIncludeGradleTestFixtures(), DO_NOT_INCLUDE_TEST_FIXTURES);
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_excludes_test_fixtures(ImportOption doNotIncludeTestFixtures) {
+        assertThat(doNotIncludeTestFixtures.includes(Location.of(URI.create("file:///any/build/classes/java/test/com/SomeTest.class"))))
+                .as("includes test class from file path").isTrue();
+        assertThat(doNotIncludeTestFixtures.includes(Location.of(URI.create("jar:file:///any/build/libs/some-test.jar!/com/SomeTest"))))
+                .as("includes test class from JAR path").isTrue();
+
+        assertThat(doNotIncludeTestFixtures.includes(Location.of(URI.create("file:///any/build/classes/java/testFixtures/com/SomeFixture.class"))))
+                .as("excludes test fixture from file path").isFalse();
+        assertThat(doNotIncludeTestFixtures.includes(Location.of(URI.create("jar:file:///any/build/libs/some-test-test-fixtures.jar!/com/SomeFixture"))))
+                .as("excludes test fixture from JAR path").isFalse();
     }
 
     @DataProvider


### PR DESCRIPTION
Gradle provides the `java-test-fixtures` plugin out of the box, which will add a separate source set for creating test fixtures (i.e. test support code). This source set can see the main sources and be seen by the test sources. Depending on how the tests are run they might be put onto the classpath as folder path (containing the compiled sources) or JAR archive. Thus, we have to exclude both, the folder where Gradle compiles the files to by convention and archives that follow the Gradle convention to end in `-test-fixtures.jar`. However, this can of course only be a heuristic. Custom modules that mimic the convention will e.g. also be excluded. But in these cases users have to customize their import options then, instead of using the predefined one.

Resolves: #949