### PR TITLE
Let `JarFileLocation` work with custom `ClassLoader` URIs

### DIFF
--- a/archunit-3rd-party-test/build.gradle
+++ b/archunit-3rd-party-test/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'archunit.java-conventions'
+}
+
+ext.moduleName = 'com.tngtech.archunit.thirdpartytest'
+
+dependencies {
+    testImplementation project(path: ':archunit', configuration: 'shadow')
+    testImplementation project(path: ':archunit', configuration: 'tests')
+    testImplementation dependency.springBootLoader
+    dependency.addGuava { dependencyNotation, config -> testImplementation(dependencyNotation, config) }
+    testImplementation dependency.log4j_slf4j
+    testImplementation dependency.junit4
+    testImplementation dependency.junit_dataprovider
+    testImplementation dependency.assertj
+}

--- a/archunit-3rd-party-test/src/test/java/com/tngtech/archunit/core/importer/SpringLocationsTest.java
+++ b/archunit-3rd-party-test/src/test/java/com/tngtech/archunit/core/importer/SpringLocationsTest.java
@@ -1,0 +1,96 @@
+package com.tngtech.archunit.core.importer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.function.Function;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
+import com.tngtech.archunit.testutil.SystemPropertiesRule;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.loader.LaunchedURLClassLoader;
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.boot.loader.archive.JarFileArchive;
+
+import static com.google.common.collect.Iterators.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static com.google.common.collect.Streams.stream;
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.tngtech.archunit.core.importer.LocationTest.classFileEntry;
+import static com.tngtech.archunit.core.importer.LocationTest.urlOfClass;
+import static com.tngtech.archunit.core.importer.LocationsTest.unchecked;
+import static com.tngtech.java.junit.dataprovider.DataProviders.testForEach;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class SpringLocationsTest {
+    /**
+     * Spring Boot configures some system properties that we want to reset afterward (e.g. custom URL stream handler)
+     */
+    @Rule
+    public final SystemPropertiesRule systemPropertiesRule = new SystemPropertiesRule();
+
+    @DataProvider
+    public static Object[][] springBootJars() {
+        Function<Function<TestJarFile, TestJarFile>, TestJarFile> createSpringBootJar = setUpJarFile -> setUpJarFile.apply(new TestJarFile())
+                .withNestedClassFilesDirectory("BOOT-INF/classes")
+                .withEntry(classFileEntry(SomeEnum.class).toAbsolutePath());
+
+        return testForEach(
+                createSpringBootJar.apply(TestJarFile::withDirectoryEntries),
+                createSpringBootJar.apply(TestJarFile::withoutDirectoryEntries)
+        );
+    }
+
+    @Test
+    @UseDataProvider("springBootJars")
+    public void finds_locations_of_packages_from_Spring_Boot_ClassLoader_for_JARs(TestJarFile jarFileToTest) throws Exception {
+        try (JarFile jarFile = jarFileToTest.create()) {
+
+            configureSpringBootContextClassLoaderKnowingOnly(jarFile);
+
+            String jarUri = new File(jarFile.getName()).toURI().toString();
+            Location location = Locations.ofPackage(SomeEnum.class.getPackage().getName()).stream()
+                    .filter(it -> it.contains(jarUri))
+                    .collect(onlyElement());
+
+            byte[] expectedClassContent = toByteArray(urlOfClass(SomeEnum.class).openStream());
+            Stream<byte[]> actualClassContents = stream(location.asClassFileSource(new ImportOptions()))
+                    .map(it -> unchecked(() -> toByteArray(it.openStream())));
+
+            boolean containsExpectedContent = actualClassContents.anyMatch(it -> Arrays.equals(it, expectedClassContent));
+            assertThat(containsExpectedContent)
+                    .as("one of the found class files has the expected class file content")
+                    .isTrue();
+        }
+    }
+
+    private static void configureSpringBootContextClassLoaderKnowingOnly(JarFile jarFile) throws IOException {
+        // This hooks in Spring Boot's own JAR URL protocol handler which knows how to handle URLs with
+        // multiple separators (e.g. "jar:file:/dir/some.jar!/BOOT-INF/classes!/pkg/some.class")
+        org.springframework.boot.loader.jar.JarFile.registerUrlProtocolHandler();
+
+        try (JarFileArchive jarFileArchive = new JarFileArchive(new File(jarFile.getName()))) {
+            JarFileArchive bootInfClassArchive = getNestedJarFileArchive(jarFileArchive, "BOOT-INF/classes/");
+
+            Thread.currentThread().setContextClassLoader(
+                    new LaunchedURLClassLoader(false, bootInfClassArchive, new URL[]{bootInfClassArchive.getUrl()}, null)
+            );
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static JarFileArchive getNestedJarFileArchive(JarFileArchive jarFileArchive, String path) throws IOException {
+        Iterator<Archive> archiveCandidates = jarFileArchive.getNestedArchives(entry -> entry.getName().equals(path), entry -> true);
+        return (JarFileArchive) getOnlyElement(archiveCandidates);
+    }
+}

--- a/archunit/src/jdk9main/java/com/tngtech/archunit/core/importer/ModuleLocationResolver.java
+++ b/archunit/src/jdk9main/java/com/tngtech/archunit/core/importer/ModuleLocationResolver.java
@@ -34,9 +34,11 @@ import static com.google.common.collect.Iterables.concat;
 import static java.util.stream.Collectors.toList;
 
 class ModuleLocationResolver implements LocationResolver {
+    private final FromClasspathAndUrlClassLoaders standardResolver = new FromClasspathAndUrlClassLoaders();
+
     @Override
     public UrlSource resolveClassPath() {
-        Iterable<URL> classpath = UrlSource.From.classPathSystemProperties();
+        Iterable<URL> classpath = standardResolver.resolveClassPath();
         Set<ModuleReference> systemModuleReferences = ModuleFinder.ofSystem().findAll();
         Set<ModuleReference> configuredModuleReferences = ModuleFinder.of(modulepath()).findAll();
         Iterable<URL> modulepath = Stream.concat(systemModuleReferences.stream(), configuredModuleReferences.stream())

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportPlugin.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportPlugin.java
@@ -51,7 +51,7 @@ interface ImportPlugin {
 
             @Override
             public void plugInLocationResolver(InitialConfiguration<LocationResolver> locationResolver) {
-                locationResolver.set(new LocationResolver.Legacy());
+                locationResolver.set(new LocationResolver.FromClasspathAndUrlClassLoaders());
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -335,8 +335,9 @@ public abstract class Location {
             }
 
             static ParsedUri from(NormalizedUri uri) {
-                String[] parts = uri.toString().split("!/", 2);
-                return new ParsedUri(parts[0] + "!/", parts[1]);
+                String uriString = uri.toString();
+                int entryPathStartIndex = uriString.lastIndexOf("!/") + 2;
+                return new ParsedUri(uriString.substring(0, entryPathStartIndex), uriString.substring(entryPathStartIndex));
             }
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/Location.java
@@ -271,8 +271,8 @@ public abstract class Location {
         @Override
         ClassFileSource asClassFileSource(ImportOptions importOptions) {
             try {
-                String[] parts = uri.toString().split("!/", 2);
-                return new ClassFileSource.FromJar(new URL(parts[0] + "!/"), parts[1], importOptions);
+                ParsedUri parsedUri = ParsedUri.from(uri);
+                return new ClassFileSource.FromJar(new URL(parsedUri.base), parsedUri.path, importOptions);
             } catch (IOException e) {
                 throw new LocationException(e);
             }
@@ -298,7 +298,7 @@ public abstract class Location {
                 // Note: We can't use a composed JAR URL like `jar:file:/path/to/file.jar!/com/example`, because opening the connection
                 //       fails with an exception if the directory entry for this path is missing (which is possible, even if there is
                 //       a class `com.example.SomeClass` in the JAR file).
-                String baseUri = uri.toString().replaceAll("!/.*", "!/");
+                String baseUri = ParsedUri.from(uri).base;
                 JarURLConnection jarUrlConnection = (JarURLConnection) new URL(baseUri).openConnection();
                 return Optional.of(jarUrlConnection.getJarFile());
             } catch (IOException e) {
@@ -308,7 +308,7 @@ public abstract class Location {
 
         private Collection<NormalizedResourceName> readJarFileContent(JarFile jarFile) {
             ImmutableList.Builder<NormalizedResourceName> result = ImmutableList.builder();
-            String prefix = uri.toString().replaceAll(".*!/", "");
+            String prefix = ParsedUri.from(uri).path;
             result.addAll(readEntries(prefix, jarFile));
             return result.build();
         }
@@ -323,6 +323,21 @@ public abstract class Location {
                 }
             }
             return result;
+        }
+
+        private static class ParsedUri {
+            final String base;
+            final String path;
+
+            private ParsedUri(String base, String path) {
+                this.base = base;
+                this.path = path;
+            }
+
+            static ParsedUri from(NormalizedUri uri) {
+                String[] parts = uri.toString().split("!/", 2);
+                return new ParsedUri(parts[0] + "!/", parts[1]);
+            }
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/LocationResolver.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/LocationResolver.java
@@ -28,7 +28,7 @@ interface LocationResolver {
     UrlSource resolveClassPath();
 
     @Internal
-    class Legacy implements LocationResolver {
+    class FromClasspathAndUrlClassLoaders implements LocationResolver {
         @Override
         public UrlSource resolveClassPath() {
             ImmutableList.Builder<URL> result = ImmutableList.builder();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationTest.java
@@ -173,12 +173,12 @@ public class LocationTest {
         return new File(urlOfClass(clazz).toURI()).getAbsoluteFile().toPath();
     }
 
-    private URI jarUriOfEntry(JarFile jarFile, String entry) {
+    static URI jarUriOfEntry(JarFile jarFile, String entry) {
         return jarUriOfEntry(jarFile, NormalizedResourceName.from(entry));
     }
 
-    private URI jarUriOfEntry(JarFile jarFile, NormalizedResourceName entry) {
-        return URI.create("jar:" + new File(jarFile.getName()).toURI().toString() + "!/" + entry);
+    private static URI jarUriOfEntry(JarFile jarFile, NormalizedResourceName entry) {
+        return URI.create("jar:" + new File(jarFile.getName()).toURI() + "!/" + entry);
     }
 
     @Test
@@ -342,7 +342,7 @@ public class LocationTest {
         return clazz.getResourceAsStream(classFileResource(clazz));
     }
 
-    private static NormalizedResourceName classFileEntry(Class<?> clazz) {
+    static NormalizedResourceName classFileEntry(Class<?> clazz) {
         return NormalizedResourceName.from(classFileResource(clazz));
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationsTest.java
@@ -189,7 +189,7 @@ public class LocationsTest {
         return StreamSupport.stream(iterable.spliterator(), false);
     }
 
-    private <T> T unchecked(ThrowingSupplier<T> supplier) {
+    static <T> T unchecked(ThrowingSupplier<T> supplier) {
         try {
             return supplier.get();
         } catch (Exception e) {
@@ -198,7 +198,7 @@ public class LocationsTest {
     }
 
     @FunctionalInterface
-    private interface ThrowingSupplier<T> {
+    interface ThrowingSupplier<T> {
         T get() throws Exception;
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/LocationsTest.java
@@ -1,17 +1,28 @@
 package com.tngtech.archunit.core.importer;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableList;
+import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.tngtech.archunit.core.importer.LocationTest.classFileEntry;
+import static com.tngtech.archunit.core.importer.LocationTest.jarUriOfEntry;
 import static com.tngtech.archunit.core.importer.LocationTest.urlOfClass;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +65,7 @@ public class LocationsTest {
      * Jar file didn't have an entry for the respective folder (e.g. java.io vs /java/io).
      */
     @Test
+    @SuppressWarnings("EmptyTryBlock")
     public void locations_of_packages_within_JAR_URIs_that_do_not_contain_package_folder() throws Exception {
         independentClasspathRule.configureClasspath();
 
@@ -69,6 +81,55 @@ public class LocationsTest {
         assertThat(source)
                 .as("URIs in " + independentClasspathRule.getIndependentTopLevelPackage())
                 .hasSize(independentClasspathRule.getNamesOfClasses().size());
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public void locations_of_packages_from_custom_ClassLoader_for_JARs_with_directory_entries() throws IOException {
+        JarFile jarFile = new TestJarFile()
+                .withDirectoryEntries()
+                .withEntry(classFileEntry(SomeEnum.class).toAbsolutePath())
+                .create();
+        URL jarUrl = getJarUrlOf(jarFile);
+
+        Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[]{jarUrl}, null));
+
+        Location location = Locations.ofPackage(SomeEnum.class.getPackage().getName()).stream()
+                .filter(it -> it.contains(jarUrl.toString()))
+                .findFirst()
+                .get();
+
+        byte[] expectedClassContent = toByteArray(urlOfClass(SomeEnum.class).openStream());
+        Stream<byte[]> actualClassContents = stream(location.asClassFileSource(new ImportOptions()))
+                .map(it -> unchecked(() -> toByteArray(it.openStream())));
+
+        boolean containsExpectedContent = actualClassContents.anyMatch(it -> Arrays.equals(it, expectedClassContent));
+        assertThat(containsExpectedContent)
+                .as("one of the actual class files has the expected class file content")
+                .isTrue();
+    }
+
+    /**
+     * This is a known limitation for now: If the JAR file doesn't contain directory entries, then asking
+     * the {@link ClassLoader} for all resources within a directory (which happens when we look for a package)
+     * will not return anything.
+     * For this we have some mitigations to additionally search the classpath, but in case this really is
+     * a highly customized {@link ClassLoader} that doesn't expose any URLs there is not much more we can do.
+     */
+    @Test
+    public void locations_of_packages_from_custom_ClassLoader_for_JARs_without_directory_entries() throws IOException {
+        JarFile jarFile = new TestJarFile()
+                .withoutDirectoryEntries()
+                .withEntry(classFileEntry(SomeEnum.class).toAbsolutePath())
+                .create();
+        URL jarUrl = getJarUrlOf(jarFile);
+
+        Thread.currentThread().setContextClassLoader(new CustomClassLoader(jarUrl));
+
+        String packageName = SomeEnum.class.getPackage().getName();
+        assertThat(Locations.ofPackage(packageName))
+                .as("Locations of package '%s'", packageName)
+                .noneMatch(it -> it.contains(jarUrl.toString()));
     }
 
     @Test
@@ -104,6 +165,10 @@ public class LocationsTest {
         );
     }
 
+    private static URL getJarUrlOf(JarFile jarFile) throws MalformedURLException {
+        return jarUriOfEntry(jarFile, "").toURL();
+    }
+
     private Iterable<URI> urisOf(Collection<Location> locations) {
         return locations.stream().map(Location::asURI).collect(toSet());
     }
@@ -118,5 +183,34 @@ public class LocationsTest {
     private URI uriOfFolderOf(Class<?> clazz) throws Exception {
         String urlAsString = urlOfClass(clazz).toExternalForm();
         return new URL(urlAsString.substring(0, urlAsString.lastIndexOf("/")) + "/").toURI();
+    }
+
+    private static <T> Stream<T> stream(Iterable<T> iterable) {
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private <T> T unchecked(ThrowingSupplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private static class CustomClassLoader extends URLClassLoader {
+        CustomClassLoader(URL... urls) {
+            super(urls, null);
+        }
+
+        @Override
+        public URL[] getURLs() {
+            // Simulate some non-standard ClassLoader by not exposing any URLs we could retrieve from the outside
+            return new URL[0];
+        }
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/TestJarFile.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/TestJarFile.java
@@ -3,12 +3,16 @@ package com.tngtech.archunit.core.importer;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 
 import com.tngtech.archunit.testutil.TestUtils;
@@ -20,6 +24,7 @@ import static org.assertj.core.util.Preconditions.checkArgument;
 
 class TestJarFile {
     private final Manifest manifest;
+    private Optional<String> nestedClassFilesDirectory = Optional.empty();
     private final Set<String> entries = new HashSet<>();
     private boolean withDirectoryEntries = false;
 
@@ -40,6 +45,11 @@ class TestJarFile {
 
     TestJarFile withManifestAttribute(Attributes.Name name, String value) {
         manifest.getMainAttributes().put(name, value);
+        return this;
+    }
+
+    public TestJarFile withNestedClassFilesDirectory(String relativePath) {
+        nestedClassFilesDirectory = Optional.of(relativePath);
         return this;
     }
 
@@ -67,54 +77,50 @@ class TestJarFile {
     }
 
     JarFile create(File jarFile) {
-        Set<String> allEntries = withDirectoryEntries ? ensureDirectoryEntries(entries) : entries;
+        Stream<TestJarEntry> testJarEntries = entries.stream()
+                .map(entry -> new TestJarEntry(entry, nestedClassFilesDirectory));
+
+        Stream<TestJarEntry> allEntries = withDirectoryEntries
+                ? ensureDirectoryEntries(testJarEntries)
+                : ensureNestedClassFilesDirectoryEntries(testJarEntries);
+
         try (JarOutputStream jarOut = new JarOutputStream(newOutputStream(jarFile.toPath()), manifest)) {
-            for (String entry : allEntries) {
-                write(jarOut, entry);
-            }
+            allEntries.distinct().forEach(entry -> write(jarOut, entry));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
         return newJarFile(jarFile);
     }
 
-    private Set<String> ensureDirectoryEntries(Set<String> entries) {
-        Set<String> result = new HashSet<>();
-        entries.forEach(entry -> {
-            result.addAll(createDirectoryEntries(entry));
-            result.add(entry);
-        });
-        return result;
+    private Stream<TestJarEntry> ensureNestedClassFilesDirectoryEntries(Stream<TestJarEntry> entries) {
+        return createAdditionalEntries(entries, TestJarEntry::getDirectoriesInPathOfNestedClassFilesDirectory);
     }
 
-    private static Set<String> createDirectoryEntries(String entry) {
-        Set<String> result = new HashSet<>();
-        int checkedUpToIndex = -1;
-        do {
-            checkedUpToIndex = entry.indexOf("/", checkedUpToIndex + 1);
-            if (checkedUpToIndex != -1) {
-                result.add(entry.substring(0, checkedUpToIndex + 1));
-            }
-        } while (checkedUpToIndex != -1);
-        return result;
+    private Stream<TestJarEntry> ensureDirectoryEntries(Stream<TestJarEntry> entries) {
+        return createAdditionalEntries(entries, TestJarEntry::getDirectoriesInPath);
+    }
+
+    private static Stream<TestJarEntry> createAdditionalEntries(Stream<TestJarEntry> entries, Function<TestJarEntry, Stream<TestJarEntry>> createAdditionalEntries) {
+        return entries.flatMap(it -> Stream.concat(createAdditionalEntries.apply(it), Stream.of(it)));
     }
 
     String createAndReturnName(File jarFile) {
         return createAndReturnName(() -> create(jarFile));
     }
 
-    private void write(JarOutputStream jarOut, String entry) throws IOException {
-        checkArgument(!entry.startsWith("/"),
-                "ZIP entries must not start with a '/' (compare ZIP spec https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT -> 4.4.17.1)");
+    private void write(JarOutputStream jarOut, TestJarEntry entry) {
+        try {
+            ZipEntry zipEntry = entry.toZipEntry();
+            jarOut.putNextEntry(zipEntry);
 
-        String absoluteResourcePath = "/" + entry;
-
-        ZipEntry zipEntry = new ZipEntry(entry);
-        jarOut.putNextEntry(zipEntry);
-        if (!zipEntry.isDirectory() && getClass().getResource(absoluteResourcePath) != null) {
-            jarOut.write(toByteArray(getClass().getResourceAsStream(absoluteResourcePath)));
+            String originResourcePath = "/" + entry.entry;
+            if (!zipEntry.isDirectory() && getClass().getResource(originResourcePath) != null) {
+                jarOut.write(toByteArray(getClass().getResourceAsStream(originResourcePath)));
+            }
+            jarOut.closeEntry();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        jarOut.closeEntry();
     }
 
     private JarFile newJarFile(File file) {
@@ -122,6 +128,77 @@ class TestJarFile {
             return new JarFile(file);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static class TestJarEntry {
+        private final String entry;
+        private final String nestedClassFilesDirectory;
+
+        TestJarEntry(String entry, Optional<String> nestedClassFilesDirectory) {
+            this(
+                    entry,
+                    nestedClassFilesDirectory
+                            .map(it -> it.endsWith("/") ? it : it + "/")
+                            .orElse("")
+            );
+        }
+
+        private TestJarEntry(String entry, String nestedClassFilesDirectory) {
+            checkArgument(!entry.startsWith("/"),
+                    "ZIP entries must not start with a '/' (compare ZIP spec https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT -> 4.4.17.1)");
+            checkArgument(!nestedClassFilesDirectory.startsWith("/"),
+                    "Nested class files dir must be relative (i.e. not start with a '/')");
+
+            this.entry = entry;
+            this.nestedClassFilesDirectory = nestedClassFilesDirectory;
+        }
+
+        ZipEntry toZipEntry() {
+            return new ZipEntry(nestedClassFilesDirectory + entry);
+        }
+
+        Stream<TestJarEntry> getDirectoriesInPath() {
+            Stream<TestJarEntry> fromClassEntries = getDirectoriesInPath(entry).stream()
+                    .map(it -> new TestJarEntry(it, nestedClassFilesDirectory));
+            Stream<TestJarEntry> fromNestedClassFilesDir = getDirectoriesInPathOfNestedClassFilesDirectory();
+            return Stream.concat(fromClassEntries, fromNestedClassFilesDir);
+        }
+
+        Stream<TestJarEntry> getDirectoriesInPathOfNestedClassFilesDirectory() {
+            return getDirectoriesInPath(nestedClassFilesDirectory).stream()
+                    .map(it -> new TestJarEntry(it, ""));
+        }
+
+        private Set<String> getDirectoriesInPath(String entryPath) {
+            Set<String> result = new HashSet<>();
+            int checkedUpToIndex = -1;
+            do {
+                checkedUpToIndex = entryPath.indexOf("/", checkedUpToIndex + 1);
+                if (checkedUpToIndex != -1) {
+                    result.add(entryPath.substring(0, checkedUpToIndex + 1));
+                }
+            } while (checkedUpToIndex != -1);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TestJarEntry that = (TestJarEntry) o;
+            return Objects.equals(entry, that.entry)
+                   && Objects.equals(nestedClassFilesDirectory, that.nestedClassFilesDirectory);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(entry, nestedClassFilesDirectory);
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ ext {
             // Dependencies for example projects / tests
             javaxAnnotationApi  : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],
             springBeans         : [group: 'org.springframework', name: 'spring-beans', version: '5.3.23'],
+            springBootLoader    : [group: 'org.springframework.boot', name: 'spring-boot-loader', version: '2.7.13'],
             jakartaInject       : [group: 'jakarta.inject', name: 'jakarta.inject-api', version: '1.0'],
             jakartaAnnotations  : [group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '1.3.5'],
             guice               : [group: 'com.google.inject', name: 'guice', version: '5.1.0'],

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ plugins {
 
 rootProject.name = 'archunit-root'
 
-include 'archunit', 'archunit-integration-test', 'archunit-java-modules-test',
+include 'archunit', 'archunit-integration-test', 'archunit-java-modules-test', 'archunit-3rd-party-test',
         'archunit-junit', 'archunit-junit4', 'archunit-junit5-api', 'archunit-junit5-engine-api', 'archunit-junit5-engine', 'archunit-junit5',
         'archunit-example:example-plain', 'archunit-example:example-junit4', 'archunit-example:example-junit5', 'archunit-maven-test', 'docs'
 


### PR DESCRIPTION
IMPORTANT: I did not add any new test cases to verify the scenario described in the following, as I was unable to get the project imported into my IDE. The existing tests still succeed so that I feel confident I didn't break anything. Furthermore, a downstream sample project producing the described scenario works with the fix applied and previously failed.

Some ClassLoaders that work with repackaged JAR files return custom resource URIs to indicate custom class loading locations. For example, the ClassLoader in a packaged Spring Boot's returns the following URI for source package named example: jar:file:/Path/to/my.jar!/BOOT-INF/classes!/example/. Note the second "!/" to indicate a classpath root.

Prior to this commit, JarFileLocation was splitting paths to a resource at the first "!/" assuming the remainder of the string would depict the actual resource path. That remainder potentially containing a further "!/" would prevent the JAR entry matching in FromJar.classFilesBeneath(…) as the entries themselves do not contain the exclamation mark.

This commit changes the treatment of the URI in JarFileLocation to rather use the *last* "!/" as splitting point so that the remainder is a proper path within the ClassLoader and the matching in FromJar.classFilesBeneath(…) works properly.