### PR TITLE
add up-to-date check for release check

### DIFF
--- a/buildSrc/src/main/groovy/archunit.java-release-check-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-release-check-conventions.gradle
@@ -1,8 +1,37 @@
+import groovy.xml.XmlSlurper
+
 import java.nio.file.Files
 import java.util.jar.JarFile
 
 plugins {
     id 'archunit.java-artifact-check-conventions'
+}
+
+task ensureReleaseCheckUpToDate {
+    doFirst {
+        def mavenProject = new XmlSlurper().parseText(getExpectedPomFileContent())
+        def releaseCheckDependencies = mavenProject.dependencies.dependency
+                .findAll { it.groupId != 'com.tngtech.archunit' }
+                .collect {
+                    [groupId: it.groupId.toString(), artifactId: it.artifactId.toString(), version: it.version.toString()]
+                }
+
+        releaseCheckDependencies.each { releaseCheckDependency ->
+            def matchingProjectDependency = dependency.values().find {
+                it.group == releaseCheckDependency.groupId && it.name == releaseCheckDependency.artifactId
+            }
+            assert matchingProjectDependency != null:
+                    "No project dependency was found for expected release dependency ${releaseCheckDependency}"
+            assert matchingProjectDependency.version == releaseCheckDependency.version:
+                    "Release check dependency version ${releaseCheckDependency} doesn't match " +
+                            "project dependency version ${matchingProjectDependency}"
+        }
+    }
+}
+check.dependsOn(ensureReleaseCheckUpToDate)
+
+ext.getExpectedPomFileContent = {
+    getClass().getResourceAsStream("release_check/${project.name}.pom").text.replace('${archunit.version}', version).stripIndent()
 }
 
 task checkUploadedArtifacts {
@@ -24,10 +53,6 @@ task checkUploadedArtifacts {
 
         def getUploadedPomFileContent = {
             new URL("${createArtifactUrl(project.name)}.pom").text.stripIndent()
-        }
-
-        def getExpectedPomFileContent = {
-            getClass().getResourceAsStream("release_check/${project.name}.pom").text.replace('${archunit.version}', version).stripIndent()
         }
 
         def checkPom = {


### PR DESCRIPTION
It happened several times that a release dependency (e.g. `slf4j-api`) was updated e.g. by Dependabot, but the respective expected POM template for the release check was forgotten to adjust. This then makes the release fail, because it thinks the produced POM file doesn't match the expected one. We now ensure during build that the release check POM file dependency versions still match the project dependencies, so this can't go out of sync anymore.