### PR TITLE
fix importing inner class using string concat of outer field

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -264,7 +264,7 @@ class ClassFileImportRecord {
     }
 
     void forEachRawConstructorCallRecord(Consumer<RawAccessRecord> doWithRecord) {
-        resolveSyntheticOrigins(rawConstructorCallRecords, COPY_RAW_ACCESS_RECORD, syntheticLambdaAccessRecorder)
+        resolveSyntheticOrigins(rawConstructorCallRecords, COPY_RAW_ACCESS_RECORD, syntheticPrivateAccessRecorder, syntheticLambdaAccessRecorder)
                 .forEach(doWithRecord);
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessesAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/AccessesAssertion.java
@@ -7,6 +7,8 @@ import java.util.Set;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.domain.JavaFieldAccess.AccessType;
 import org.assertj.core.api.Condition;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +37,9 @@ public class AccessesAssertion {
         }
         assertThat(actualRemaining).as("Unexpected " + JavaAccess.class.getSimpleName()).isEmpty();
         return this;
-    }public static AccessCondition access() {
+    }
+
+    public static AccessCondition access() {
         return new AccessCondition();
     }
 
@@ -67,6 +71,15 @@ public class AccessesAssertion {
             return new AccessCondition(
                     predicate.and(toCodeUnit)
                             .as("%s to target %s.%s", predicate.getDescription(), owner.getName(), name));
+        }
+
+        public Condition<? super JavaAccess<?>> withAccessType(AccessType accessType) {
+            DescribedPredicate<JavaAccess<?>> withAccessType = DescribedPredicate.describe("", access ->
+                    access instanceof JavaFieldAccess
+                            && ((JavaFieldAccess) access).getAccessType().equals(accessType));
+            return new AccessCondition(
+                    predicate.and(withAccessType)
+                            .as("%s with access type %s", predicate.getDescription(), accessType));
         }
 
         public AccessCondition declaredInLambda() {


### PR DESCRIPTION
We weren't aware that the compiler occasionally generates synthetic `access$123` methods that call constructors. More precisely for the following constellation
```
class Outer {
  String field = "";
  class Inner {
    void concat() {
      field += "any";
    }
  }
}
```
the compiler generates bytecode instantiating and using a `StringBuilder`. But for constructor calls the synthetic access resolution was not hooked in, because we assumed that those methods would never call a constructor. This in turn lead to the bug
```
java.lang.IllegalStateException: Never found a JavaCodeUnit that matches supposed origin CodeUnit{name='access$123'...
```
I.e. the method `access$123` was filtered out as synthetic, but the origin of the constructor call had not been resolved to the actual `Inner.concat` method.

Resolves: #1146
Resolves: #1194