### PR TITLE
adjust expected `slf4j-api` version to actual one

### DIFF
--- a/buildSrc/src/main/resources/release_check/archunit.pom
+++ b/buildSrc/src/main/resources/release_check/archunit.pom
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.9</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This has again been overlooked, when upgrading the dependency. Unfortunately, still nobody found the time to add an automated check for this to prevent this problem in the future.