### PR TITLE
reduce log output in maven integration tests

### DIFF
--- a/archunit-maven-test/build.gradle
+++ b/archunit-maven-test/build.gradle
@@ -95,9 +95,10 @@ task initializeMavenTest {
 }
 
 def mavenCommand = { String... params ->
+    def allParams = ['--batch-mode', '--no-transfer-progress'] + params.toList()
     OperatingSystem.current().isWindows() ?
-            ['cmd', '/c', 'mvnw.cmd'] + params.toList() :
-            ['./mvnw'] + params.toList()
+            ['cmd', '/c', 'mvnw.cmd'] + allParams :
+            ['./mvnw'] + allParams
 }
 
 def addMavenTest = { IntegrationTestConfig config ->


### PR DESCRIPTION
The maven process started by the integration tests produces several thousand lines of output for downloading artifacts

<details><summary>like this:</summary>

```
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom
Progress (1): 2.7/3.9 kB
Progress (1): 3.9 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.pom (3.9 kB at 27 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom
Progress (1): 2.7/13 kB
Progress (1): 5.5/13 kB
Progress (1): 8.2/13 kB
Progress (1): 11/13 kB 
Progress (1): 13 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom (13 kB at 767 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom
Progress (1): 2.7/26 kB
Progress (1): 5.5/26 kB
Progress (1): 8.2/26 kB
Progress (1): 11/26 kB 
Progress (1): 14/26 kB
Progress (1): 16/26 kB
Progress (1): 19/26 kB
Progress (1): 21/26 kB
Progress (1): 24/26 kB
Progress (1): 26 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom (26 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom
Progress (1): 2.7/15 kB
Progress (1): 5.5/15 kB
Progress (1): 8.2/15 kB
Progress (1): 11/15 kB 
Progress (1): 14/15 kB
Progress (1): 15 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom (15 kB at 643 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar
Progress (1): 4.1/25 kB
Progress (1): 8.2/25 kB
Progress (1): 12/25 kB 
Progress (1): 16/25 kB
Progress (1): 20/25 kB
Progress (1): 24/25 kB
Progress (1): 25 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/2.5/maven-clean-plugin-2.5.jar (25 kB at 912 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom
Progress (1): 4.1/8.1 kB
Progress (1): 8.1 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom (8.1 kB at 541 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom
Progress (1): 4.1/9.2 kB
Progress (1): 8.2/9.2 kB
Progress (1): 9.2 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom (9.2 kB at 541 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom
Progress (1): 4.1/30 kB
Progress (1): 8.2/30 kB
Progress (1): 12/30 kB 
Progress (1): 16/30 kB
Progress (1): 20/30 kB
Progress (1): 25/30 kB
Progress (1): 29/30 kB
Progress (1): 30 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom (30 kB at 2.0 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom
Progress (1): 4.1/15 kB
Progress (1): 8.2/15 kB
Progress (1): 12/15 kB 
Progress (1): 15 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom (15 kB at 1.3 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar
Progress (1): 4.1/30 kB
Progress (1): 8.2/30 kB
Progress (1): 12/30 kB 
Progress (1): 16/30 kB
Progress (1): 20/30 kB
Progress (1): 24/30 kB
Progress (1): 28/30 kB
Progress (1): 30 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar (30 kB at 1.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.pom
Progress (1): 4.1/12 kB
Progress (1): 8.2/12 kB
Progress (1): 12/12 kB 
Progress (1): 12 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.pom (12 kB at 624 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom
Progress (1): 4.1/11 kB
Progress (1): 8.2/11 kB
Progress (1): 11 kB    
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/33/maven-plugins-33.pom (11 kB at 465 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom
Progress (1): 4.1/44 kB
Progress (1): 8.2/44 kB
Progress (1): 12/44 kB 
Progress (1): 16/44 kB
Progress (1): 20/44 kB
Progress (1): 24/44 kB
Progress (1): 28/44 kB
Progress (1): 32/44 kB
Progress (1): 36/44 kB
Progress (1): 40/44 kB
Progress (1): 44 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/33/maven-parent-33.pom (44 kB at 2.6 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom
Progress (1): 4.1/17 kB
Progress (1): 8.2/17 kB
Progress (1): 12/17 kB 
Progress (1): 16/17 kB
Progress (1): 17 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/21/apache-21.pom (17 kB at 1.6 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.jar
Progress (1): 4.1/62 kB
Progress (1): 8.2/62 kB
Progress (1): 12/62 kB 
Progress (1): 16/62 kB
Progress (1): 20/62 kB
Progress (1): 25/62 kB
Progress (1): 29/62 kB
Progress (1): 33/62 kB
Progress (1): 37/62 kB
Progress (1): 41/62 kB
Progress (1): 45/62 kB
Progress (1): 49/62 kB
Progress (1): 53/62 kB
Progress (1): 57/62 kB
Progress (1): 61/62 kB
Progress (1): 62 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.8.1/maven-compiler-plugin-3.8.1.jar (62 kB at 2.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.pom
Progress (1): 4.1/5.0 kB
Progress (1): 5.0 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.pom (5.0 kB at 312 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.22.2/surefire-2.22.2.pom
Progress (1): 4.1/26 kB
Progress (1): 8.2/26 kB
Progress (1): 12/26 kB 
Progress (1): 16/26 kB
Progress (1): 20/26 kB
Progress (1): 25/26 kB
Progress (1): 26 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.22.2/surefire-2.22.2.pom (26 kB at 2.3 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.jar
Progress (1): 4.1/41 kB
Progress (1): 8.2/41 kB
Progress (1): 12/41 kB 
Progress (1): 16/41 kB
Progress (1): 20/41 kB
Progress (1): 25/41 kB
Progress (1): 29/41 kB
Progress (1): 33/41 kB
Progress (1): 37/41 kB
Progress (1): 41 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.22.2/maven-surefire-plugin-2.22.2.jar (41 kB at 3.7 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.pom
Progress (1): 1.6 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.pom (1.6 kB at 146 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.3/slf4j-parent-2.0.3.pom
Progress (1): 4.1/16 kB
Progress (1): 8.2/16 kB
Progress (1): 12/16 kB 
Progress (1): 16/16 kB
Progress (1): 16 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.3/slf4j-parent-2.0.3.pom (16 kB at 1.0 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom
Progress (1): 4.1/27 kB
Progress (1): 8.2/27 kB
Progress (1): 12/27 kB 
Progress (1): 16/27 kB
Progress (1): 20/27 kB
Progress (1): 24/27 kB
Progress (1): 27 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/junit/junit/4.13.2/junit-4.13.2.pom (27 kB at 1.4 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom
Progress (1): 766 B
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.pom (766 B at 85 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom
Progress (1): 2.0 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-parent/1.3/hamcrest-parent-1.3.pom (2.0 kB at 164 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom
Progress (1): 4.1/14 kB
Progress (1): 8.2/14 kB
Progress (1): 12/14 kB 
Progress (1): 14 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom (14 kB at 1.0 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/net/java/jvnet-parent/3/jvnet-parent-3.pom
Progress (1): 4.1/4.8 kB
Progress (1): 4.8 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/net/java/jvnet-parent/3/jvnet-parent-3.pom (4.8 kB at 399 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-ejb_3.1_spec/1.0.2/geronimo-ejb_3.1_spec-1.0.2.pom
Progress (1): 4.1/4.8 kB
Progress (1): 4.8 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-ejb_3.1_spec/1.0.2/geronimo-ejb_3.1_spec-1.0.2.pom (4.8 kB at 218 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-java5-flava/2.0/genesis-java5-flava-2.0.pom
Progress (1): 4.1/5.5 kB
Progress (1): 5.5 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-java5-flava/2.0/genesis-java5-flava-2.0.pom (5.5 kB at 457 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-default-flava/2.0/genesis-default-flava-2.0.pom
Progress (1): 4.1/18 kB
Progress (1): 8.2/18 kB
Progress (1): 12/18 kB 
Progress (1): 16/18 kB
Progress (1): 18 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis-default-flava/2.0/genesis-default-flava-2.0.pom (18 kB at 1.6 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis/2.0/genesis-2.0.pom
Progress (1): 4.1/18 kB
Progress (1): 8.2/18 kB
Progress (1): 12/18 kB 
Progress (1): 16/18 kB
Progress (1): 18 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/genesis/genesis/2.0/genesis-2.0.pom (18 kB at 1.3 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom
Progress (1): 4.1/13 kB
Progress (1): 8.2/13 kB
Progress (1): 12/13 kB 
Progress (1): 13 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom (13 kB at 1.6 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-jpa_2.0_spec/1.1/geronimo-jpa_2.0_spec-1.1.pom
Progress (1): 4.1/7.6 kB
Progress (1): 7.6 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-jpa_2.0_spec/1.1/geronimo-jpa_2.0_spec-1.1.pom (7.6 kB at 633 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/joda-time/joda-time/2.11.2/joda-time-2.11.2.pom
Progress (1): 4.1/39 kB
Progress (1): 8.2/39 kB
Progress (1): 12/39 kB 
Progress (1): 16/39 kB
Progress (1): 20/39 kB
Progress (1): 25/39 kB
Progress (1): 29/39 kB
Progress (1): 33/39 kB
Progress (1): 37/39 kB
Progress (1): 39 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/joda-time/joda-time/2.11.2/joda-time-2.11.2.pom (39 kB at 2.4 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-beans/5.3.23/spring-beans-5.3.23.pom
Progress (1): 2.0 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/spring-beans/5.3.23/spring-beans-5.3.23.pom (2.0 kB at 168 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-core/5.3.23/spring-core-5.3.23.pom
Progress (1): 2.0 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/spring-core/5.3.23/spring-core-5.3.23.pom (2.0 kB at 252 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-jcl/5.3.23/spring-jcl-5.3.23.pom
Progress (1): 1.8 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/spring-jcl/5.3.23/spring-jcl-5.3.23.pom (1.8 kB at 131 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.pom
Progress (1): 3.4 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.pom (3.4 kB at 341 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.5/project-1.0.5.pom
Progress (1): 4.1/13 kB
Progress (1): 8.2/13 kB
Progress (1): 12/13 kB 
Progress (1): 13 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.5/project-1.0.5.pom (13 kB at 1.5 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.pom
Progress (1): 4.1/16 kB
Progress (1): 8.2/16 kB
Progress (1): 12/16 kB 
Progress (1): 16 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.pom (16 kB at 1.7 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/jakarta/annotation/ca-parent/1.3.5/ca-parent-1.3.5.pom
Progress (1): 2.8 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/jakarta/annotation/ca-parent/1.3.5/ca-parent-1.3.5.pom (2.8 kB at 233 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0.pom
Progress (1): 4.1/8.9 kB
Progress (1): 8.2/8.9 kB
Progress (1): 8.9 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0.pom (8.9 kB at 328 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/inject/guice-parent/5.1.0/guice-parent-5.1.0.pom
Progress (1): 4.1/18 kB
Progress (1): 8.2/18 kB
Progress (1): 12/18 kB 
Progress (1): 16/18 kB
Progress (1): 18 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/inject/guice-parent/5.1.0/guice-parent-5.1.0.pom (18 kB at 808 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/google/5/google-5.pom
Progress (1): 2.5 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/google/5/google-5.pom (2.5 kB at 223 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.pom
Progress (1): 612 B
                   
Downloaded from central: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.pom (612 B at 31 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.pom
Progress (1): 363 B
                   
Downloaded from central: https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.pom (363 B at 45 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-jre/guava-30.1-jre.pom
Progress (1): 4.1/12 kB
Progress (1): 8.2/12 kB
Progress (1): 12 kB    
                   
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/30.1-jre/guava-30.1-jre.pom (12 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-jre/guava-parent-30.1-jre.pom
Progress (1): 4.1/14 kB
Progress (1): 8.2/14 kB
Progress (1): 12/14 kB 
Progress (1): 14 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/30.1-jre/guava-parent-30.1-jre.pom (14 kB at 677 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom
Progress (1): 2.4 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom (2.4 kB at 268 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom
Progress (1): 4.1/10 kB
Progress (1): 8.2/10 kB
Progress (1): 10 kB    
                   
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom (10 kB at 485 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom
Progress (1): 4.1/6.6 kB
Progress (1): 6.6 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom (6.6 kB at 505 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom
Progress (1): 2.3 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom (2.3 kB at 20 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom
Progress (1): 4.1/4.3 kB
Progress (1): 4.3 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom (4.3 kB at 238 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
Progress (1): 4.1/4.8 kB
Progress (1): 4.8 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom (4.8 kB at 402 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.pom
Progress (1): 2.2 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/checkerframework/checker-qual/3.5.0/checker-qual-3.5.0.pom (2.2 kB at 271 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.pom
Progress (1): 2.1 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.3.4/error_prone_annotations-2.3.4.pom (2.1 kB at 176 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.4/error_prone_parent-2.3.4.pom
Progress (1): 4.1/5.4 kB
Progress (1): 5.4 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.3.4/error_prone_parent-2.3.4.pom (5.4 kB at 678 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom
Progress (1): 2.8 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom (2.8 kB at 276 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/tngtech/java/junit-dataprovider/1.11.0/junit-dataprovider-1.11.0.pom
Progress (1): 1.4 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/com/tngtech/java/junit-dataprovider/1.11.0/junit-dataprovider-1.11.0.pom (1.4 kB at 136 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.23.1/assertj-core-3.23.1.pom
Progress (1): 4.1/24 kB
Progress (1): 8.2/24 kB
Progress (1): 12/24 kB 
Progress (1): 16/24 kB
Progress (1): 20/24 kB
Progress (1): 24 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/assertj/assertj-core/3.23.1/assertj-core-3.23.1.pom (24 kB at 2.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/assertj/assertj-parent-pom/2.2.17/assertj-parent-pom-2.2.17.pom
Progress (1): 4.1/24 kB
Progress (1): 8.2/24 kB
Progress (1): 12/24 kB 
Progress (1): 16/24 kB
Progress (1): 20/24 kB
Progress (1): 24 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/assertj/assertj-parent-pom/2.2.17/assertj-parent-pom-2.2.17.pom (24 kB at 2.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.8.2/junit-bom-5.8.2.pom
Progress (1): 4.1/5.6 kB
Progress (1): 5.6 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.8.2/junit-bom-5.8.2.pom (5.6 kB at 626 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/4.5.1/mockito-bom-4.5.1.pom
Progress (1): 3.0 kB
                    
Downloaded from central: https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/4.5.1/mockito-bom-4.5.1.pom (3.0 kB at 373 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.12.10/byte-buddy-1.12.10.pom
Progress (1): 4.1/17 kB
Progress (1): 8.2/17 kB
Progress (1): 12/17 kB 
Progress (1): 16/17 kB
Progress (1): 17 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy/1.12.10/byte-buddy-1.12.10.pom (17 kB at 1.3 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.12.10/byte-buddy-parent-1.12.10.pom
Progress (1): 4.1/45 kB
Progress (1): 8.2/45 kB
Progress (1): 12/45 kB 
Progress (1): 16/45 kB
Progress (1): 20/45 kB
Progress (1): 25/45 kB
Progress (1): 29/45 kB
Progress (1): 33/45 kB
Progress (1): 37/45 kB
Progress (1): 41/45 kB
Progress (1): 45 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/net/bytebuddy/byte-buddy-parent/1.12.10/byte-buddy-parent-1.12.10.pom (45 kB at 3.8 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/jooq/joox-java-6/1.6.0/joox-java-6-1.6.0.pom
Progress (1): 4.1/12 kB
Progress (1): 8.2/12 kB
Progress (1): 12 kB    
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/jooq/joox-java-6/1.6.0/joox-java-6-1.6.0.pom (12 kB at 875 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.pom
Progress (1): 4.1/23 kB
Progress (1): 8.2/23 kB
Progress (1): 12/23 kB 
Progress (1): 16/23 kB
Progress (1): 20/23 kB
Progress (1): 23 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.pom (23 kB at 2.1 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api-parent/2.3.0/jaxb-api-parent-2.3.0.pom
Progress (1): 4.1/5.6 kB
Progress (1): 5.6 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/javax/xml/bind/jaxb-api-parent/2.3.0/jaxb-api-parent-2.3.0.pom (5.6 kB at 256 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/net/java/jvnet-parent/5/jvnet-parent-5.pom
Progress (1): 4.1/8.9 kB
Progress (1): 8.2/8.9 kB
Progress (1): 8.9 kB    
                    
Downloaded from central: https://repo.maven.apache.org/maven2/net/java/jvnet-parent/5/jvnet-parent-5.pom (8.9 kB at 355 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.jar
Downloading from central: https://repo.maven.apache.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-ejb_3.1_spec/1.0.2/geronimo-ejb_3.1_spec-1.0.2.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-jpa_2.0_spec/1.1/geronimo-jpa_2.0_spec-1.1.jar
Downloading from central: https://repo.maven.apache.org/maven2/joda-time/joda-time/2.11.2/joda-time-2.11.2.jar
Progress (1): 4.1/61 kB
Progress (1): 8.2/61 kB
Progress (1): 12/61 kB 
Progress (1): 16/61 kB
Progress (1): 20/61 kB
Progress (1): 25/61 kB
Progress (1): 29/61 kB
Progress (1): 33/61 kB
Progress (1): 37/61 kB
Progress (1): 41/61 kB
Progress (1): 45/61 kB
Progress (1): 49/61 kB
Progress (1): 53/61 kB
Progress (1): 57/61 kB
Progress (1): 61 kB   
                   
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.3/slf4j-api-2.0.3.jar (61 kB at 3.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-beans/5.3.23/spring-beans-5.3.23.jar
Progress (1): 4.1/699 kB
Progress (1): 8.2/699 kB
Progress (1): 12/699 kB 
Progress (1): 16/699 kB
Progress (1): 20/699 kB
Progress (1): 24/699 kB
Progress (1): 28/699 kB
Progress (1): 32/699 kB
Progress (1): 36/699 kB
Progress (1): 40/699 kB
Progress (1): 45/699 kB
Progress (1): 49/699 kB
Progress (1): 53/699 kB
Progress (1): 57/699 kB
Progress (1): 61/699 kB
Progress (1): 65/699 kB
Progress (1): 69/699 kB
Progress (1): 73/699 kB
Progress (1): 77/699 kB
Progress (1): 81/699 kB
Progress (1): 85/699 kB
Progress (1): 90/699 kB
Progress (1): 94/699 kB
Progress (1): 98/699 kB
Progress (1): 102/699 kB
Progress (1): 106/699 kB
Progress (1): 110/699 kB
Progress (1): 114/699 kB
Progress (1): 118/699 kB
Progress (1): 122/699 kB
Progress (1): 126/699 kB
Progress (1): 131/699 kB
Progress (1): 135/699 kB
Progress (1): 139/699 kB
Progress (1): 143/699 kB
Progress (1): 147/699 kB
Progress (2): 147/699 kB | 2.7/27 kB
Progress (2): 147/699 kB | 5.5/27 kB
Progress (2): 151/699 kB | 5.5/27 kB
Progress (2): 151/699 kB | 8.2/27 kB
Progress (2): 155/699 kB | 8.2/27 kB
Progress (2): 159/699 kB | 8.2/27 kB
Progress (2): 163/699 kB | 8.2/27 kB
Progress (2): 163/699 kB | 11/27 kB 
Progress (2): 163/699 kB | 14/27 kB
Progress (2): 163/699 kB | 16/27 kB
Progress (2): 167/699 kB | 16/27 kB
Progress (2): 171/699 kB | 16/27 kB
Progress (2): 176/699 kB | 16/27 kB
Progress (2): 176/699 kB | 19/27 kB
Progress (2): 176/699 kB | 22/27 kB
Progress (3): 176/699 kB | 22/27 kB | 4.1/120 kB
Progress (3): 176/699 kB | 25/27 kB | 4.1/120 kB
Progress (3): 176/699 kB | 25/27 kB | 8.2/120 kB
Progress (3): 176/699 kB | 25/27 kB | 12/120 kB 
Progress (3): 180/699 kB | 25/27 kB | 12/120 kB
Progress (4): 180/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 184/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 188/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 192/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 196/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 200/699 kB | 25/27 kB | 12/120 kB | 2.7/53 kB
Progress (4): 200/699 kB | 27 kB | 12/120 kB | 2.7/53 kB   
Progress (4): 200/699 kB | 27 kB | 16/120 kB | 2.7/53 kB
Progress (4): 204/699 kB | 27 kB | 16/120 kB | 2.7/53 kB
Progress (4): 208/699 kB | 27 kB | 16/120 kB | 2.7/53 kB
Progress (4): 212/699 kB | 27 kB | 16/120 kB | 2.7/53 kB
Progress (4): 212/699 kB | 27 kB | 16/120 kB | 5.5/53 kB
Progress (4): 212/699 kB | 27 kB | 20/120 kB | 5.5/53 kB
Progress (4): 212/699 kB | 27 kB | 25/120 kB | 5.5/53 kB
Progress (4): 212/699 kB | 27 kB | 29/120 kB | 5.5/53 kB
Progress (4): 212/699 kB | 27 kB | 33/120 kB | 5.5/53 kB
Progress (4): 212/699 kB | 27 kB | 33/120 kB | 8.2/53 kB
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 8.2/53 kB
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 11/53 kB 
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 14/53 kB
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 16/53 kB
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 19/53 kB
Progress (4): 217/699 kB | 27 kB | 33/120 kB | 22/53 kB
Progress (4): 217/699 kB | 27 kB | 37/120 kB | 22/53 kB
Progress (4): 217/699 kB | 27 kB | 41/120 kB | 22/53 kB
Progress (4): 217/699 kB | 27 kB | 45/120 kB | 22/53 kB
Progress (4): 217/699 kB | 27 kB | 49/120 kB | 22/53 kB
                                                       
Downloaded from central: https://repo.maven.apache.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar (27 kB at 359 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-core/5.3.23/spring-core-5.3.23.jar
Progress (3): 221/699 kB | 49/120 kB | 22/53 kB
Progress (3): 225/699 kB | 49/120 kB | 22/53 kB
Progress (3): 225/699 kB | 49/120 kB | 25/53 kB
Progress (3): 225/699 kB | 49/120 kB | 27/53 kB
Progress (3): 225/699 kB | 49/120 kB | 30/53 kB
Progress (3): 225/699 kB | 49/120 kB | 33/53 kB
Progress (3): 225/699 kB | 49/120 kB | 36/53 kB
Progress (3): 225/699 kB | 49/120 kB | 38/53 kB
Progress (3): 225/699 kB | 53/120 kB | 38/53 kB
Progress (3): 225/699 kB | 57/120 kB | 38/53 kB
Progress (3): 225/699 kB | 61/120 kB | 38/53 kB
Progress (3): 225/699 kB | 66/120 kB | 38/53 kB
Progress (3): 225/699 kB | 66/120 kB | 41/53 kB
Progress (3): 225/699 kB | 66/120 kB | 44/53 kB
Progress (3): 225/699 kB | 70/120 kB | 44/53 kB
Progress (3): 225/699 kB | 74/120 kB | 44/53 kB
Progress (3): 225/699 kB | 78/120 kB | 44/53 kB
Progress (4): 225/699 kB | 78/120 kB | 44/53 kB | 4.1/632 kB
Progress (4): 229/699 kB | 78/120 kB | 44/53 kB | 4.1/632 kB
Progress (4): 229/699 kB | 78/120 kB | 44/53 kB | 8.2/632 kB
Progress (4): 229/699 kB | 78/120 kB | 44/53 kB | 12/632 kB 
Progress (4): 229/699 kB | 78/120 kB | 44/53 kB | 16/632 kB
Progress (4): 229/699 kB | 82/120 kB | 44/53 kB | 16/632 kB
Progress (4): 229/699 kB | 82/120 kB | 47/53 kB | 16/632 kB
Progress (5): 229/699 kB | 82/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 233/699 kB | 82/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 82/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 86/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 90/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 94/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 47/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 49/53 kB | 16/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 49/53 kB | 20/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 49/53 kB | 25/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 49/53 kB | 29/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 49/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 98/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 102/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 106/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 111/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 237/699 kB | 115/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 241/699 kB | 115/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 115/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 52/53 kB | 33/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 52/53 kB | 37/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 52/53 kB | 41/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 52/53 kB | 45/632 kB | 0/1.5 MB
Progress (5): 245/699 kB | 119/120 kB | 53 kB | 45/632 kB | 0/1.5 MB   
Progress (5): 245/699 kB | 119/120 kB | 53 kB | 49/632 kB | 0/1.5 MB
Progress (5): 249/699 kB | 119/120 kB | 53 kB | 49/632 kB | 0/1.5 MB
Progress (5): 253/699 kB | 119/120 kB | 53 kB | 49/632 kB | 0/1.5 MB
Progress (5): 253/699 kB | 119/120 kB | 53 kB | 49/632 kB | 0/1.5 MB
Progress (5): 253/699 kB | 120 kB | 53 kB | 49/632 kB | 0/1.5 MB    
Progress (5): 253/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
Progress (5): 253/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
Progress (5): 253/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
Progress (5): 253/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
Progress (5): 257/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
Progress (5): 262/699 kB | 120 kB | 53 kB | 49/632 kB | 0.1/1.5 MB
                                                                  
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-ejb_3.1_spec/1.0.2/geronimo-ejb_3.1_spec-1.0.2.jar (53 kB at 548 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/spring-jcl/5.3.23/spring-jcl-5.3.23.jar
Progress (4): 262/699 kB | 120 kB | 53/632 kB | 0.1/1.5 MB
Progress (4): 262/699 kB | 120 kB | 57/632 kB | 0.1/1.5 MB
Progress (4): 262/699 kB | 120 kB | 57/632 kB | 0.1/1.5 MB
Progress (4): 262/699 kB | 120 kB | 61/632 kB | 0.1/1.5 MB
Progress (4): 266/699 kB | 120 kB | 61/632 kB | 0.1/1.5 MB
Progress (4): 270/699 kB | 120 kB | 61/632 kB | 0.1/1.5 MB
Progress (4): 274/699 kB | 120 kB | 61/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 61/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 66/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 66/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 70/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 74/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 74/632 kB | 0.1/1.5 MB
Progress (4): 278/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 282/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 286/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 290/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 294/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 294/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 298/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 303/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (4): 303/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB
Progress (5): 303/699 kB | 120 kB | 78/632 kB | 0.1/1.5 MB | 4.1/24 kB
                                                                      
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/geronimo/specs/geronimo-jpa_2.0_spec/1.1/geronimo-jpa_2.0_spec-1.1.jar (120 kB at 1.2 MB/s)
Downloading from central: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar
Progress (4): 303/699 kB | 82/632 kB | 0.1/1.5 MB | 4.1/24 kB
Progress (4): 303/699 kB | 82/632 kB | 0.1/1.5 MB | 8.2/24 kB
Progress (4): 303/699 kB | 82/632 kB | 0.1/1.5 MB | 12/24 kB 
Progress (4): 303/699 kB | 86/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 90/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 94/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 98/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 98/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 102/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 106/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 111/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 303/699 kB | 115/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 307/699 kB | 115/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 311/699 kB | 115/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 311/699 kB | 119/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 311/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 311/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 315/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 319/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 323/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (4): 327/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB
Progress (5): 327/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB | 4.1/4.7 kB
Progress (5): 327/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB | 4.7 kB    
Progress (5): 331/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB | 4.7 kB
Progress (5): 335/699 kB | 123/632 kB | 0.1/1.5 MB | 12/24 kB | 4.7 kB
Progress (5): 335/699 kB | 123/632 kB | 0.1/1.5 MB | 16/24 kB | 4.7 kB
Progress (5): 339/699 kB | 123/632 kB | 0.1/1.5 MB | 16/24 kB | 4.7 kB
Progress (5): 339/699 kB | 123/632 kB | 0.1/1.5 MB | 20/24 kB | 4.7 kB
Progress (5): 339/699 kB | 123/632 kB | 0.1/1.5 MB | 20/24 kB | 4.7 kB
Progress (5): 339/699 kB | 127/632 kB | 0.1/1.5 MB | 20/24 kB | 4.7 kB
Progress (5): 339/699 kB | 131/632 kB | 0.1/1.5 MB | 20/24 kB | 4.7 kB
Progress (5): 339/699 kB | 131/632 kB | 0.1/1.5 MB | 24/24 kB | 4.7 kB
Progress (5): 339/699 kB | 131/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB   
Progress (5): 339/699 kB | 135/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 339/699 kB | 139/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 339/699 kB | 143/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 339/699 kB | 147/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 147/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 152/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 156/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 160/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 164/632 kB | 0.1/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 164/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 164/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 168/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 172/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 176/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
Progress (5): 344/699 kB | 180/632 kB | 0.2/1.5 MB | 24 kB | 4.7 kB
                                                                   
Downloaded from central: https://repo.maven.apache.org/maven2/jakarta/inject/jakarta.inject-api/1.0/jakarta.inject-api-1.0.jar (4.7 kB at 62 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar
Progress (4): 348/699 kB | 180/632 kB | 0.2/1.5 MB | 24 kB
Progress (4): 348/699 kB | 184/632 kB | 0.2/1.5 MB | 24 kB
Progress (4): 348/699 kB | 184/632 kB | 0.2/1.5 MB | 24 kB
Progress (4): 348/699 kB | 184/632 kB | 0.2/1.5 MB | 24 kB
                                                          
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/spring-jcl/5.3.23/spring-jcl-5.3.23.jar (24 kB at 305 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/google/inject/guice/5.1.0/guice-5.1.0.jar
Progress (3): 352/699 kB | 184/632 kB | 0.2/1.5 MB
Progress (3): 352/699 kB | 188/632 kB | 0.2/1.5 MB
Progress (3): 356/699 kB | 188/632 kB | 0.2/1.5 MB
Progress (3): 360/699 kB | 188/632 kB | 0.2/1.5 MB
Progress (3): 360/699 kB | 188/632 kB | 0.2/1.5 MB
Progress (3): 360/699 kB | 193/632 kB | 0.2/1.5 MB
Progress (3): 360/699 kB | 197/632 kB | 0.2/1.5 MB
Progress (3): 364/699 kB | 197/632 kB | 0.2/1.5 MB
Progress (3): 368/699 kB | 197/632 kB | 0.2/1.5 MB
Progress (3): 368/699 kB | 197/632 kB | 0.2/1.5 MB
Progress (3): 368/699 kB | 201/632 kB | 0.2/1.5 MB
Progress (3): 368/699 kB | 205/632 kB | 0.2/1.5 MB
Progress (3): 368/699 kB | 209/632 kB | 0.2/1.5 MB
Progress (3): 372/699 kB | 209/632 kB | 0.2/1.5 MB
Progress (3): 376/699 kB | 209/632 kB | 0.2/1.5 MB
Progress (3): 376/699 kB | 209/632 kB | 0.2/1.5 MB
Progress (3): 376/699 kB | 209/632 kB | 0.2/1.5 MB
Progress (4): 376/699 kB | 209/632 kB | 0.2/1.5 MB | 4.1/25 kB
Progress (4): 376/699 kB | 209/632 kB | 0.2/1.5 MB | 8.2/25 kB
Progress (4): 376/699 kB | 209/632 kB | 0.2/1.5 MB | 12/25 kB 
Progress (4): 376/699 kB | 209/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 376/699 kB | 213/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 376/699 kB | 213/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 376/699 kB | 213/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 376/699 kB | 217/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 376/699 kB | 221/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 380/699 kB | 221/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 380/699 kB | 221/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (4): 380/699 kB | 221/632 kB | 0.2/1.5 MB | 16/25 kB
Progress (5): 380/699 kB | 221/632 kB | 0.2/1.5 MB | 16/25 kB | 4.1/778 kB
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 4.1/778 kB
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 8.2/778 kB
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 12/778 kB 
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 16/778 kB
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 16/778 kB
Progress (5): 380/699 kB | 221/632 kB | 0.3/1.5 MB | 16/25 kB | 16/778 kB
Progress (5): 380/699 kB | 225/632 kB | 0.3/1.5 MB | 16/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 16/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 20/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 16/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 20/778 kB
Progress (5): 380/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 25/778 kB
Progress (5): 384/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 25/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 25/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 25/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 25/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 29/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 33/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 37/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 41/778 kB
Progress (5): 389/699 kB | 229/632 kB | 0.3/1.5 MB | 25/25 kB | 45/778 kB
Progress (5): 389/699 kB | 233/632 kB | 0.3/1.5 MB | 25/25 kB | 45/778 kB
Progress (5): 389/699 kB | 238/632 kB | 0.3/1.5 MB | 25/25 kB | 45/778 kB
Progress (5): 389/699 kB | 242/632 kB | 0.3/1.5 MB | 25/25 kB | 45/778 kB
Progress (5): 389/699 kB | 242/632 kB | 0.3/1.5 MB | 25 kB | 45/778 kB   
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 45/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 49/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 49/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 49/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 53/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 57/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 61/778 kB
Progress (5): 389/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 66/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 66/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 70/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 74/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 78/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 82/778 kB
Progress (5): 393/699 kB | 246/632 kB | 0.3/1.5 MB | 25 kB | 82/778 kB
Progress (5): 393/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 82/778 kB
Progress (5): 393/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 86/778 kB
Progress (5): 393/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 86/778 kB
Progress (5): 397/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 86/778 kB
Progress (5): 401/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 86/778 kB
Progress (5): 401/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 90/778 kB
Progress (5): 401/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 94/778 kB
Progress (5): 401/699 kB | 250/632 kB | 0.3/1.5 MB | 25 kB | 98/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 98/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 102/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 102/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 106/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 111/778 kB
Progress (5): 401/699 kB | 254/632 kB | 0.3/1.5 MB | 25 kB | 115/778 kB
Progress (5): 401/699 kB | 258/632 kB | 0.3/1.5 MB | 25 kB | 115/778 kB
                                                                       
Downloaded from central: https://repo.maven.apache.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar (25 kB at 261 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar
Progress (4): 401/699 kB | 258/632 kB | 0.3/1.5 MB | 119/778 kB
Progress (4): 405/699 kB | 258/632 kB | 0.3/1.5 MB | 119/778 kB
Progress (4): 405/699 kB | 258/632 kB | 0.4/1.5 MB | 119/778 kB
Progress (4): 405/699 kB | 258/632 kB | 0.4/1.5 MB | 123/778 kB
Progress (4): 405/699 kB | 258/632 kB | 0.4/1.5 MB | 127/778 kB
Progress (4): 405/699 kB | 258/632 kB | 0.4/1.5 MB | 131/778 kB
Progress (4): 405/699 kB | 262/632 kB | 0.4/1.5 MB | 131/778 kB
Progress (4): 409/699 kB | 262/632 kB | 0.4/1.5 MB | 131/778 kB
Progress (4): 413/699 kB | 262/632 kB | 0.4/1.5 MB | 131/778 kB
Progress (4): 417/699 kB | 262/632 kB | 0.4/1.5 MB | 131/778 kB
Progress (4): 417/699 kB | 262/632 kB | 0.4/1.5 MB | 135/778 kB
Progress (4): 417/699 kB | 262/632 kB | 0.4/1.5 MB | 139/778 kB
Progress (4): 417/699 kB | 262/632 kB | 0.4/1.5 MB | 143/778 kB
Progress (4): 417/699 kB | 262/632 kB | 0.4/1.5 MB | 143/778 kB
Progress (4): 421/699 kB | 262/632 kB | 0.4/1.5 MB | 143/778 kB
Progress (4): 421/699 kB | 262/632 kB | 0.4/1.5 MB | 143/778 kB
Progress (4): 421/699 kB | 262/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 262/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 266/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 270/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 270/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 274/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 421/699 kB | 279/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 279/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 283/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 287/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 291/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 295/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (4): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 147/778 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 147/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 147/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 147/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 152/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 156/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 425/699 kB | 299/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 425/699 kB | 303/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 430/699 kB | 303/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 430/699 kB | 303/632 kB | 0.4/1.5 MB | 160/778 kB | 2.5 kB
Progress (5): 430/699 kB | 303/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 430/699 kB | 307/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 430/699 kB | 311/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 430/699 kB | 315/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 430/699 kB | 319/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 430/699 kB | 319/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 434/699 kB | 319/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 434/699 kB | 324/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 434/699 kB | 328/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 434/699 kB | 332/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 434/699 kB | 336/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 438/699 kB | 336/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 438/699 kB | 340/632 kB | 0.4/1.5 MB | 164/778 kB | 2.5 kB
Progress (5): 438/699 kB | 340/632 kB | 0.4/1.5 MB | 168/778 kB | 2.5 kB
Progress (5): 438/699 kB | 344/632 kB | 0.4/1.5 MB | 168/778 kB | 2.5 kB
Progress (5): 438/699 kB | 344/632 kB | 0.4/1.5 MB | 168/778 kB | 2.5 kB
                                                                        
Downloaded from central: https://repo.maven.apache.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar (2.5 kB at 24 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
Progress (4): 442/699 kB | 344/632 kB | 0.4/1.5 MB | 168/778 kB
Progress (4): 446/699 kB | 344/632 kB | 0.4/1.5 MB | 168/778 kB
Progress (4): 450/699 kB | 344/632 kB | 0.4/1.5 MB | 168/778 kB
Progress (4): 450/699 kB | 348/632 kB | 0.4/1.5 MB | 168/778 kB
Progress (4): 450/699 kB | 352/632 kB | 0.4/1.5 MB | 168/778 kB
Progress (4): 450/699 kB | 352/632 kB | 0.4/1.5 MB | 172/778 kB
Progress (4): 454/699 kB | 352/632 kB | 0.4/1.5 MB | 172/778 kB
Progress (4): 458/699 kB | 352/632 kB | 0.4/1.5 MB | 172/778 kB
Progress (4): 462/699 kB | 352/632 kB | 0.4/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 352/632 kB | 0.4/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 352/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 356/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 360/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 172/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 176/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 180/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 180/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 180/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 184/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 188/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 193/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 193/778 kB
Progress (4): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 197/778 kB
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 197/778 kB | 4.1/4.5 kB
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 197/778 kB | 4.5 kB    
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 201/778 kB | 4.5 kB
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 205/778 kB | 4.5 kB
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 209/778 kB | 4.5 kB
Progress (5): 466/699 kB | 365/632 kB | 0.5/1.5 MB | 213/778 kB | 4.5 kB
Progress (5): 466/699 kB | 369/632 kB | 0.5/1.5 MB | 213/778 kB | 4.5 kB
Progress (5): 466/699 kB | 369/632 kB | 0.5/1.5 MB | 217/778 kB | 4.5 kB
Progress (5): 466/699 kB | 369/632 kB | 0.5/1.5 MB | 221/778 kB | 4.5 kB
Progress (5): 466/699 kB | 369/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 466/699 kB | 373/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 466/699 kB | 377/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 466/699 kB | 381/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 466/699 kB | 385/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 470/699 kB | 385/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 475/699 kB | 385/632 kB | 0.5/1.5 MB | 225/778 kB | 4.5 kB
Progress (5): 475/699 kB | 385/632 kB | 0.5/1.5 MB | 229/778 kB | 4.5 kB
Progress (5): 479/699 kB | 385/632 kB | 0.5/1.5 MB | 229/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 229/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 233/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 238/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 242/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 246/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 246/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 250/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 483/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 487/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 491/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 495/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 499/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 503/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 507/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 511/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 516/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 520/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 524/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 528/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 532/699 kB | 385/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 532/699 kB | 389/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 536/699 kB | 389/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 536/699 kB | 393/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 536/699 kB | 397/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
Progress (5): 536/699 kB | 401/632 kB | 0.5/1.5 MB | 254/778 kB | 4.5 kB
                                                                        
Downloaded from central: https://repo.maven.apache.org/maven2/aopalliance/aopalliance/1.0/aopalliance-1.0.jar (4.5 kB at 37 kB/s)
```
</details>

This PR adds the [options `--batch-mode --no-transfer-progress`](https://maven.apache.org/ref/current/maven-embedder/cli.html) to the maven command to avoid these.