### PR TITLE
Allow to retrieve involved raw types of `JavaType` and `JavaMember`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -656,6 +656,11 @@ public final class JavaClass
         return this;
     }
 
+    @Override
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return ImmutableSet.of(getBaseComponentType());
+    }
+
     @PublicAPI(usage = ACCESS)
     public Optional<JavaClass> getRawSuperclass() {
         return superclass.getRaw();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaCodeUnit.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -43,6 +44,7 @@ import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.formatMethod;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Represents a unit of code containing accesses to other units of code. A unit of code can be
@@ -167,6 +169,22 @@ public abstract class JavaCodeUnit
     @PublicAPI(usage = ACCESS)
     public JavaClass getRawReturnType() {
         return returnType.getRaw();
+    }
+
+    /**
+     * @return All raw types involved in this code unit's signature,
+     *         which is the union of all raw types involved in the {@link #getReturnType() return type},
+     *         the {@link #getParameterTypes() parameter types} and the {@link #getTypeParameters() type parameters} of this code unit.
+     *         For a definition of "all raw types involved" consult {@link JavaType#getAllInvolvedRawTypes()}.
+     */
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return Stream.of(
+                Stream.of(this.returnType.get()),
+                this.parameters.getParameterTypes().stream(),
+                this.typeParameters.stream()
+        ).flatMap(s -> s).map(JavaType::getAllInvolvedRawTypes).flatMap(Set::stream).collect(toSet());
     }
 
     @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaField.java
@@ -62,6 +62,15 @@ public final class JavaField extends JavaMember implements HasType {
         return type.toErasure();
     }
 
+    /**
+     * @return All raw types involved in this field's signature, which is equivalent to {@link #getType()}.{@link JavaType#getAllInvolvedRawTypes() getAllInvolvedRawTypes()}.
+     */
+    @Override
+    @PublicAPI(usage = ACCESS)
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return getType().getAllInvolvedRawTypes();
+    }
+
     @Override
     @PublicAPI(usage = ACCESS)
     public Set<JavaFieldAccess> getAccessesToSelf() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
@@ -15,6 +15,8 @@
  */
 package com.tngtech.archunit.core.domain;
 
+import java.util.Set;
+
 import com.tngtech.archunit.PublicAPI;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -65,6 +67,11 @@ public final class JavaGenericArrayType implements JavaType {
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
+    }
+
+    @Override
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return this.componentType.getAllInvolvedRawTypes();
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMember.java
@@ -63,6 +63,15 @@ public abstract class JavaMember implements
         this.modifiers = checkNotNull(builder.getModifiers());
     }
 
+    /**
+     * Similar to {@link JavaType#getAllInvolvedRawTypes()}, this method returns all raw types involved in this {@link JavaMember member's} signature.
+     * For more concrete details refer to {@link JavaField#getAllInvolvedRawTypes()} and {@link JavaCodeUnit#getAllInvolvedRawTypes()}.
+     *
+     * @return All raw types involved in the signature of this member
+     */
+    @PublicAPI(usage = ACCESS)
+    public abstract Set<JavaClass> getAllInvolvedRawTypes();
+
     @Override
     @PublicAPI(usage = ACCESS)
     public Set<? extends JavaAnnotation<? extends JavaMember>> getAnnotations() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -16,6 +16,7 @@
 package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.Type;
+import java.util.Set;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
@@ -55,6 +56,33 @@ public interface JavaType extends HasName {
      */
     @PublicAPI(usage = ACCESS)
     JavaClass toErasure();
+
+    /**
+     * Returns the set of all raw types that are involved in this type.
+     * If this type is a {@link JavaClass}, then this method trivially returns only the class itself.
+     * If this type is a {@link JavaParameterizedType}, {@link JavaTypeVariable}, {@link JavaWildcardType}, etc.,
+     * then this method returns all raw types involved in type arguments and upper and lower bounds recursively.
+     * If this type is an array type, then this method returns all raw types involved in the component type of the array type.
+     * <br><br>
+     * Examples:<br>
+     * For the parameterized type
+     * <pre><code>
+     * List&lt;String&gt;</code></pre>
+     * the result would be the {@link JavaClass classes} <code>[List, String]</code>.<br>
+     * For the parameterized type
+     * <pre><code>
+     * Map&lt;? extends Serializable, List&lt;? super Integer[]&gt;&gt;</code></pre>
+     * the result would be <code>[Map, Serializable, List, Integer]</code>.<br>
+     * And for the type variable
+     * <pre><code>
+     * T extends List&lt;? super Integer&gt;</code></pre>
+     * the result would be <code>[List, Integer]</code>.<br>
+     * Thus, this method offers a quick way to determine all types a (possibly complex) type depends on.
+     *
+     * @return All raw types involved in this {@link JavaType}
+     */
+    @PublicAPI(usage = ACCESS)
+    Set<JavaClass> getAllInvolvedRawTypes();
 
     /**
      * Predefined {@link ChainableFunction functions} to transform {@link JavaType}.

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.TypeVariable;
 import java.util.List;
+import java.util.Set;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.HasDescription;
@@ -28,6 +29,7 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Represents a type variable used by generic types and members.<br>
@@ -117,6 +119,14 @@ public final class JavaTypeVariable<OWNER extends HasDescription> implements Jav
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
+    }
+
+    @Override
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return this.upperBounds.stream()
+                .map(JavaType::getAllInvolvedRawTypes)
+                .flatMap(Set::stream)
+                .collect(toSet());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -17,6 +17,8 @@ package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.WildcardType;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.properties.HasUpperBounds;
@@ -25,6 +27,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Represents a wildcard type in a type signature (compare the JLS).
@@ -93,6 +96,14 @@ public final class JavaWildcardType implements JavaType, HasUpperBounds {
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
+    }
+
+    @Override
+    public Set<JavaClass> getAllInvolvedRawTypes() {
+        return Stream.concat(upperBounds.stream(), lowerBounds.stream())
+                .map(JavaType::getAllInvolvedRawTypes)
+                .flatMap(Set::stream)
+                .collect(toSet());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -88,6 +88,7 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
 @Internal
 @SuppressWarnings("UnusedReturnValue")
@@ -1214,6 +1215,14 @@ public final class DomainBuilders {
         @Override
         public JavaClass toErasure() {
             return type.toErasure();
+        }
+
+        @Override
+        public Set<JavaClass> getAllInvolvedRawTypes() {
+            return Stream.concat(
+                    type.getAllInvolvedRawTypes().stream(),
+                    typeArguments.stream().map(JavaType::getAllInvolvedRawTypes).flatMap(Set::stream)
+            ).collect(toSet());
         }
 
         @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -175,6 +175,28 @@ public class JavaClassTest {
     }
 
     @Test
+    public void get_all_involved_raw_types_returns_only_self_for_non_array_type() {
+        class SimpleClass {
+        }
+
+        JavaClass clazz = new ClassFileImporter().importClass(SimpleClass.class);
+
+        assertThatTypes(clazz.getAllInvolvedRawTypes()).matchExactly(SimpleClass.class);
+    }
+
+    @Test
+    public void get_all_involved_raw_types_returns_component_type_for_array_type() {
+        class SimpleClass {
+            @SuppressWarnings("unused")
+            SimpleClass[][] field;
+        }
+
+        JavaType arrayType = new ClassFileImporter().importClass(SimpleClass.class).getField("field").getType();
+
+        assertThatTypes(arrayType.getAllInvolvedRawTypes()).matchExactly(SimpleClass.class);
+    }
+
+    @Test
     public void finds_component_type_chain_of_otherwise_unreferenced_component_type() {
         @SuppressWarnings("unused")
         class OnlyReferencingMultiDimArray {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
@@ -1,8 +1,11 @@
 package com.tngtech.archunit.core.domain;
 
 import java.io.File;
+import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -20,11 +23,27 @@ import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_RAW_TYPE;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatAnnotation;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(DataProviderRunner.class)
 public class JavaCodeUnitTest {
+
+    @Test
+    public void offers_all_involved_raw_types() {
+        class SampleClass<T extends Collection<? super File> & Serializable> {
+            @SuppressWarnings("unused")
+            T method(List<Map<? extends Number, Set<? super String[][]>>> input) {
+                return null;
+            }
+        }
+
+        JavaMethod method = new ClassFileImporter().importClass(SampleClass.class).getMethod("method", List.class);
+
+        assertThatTypes(method.getAllInvolvedRawTypes())
+                .matchInAnyOrder(Collection.class, File.class, Serializable.class, List.class, Map.class, Number.class, Set.class, String.class);
+    }
 
     @Test
     public void offers_all_calls_from_Self() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaFieldTest.java
@@ -1,0 +1,25 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+
+public class JavaFieldTest {
+    @Test
+    public void offers_all_involved_raw_types() {
+        class SomeClass {
+            @SuppressWarnings("unused")
+            List<? super Map<? extends Serializable, ? super Set<Number[][]>>> field;
+        }
+
+        JavaField field = new ClassFileImporter().importClass(SomeClass.class).getField("field");
+
+        assertThatTypes(field.getAllInvolvedRawTypes()).matchInAnyOrder(List.class, Map.class, Serializable.class, Set.class, Number.class);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.testutil.Assertions.assertThat;
 import static com.tngtech.archunit.testutil.Assertions.assertThatType;
 import static com.tngtech.archunit.testutil.Assertions.assertThatTypeErasuresOf;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
 
 public class JavaTypeVariableTest {
 
@@ -117,6 +118,30 @@ public class JavaTypeVariableTest {
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(3)).toErasure()).matches(Object[].class);
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(4)).toErasure()).matches(String[][].class);
         assertThatType(getTypeArgumentOfFirstBound(typeParameters.get(5)).toErasure()).matches(List[][][].class);
+    }
+
+    @Test
+    public void all_involved_raw_types() {
+        class SampleClass<T extends String & List<Serializable[]>> {
+            @SuppressWarnings("unused")
+            private T field;
+        }
+
+        JavaTypeVariable<?> typeVariable = (JavaTypeVariable<?>) new ClassFileImporter().importClass(SampleClass.class).getField("field").getType();
+
+        assertThatTypes(typeVariable.getAllInvolvedRawTypes()).matchInAnyOrder(String.class, List.class, Serializable.class);
+    }
+
+    @Test
+    public void all_involved_raw_types_of_generic_array() {
+        class SampleClass<T extends String & List<Serializable>> {
+            @SuppressWarnings("unused")
+            private T[][] field;
+        }
+
+        JavaGenericArrayType typeVariable = (JavaGenericArrayType) new ClassFileImporter().importClass(SampleClass.class).getField("field").getType();
+
+        assertThatTypes(typeVariable.getAllInvolvedRawTypes()).matchInAnyOrder(String.class, List.class, Serializable.class);
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaWildcardTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaWildcardTypeTest.java
@@ -1,7 +1,10 @@
 package com.tngtech.archunit.core.domain;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -152,6 +155,50 @@ public class JavaWildcardTypeTest {
 
         wildcard = importWildcardTypeOf(ClassWithBoundTypeParameterWithGenericArrayBounds.class, 5);
         assertThatType(wildcard.toErasure()).matches(List[][][].class);
+    }
+
+    @Test
+    public void allInvolvedRawTypes_finds_no_involved_raw_types_of_unbound_wildcard() {
+        @SuppressWarnings("unused")
+        class SampleClass<T extends List<?>> {
+        }
+
+        JavaWildcardType type = importWildcardTypeOf(SampleClass.class);
+
+        assertThat(type.getAllInvolvedRawTypes()).isEmpty();
+    }
+
+    @Test
+    public void allInvolvedRawTypes_finds_involved_raw_types_of_lower_bounds() {
+        @SuppressWarnings("unused")
+        class SampleClass<T extends List<? super String>> {
+        }
+
+        JavaWildcardType type = importWildcardTypeOf(SampleClass.class);
+
+        assertThatTypes(type.getAllInvolvedRawTypes()).matchInAnyOrder(String.class);
+    }
+
+    @Test
+    public void allInvolvedRawTypes_finds_involved_raw_types_of_upper_bounds() {
+        @SuppressWarnings("unused")
+        class SampleClass<T extends List<? extends String>> {
+        }
+
+        JavaWildcardType type = importWildcardTypeOf(SampleClass.class);
+
+        assertThatTypes(type.getAllInvolvedRawTypes()).matchInAnyOrder(String.class);
+    }
+
+    @Test
+    public void allInvolvedRawTypes_finds_involved_raw_types_for_complex_upper_and_lower_bounds() {
+        @SuppressWarnings("unused")
+        class SampleClass<T extends List<? extends Map<? extends List<String[][]>, Set<? super File[]>>>> {
+        }
+
+        JavaWildcardType type = importWildcardTypeOf(SampleClass.class);
+
+        assertThatTypes(type.getAllInvolvedRawTypes()).matchInAnyOrder(Map.class, List.class, String.class, Set.class, File.class);
     }
 
     @Test

--- a/develop/ArchUnit-codestyle-intellij.xml
+++ b/develop/ArchUnit-codestyle-intellij.xml
@@ -22,6 +22,7 @@
         <option name="CLASS_NAMES_IN_JAVADOC" value="3"/>
     </JavaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
+        <option name="RIGHT_MARGIN" value="300"/>
         <option name="KEEP_FIRST_COLUMN_COMMENT" value="false"/>
         <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
         <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>


### PR DESCRIPTION
This PR adds two new methods: `JavaType.getAllInvolvedRawTypes()` and `JavaCodeUnit.getAllInvolvedRawTypes()`.
`JavaType.getAllInvolvedRawTypes()` returns all involved types in this `JavaType` (e.g. return type of a method)
i.e. for a method `public Map<? extends String, ? super Map<Serializable, Object>> method(List<String> input) {...}`
the methods should return the following:
- `method.getReturnType().getAllInvolvedRawTypes()` would return `Set.of(Map.class, String.class, Serializable.class, Object.class)`
- `method.getAllInvolvedRawTypes()` would return `Set.of(Map.class, String.class, Serializable.class, Object.class, List.class)`

WDYT? Feedback is highly appreciated :)

Resolves: #723 