### PR TITLE
Eliminate redundant line number

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/Dependency.java
@@ -58,7 +58,6 @@ import static com.tngtech.archunit.base.Optionals.asSet;
 public final class Dependency implements HasDescription, Comparable<Dependency>, HasSourceCodeLocation {
     private final JavaClass originClass;
     private final JavaClass targetClass;
-    private final int lineNumber;
     private final String description;
     private final SourceCodeLocation sourceCodeLocation;
     private final int hashCode;
@@ -70,7 +69,6 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
 
         this.originClass = originClass;
         this.targetClass = targetClass;
-        this.lineNumber = lineNumber;
         this.description = description;
         this.sourceCodeLocation = SourceCodeLocation.of(originClass, lineNumber);
         hashCode = Objects.hash(originClass, targetClass, lineNumber, description);
@@ -276,7 +274,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
     @PublicAPI(usage = ACCESS)
     public int compareTo(Dependency o) {
         return ComparisonChain.start()
-                .compare(lineNumber, o.lineNumber)
+                .compare(sourceCodeLocation.getLineNumber(), o.sourceCodeLocation.getLineNumber())
                 .compare(getDescription(), o.getDescription())
                 .result();
     }
@@ -297,7 +295,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
         Dependency other = (Dependency) obj;
         return Objects.equals(this.originClass, other.originClass)
                 && Objects.equals(this.targetClass, other.targetClass)
-                && Objects.equals(this.lineNumber, other.lineNumber)
+                && Objects.equals(this.sourceCodeLocation.getLineNumber(), other.sourceCodeLocation.getLineNumber())
                 && Objects.equals(this.description, other.description);
     }
 
@@ -306,7 +304,7 @@ public final class Dependency implements HasDescription, Comparable<Dependency>,
         return MoreObjects.toStringHelper(this)
                 .add("originClass", originClass)
                 .add("targetClass", targetClass)
-                .add("lineNumber", lineNumber)
+                .add("sourceCodeLocation", sourceCodeLocation)
                 .add("description", description)
                 .toString();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/InstanceofCheck.java
@@ -29,14 +29,12 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, H
 
     private final JavaCodeUnit owner;
     private final JavaClass type;
-    private final int lineNumber;
     private final boolean declaredInLambda;
     private final SourceCodeLocation sourceCodeLocation;
 
     private InstanceofCheck(JavaCodeUnit owner, JavaClass type, int lineNumber, boolean declaredInLambda) {
         this.owner = checkNotNull(owner);
         this.type = checkNotNull(type);
-        this.lineNumber = lineNumber;
         this.declaredInLambda = declaredInLambda;
         sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
     }
@@ -61,7 +59,7 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, H
 
     @PublicAPI(usage = ACCESS)
     public int getLineNumber() {
-        return lineNumber;
+        return sourceCodeLocation.getLineNumber();
     }
 
     @PublicAPI(usage = ACCESS)
@@ -79,7 +77,7 @@ public final class InstanceofCheck implements HasType, HasOwner<JavaCodeUnit>, H
         return toStringHelper(this)
                 .add("owner", owner)
                 .add("type", type)
-                .add("lineNumber", lineNumber)
+                .add("sourceCodeLocation", sourceCodeLocation)
                 .add("declaredInLambda", declaredInLambda)
                 .toString();
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -37,15 +37,13 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
     private final JavaCodeUnit origin;
     private final TARGET target;
-    private final int lineNumber;
     private final SourceCodeLocation sourceCodeLocation;
     private final boolean declaredInLambda;
 
     JavaAccess(JavaAccessBuilder<TARGET, ?> builder) {
         this.origin = checkNotNull(builder.getOrigin());
         this.target = checkNotNull(builder.getTarget());
-        this.lineNumber = builder.getLineNumber();
-        this.sourceCodeLocation = SourceCodeLocation.of(getOriginOwner(), lineNumber);
+        this.sourceCodeLocation = SourceCodeLocation.of(getOriginOwner(), builder.getLineNumber());
         this.declaredInLambda = builder.isDeclaredInLambda();
     }
 
@@ -77,7 +75,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
     @PublicAPI(usage = ACCESS)
     public int getLineNumber() {
-        return lineNumber;
+        return sourceCodeLocation.getLineNumber();
     }
 
     @Override
@@ -100,7 +98,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
     @Override
     public String toString() {
         return getClass().getSimpleName() +
-                "{origin=" + origin + ", target=" + target + ", lineNumber=" + lineNumber + additionalToStringFields() + '}';
+                "{origin=" + origin + ", target=" + target + ", lineNumber=" + getLineNumber() + additionalToStringFields() + '}';
     }
 
     String additionalToStringFields() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaMethod.java
@@ -77,6 +77,7 @@ public final class JavaMethod extends JavaCodeUnit {
         return true;
     }
 
+    @Override
     @PublicAPI(usage = ACCESS)
     public Set<JavaMethodCall> getCallsOfSelf() {
         return getReverseDependencies().getCallsTo(this);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReferencedClassObject.java
@@ -29,14 +29,12 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUnit>, HasSourceCodeLocation {
     private final JavaCodeUnit owner;
     private final JavaClass value;
-    private final int lineNumber;
     private final SourceCodeLocation sourceCodeLocation;
     private final boolean declaredInLambda;
 
     private ReferencedClassObject(JavaCodeUnit owner, JavaClass value, int lineNumber, boolean declaredInLambda) {
         this.owner = checkNotNull(owner);
         this.value = checkNotNull(value);
-        this.lineNumber = lineNumber;
         sourceCodeLocation = SourceCodeLocation.of(owner.getOwner(), lineNumber);
         this.declaredInLambda = declaredInLambda;
     }
@@ -66,7 +64,7 @@ public final class ReferencedClassObject implements HasType, HasOwner<JavaCodeUn
 
     @PublicAPI(usage = ACCESS)
     public int getLineNumber() {
-        return lineNumber;
+        return sourceCodeLocation.getLineNumber();
     }
 
     @Override


### PR DESCRIPTION
Some classes store a `int lineNumber` field next to a `SourceCodeLocation`.
This PR eliminates the redundancy, which suggests more degrees of freedom than there actually are.