### PR TITLE
support type cast detection

### DIFF
--- a/archunit-example/example-junit4/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
+++ b/archunit-example/example-junit4/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
@@ -7,3 +7,4 @@ Method <com.tngtech.archunit.example.layers.persistence.second.dao.OtherDao.getE
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.findById(long)> calls method <javax.persistence.EntityManager.find(java.lang.Class, java.lang.Object)> in (OtherJpa.java:19)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.getEntityManager()> has return type <javax.persistence.EntityManager> in (OtherJpa.java:0)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> calls method <javax.persistence.EntityManager.unwrap(java.lang.Class)> in (OtherJpa.java:24)
+Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> casts <com.tngtech.archunit.example.layers.service.ProxiedConnection> in (OtherJpa.java:27)

--- a/archunit-example/example-junit5/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
+++ b/archunit-example/example-junit5/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
@@ -7,3 +7,4 @@ Method <com.tngtech.archunit.example.layers.persistence.second.dao.OtherDao.getE
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.findById(long)> calls method <javax.persistence.EntityManager.find(java.lang.Class, java.lang.Object)> in (OtherJpa.java:19)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.getEntityManager()> has return type <javax.persistence.EntityManager> in (OtherJpa.java:0)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> calls method <javax.persistence.EntityManager.unwrap(java.lang.Class)> in (OtherJpa.java:24)
+Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> casts <com.tngtech.archunit.example.layers.service.ProxiedConnection> in (OtherJpa.java:27)

--- a/archunit-example/example-plain/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
+++ b/archunit-example/example-plain/src/test/resources/frozen/e77ec262-4d5c-4a7b-b41f-362a71e5a1d8
@@ -7,3 +7,4 @@ Method <com.tngtech.archunit.example.layers.persistence.second.dao.OtherDao.getE
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.findById(long)> calls method <javax.persistence.EntityManager.find(java.lang.Class, java.lang.Object)> in (OtherJpa.java:19)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.getEntityManager()> has return type <javax.persistence.EntityManager> in (OtherJpa.java:0)
 Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> calls method <javax.persistence.EntityManager.unwrap(java.lang.Class)> in (OtherJpa.java:24)
+Method <com.tngtech.archunit.example.layers.persistence.second.dao.jpa.OtherJpa.testConnection()> casts <com.tngtech.archunit.example.layers.service.ProxiedConnection> in (OtherJpa.java:27)

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/integration/ExamplesIntegrationTest.java
@@ -672,6 +672,9 @@ class ExamplesIntegrationTest {
                 .by(method(OtherJpa.class, "testConnection")
                         .checkingInstanceOf(ProxiedConnection.class)
                         .inLine(26))
+                .by(method(OtherJpa.class, "testConnection")
+                        .casting(ProxiedConnection.class)
+                        .inLine(27))
 
                 .ofRule("no classes should depend on classes that are assignable to javax.persistence.EntityManager")
                 .by(callFromMethod(ServiceViolatingDaoRules.class, "illegallyUseEntityManager").
@@ -847,6 +850,9 @@ class ExamplesIntegrationTest {
                 .by(method(OtherJpa.class, "testConnection")
                         .checkingInstanceOf(ProxiedConnection.class)
                         .inLine(26))
+                .by(method(OtherJpa.class, "testConnection")
+                        .casting(ProxiedConnection.class)
+                        .inLine(27))
 
                 .ofRule("classes that reside in a package '..service..' should " +
                         "only have dependent classes that reside in any package ['..controller..', '..service..']")
@@ -866,6 +872,9 @@ class ExamplesIntegrationTest {
                 .by(method(OtherJpa.class, "testConnection")
                         .checkingInstanceOf(ProxiedConnection.class)
                         .inLine(26))
+                .by(method(OtherJpa.class, "testConnection")
+                        .casting(ProxiedConnection.class)
+                        .inLine(27))
 
                 .ofRule("classes that reside in a package '..service..' should "
                         + "only depend on classes that reside in any package ['..service..', '..persistence..', 'java..', 'javax..']")
@@ -972,6 +981,9 @@ class ExamplesIntegrationTest {
                                         .toMethod(ProxiedConnection.class, "refresh")
                                         .inLine(27)
                                         .asDependency())
+                                .by(method(OtherJpa.class, "testConnection")
+                                        .casting(ProxiedConnection.class)
+                                        .inLine(27))
 
                                 .by(typeParameter(ServiceHelper.class, "TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeUtility.class))
                                 .by(typeParameter(ServiceHelper.class, "ANOTHER_TYPE_PARAMETER_VIOLATING_LAYER_RULE").dependingOn(SomeEnum.class))

--- a/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
+++ b/archunit-integration-test/src/test/java/com/tngtech/archunit/testutils/ExpectedDependency.java
@@ -295,6 +295,10 @@ public class ExpectedDependency implements ExpectedRelation {
             return new AddsLineNumber(owner, getOriginName(), "checks instanceof", target);
         }
 
+        public AddsLineNumber casting(Class<?> target) {
+            return new AddsLineNumber(owner, getOriginName(), "casts", target);
+        }
+
         public AddsLineNumber referencingClassObject(Class<?> target) {
             return new AddsLineNumber(owner, getOriginName(), "references class object", target);
         }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -128,6 +128,12 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
                 instanceofCheck.getRawType(), instanceofCheck.getSourceCodeLocation());
     }
 
+    static Set<Dependency> tryCreateFromTypeCast(TypeCast typeCast) {
+        return tryCreateDependency(
+                typeCast.getOwner(), "casts",
+                typeCast.getRawType(), typeCast.getSourceCodeLocation());
+    }
+
     static Set<Dependency> tryCreateFromReferencedClassObject(ReferencedClassObject referencedClassObject) {
         return tryCreateDependency(
                 referencedClassObject.getOwner(), "references class object",

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -184,6 +184,10 @@ public class DomainObjectCreationContext {
         return InstanceofCheck.from(codeUnit, type, lineNumber, declaredInLambda);
     }
 
+    public static TypeCast createTypeCast(JavaCodeUnit codeUnit, JavaClass type, int lineNumber, boolean declaredInLambda) {
+        return TypeCast.from(codeUnit, type, lineNumber, declaredInLambda);
+    }
+
     public static <OWNER extends HasDescription> JavaTypeVariable<OWNER> createTypeVariable(String name, OWNER owner, JavaClass erasure) {
         return new JavaTypeVariable<>(name, owner, erasure);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -67,5 +67,7 @@ public interface ImportContext {
 
     Set<InstanceofCheck> createInstanceofChecksFor(JavaCodeUnit codeUnit);
 
+    Set<TypeCast> createTypeCastsFor(JavaCodeUnit codeUnit);
+
     JavaClass resolveClass(String fullyQualifiedClassName);
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -646,6 +646,11 @@ public final class JavaClass
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<TypeCast> getTypeCasts() {
+        return members.getTypeCasts();
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<ReferencedClassObject> getReferencedClassObjects() {
         return members.getReferencedClassObjects();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -49,6 +49,7 @@ class JavaClassDependencies {
                         throwsDeclarationDependenciesFromSelf(),
                         annotationDependenciesFromSelf(),
                         instanceofCheckDependenciesFromSelf(),
+                        typeCastDependenciesFromSelf(),
                         referencedClassObjectDependenciesFromSelf(),
                         typeParameterDependenciesFromSelf()
                 ).collect(toImmutableSet())
@@ -180,6 +181,11 @@ class JavaClassDependencies {
     private Stream<Dependency> instanceofCheckDependenciesFromSelf() {
         return javaClass.getInstanceofChecks().stream()
                 .flatMap(instanceofCheck -> Dependency.tryCreateFromInstanceofCheck(instanceofCheck).stream());
+    }
+
+    private Stream<Dependency> typeCastDependenciesFromSelf() {
+        return javaClass.getTypeCasts().stream()
+                .flatMap(typeCast -> Dependency.tryCreateFromTypeCast(typeCast).stream());
     }
 
     private Stream<Dependency> referencedClassObjectDependenciesFromSelf() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -191,6 +191,14 @@ class JavaClassMembers {
         return result.build();
     }
 
+    Set<TypeCast> getTypeCasts() {
+        ImmutableSet.Builder<TypeCast> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getTypeCasts());
+        }
+        return result.build();
+    }
+
     Set<ReferencedClassObject> getReferencedClassObjects() {
         ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
         for (JavaCodeUnit codeUnit : codeUnits) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -72,6 +72,7 @@ public abstract class JavaCodeUnit
     private Set<TryCatchBlock> tryCatchBlocks = Collections.emptySet();
     private Set<ReferencedClassObject> referencedClassObjects;
     private Set<InstanceofCheck> instanceofChecks;
+    private Set<TypeCast> typeCasts;
 
     JavaCodeUnit(JavaCodeUnitBuilder<?, ?> builder) {
         super(builder);
@@ -208,6 +209,11 @@ public abstract class JavaCodeUnit
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<TypeCast> getTypeCasts() {
+        return typeCasts;
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<TryCatchBlock> getTryCatchBlocks() {
         return tryCatchBlocks;
     }
@@ -281,6 +287,7 @@ public abstract class JavaCodeUnit
                 .collect(toImmutableSet());
         referencedClassObjects = context.createReferencedClassObjectsFor(this);
         instanceofChecks = context.createInstanceofChecksFor(this);
+        typeCasts = context.createTypeCastsFor(this);
     }
 
     @ResolvesTypesViaReflection

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/TypeCast.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/TypeCast.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2023 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.domain;
+
+import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.properties.HasOwner;
+import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
+import com.tngtech.archunit.core.domain.properties.HasType;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+
+@PublicAPI(usage = ACCESS)
+public final class TypeCast implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
+
+    private final JavaCodeUnit owner;
+    private final JavaClass type;
+    private final int lineNumber;
+    private final boolean declaredInLambda;
+    private final SourceCodeLocation sourceCodeLocation;
+
+    private TypeCast(JavaCodeUnit owner, JavaClass type, int lineNumber, boolean declaredInLambda) {
+        this.owner = checkNotNull(owner);
+        this.type = checkNotNull(type);
+        this.lineNumber = lineNumber;
+        this.declaredInLambda = declaredInLambda;
+        sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaClass getRawType() {
+        return type;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaType getType() {
+        return type;
+    }
+
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public JavaCodeUnit getOwner() {
+        return owner;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
+    }
+
+    @Override
+    public SourceCodeLocation getSourceCodeLocation() {
+        return sourceCodeLocation;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("owner", owner)
+                .add("type", type)
+                .add("lineNumber", lineNumber)
+                .add("declaredInLambda", declaredInLambda)
+                .toString();
+    }
+
+    static TypeCast from(JavaCodeUnit owner, JavaClass type, int lineNumber, boolean declaredInLambda) {
+        return new TypeCast(owner, type, lineNumber, declaredInLambda);
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -85,6 +85,7 @@ class ClassFileImportRecord {
     private final Set<RawAccessRecord> rawConstructorReferenceRecords = new HashSet<>();
     private final Set<RawReferencedClassObject> rawReferencedClassObjects = new HashSet<>();
     private final Set<RawInstanceofCheck> rawInstanceofChecks = new HashSet<>();
+    private final Set<RawTypeCast> rawTypeCasts = new HashSet<>();
     private final Set<RawTryCatchBlock> rawTryCatchBlocks = new HashSet<>();
     private final SyntheticAccessRecorder syntheticLambdaAccessRecorder = createSyntheticLambdaAccessRecorder();
     private final SyntheticAccessRecorder syntheticPrivateAccessRecorder = createSyntheticPrivateAccessRecorder();
@@ -253,6 +254,10 @@ class ClassFileImportRecord {
         rawInstanceofChecks.add(instanceofCheck);
     }
 
+    void registerTypeCast(RawTypeCast typeCast) {
+        rawTypeCasts.add(typeCast);
+    }
+
     void forEachRawFieldAccessRecord(Consumer<RawAccessRecord.ForField> doWithRecord) {
         resolveSyntheticOrigins(rawFieldAccessRecords, COPY_RAW_FIELD_ACCESS_RECORD, syntheticPrivateAccessRecorder, syntheticLambdaAccessRecorder)
                 .forEach(doWithRecord);
@@ -286,6 +291,11 @@ class ClassFileImportRecord {
     void forEachRawInstanceofCheck(Consumer<RawInstanceofCheck> doWithInstanceofCheck) {
         resolveSyntheticOrigins(rawInstanceofChecks, COPY_RAW_INSTANCEOF_CHECK, syntheticLambdaAccessRecorder)
                 .forEach(doWithInstanceofCheck);
+    }
+
+    void forEachRawTypeCast(Consumer<RawTypeCast> doWithTypeCast) {
+        resolveSyntheticOrigins(rawTypeCasts, COPY_RAW_TYPE_CAST, syntheticLambdaAccessRecorder)
+                .forEach(doWithTypeCast);
     }
 
     public void forEachRawTryCatchBlock(Consumer<RawTryCatchBlock> doWithTryCatchBlock) {
@@ -331,6 +341,9 @@ class ClassFileImportRecord {
 
     private static final Function<RawInstanceofCheck, RawInstanceofCheck.Builder> COPY_RAW_INSTANCEOF_CHECK =
             instanceofCheck -> copyInto(new RawInstanceofCheck.Builder(), instanceofCheck);
+
+    private static final Function<RawTypeCast, RawTypeCast.Builder> COPY_RAW_TYPE_CAST =
+            typeCast -> copyInto(new RawTypeCast.Builder(), typeCast);
 
     private static final Function<RawTryCatchBlock, RawTryCatchBlock.Builder> COPY_RAW_TRY_CATCH_BLOCK = RawTryCatchBlock.Builder::from;
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
@@ -57,6 +57,8 @@ interface DeclarationHandler {
 
     void onDeclaredInstanceofCheck(String typeName);
 
+    void onDeclaredTypeCast(String typeName);
+
     void onDeclaredThrowsClause(Collection<String> exceptionTypeNames);
 
     void onDeclaredGenericSignatureType(String typeName);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -334,6 +334,11 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         @Override
+        public void visitVarInsn(int opcode, int varIndex) {
+            accessHandler.handleVariableInstruction(opcode, varIndex);
+        }
+
+        @Override
         public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
             return new AnnotationProcessor(addAnnotationAtIndex(parameterAnnotationsByIndex, parameter), declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
         }
@@ -387,6 +392,10 @@ class JavaClassProcessor extends ClassVisitor {
                 JavaClassDescriptor instanceOfCheckType = JavaClassDescriptorImporter.createFromAsmObjectTypeName(type);
                 accessHandler.handleInstanceofCheck(instanceOfCheckType, actualLineNumber);
                 declarationHandler.onDeclaredInstanceofCheck(instanceOfCheckType.getFullyQualifiedClassName());
+            } else if (opcode == Opcodes.CHECKCAST) {
+                JavaClassDescriptor typeCastType = JavaClassDescriptorImporter.createFromAsmObjectTypeName(type);
+                accessHandler.handleTypeCast(typeCastType, actualLineNumber);
+                declarationHandler.onDeclaredTypeCast(typeCastType.getFullyQualifiedClassName());
             }
         }
 
@@ -505,6 +514,8 @@ class JavaClassProcessor extends ClassVisitor {
     }
 
     interface AccessHandler {
+        void handleVariableInstruction(int opcode, int varIndex);
+
         void handleFieldInstruction(int opcode, String owner, String name, String desc);
 
         void setContext(CodeUnit codeUnit);
@@ -523,6 +534,8 @@ class JavaClassProcessor extends ClassVisitor {
 
         void handleInstanceofCheck(JavaClassDescriptor instanceOfCheckType, int lineNumber);
 
+        void handleTypeCast(JavaClassDescriptor typeCastType, int lineNumber);
+
         void handleTryCatchBlock(Label start, Label end, Label handler, JavaClassDescriptor throwableType);
 
         void handleTryFinallyBlock(Label start, Label end, Label handler);
@@ -531,6 +544,10 @@ class JavaClassProcessor extends ClassVisitor {
 
         @Internal
         class NoOp implements AccessHandler {
+            @Override
+            public void handleVariableInstruction(int opcode, int varIndex) {
+            }
+
             @Override
             public void handleFieldInstruction(int opcode, String owner, String name, String desc) {
             }
@@ -565,6 +582,10 @@ class JavaClassProcessor extends ClassVisitor {
 
             @Override
             public void handleInstanceofCheck(JavaClassDescriptor instanceOfCheckType, int lineNumber) {
+            }
+
+            @Override
+            public void handleTypeCast(JavaClassDescriptor typeCastType, int lineNumber) {
             }
 
             @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/RawTypeCast.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/RawTypeCast.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2023 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+import com.tngtech.archunit.core.domain.JavaClassDescriptor;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class RawTypeCast implements RawCodeUnitDependency<JavaClassDescriptor> {
+    private final RawAccessRecord.CodeUnit origin;
+    private final JavaClassDescriptor target;
+    private final int lineNumber;
+    private final boolean declaredInLambda;
+
+    private RawTypeCast(RawAccessRecord.CodeUnit origin, JavaClassDescriptor target, int lineNumber, boolean declaredInLambda) {
+        this.origin = checkNotNull(origin);
+        this.target = checkNotNull(target);
+        this.lineNumber = lineNumber;
+        this.declaredInLambda = declaredInLambda;
+    }
+
+    @Override
+    public RawAccessRecord.CodeUnit getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public JavaClassDescriptor getTarget() {
+        return target;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public boolean isDeclaredInLambda() {
+        return declaredInLambda;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add("origin", origin)
+                .add("target", target)
+                .add("lineNumber", lineNumber)
+                .add("declaredInLambda", declaredInLambda)
+                .toString();
+    }
+
+    static class Builder implements RawCodeUnitDependency.Builder<RawTypeCast, JavaClassDescriptor> {
+        private RawAccessRecord.CodeUnit origin;
+        private JavaClassDescriptor target;
+        private int lineNumber;
+        private boolean declaredInLambda;
+
+        @Override
+        public RawTypeCast.Builder withOrigin(RawAccessRecord.CodeUnit origin) {
+            this.origin = origin;
+            return this;
+        }
+
+        @Override
+        public RawTypeCast.Builder withTarget(JavaClassDescriptor target) {
+            this.target = target;
+            return this;
+        }
+
+        @Override
+        public RawTypeCast.Builder withLineNumber(int lineNumber) {
+            this.lineNumber = lineNumber;
+            return this;
+        }
+
+        @Override
+        public RawTypeCast.Builder withDeclaredInLambda(boolean declaredInLambda) {
+            this.declaredInLambda = declaredInLambda;
+            return this;
+        }
+
+        @Override
+        public RawTypeCast build() {
+            return new RawTypeCast(origin, target, lineNumber, declaredInLambda);
+        }
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/TypeCastRecorder.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/TypeCastRecorder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2023 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.core.importer;
+
+class TypeCastRecorder {
+    private static final String CLASS_INTERNAL_NAME = "java/lang/Class";
+    private static final String METHOD_DESCRIPTOR = "(Ljava/lang/Object;)Ljava/lang/Object;";
+    private static final String CAST_METHOD_NAME = "cast";
+
+    private boolean implicit;
+    
+    void reset() {
+        implicit = false;
+    }
+
+    void registerMethodInstruction(String owner, String name, String desc) {
+        implicit = !CLASS_INTERNAL_NAME.equals(owner) || !CAST_METHOD_NAME.equals(name) || !METHOD_DESCRIPTOR.equals(desc);
+    }
+
+    boolean isImplicit() {
+        return implicit;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ClassWithDependencyOnTypeCast.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ClassWithDependencyOnTypeCast.java
@@ -1,0 +1,21 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+@SuppressWarnings({"unused", "ConstantConditions"})
+public class ClassWithDependencyOnTypeCast {
+
+    private static final Object OBJ = new TypeCastTarget();
+    private static final TypeCastTarget TARGET = (TypeCastTarget) OBJ;
+
+    private final TypeCastTarget obj;
+
+    ClassWithDependencyOnTypeCast(Object o) {
+        this.obj = (TypeCastTarget) o;
+    }
+
+    TypeCastTarget method(Object o) {
+        return (TypeCastTarget) o;
+    }
+    
+    public static class TypeCastTarget {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -31,6 +31,7 @@ import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaWildcardType;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
+import com.tngtech.archunit.core.domain.TypeCast;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.ImporterWithAdjustedResolutionRuns;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
@@ -544,6 +545,23 @@ public class ClassFileImporterAutomaticResolutionTest {
 
         assertThat(instanceofCheck.getRawType()).isFullyImported(true);
         assertThatType(instanceofCheck.getRawType()).matches(String.class);
+    }
+
+    @Test
+    public void automatically_resolves_type_cast_targets() {
+        @SuppressWarnings("unused")
+        class Origin {
+            String call(Object obj) {
+                return (String) obj;
+            }
+        }
+
+        JavaClass javaClass = ImporterWithAdjustedResolutionRuns.disableAllIterationsExcept(MAX_ITERATIONS_FOR_ACCESSES_TO_TYPES_PROPERTY_NAME)
+                .importClass(Origin.class);
+        TypeCast typeCast = getOnlyElement(javaClass.getTypeCasts());
+
+        assertThat(typeCast.getRawType()).isFullyImported(true);
+        assertThatType(typeCast.getRawType()).matches(String.class);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterLambdaDependenciesTest.java
@@ -21,8 +21,10 @@ import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.TryCatchBlock;
+import com.tngtech.archunit.core.domain.TypeCast;
 import com.tngtech.archunit.core.importer.testexamples.instanceofcheck.CheckingInstanceofFromLambda;
 import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjectsFromLambda;
+import com.tngtech.archunit.core.importer.testexamples.typecast.TypeCastFromLambda;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -41,8 +43,10 @@ import static com.tngtech.archunit.testutil.Assertions.assertThatAccesses;
 import static com.tngtech.archunit.testutil.Assertions.assertThatCall;
 import static com.tngtech.archunit.testutil.Assertions.assertThatInstanceofChecks;
 import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypeCasts;
 import static com.tngtech.archunit.testutil.assertion.AccessesAssertion.access;
 import static com.tngtech.archunit.testutil.assertion.InstanceofChecksAssertion.instanceofCheck;
+import static com.tngtech.archunit.testutil.assertion.TypeCastsAssertion.typeCast;
 import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
 import static com.tngtech.archunit.testutil.assertion.TryCatchBlockAssertion.tryCatchBlock;
 import static com.tngtech.java.junit.dataprovider.DataProviders.$;
@@ -573,6 +577,17 @@ public class ClassFileImporterLambdaDependenciesTest {
         assertThatInstanceofChecks(instanceofChecks).containInstanceofChecks(
                 instanceofCheck(FilterInputStream.class, 11).declaredInLambda(),
                 instanceofCheck(File.class, 15).declaredInLambda()
+        );
+    }
+
+    @Test
+    public void imports_type_casts_in_lambda() {
+        JavaClasses classes = new ClassFileImporter().importClasses(TypeCastFromLambda.class);
+        Set<TypeCast> typeCasts = classes.get(TypeCastFromLambda.class).getTypeCasts();
+
+        assertThatTypeCasts(typeCasts).containTypeCasts(
+                typeCast(FilterInputStream.class, 10).declaredInLambda(),
+                typeCast(File.class, 18).declaredInLambda()
         );
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterMembersTest.java
@@ -43,6 +43,11 @@ import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithObj
 import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithStringStringMethod;
 import com.tngtech.archunit.core.importer.testexamples.methodimport.ClassWithThrowingMethod;
 import com.tngtech.archunit.core.importer.testexamples.referencedclassobjects.ReferencingClassObjects;
+import com.tngtech.archunit.core.importer.testexamples.typecast.ClassWithMultipleTypeCasts;
+import com.tngtech.archunit.core.importer.testexamples.typecast.TypeCastInConstructor;
+import com.tngtech.archunit.core.importer.testexamples.typecast.TypeCastInMethod;
+import com.tngtech.archunit.core.importer.testexamples.typecast.TypeCastInStaticInitializer;
+import com.tngtech.archunit.core.importer.testexamples.typecast.TypeCastTestedType;
 import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.ExpectedReferencedClassObject;
 import org.assertj.core.util.Objects;
 import org.junit.Test;
@@ -65,11 +70,13 @@ import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatInstanceofChecks;
 import static com.tngtech.archunit.testutil.Assertions.assertThatReferencedClassObjects;
 import static com.tngtech.archunit.testutil.Assertions.assertThatThrowsClause;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypeCasts;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
 import static com.tngtech.archunit.testutil.assertion.InstanceofChecksAssertion.instanceofCheck;
 import static com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion.referencedClassObject;
+import static com.tngtech.archunit.testutil.assertion.TypeCastsAssertion.typeCast;
 import static java.util.stream.Collectors.toSet;
 
 public class ClassFileImporterMembersTest {
@@ -305,6 +312,24 @@ public class ClassFileImporterMembersTest {
                         instanceofCheck(InstanceofChecked.class, 6),
                         instanceofCheck(InstanceofChecked.class, 10),
                         instanceofCheck(InstanceofChecked.class, 15));
+    }
+
+    @Test
+    public void imports_type_casts() {
+        assertThatTypeCasts(new ClassFileImporter().importClass(TypeCastInConstructor.class).getConstructor(Object.class).getTypeCasts())
+                .containTypeCasts(typeCast(TypeCastTestedType.class, 8));
+        assertThatTypeCasts(new ClassFileImporter().importClass(TypeCastInMethod.class).getMethod("method", Object.class).getTypeCasts())
+                .containTypeCasts(typeCast(TypeCastTestedType.class, 6));
+        assertThatTypeCasts(new ClassFileImporter().importClass(TypeCastInStaticInitializer.class).getStaticInitializer().get().getTypeCasts())
+                .containTypeCasts(typeCast(TypeCastTestedType.class, 7));
+        assertThatTypeCasts(new ClassFileImporter().importClass(ClassWithMultipleTypeCasts.class).getTypeCasts())
+                .hasSize(5)
+                .containTypeCasts(
+                        typeCast(TypeCastTestedType.class, 9),
+                        typeCast(TypeCastTestedType.class, 14),
+                        typeCast(TypeCastTestedType.class, 26),
+                        typeCast(TypeCastTestedType.class, 30),
+                        typeCast(TypeCastTestedType.class, 36).declaredInLambda());
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -36,6 +36,7 @@ import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaTypeVariable;
 import com.tngtech.archunit.core.domain.ReferencedClassObject;
+import com.tngtech.archunit.core.domain.TypeCast;
 import com.tngtech.archunit.core.importer.DomainBuilders.BuilderWithBuildParameter;
 import com.tngtech.archunit.core.importer.DomainBuilders.FieldAccessTargetBuilder;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAnnotationBuilder.ValueBuilder;
@@ -438,6 +439,11 @@ public class ImportTestUtils {
 
         @Override
         public Set<InstanceofCheck> createInstanceofChecksFor(JavaCodeUnit codeUnit) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<TypeCast> createTypeCastsFor(JavaCodeUnit codeUnit) {
             return Collections.emptySet();
         }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/ClassWithMultipleTypeCasts.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/ClassWithMultipleTypeCasts.java
@@ -1,0 +1,73 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+import java.util.List;
+
+
+@SuppressWarnings({"StatementWithEmptyBody", "unused", "ConstantConditions"})
+public class ClassWithMultipleTypeCasts {
+    private static final Object OBJ = new TypeCastTestedType();
+    private static final TypeCastTestedType TARGET = (TypeCastTestedType) OBJ;
+
+    private final TypeCastTestedType obj;
+
+    ClassWithMultipleTypeCasts(Object o) {
+        this.obj = (TypeCastTestedType) o;
+    }
+
+    TypeCastTestedType methodWithoutCast(TypeCastTestedType o) {
+        return o;
+    }
+
+    TypeCastTestedType methodWithoutCast(Object o) {
+        return TypeCaster.cast(o);
+    }
+
+    TypeCastTestedType methodWithExplicitCast(Object o) {
+        return (TypeCastTestedType) o;
+    }
+
+    TypeCastTestedType methodWithImplicitCastUsingClassCast(Object o) {
+        return TypeCastTestedType.class.cast(o);
+    }
+
+    TypeCastTestedType methodWithExplicitCastInLambdas(Object o) {
+        List<Object> objects = List.of(new TypeCastTestedType());
+
+        return objects.stream().map(obj -> (TypeCastTestedType) obj)
+                .findFirst()
+                .get();
+    }
+
+    TypeCastTestedType methodWithImplicitCastInLambdas(Object o) {
+        List<Object> objects = List.of(new TypeCastTestedType());
+
+        return objects.stream().map(TypeCastTestedType.class::cast)
+                .findFirst()
+                .get();
+    }
+
+    TypeCastTestedType methodWithImplicitCastDueToDelegation(Object o) {
+        TypeCaster<TypeCastTestedType> caster = new TypeCaster<>(o, TypeCastTestedType.class);
+        TypeCastTestedType result = caster.cast();
+        System.out.println(result);
+
+        return result;
+    }
+    
+    private static class TypeCaster<T> {
+        private T target;
+
+        @SuppressWarnings("unchecked")
+        TypeCaster(Object target, Class<T> type) {
+            this.target = (T) target;
+        }
+
+        public T cast() {
+            return target;
+        }
+
+        static TypeCastTestedType cast(Object o) {
+            return (TypeCastTestedType) o;
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastFromLambda.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastFromLambda.java
@@ -1,0 +1,20 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+import java.io.File;
+import java.io.FilterInputStream;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class TypeCastFromLambda {
+    Function<?, ?> reference() {
+        return (object) -> (FilterInputStream) object;
+    }
+    
+    Function<?, ?> referenceUsingMethodReference() {
+        return FilterInputStream.class::cast; // Not a cast, but a method reference which does a type cast
+    }
+
+    Supplier<Function<?, ?>> nestedReference() {
+        return () -> (object) -> (File) object;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInConstructor.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInConstructor.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+public class TypeCastInConstructor {
+    @SuppressWarnings("unused")
+    private TypeCastTestedType value;
+
+    public TypeCastInConstructor(Object param) {
+        value = (TypeCastTestedType) param;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInMethod.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInMethod.java
@@ -1,0 +1,8 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+@SuppressWarnings("unused")
+public class TypeCastInMethod {
+    TypeCastTestedType method(Object param) {
+        return (TypeCastTestedType) param;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInStaticInitializer.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastInStaticInitializer.java
@@ -1,0 +1,9 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+@SuppressWarnings({"unused", "ConstantConditions"})
+public class TypeCastInStaticInitializer {
+    static {
+        Object foo = new TypeCastTestedType();
+        TypeCastTestedType bar = (TypeCastTestedType) foo;
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastTestedType.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/typecast/TypeCastTestedType.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.typecast;
+
+public class TypeCastTestedType {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/Assertions.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsClause;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.core.domain.TryCatchBlock;
+import com.tngtech.archunit.core.domain.TypeCast;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
@@ -65,6 +66,7 @@ import com.tngtech.archunit.testutil.assertion.ReferencedClassObjectsAssertion;
 import com.tngtech.archunit.testutil.assertion.ThrowsClauseAssertion;
 import com.tngtech.archunit.testutil.assertion.ThrowsDeclarationAssertion;
 import com.tngtech.archunit.testutil.assertion.TryCatchBlockAssertion;
+import com.tngtech.archunit.testutil.assertion.TypeCastsAssertion;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     public static <T> ArchConditionAssertion<T> assertThat(ArchCondition<T> archCondition) {
@@ -161,6 +163,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static InstanceofChecksAssertion assertThatInstanceofChecks(Set<InstanceofCheck> instanceofChecks) {
         return new InstanceofChecksAssertion(instanceofChecks);
+    }
+
+    public static TypeCastsAssertion assertThatTypeCasts(Set<TypeCast> typeCasts) {
+        return new TypeCastsAssertion(typeCasts);
     }
 
     public static JavaEnumConstantAssertion assertThat(JavaEnumConstant enumConstant) {

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TypeCastsAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/TypeCastsAssertion.java
@@ -1,0 +1,89 @@
+package com.tngtech.archunit.testutil.assertion;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.google.common.collect.ImmutableSet;
+import com.tngtech.archunit.core.domain.TypeCast;
+
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeCastsAssertion extends AbstractIterableAssert<TypeCastsAssertion, Set<TypeCast>, TypeCast, TypeCastsAssertion.TypeCastAssertion> {
+    public TypeCastsAssertion(Set<TypeCast> typeCasts) {
+        super(typeCasts, TypeCastsAssertion.class);
+    }
+
+    @Override
+    protected TypeCastAssertion toAssert(TypeCast value, String description) {
+        return new TypeCastAssertion(value).as(description);
+    }
+
+    @Override
+    protected TypeCastsAssertion newAbstractIterableAssert(Iterable<? extends TypeCast> iterable) {
+        return new TypeCastsAssertion(ImmutableSet.copyOf(iterable));
+    }
+
+    public void containTypeCasts(ExpectedTypeCast... expectedTypeCasts) {
+        containTypeCasts(List.of(expectedTypeCasts));
+    }
+
+    public void containTypeCasts(Iterable<ExpectedTypeCast> expectedTypeCasts) {
+        Set<ExpectedTypeCast> unmatchedClassObjects = stream(expectedTypeCasts.spliterator(), false)
+                .filter(expected -> actual.stream().noneMatch(expected))
+                .collect(toSet());
+        assertThat(unmatchedClassObjects).as("Type cast not contained in %s", actual).isEmpty();
+    }
+
+    static class TypeCastAssertion extends AbstractObjectAssert<TypeCastAssertion, TypeCast> {
+        TypeCastAssertion(TypeCast typeCast) {
+            super(typeCast, TypeCastAssertion.class);
+        }
+    }
+
+    public static ExpectedTypeCast typeCast(Class<?> type, int lineNumber) {
+        return new ExpectedTypeCast(type, lineNumber);
+    }
+
+    public static class ExpectedTypeCast implements Predicate<TypeCast> {
+        private final Class<?> type;
+        private final int lineNumber;
+        private final boolean declaredInLambda;
+
+        private ExpectedTypeCast(Class<?> type, int lineNumber) {
+            this(type, lineNumber, false);
+        }
+
+        private ExpectedTypeCast(Class<?> type, int lineNumber, boolean declaredInLambda) {
+            this.type = type;
+            this.lineNumber = lineNumber;
+            this.declaredInLambda = declaredInLambda;
+        }
+
+        public ExpectedTypeCast declaredInLambda() {
+            return new ExpectedTypeCast(type, lineNumber, true);
+        }
+
+        @Override
+        public boolean test(TypeCast input) {
+            return input.getRawType().isEquivalentTo(type) 
+                    && input.getLineNumber() == lineNumber
+                    && input.isDeclaredInLambda() == declaredInLambda;
+        }
+
+        @Override
+        public String toString() {
+            return toStringHelper(this)
+                    .add("type", type)
+                    .add("lineNumber", lineNumber)
+                    .add("declaredInLambda", declaredInLambda)
+                    .toString();
+        }
+    }
+}


### PR DESCRIPTION
- Detect *checkcast* asm instructions as TypeCast (similar to InstanceofCheck)
- Implicit checkcast instructions generated by compiler due to method invocations are ignored

I decided to implement this feature myself since I have a real use case which I need this and the other PR that started implementing it has no activity since almost 1 year.

Just a brief info about the use case that I need:
> Detect certain type casts that should be forbidden in our code because it could lead to ClassCastException due to use of hibernate proxies and polymorphic entities

Some notes to add:

1. This feature detect type casts statements in java. It doesn't consider calls to the cast method of a given class as a `cast` statement. So `FooBar foo = FooBar.class.cast(obj)` is not considered as a type cast. It's just a call to a method which does the cast.
2. Some `checkcast` instructions are ignored deliberately. In java bytecode we might encounter `checkcast` after a call to a method, as the following example in `com.tngtech.archunit.example.onionarchitecture.adapter.cli.AdministrationCLI`:
```java
    private static void handle(String[] args, AdministrationPort port) {
        // violates the pairwise independence of adapters
        ProductRepository repository = port.getInstanceOf(ProductRepository.class);
        long count = repository.getTotalCount();
        // parse arguments and re-configure application according to count through port
    }
```
```bytecode
  private static void handle(java.lang.String[], com.tngtech.archunit.example.onionarchitecture.application.AdministrationPort);
    Code:
       0: aload_1
       1: ldc           #19                 // class com/tngtech/archunit/example/onionarchitecture/adapter/persistence/ProductRepository
       3: invokeinterface #21,  2           // InterfaceMethod com/tngtech/archunit/example/onionarchitecture/application/AdministrationPort.getInstanceOf:(Ljava/lang/Class;)Ljava/lang/Object;
       8: checkcast     #19                 // class com/tngtech/archunit/example/onionarchitecture/adapter/persistence/ProductRepository
      11: astore_2
      12: aload_2
      13: invokeinterface #27,  1           // InterfaceMethod com/tngtech/archunit/example/onionarchitecture/adapter/persistence/ProductRepository.getTotalCount:()J
      18: lstore_3
      19: return
```
Java compiler adds a `checkcast` after the method call `port.getInstanceOf(ProductRepository.class)`. While implementing this feature, I was detecting this as an `implicit` cast, but that proved of no use and brought only more confusion.

Resolves #710