### PR TITLE
Bump various dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Build JDK
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
@@ -79,12 +79,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Build JDK
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
       - name: Set up Test JDK
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.test_java_version }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Gradle JDK
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: 17

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
     id 'com.github.spotbugs' version '5.0.13' apply false
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0" apply false
-    id "com.diffplug.spotless" version "6.16.0" apply false
+    id "com.diffplug.spotless" version "6.17.0" apply false
     id 'com.github.ben-manes.versions' version '0.46.0' apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,24 +46,24 @@ ext {
                                           exclude module: 'j2objc-annotations'
                                       }
                                   },
-            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.3'],
-            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'],
-            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'],
-            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.19.0'],
+            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.6'],
+            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'],
+            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'],
+            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'],
 
             junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.1'],
-            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.1'],
-            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.9.1'],
-            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.9.1'],
-            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.9.1'],
-            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.9.1'],
+            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.9.2'],
+            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.9.2'],
+            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.9.2'],
+            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.9.2'],
+            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.9.2'],
+            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.9.2'],
             hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'],
             junit_dataprovider  : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
             mockito             : [group: 'org.mockito', name: 'mockito-core', version: '4.6.1'],
             mockito_junit5      : [group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'],
-            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.23.1'],
-            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.5.0'],
+            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.24.2'],
+            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.24.2'],
 
             // Dependencies for example projects / tests
             javaxAnnotationApi  : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],
@@ -74,7 +74,7 @@ ext {
             // NOTE: The pure javaee-api dependencies are crippled, so to run any test we need to choose a full implementation provider
             geronimoEjb         : [group: 'org.apache.geronimo.specs', name: 'geronimo-ejb_3.1_spec', version: '1.0.2'],
             geronimoJpa         : [group: 'org.apache.geronimo.specs', name: 'geronimo-jpa_2.0_spec', version: '1.1'],
-            jodaTime            : [group: 'joda-time', name: 'joda-time', version: '2.11.2'],
+            jodaTime            : [group: 'joda-time', name: 'joda-time', version: '2.12.2'],
             joox                : [group: 'org.jooq', name: 'joox-java-6', version: '1.6.0']
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'archunit.base-conventions'
     id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.github.spotbugs' version '5.0.13' apply false
+    id 'com.github.spotbugs' version '5.0.14' apply false
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0" apply false
     id "com.diffplug.spotless" version "6.17.0" apply false
     id 'com.github.ben-manes.versions' version '0.46.0' apply false

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.1)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -9,7 +9,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -82,7 +82,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.0)
-    minitest (5.17.0)
+    minitest (5.18.0)
     multipart-post (2.1.1)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -110,7 +110,7 @@ GEM
       faraday (> 0.8, < 2.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     webrick (1.7.0)

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -24,7 +24,7 @@ asciidoctor {
     asciidoctorj {
         modules {
             diagram.use()
-            diagram.version '1.5.16'
+            diagram.version '2.2.4'
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.gradle.enterprise" version "3.12.4"
+    id "com.gradle.enterprise" version "3.12.6"
 }
 
 rootProject.name = 'archunit-root'


### PR DESCRIPTION
```
Group                    Name                                   Version

org.slf4j                slf4j-api                              2.0.3  -> 2.0.6
org.apache.logging.log4j log4j-{api,core,slf4j2-impl}           2.19.0 -> 2.20.0
org.junit.jupiter        junit-jupiter-{api,engine}             5.9.1  -> 5.9.2
org.junit.vintage        junit-vintage-engine                   5.9.1  -> 5.9.2
org.junit.platform       junit-platform-{runner,commons,engine} 1.9.1  -> 1.9.2

org.assertj              asertj-{core,guava}                    3.*    -> 3.24.2

joda-time                joda-time                              2.11.2 -> 2.12.2

org.asciidoctor          asciidoctorj-diagram                   1.5.16 -> 2.2.4
```