### PR TITLE
add support to detect accesses of fields by specific methods

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -1274,6 +1274,21 @@ public final class ArchConditions {
                 origin.is(matching(JavaConstructor.class, predicate)), GET_CALLS_OF_SELF);
     }
 
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaField> beAccessedByMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
+        return new ArchCondition<JavaField>("be accessed by methods that " + predicate.getDescription()) {
+            @Override
+            public void check(JavaField field, ConditionEvents events) {
+                field.getAccessesToSelf().stream()
+                        .filter(access -> access.getOrigin() instanceof JavaMethod)
+                        .forEach(access -> {
+                            boolean satisfied = predicate.test((JavaMethod) access.getOrigin());
+                            events.add(new SimpleConditionEvent(field, satisfied, access.getDescription()));
+                        });
+            }
+        };
+    }
+
     /**
      * Derives an {@link ArchCondition} from a {@link DescribedPredicate}. Similar to {@link ArchCondition#from(DescribedPredicate)},
      * but more conveniently creates a message to be used within a 'have'-sentence.

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/FieldsShouldInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/FieldsShouldInternal.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ClassesTransformer;
 import com.tngtech.archunit.lang.Priority;
@@ -92,5 +93,15 @@ class FieldsShouldInternal
     @Override
     public FieldsShouldInternal notHaveRawType(DescribedPredicate<? super JavaClass> predicate) {
         return addCondition(not(ArchConditions.haveRawType(predicate)));
+    }
+
+    @Override
+    public FieldsShouldInternal beAccessedByMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
+        return addCondition(ArchConditions.beAccessedByMethodsThat(predicate));
+    }
+
+    @Override
+    public FieldsShouldInternal notBeAccessedByMethodsThat(DescribedPredicate<? super JavaMethod> predicate) {
+        return addCondition(not(ArchConditions.beAccessedByMethodsThat(predicate)));
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/FieldsShould.java
@@ -18,6 +18,7 @@ package com.tngtech.archunit.lang.syntax.elements;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
@@ -155,6 +156,35 @@ public interface FieldsShould<CONJUNCTION extends FieldsShouldConjunction> exten
      */
     @PublicAPI(usage = ACCESS)
     CONJUNCTION notHaveRawType(DescribedPredicate<? super JavaClass> predicate);
+
+    /**
+     * Asserts that fields are accessed by at least one method matching the given predicate.
+     * This mostly makes sense in the negated form
+     * <pre><code>
+     * {@link ArchRuleDefinition#noFields() noFields()}.{@link GivenFields#should() should()}.{@link #beAccessedByMethodsThat(DescribedPredicate)}
+     * </code></pre>
+     * In this form it is equivalent to
+     * <pre><code>
+     * {@link ArchRuleDefinition#fields()} fields()}.{@link GivenFields#should() should()}.{@link #notBeAccessedByMethodsThat(DescribedPredicate)}
+     * </code></pre>
+     * but might be useful for chaining multiple conditions via <code>{@link FieldsShouldConjunction#andShould()}</code>.
+     *
+     * @param predicate A predicate determining the methods this field should not be accessed by
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     * @see #notBeAccessedByMethodsThat(DescribedPredicate)
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION beAccessedByMethodsThat(DescribedPredicate<? super JavaMethod> predicate);
+
+    /**
+     * Asserts that fields are not accessed by methods matching the given predicate.
+     *
+     * @param predicate A predicate determining the methods this field should not be accessed by
+     * @return A syntax element that can either be used as working rule, or to continue specifying a more complex rule
+     * @see #beAccessedByMethodsThat(DescribedPredicate)
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION notBeAccessedByMethodsThat(DescribedPredicate<? super JavaMethod> predicate);
 
     /**
      * Asserts that fields are static.


### PR DESCRIPTION
This PR adds a method to the public API of `FieldsShould` to check if a field has been accessed by methods matching a given predicate. This is checked by a new `ArchCondition`.

I've diverged a little bit from the original suggestion of this issue: I chose to stay consistent with the current API and return an `ArchCondition<JavaField>` to allow method chaining, e.g.

```
fields().that().inSomeCondition()
    .should().notBeAccessedByMethodsThat(...)
    .andShould().notBeFinal()
    .andShould()....
```

What do you think? Any feedback is highly appreciated :)

Resolves: #857