### PR TITLE
Add (not)`haveFullyQualifiedNameAnyOf` to API

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/properties/HasName.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.Formatters;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
@@ -117,6 +118,11 @@ public interface HasName {
             return new NameEqualsPredicate(name);
         }
 
+        @PublicAPI(usage = ACCESS)
+        public static DescribedPredicate<HasName> nameAnyOf(String... classNames) {
+            return new NameEqualsAnyOfPredicate(classNames);
+        }
+
         /**
          * Matches names against a regular expression.
          */
@@ -151,6 +157,26 @@ public interface HasName {
             @Override
             public boolean test(HasName input) {
                 return input.getName().equals(name);
+            }
+        }
+
+        private static class NameEqualsAnyOfPredicate extends DescribedPredicate<HasName> {
+            private final String[] names;
+
+            NameEqualsAnyOfPredicate(String[] names) {
+                super(String.format("name '%s'", Formatters.joinSingleQuoted(names)));
+                this.names = names;
+            }
+
+            @Override
+            public boolean test(HasName input) {
+                for (String name : names) {
+                    if (input.getName().equals(name)) {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -116,6 +116,7 @@ import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicate
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullName;
 import static com.tngtech.archunit.core.domain.properties.HasName.AndFullName.Predicates.fullNameMatching;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.name;
+import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameAnyOf;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameContaining;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameEndingWith;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
@@ -516,6 +517,22 @@ public final class ArchConditions {
     @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> notHaveFullyQualifiedName(String name) {
         return not(haveFullyQualifiedName(name));
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveFullyQualifiedNameAnyOf(String... classNames) {
+        return have(fullyQualifiedNameAnyOf(classNames));
+    }
+
+    @Internal
+    public static DescribedPredicate<HasName> fullyQualifiedNameAnyOf(String[] classNames) {
+        DescribedPredicate<HasName> predicate = nameAnyOf(classNames);
+        return predicate.as("fully qualified " + predicate.getDescription());
+    }
+
+    @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> notHaveFullyQualifiedNameAnyOf(String... classNames) {
+        return not(haveFullyQualifiedNameAnyOf(classNames));
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/ClassesThatInternal.java
@@ -431,6 +431,16 @@ class ClassesThatInternal<CONJUNCTION> implements ClassesThat<CONJUNCTION> {
     }
 
     @Override
+    public CONJUNCTION haveFullyQualifiedNameAnyOf(String... classNames) {
+        return givenWith(SyntaxPredicates.haveFullyQualifiedNameAnyOf(classNames));
+    }
+
+    @Override
+    public CONJUNCTION doNotHaveFullyQualifiedNameAnyOf(String... classNames) {
+        return givenWith(SyntaxPredicates.doNotHaveFullyQualifiedNameAnyOf(classNames));
+    }
+
+    @Override
     public CONJUNCTION haveSimpleName(String name) {
         return givenWith(SyntaxPredicates.haveSimpleName(name));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/MembersDeclaredInClassesThat.java
@@ -73,6 +73,16 @@ class MembersDeclaredInClassesThat<MEMBER extends JavaMember, CONJUNCTION extend
     }
 
     @Override
+    public CONJUNCTION haveFullyQualifiedNameAnyOf(String... classNames) {
+        return givenWith(SyntaxPredicates.haveFullyQualifiedNameAnyOf(classNames));
+    }
+
+    @Override
+    public CONJUNCTION doNotHaveFullyQualifiedNameAnyOf(String... classNames) {
+        return givenWith(SyntaxPredicates.doNotHaveFullyQualifiedNameAnyOf(classNames));
+    }
+
+    @Override
     public CONJUNCTION haveSimpleName(String name) {
         return givenWith(SyntaxPredicates.haveSimpleName(name));
     }

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/SyntaxPredicates.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/SyntaxPredicates.java
@@ -35,6 +35,7 @@ import static com.tngtech.archunit.core.domain.JavaModifier.STATIC;
 import static com.tngtech.archunit.core.domain.properties.HasModifiers.Predicates.modifier;
 import static com.tngtech.archunit.core.domain.properties.HasName.Predicates.nameMatching;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.fullyQualifiedName;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.fullyQualifiedNameAnyOf;
 import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
 
 class SyntaxPredicates {
@@ -108,6 +109,14 @@ class SyntaxPredicates {
 
     static DescribedPredicate<HasName> doNotHaveFullyQualifiedName(String name) {
         return doNot(have(fullyQualifiedName(name)));
+    }
+
+    static DescribedPredicate<HasName> haveFullyQualifiedNameAnyOf(String[] classNames) {
+        return have(fullyQualifiedNameAnyOf(classNames));
+    }
+
+    static DescribedPredicate<HasName> doNotHaveFullyQualifiedNameAnyOf(String[] classNames) {
+        return doNot(have(fullyQualifiedNameAnyOf(classNames)));
     }
 
     static DescribedPredicate<JavaClass> haveSimpleName(String name) {

--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/ClassesThat.java
@@ -56,6 +56,24 @@ public interface ClassesThat<CONJUNCTION> {
     CONJUNCTION doNotHaveFullyQualifiedName(String name);
 
     /**
+     * Matches classes by their fully qualified class name.
+     *
+     * @param classNames One or more fully qualified class names
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION haveFullyQualifiedNameAnyOf(String... classNames);
+
+        /**
+     * Matches classes that do not have a certain fully qualified class name.
+     *
+     * @param classNames One or more fully qualified class names
+     * @return A syntax conjunction element, which can be completed to form a full rule
+     */
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION doNotHaveFullyQualifiedNameAnyOf(String... classNames);
+
+    /**
      * Matches classes by their simple class name.
      *
      * @param name The simple class name

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenClassesThatTest.java
@@ -74,6 +74,22 @@ public class GivenClassesThatTest {
     }
 
     @Test
+    public void haveFullyQualifiedNameAnyOf() {
+        List<JavaClass> classes = filterResultOf(classes().that().haveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatType(getOnlyElement(classes)).matches(List.class);
+    }
+
+    @Test
+    public void doNotHaveFullyQualifiedNameAnyOf() {
+        List<JavaClass> classes = filterResultOf(classes().that().doNotHaveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatTypes(classes).matchInAnyOrder(String.class, Iterable.class);
+    }
+
+    @Test
     public void haveSimpleName() {
         List<JavaClass> classes = filterResultOf(classes().that().haveSimpleName(List.class.getSimpleName()))
                 .on(List.class, String.class, Iterable.class);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/GivenMembersDeclaredInClassesThatTest.java
@@ -69,6 +69,22 @@ public class GivenMembersDeclaredInClassesThatTest {
     }
 
     @Test
+    public void haveFullyQualifiedNameAnyOf() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().haveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(List.class);
+    }
+
+    @Test
+    public void doNotHaveFullyQualifiedNameAnyOf() {
+        List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().doNotHaveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(List.class, String.class, Iterable.class);
+
+        assertThatMembers(members).matchInAnyOrderMembersOf(String.class, Iterable.class);
+    }
+
+    @Test
     public void haveSimpleName() {
         List<JavaMember> members = filterResultOf(members().that().areDeclaredInClassesThat().haveSimpleName(List.class.getSimpleName()))
                 .on(List.class, String.class, Iterable.class);

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldClassesThatTest.java
@@ -91,6 +91,26 @@ public class ShouldClassesThatTest {
 
     @Test
     @UseDataProvider("no_classes_should_that_rule_starts")
+    public void haveFullyQualifiedNameAnyOf(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.haveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatType(getOnlyElement(classes)).matches(ClassAccessingList.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
+    public void doNotHaveFullyQualifiedNameAnyOf(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                noClassesShouldThatRuleStart.doNotHaveFullyQualifiedNameAnyOf(List.class.getName()))
+                .on(ClassAccessingList.class, ClassAccessingString.class, ClassAccessingIterable.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessingString.class, ClassAccessingIterable.class);
+    }
+
+    @Test
+    @UseDataProvider("no_classes_should_that_rule_starts")
     public void haveSimpleName(ClassesThat<ClassesShouldConjunction> noClassesShouldThatRuleStart) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 noClassesShouldThatRuleStart.haveSimpleName(List.class.getSimpleName()))
@@ -1735,7 +1755,7 @@ public class ShouldClassesThatTest {
 
         @SuppressWarnings("unused")
         static class Level1TransitivelyDependentClass1 {
-             Level2TransitivelyDependentClass1 transitiveDependency1;
+            Level2TransitivelyDependentClass1 transitiveDependency1;
         }
 
         static class Level2TransitivelyDependentClass1 {

--- a/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/syntax/elements/ShouldOnlyByClassesThatTest.java
@@ -86,6 +86,32 @@ public class ShouldOnlyByClassesThatTest {
 
     @Test
     @UseDataProvider("should_only_be_by_rule_starts")
+    public void haveFullyQualifiedNameAnyOf(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.haveFullyQualifiedNameAnyOf(Foo.class.getName()))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatTypes(classes).matchInAnyOrder(
+                ClassAccessedByBar.class, Bar.class,
+                ClassAccessedByBaz.class, Baz.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
+    public void doNotHaveFullyQualifiedNameAnyOf(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
+        Set<JavaClass> classes = filterClassesAppearingInFailureReport(
+                classesShouldOnlyBeBy.doNotHaveFullyQualifiedNameAnyOf(Foo.class.getName()))
+                .on(ClassAccessedByFoo.class, Foo.class,
+                        ClassAccessedByBar.class, Bar.class,
+                        ClassAccessedByBaz.class, Baz.class);
+
+        assertThatTypes(classes).matchInAnyOrder(ClassAccessedByFoo.class, Foo.class);
+    }
+
+    @Test
+    @UseDataProvider("should_only_be_by_rule_starts")
     public void haveSimpleName(ClassesThat<ClassesShouldConjunction> classesShouldOnlyBeBy) {
         Set<JavaClass> classes = filterClassesAppearingInFailureReport(
                 classesShouldOnlyBeBy.haveSimpleName(Foo.class.getSimpleName()))
@@ -1422,6 +1448,7 @@ public class ShouldOnlyByClassesThatTest {
 
     // This must be loaded via Reflection, otherwise the test will be tainted by the dependency on the class object
     private static final Class<?> ClassAccessingAnonymousClass_Reference = classForName("com.tngtech.archunit.lang.syntax.elements.ShouldOnlyByClassesThatTest$ClassAccessingAnonymousClass");
+
     private static class ClassAccessingAnonymousClass {
         @SuppressWarnings("unused")
         void access() {


### PR DESCRIPTION
Use case: we wanted to do some whitelisting of certain classes for a particular check, deprecating all usage of a given Java package (`org.joda.time`). We couldn't use existing predicates for this because:

* Existing checks like `areAssignableFrom` and `areAssignableTo` only operate on a single class.
* Also, `assignableFrom` is unsuitable for one of our checks since that would implicitly whitelist the base class.
* There is also `belongToAnyOf` which would be more correct, but it has to be combined with `areNotNestedClasses` in that case to avoid running checks on nested classes. (We run both a "normal" test for the whitelisted classes to allow them to use the deprecated package, but also an "inverted" test to ensure classes don't remain whitelisted when they no longer use the deprecated code. I don't remember if this worked or not, but either way, it feels more complex to have to jump through hoops to do an "exact" check for multiple whitelisted classes)

Hence, the suggested new additions to the API in this PR.