### PR TITLE
support dependOnClassesThat() for methods

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/syntax/elements/CodeUnitsShould.java
@@ -314,6 +314,18 @@ public interface CodeUnitsShould<CONJUNCTION extends CodeUnitsShouldConjunction<
     @PublicAPI(usage = ACCESS)
     CONJUNCTION notHaveRawReturnType(DescribedPredicate<? super JavaClass> predicate);
 
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION dependOnArgumentsThat(DescribedPredicate<? super JavaClass> predicate);
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION dependOnReturnTypesThat(DescribedPredicate<? super JavaClass> predicate);
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION accessClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
+    @PublicAPI(usage = ACCESS)
+    CONJUNCTION dependOnClassesThat(DescribedPredicate<? super JavaClass> predicate);
+
     /**
      * Asserts that {@link JavaCodeUnit JavaCodeUnits} declare a {@link Throwable} of the specified type in their throws clause.
      * <br><br>


### PR DESCRIPTION
This adds the following new methods to the public API to check if methods depend on a certain class (matched by `predicate`):
- `dependOnArgumentsThat(DescribedPredicate<? super JavaClass> predicate)`
- `dependOnReturnTypesThat(DescribedPredicate<? super JavaClass> predicate)`
- `accessClassesThat(DescribedPredicate<? super JavaClass> predicate)`
- `dependOnClassesThat(DescribedPredicate<? super JavaClass> predicate)`

The first three methods check for violations of 1) arguments 2) return types and 3) class access referencing `BadClass`. The last rule (`dependOnClassesThat()`) checks for any violation of the first three rules (somehow a convenience function if none of the fine granular access is desired)

What do you think? Any feedback is highly appreciated :)

Resolves: #1060