### PR TITLE
Ensure final newline in violation store files

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStore.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStore.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.lang.ArchRule;
@@ -151,24 +150,23 @@ public final class TextFileBasedViolationStore implements ViolationStore {
     }
 
     private void write(List<String> violations, File ruleDetails) {
-        String updatedViolations = Joiner.on("\n").join(escape(violations));
+        StringBuilder builder = new StringBuilder();
+        for (String violation : violations) {
+            builder.append(escape(violation)).append("\n");
+        }
         try {
-            Files.write(ruleDetails.toPath(), updatedViolations.getBytes(UTF_8));
+            Files.write(ruleDetails.toPath(), builder.toString().getBytes(UTF_8));
         } catch (IOException e) {
             throw new StoreUpdateFailedException(e);
         }
     }
 
-    private List<String> escape(List<String> violations) {
-        return replaceCharacter(violations, "\n", "\\\n");
+    private String escape(String violation) {
+        return violation.replace("\n", "\\\n");
     }
 
-    private List<String> unescape(List<String> violations) {
-        return replaceCharacter(violations, "\\\n", "\n");
-    }
-
-    private List<String> replaceCharacter(List<String> violations, String characterToReplace, String replacement) {
-        return violations.stream().map(violation -> violation.replace(characterToReplace, replacement)).collect(toList());
+    private String unescape(String violation) {
+        return violation.replace("\\\n", "\n");
     }
 
     private String ensureRuleFileName(ArchRule rule) {
@@ -197,8 +195,9 @@ public final class TextFileBasedViolationStore implements ViolationStore {
 
     private List<String> readLines(String ruleDetailsFileName) {
         String violationsText = readStoreFile(ruleDetailsFileName);
-        List<String> lines = Splitter.on(UNESCAPED_LINE_BREAK_PATTERN).omitEmptyStrings().splitToList(violationsText);
-        return unescape(lines);
+        return Splitter.on(UNESCAPED_LINE_BREAK_PATTERN).omitEmptyStrings().splitToStream(violationsText)
+                .map(this::unescape)
+                .collect(toList());
     }
 
     private String readStoreFile(String fileName) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
@@ -60,8 +60,8 @@ public class TextFileBasedViolationStoreTest {
         String ruleViolationsFile = properties.getProperty(defaultRule().getDescription());
         assertThat(ruleViolationsFile).isNotBlank();
 
-        List<String> violationLines = Files.readLines(new File(configuredFolder, ruleViolationsFile), UTF_8);
-        assertThat(violationLines).containsOnly("first violation", "second violation");
+        String contents = Files.asCharSource(new File(configuredFolder, ruleViolationsFile), UTF_8).read();
+        assertThat(contents).isEqualTo("first violation\nsecond violation\n");
     }
 
     @Test


### PR DESCRIPTION
For a file to be considered a text file, it needs to end with a newline character. Previously, ArchUnit did not add the final newline, which broke Git diff and other tools.

Additionally, remove unnecessary list allocation: 1 when reading and 1 when writing a violation store file.

Resolves #1057