### PR TITLE
adjust all log-levels besides WARN to TRACE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,35 @@ To submit a contribution, please follow the following workflow:
 ### Commits
 
 Commit messages should be clear and fully elaborate the context and the reason of a change.
-If your commit refers to an issue, please post-fix it with the issue number, e.g.
+Each commit message should follow the following conventions:
+
+* it may use markdown to improve readability on GitHub
+* it must start with a title
+  * less than 70 characters
+  * starting lowercase
+  * written in imperative style as to complete the statement "if applied this commit will" (e.g. "fix race condition when loading import plugins")
+* if the commit is not trivial the title should be followed by a body
+  * separated from the title by a blank line
+  * explaining all necessary context and reasons for the change
+* if your commit refers to an issue, please post-fix it with the issue number, e.g. `Issue: #123` or `Resolves: #123`
+
+A full example:
 
 ```
-Issue: #123
+report classes contained in multiple PlantUML components as violation
+
+So far when checking an `ArchRule` based on `PlantUmlArchCondition` we were throwing an exception
+if a class was contained in multiple diagram components. 
+This causes problems for legacy code bases where some classes might violate the conventions
+in such a way, which should be frozen as violations to be iteratively fixed. 
+But throwing a `ComponentIntersectionException` prevents any such approach. 
+We thus replace the `ComponentIntersectionException` by a regular rule violation that can be treated
+like any other violation of the architecture and in particular be frozen via `FreezingArchRule`.
+
+Resolves: #960
 ```
 
-Furthermore, commits should be signed off according to the [DCO](DCO).
+Furthermore, commits must be signed off according to the [DCO](DCO).
 
 ### Pull Requests
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -50,10 +50,6 @@ public final class JavaField extends JavaMember implements HasType {
         return getOwner().getName() + "." + getName();
     }
 
-    /**
-     * Note: This is still work in progress and thus does not support generic types at the moment.
-     *       In the future the result can possibly also be a {@link JavaParameterizedType} or {@link JavaTypeVariable}
-     */
     @Override
     @PublicAPI(usage = ACCESS)
     public JavaType getType() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -15,12 +15,29 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import java.lang.reflect.Type;
+
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Represents a general Java type. This can e.g. be a class like {@code java.lang.String}, a parameterized type
+ * like {@code List<String>} or a type variable like {@code T}.<br>
+ * Besides having a {@link HasName#getName() name} and offering the possibility to being converted to an
+ * {@link #toErasure() erasure} (which is then always {@link JavaClass a raw class object}) {@link JavaType} doesn't offer
+ * an extensive API. Instead, users can check a {@link JavaType} for being an instance of a concrete subtype
+ * (like {@link JavaTypeVariable}) and then cast it to the respective subclass
+ * (same as with {@link Type} of the Java Reflection API).
+ *
+ * @see JavaClass
+ * @see JavaParameterizedType
+ * @see JavaTypeVariable
+ * @see JavaWildcardType
+ * @see JavaGenericArrayType
+ */
 @PublicAPI(usage = ACCESS)
 public interface JavaType extends HasName {
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasType.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaParameterizedType;
 import com.tngtech.archunit.core.domain.JavaType;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
@@ -29,9 +30,21 @@ import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_
 @PublicAPI(usage = ACCESS)
 public interface HasType {
 
+    /**
+     * @return The (possibly generic) {@link JavaType} of this object. Refer to the documentation of {@link JavaType}
+     *         for further information.
+     * @see #getRawType()
+     */
     @PublicAPI(usage = ACCESS)
     JavaType getType();
 
+    /**
+     * @return The raw type of this object. This is effectively the same as calling
+     *         {@link #getType()}.{@link JavaType#toErasure() toErasure()}. E.g. given a {@link JavaParameterizedType}
+     *         {@code java.util.List<String>} the raw type (i.e. type erasure) would be the
+     *         {@link JavaClass} {@code java.util.List}.
+     * @see #getType()
+     */
     @PublicAPI(usage = ACCESS)
     JavaClass getRawType();
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -124,7 +124,7 @@ class DependencyResolutionProcess {
     }
 
     private void logConfiguration() {
-        log.debug("Automatically resolving transitive class dependencies with the following configuration:{}{}{}{}{}{}",
+        log.trace("Automatically resolving transitive class dependencies with the following configuration:{}{}{}{}{}{}",
                 formatConfigProperty(MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME, maxRunsForMemberTypes),
                 formatConfigProperty(MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME, maxRunsForAccessesToTypes),
                 formatConfigProperty(MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME, maxRunsForSupertypes),

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/JohnsonCycleFinder.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/JohnsonCycleFinder.java
@@ -119,7 +119,7 @@ class JohnsonCycleFinder {
         private boolean maxNumberOfCyclesReached = false;
 
         private Result() {
-            log.debug("Maximum number of cycles to detect is set to {}; "
+            log.trace("Maximum number of cycles to detect is set to {}; "
                             + "this limit can be adapted using the `archunit.properties` value `{}=xxx`",
                     configuration.getMaxNumberOfCyclesToDetect(), MAX_NUMBER_OF_CYCLES_TO_DETECT_PROPERTY_NAME);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/dependencies/SliceCycleArchCondition.java
@@ -174,7 +174,7 @@ class SliceCycleArchCondition extends ArchCondition<Slice> {
         private final CycleConfiguration cycleConfiguration = new CycleConfiguration();
 
         private EventRecorder() {
-            log.debug("Maximum number of dependencies to report per edge is set to {}; "
+            log.trace("Maximum number of dependencies to report per edge is set to {}; "
                             + "this limit can be adapted using the `archunit.properties` value `{}=xxx`",
                     cycleConfiguration.getMaxNumberOfDependenciesToShowPerEdge(), MAX_NUMBER_OF_DEPENDENCIES_TO_SHOW_PER_EDGE_PROPERTY_NAME);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/FreezingArchRule.java
@@ -134,13 +134,13 @@ public final class FreezingArchRule implements ArchRule {
     }
 
     private EvaluationResult storeViolationsAndReturnSuccess(EvaluationResultLineBreakAdapter result) {
-        log.debug("No results present for rule '{}'. Freezing rule result...", delegate.getDescription());
+        log.trace("No results present for rule '{}'. Freezing rule result...", delegate.getDescription());
         store.save(delegate, result.getViolations());
         return new EvaluationResult(delegate, result.getPriority());
     }
 
     private EvaluationResult removeObsoleteViolationsFromStoreAndReturnNewViolations(EvaluationResultLineBreakAdapter result) {
-        log.debug("Found frozen result for rule '{}'", delegate.getDescription());
+        log.trace("Found frozen result for rule '{}'", delegate.getDescription());
         List<String> knownViolations = store.getViolations(delegate);
         CategorizedViolations categorizedViolations = new CategorizedViolations(matcher, result, knownViolations);
         removeObsoleteViolationsFromStore(categorizedViolations);
@@ -149,14 +149,14 @@ public final class FreezingArchRule implements ArchRule {
 
     private void removeObsoleteViolationsFromStore(CategorizedViolations categorizedViolations) {
         List<String> solvedViolations = categorizedViolations.getStoredSolvedViolations();
-        log.debug("Removing {} obsolete violations from store: {}", solvedViolations.size(), solvedViolations);
+        log.trace("Removing {} obsolete violations from store: {}", solvedViolations.size(), solvedViolations);
         if (!solvedViolations.isEmpty()) {
             store.save(delegate, categorizedViolations.getStoredUnsolvedViolations());
         }
     }
 
     private EvaluationResult filterOutKnownViolations(EvaluationResultLineBreakAdapter result, Set<String> knownActualViolations) {
-        log.debug("Filtering out known violations: {}", knownActualViolations);
+        log.trace("Filtering out known violations: {}", knownActualViolations);
         return result.filterDescriptionsMatching(violation -> !knownActualViolations.contains(violation));
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationStoreFactory.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/ViolationStoreFactory.java
@@ -88,7 +88,7 @@ class ViolationStoreFactory {
             storeFolder = new File(path);
             ensureExistence(storeFolder);
             File storedRulesFile = getStoredRulesFile();
-            log.info("Initializing {} at {}", TextFileBasedViolationStore.class.getSimpleName(), storedRulesFile.getAbsolutePath());
+            log.trace("Initializing {} at {}", TextFileBasedViolationStore.class.getSimpleName(), storedRulesFile.getAbsolutePath());
             storedRules = new FileSyncedProperties(storedRulesFile);
             checkInitialization(storedRules.initializationSuccessful(), "Cannot create rule store at %s", storedRulesFile.getAbsolutePath());
         }
@@ -120,7 +120,7 @@ class ViolationStoreFactory {
 
         @Override
         public void save(ArchRule rule, List<String> violations) {
-            log.debug("Storing evaluated rule '{}' with {} violations: {}", rule.getDescription(), violations.size(), violations);
+            log.trace("Storing evaluated rule '{}' with {} violations: {}", rule.getDescription(), violations.size(), violations);
             if (!storeUpdateAllowed) {
                 throw new StoreUpdateFailedException(String.format(
                         "Updating frozen violations is disabled (enable by configuration %s.%s=true)",
@@ -155,7 +155,7 @@ class ViolationStoreFactory {
             String ruleFileName;
             if (storedRules.containsKey(rule.getDescription())) {
                 ruleFileName = storedRules.getProperty(rule.getDescription());
-                log.debug("Rule '{}' is already stored in file {}", rule.getDescription(), ruleFileName);
+                log.trace("Rule '{}' is already stored in file {}", rule.getDescription(), ruleFileName);
             } else {
                 ruleFileName = createNewRuleId(rule).toString();
             }
@@ -164,7 +164,7 @@ class ViolationStoreFactory {
 
         private UUID createNewRuleId(ArchRule rule) {
             UUID ruleId = UUID.randomUUID();
-            log.debug("Assigning new ID {} to rule '{}'", ruleId, rule.getDescription());
+            log.trace("Assigning new ID {} to rule '{}'", ruleId, rule.getDescription());
             storedRules.setProperty(rule.getDescription(), ruleId.toString());
             return ruleId;
         }
@@ -174,7 +174,7 @@ class ViolationStoreFactory {
             String ruleDetailsFileName = storedRules.getProperty(rule.getDescription());
             checkArgument(ruleDetailsFileName != null, "No rule stored with description '%s'", rule.getDescription());
             List<String> result = readLines(ruleDetailsFileName);
-            log.debug("Retrieved stored rule '{}' with {} violations: {}", rule.getDescription(), result.size(), result);
+            log.trace("Retrieved stored rule '{}' with {} violations: {}", rule.getDescription(), result.size(), result);
             return result;
         }
 


### PR DESCRIPTION
Over the years there have been continuous issues by people not configuring their logging system appropriately and then being spammed by masses of DEBUG logs. In particular, because ArchUnit hooks into SLF4J and as it seems e.g. Spring Boot sets the log-level to DEBUG if the configuration is missing. While I principally think people should just correctly configure their logging infrastructure I've also been worn down over time ;-) So, I will reduce all non-WARN levels to TRACE now and accept that it will not be possible anymore to distinguish extremely spammy output (like "found access from x to y") from more central output (like "dependency resolution configuration") by log-level.

Resolves: #1038
Resolves: #1049