### PR TITLE
Extend user guide's domain model overview

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -24,7 +24,7 @@ asciidoctor {
     asciidoctorj {
         modules {
             diagram.use()
-            diagram.version '2.2.4'
+            diagram.version '2.2.14'  // https://github.com/asciidoctor/asciidoctorj-diagram/releases/
         }
     }
 }
@@ -34,7 +34,7 @@ asciidoctor.doFirst {
 }
 
 asciidoctorj {
-    version = '2.3.0'
+    version = '2.5.11'  // https://github.com/asciidoctor/asciidoctorj/releases
 }
 
 asciidoctor.dependsOn cleanUserGuide

--- a/docs/userguide/004_What_to_Check.adoc
+++ b/docs/userguide/004_What_to_Check.adoc
@@ -4,7 +4,7 @@ The following section illustrates some typical checks you could do with ArchUnit
 
 === Package Dependency Checks
 
-[plantuml, "package-deps-no-access"]
+[plantuml, "package-deps-no-access", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 skinparam component {
@@ -23,7 +23,7 @@ noClasses().that().resideInAPackage("..source..")
     .should().dependOnClassesThat().resideInAPackage("..foo..")
 ----
 
-[plantuml, "package-deps-only-access"]
+[plantuml, "package-deps-only-access", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 skinparam component {
@@ -47,7 +47,7 @@ classes().that().resideInAPackage("..foo..")
 
 === Class Dependency Checks
 
-[plantuml, "class-naming-deps"]
+[plantuml, "class-naming-deps", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -79,7 +79,7 @@ classes().that().haveNameMatching(".*Bar")
 
 === Class and Package Containment Checks
 
-[plantuml, "class-package-contain"]
+[plantuml, "class-package-contain", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -113,7 +113,7 @@ classes().that().haveSimpleNameStartingWith("Foo")
 
 === Inheritance Checks
 
-[plantuml, "inheritance-naming-check"]
+[plantuml, "inheritance-naming-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -145,7 +145,7 @@ classes().that().implement(Connection.class)
     .should().haveSimpleNameEndingWith("Connection")
 ----
 
-[plantuml, "inheritance-access-check"]
+[plantuml, "inheritance-access-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -183,7 +183,7 @@ classes().that().areAssignableTo(EntityManager.class)
 
 === Annotation Checks
 
-[plantuml, "inheritance-annotation-check"]
+[plantuml, "inheritance-annotation-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -216,7 +216,7 @@ classes().that().areAssignableTo(EntityManager.class)
 
 === Layer Checks
 
-[plantuml, "layer-check"]
+[plantuml, "layer-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -270,7 +270,7 @@ layeredArchitecture()
 
 === Cycle Checks
 
-[plantuml, "cycle-check"]
+[plantuml, "cycle-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 

--- a/docs/userguide/004_What_to_Check.adoc
+++ b/docs/userguide/004_What_to_Check.adoc
@@ -49,6 +49,8 @@ classes().that().resideInAPackage("..foo..")
 
 [plantuml, "class-naming-deps", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -69,6 +71,7 @@ note top on link #crimson: forbidden
 
 Bar --> FooBar #green
 note left on link #green: allowed
+@enduml
 ----
 
 [source,java]
@@ -81,6 +84,8 @@ classes().that().haveNameMatching(".*Bar")
 
 [plantuml, "class-package-contain", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -103,6 +108,7 @@ package com.wrong {
 
 note "resides in wrong package" as WrongPackage #crimson
 FooController .. WrongPackage
+@enduml
 ----
 
 [source,java]
@@ -115,6 +121,8 @@ classes().that().haveSimpleNameStartingWith("Foo")
 
 [plantuml, "inheritance-naming-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -137,6 +145,7 @@ FtpConnection --|> Connection #green
 SshThing --|> Connection #crimson
 
 note right on link #crimson: Has wrong name
+@enduml
 ----
 
 [source,java]
@@ -147,6 +156,8 @@ classes().that().implement(Connection.class)
 
 [plantuml, "inheritance-access-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -173,6 +184,7 @@ ValidPersistenceUser --> EntityManager #green
 IllegalPersistenceUser --> EntityManager #crimson
 
 note right on link #crimson: Accessor resides in wrong package
+@enduml
 ----
 
 [source,java]
@@ -185,6 +197,8 @@ classes().that().areAssignableTo(EntityManager.class)
 
 [plantuml, "inheritance-annotation-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -206,6 +220,7 @@ ValidPersistenceUser --> EntityManager #green
 IllegalPersistenceUser --> EntityManager #crimson
 
 note right on link #crimson: Accessor is not annotated with @Transactional
+@enduml
 ----
 
 [source,java]
@@ -218,6 +233,8 @@ classes().that().areAssignableTo(EntityManager.class)
 
 [plantuml, "layer-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -253,6 +270,7 @@ note right on link #crimson: Access goes against layers
 
 SomePersistenceManager -up--> SomeServiceOne #crimson
 note right on link #crimson: Access goes against layers
+@enduml
 ----
 
 [source,java]
@@ -272,6 +290,8 @@ layeredArchitecture()
 
 [plantuml, "cycle-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -301,6 +321,7 @@ ClassOneInModuleOne --> ClassTwoInModuleTwo #crimson
 ClassOneInModuleTwo --> ClassOneInModuleThree #crimson
 ClassTwoInModuleThree --> ClassOneInModuleOne #crimson
 note right on link #crimson: Combination of accesses forms cycle
+@enduml
 ----
 
 [source,java]

--- a/docs/userguide/004_What_to_Check.adoc
+++ b/docs/userguide/004_What_to_Check.adoc
@@ -86,6 +86,7 @@ classes().that().haveNameMatching(".*Bar")
 ----
 @startuml
 hide empty members
+set separator none
 skinparam componentStyle uml2
 
 skinparam component {
@@ -158,6 +159,7 @@ classes().that().implement(Connection.class)
 ----
 @startuml
 hide empty members
+set separator none
 skinparam componentStyle uml2
 
 skinparam component {
@@ -235,6 +237,7 @@ classes().that().areAssignableTo(EntityManager.class)
 ----
 @startuml
 hide empty members
+set separator none
 skinparam componentStyle uml2
 
 skinparam component {
@@ -292,6 +295,7 @@ layeredArchitecture()
 ----
 @startuml
 hide empty members
+set separator none
 skinparam componentStyle uml2
 
 skinparam component {

--- a/docs/userguide/006_The_Core_API.adoc
+++ b/docs/userguide/006_The_Core_API.adoc
@@ -89,45 +89,122 @@ like this:
 
 [plantuml, "domain-overview"]
 ----
-skinparam componentStyle uml2
+@startuml
+skinparam hyperlinkUnderline false
+hide empty members
 
-skinparam component {
-  BorderColor #grey
-  BackgroundColor #white
-}
+!function $getDomainLink($name, $prefix="") !return "[[https://javadoc.io/doc/com.tngtech.archunit/archunit/latest/com/tngtech/archunit/core/domain/" + $prefix + $name + ".html " + $name + "]]"
+!function $getAccessTargetLink($name) !return $getDomainLink($name, "AccessTarget.")
 
-skinparam class {
-  BorderColor #grey
-  BackgroundColor #white
-}
+!unquoted procedure domainLink($name, $parameter="")
+  "$getDomainLink($name)$parameter " as $name
+!endprocedure
 
-class JavaPackage
-class JavaClass
-class JavaMember
-class JavaField
-class JavaCodeUnit
-class ThrowsClause
-class JavaConstructor
-class JavaMethod
-class JavaStaticInitializer
+!unquoted procedure accessTargetLink($name)
+    "$getAccessTargetLink($name) " as $name
+!endprocedure
 
-class JavaFieldAccess
-class JavaConstructorCall
-class JavaMethodCall
+interface domainLink(JavaType)
+interface domainLink(JavaParameterizedType)
+class domainLink(JavaGenericArrayType)
+class domainLink(JavaWildcardType)
+class domainLink(JavaTypeVariable)
 
-JavaPackage *--* "1..*" JavaClass : has
-JavaClass *-- "0..*" JavaMember : has
-JavaMember <|-- JavaField : extends
-JavaMember <|-- JavaCodeUnit : extends
-JavaCodeUnit <|-- JavaConstructor : extends
-JavaCodeUnit <|-- JavaMethod : extends
-JavaCodeUnit <|-- JavaStaticInitializer : extends
-JavaConstructor *-- "1" ThrowsClause : has
-JavaMethod *-- "1" ThrowsClause : has
+class domainLink(JavaClasses)<<Collection<JavaClass>>>
 
-JavaCodeUnit *-- "0..*" JavaFieldAccess : has
-JavaCodeUnit *-- "0..*" JavaMethodCall : has
-JavaCodeUnit *-- "0..*" JavaConstructorCall : has
+class domainLink(JavaPackage)
+class domainLink(JavaClass)
+abstract class domainLink(JavaMember)
+
+class domainLink(JavaField)
+abstract class domainLink(JavaCodeUnit)
+class domainLink(JavaParameter)
+class domainLink(JavaMethod)
+class domainLink(JavaConstructor)
+class domainLink(JavaStaticInitializer)
+
+class domainLink(JavaAnnotation, <OWNER>)
+
+class domainLink(ThrowsClause, <LOCATION>)<<List<ThrowsDeclaration<LOCATION>>>
+class domainLink(ThrowsDeclaration)
+class domainLink(ReferencedClassObject)
+class domainLink(InstanceofCheck)
+class domainLink(TryCatchBlock)
+abstract class domainLink(JavaAccess, \n<TARGET extends $getDomainLink(AccessTarget)>)
+class domainLink(JavaFieldAccess)
+abstract class domainLink(JavaCodeUnitAccess, \n<T extends $getAccessTargetLink(CodeUnitAccessTarget)>)
+abstract class domainLink(JavaCodeUnitReference, \n<T extends $getAccessTargetLink(CodeUnitReferenceTarget)>)
+class domainLink(JavaMethodReference)
+class domainLink(JavaConstructorReference)
+abstract class domainLink(JavaCall, \n<T extends $getAccessTargetLink(CodeUnitCallTarget)>)
+class domainLink(JavaMethodCall)
+class domainLink(JavaConstructorCall)
+
+abstract class domainLink(AccessTarget)
+class accessTargetLink(FieldAccessTarget)
+abstract class accessTargetLink(CodeUnitAccessTarget)
+abstract class accessTargetLink(CodeUnitReferenceTarget)
+class accessTargetLink(MethodReferenceTarget)
+class accessTargetLink(ConstructorReferenceTarget)
+abstract class accessTargetLink(CodeUnitCallTarget)
+class accessTargetLink(MethodCallTarget)
+class accessTargetLink(ConstructorCallTarget)
+
+JavaClass ---u-|> JavaType
+JavaParameterizedType --|> JavaType
+JavaTypeVariable --|> JavaType
+JavaGenericArrayType --|> JavaType
+JavaWildcardType --|> JavaType
+
+JavaClasses -. JavaClass : contains >
+
+JavaPackage ||-{ "1..*" JavaClass : has >
+
+JavaParameter ||--{ "0..*" JavaAnnotation : has >
+JavaPackage ||--{ "0..*" JavaAnnotation : has >
+JavaClass ||--{ "0..*" JavaAnnotation : has >
+JavaMember ||--{ "0..*" JavaAnnotation : has >
+
+JavaClass ||-{ "0..*" JavaMember : has >
+
+JavaMember <|-- JavaField
+JavaMember <|--r- JavaCodeUnit
+
+JavaCodeUnit ||--{ "0..*" JavaParameter : has >
+JavaCodeUnit <|-- JavaMethod
+JavaCodeUnit <|--- JavaConstructor
+JavaCodeUnit <|-- JavaStaticInitializer
+
+JavaCodeUnit ||--u{ "0..*" InstanceofCheck : has >
+JavaCodeUnit ||--u{ "0..*" ReferencedClassObject : has >
+JavaCodeUnit ||--u|| "1" ThrowsClause : has >
+JavaCodeUnit ||--u{ "0..*" TryCatchBlock : has >
+JavaCodeUnit ||--r-{ "0..*" JavaAccess : has >
+
+ThrowsClause ||-u-{ "0..*" ThrowsDeclaration : has >
+
+JavaAccess <|-- JavaFieldAccess : T =\n$getAccessTargetLink(FieldAccessTarget)
+JavaAccess <|-- JavaCodeUnitAccess
+
+JavaCodeUnitAccess <|-- JavaCall
+JavaCall <|-- JavaMethodCall : T =\n$getAccessTargetLink(MethodCallTarget)
+JavaCall <|--- JavaConstructorCall : T=\n$getAccessTargetLink(ConstructorCallTarget)
+
+JavaCodeUnitAccess <|-- JavaCodeUnitReference
+JavaCodeUnitReference <|-- JavaMethodReference : T=\n$getAccessTargetLink(MethodReferenceTarget)
+JavaCodeUnitReference <|--- JavaConstructorReference : T=\n$getAccessTargetLink(ConstructorReferenceTarget)
+
+JavaAccess ||-r-|| "1" AccessTarget : has >
+FieldAccessTarget -u-|> AccessTarget
+FieldAccessTarget -[hidden]r-> CodeUnitAccessTarget
+CodeUnitAccessTarget -u-|> AccessTarget
+CodeUnitCallTarget -u-|> CodeUnitAccessTarget
+MethodCallTarget -u-|> CodeUnitCallTarget
+ConstructorCallTarget --u-|> CodeUnitCallTarget
+CodeUnitReferenceTarget -u-|> CodeUnitAccessTarget
+MethodReferenceTarget -u-|> CodeUnitReferenceTarget
+ConstructorReferenceTarget --u-|> CodeUnitReferenceTarget
+@enduml
 ----
 
 Most objects resemble the Java Reflection API, including inheritance relations. Thus a `JavaClass`

--- a/docs/userguide/006_The_Core_API.adoc
+++ b/docs/userguide/006_The_Core_API.adoc
@@ -140,16 +140,6 @@ abstract class domainLink(JavaCall, \n<T extends $getAccessTargetLink(CodeUnitCa
 class domainLink(JavaMethodCall)
 class domainLink(JavaConstructorCall)
 
-abstract class domainLink(AccessTarget)
-class accessTargetLink(FieldAccessTarget)
-abstract class accessTargetLink(CodeUnitAccessTarget)
-abstract class accessTargetLink(CodeUnitReferenceTarget)
-class accessTargetLink(MethodReferenceTarget)
-class accessTargetLink(ConstructorReferenceTarget)
-abstract class accessTargetLink(CodeUnitCallTarget)
-class accessTargetLink(MethodCallTarget)
-class accessTargetLink(ConstructorCallTarget)
-
 JavaClass ---u-|> JavaType
 JavaParameterizedType --|> JavaType
 JavaTypeVariable --|> JavaType
@@ -193,17 +183,6 @@ JavaCall <|--- JavaConstructorCall : T=\n$getAccessTargetLink(ConstructorCallTar
 JavaCodeUnitAccess <|-- JavaCodeUnitReference
 JavaCodeUnitReference <|-- JavaMethodReference : T=\n$getAccessTargetLink(MethodReferenceTarget)
 JavaCodeUnitReference <|--- JavaConstructorReference : T=\n$getAccessTargetLink(ConstructorReferenceTarget)
-
-JavaAccess ||-r-|| "1" AccessTarget : has >
-FieldAccessTarget -u-|> AccessTarget
-FieldAccessTarget -[hidden]r-> CodeUnitAccessTarget
-CodeUnitAccessTarget -u-|> AccessTarget
-CodeUnitCallTarget -u-|> CodeUnitAccessTarget
-MethodCallTarget -u-|> CodeUnitCallTarget
-ConstructorCallTarget --u-|> CodeUnitCallTarget
-CodeUnitReferenceTarget -u-|> CodeUnitAccessTarget
-MethodReferenceTarget -u-|> CodeUnitReferenceTarget
-ConstructorReferenceTarget --u-|> CodeUnitReferenceTarget
 @enduml
 ----
 

--- a/docs/userguide/006_The_Core_API.adoc
+++ b/docs/userguide/006_The_Core_API.adoc
@@ -209,6 +209,8 @@ inheritance is not completely straight forward. Consider for example
 
 [plantuml, "resolution-example", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -232,7 +234,7 @@ class SuperclassBeingAccessed {
 
 SuperclassBeingAccessed <|-- ClassBeingAccessed
 ClassAccessing o-- ClassBeingAccessed
-
+@enduml
 ----
 
 The bytecode will record a field access from `ClassAccessing.accessField()` to
@@ -246,6 +248,8 @@ The situation looks roughly like
 
 [plantuml, "resolution-overview", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -276,6 +280,7 @@ MethodCallTarget "1" -- "0..*" JavaMethod : resolves to
 
 JavaConstructorCall "1" *-- "1" ConstructorCallTarget : has
 ConstructorCallTarget "1" -- "0..1" JavaConstructor : resolves to
+@enduml
 ----
 
 Two things might seem strange at the first look.
@@ -292,6 +297,8 @@ cases, for example:
 
 [plantuml, "diamond-example", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam component {
@@ -304,13 +311,13 @@ skinparam class {
   BackgroundColor #white
 }
 
-class A <<interface>> {
+interface A <<interface>> {
   void targetMethod()
 }
-class B <<interface>> {
+interface B <<interface>> {
   void targetMethod()
 }
-class C <<abstract>> {
+abstract class C <<abstract>> {
 }
 class D {
   void callTargetMethod()
@@ -319,6 +326,7 @@ class D {
 A <|-- C : implements
 B <|-- C : implements
 D -right- C : calls targetMethod()
+@enduml
 ----
 
 While this situation will always be resolved in a specified way for a real program,

--- a/docs/userguide/006_The_Core_API.adoc
+++ b/docs/userguide/006_The_Core_API.adoc
@@ -87,7 +87,7 @@ The domain objects represent Java code, thus the naming should be pretty straigh
 commonly, the `ClassFileImporter` imports instances of type `JavaClass`. A rough overview looks
 like this:
 
-[plantuml, "domain-overview"]
+[plantuml, "domain-overview", svg, opts=interactive]
 ----
 @startuml
 skinparam hyperlinkUnderline false
@@ -207,7 +207,7 @@ For example, every `JavaField` allows to call `JavaField#getAccessesToSelf()` to
 code units within the graph that access this specific field. The resolution process through
 inheritance is not completely straight forward. Consider for example
 
-[plantuml, "resolution-example"]
+[plantuml, "resolution-example", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -244,7 +244,7 @@ member within another class. If a member is queried for `accessesToSelf()` thoug
 will resolve the necessary targets and determine, which member is represented by which target.
 The situation looks roughly like
 
-[plantuml, "resolution-overview"]
+[plantuml, "resolution-overview", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -290,7 +290,7 @@ Second, why can there be more than one resolved methods for method calls?
 The reason for this is that a call target might indeed match several methods in those
 cases, for example:
 
-[plantuml, "diamond-example"]
+[plantuml, "diamond-example", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 

--- a/docs/userguide/007_The_Lang_API.adoc
+++ b/docs/userguide/007_The_Lang_API.adoc
@@ -246,7 +246,7 @@ detailed about fields, methods or constructors. A generic API will never be able
 every imaginable concept out of the box. Thus ArchUnit's rule API has at its foundation
 a more generic API that controls the types of objects that our concept targets.
 
-[plantuml, "import-vs-lang"]
+[plantuml, "import-vs-lang", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -57,6 +57,8 @@ More precisely, the following holds:
 
 [plantuml, "onion-architecture-check", svg, opts=interactive]
 ----
+@startuml
+hide empty members
 skinparam componentStyle uml2
 
 skinparam class {
@@ -112,6 +114,7 @@ note right on link #crimson: application services must not\nknow about any adapt
 
 Cli --> RestController #crimson
 note right on link #crimson: one adapter must not know\nabout any other adapter
+@enduml
 ----
 
 

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -55,7 +55,7 @@ More precisely, the following holds:
   contain dependencies on any `adapter` package.
 
 
-[plantuml, "onion-architecture-check"]
+[plantuml, "onion-architecture-check", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 
@@ -357,7 +357,7 @@ Diagrams supported have to be component diagrams and associate classes to compon
 The way this works is to use the respective package identifiers (compare
 `ArchConditions.onlyHaveDependenciesInAnyPackage(..)`) as stereotypes:
 
-[plantuml, "simple-plantuml-archrule-example"]
+[plantuml, "simple-plantuml-archrule-example", svg, opts=interactive]
 ----
 [Some Source] <<..some.source..>>
 [Some Target] <<..some.target..>> as target
@@ -600,7 +600,7 @@ The `CCD` of the system divided by the `CCD` of a balanced binary tree with the 
 
 ===== Example
 
-[plantuml,"lakos-example"]
+[plantuml, "lakos-example", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 skinparam component {
@@ -690,7 +690,7 @@ so it makes sense to only consider those classes to calculate the *A* value.
 The following provides some example where the `A` values assume some random factor
 of abstract classes within the respective component.
 
-[plantuml,"martin-example"]
+[plantuml, "martin-example", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 skinparam component {
@@ -755,7 +755,7 @@ The metrics are composed from the following definitions:
 
 ===== Example
 
-[plantuml,"dowalil-example"]
+[plantuml, "dowalil-example", svg, opts=interactive]
 ----
 skinparam componentStyle uml2
 skinparam component {

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -59,6 +59,7 @@ More precisely, the following holds:
 ----
 @startuml
 hide empty members
+set separator none
 skinparam componentStyle uml2
 
 skinparam class {


### PR DESCRIPTION
This PR extends the [user guide's domain model overview](https://www.archunit.org/userguide/html/000_Index.html#_domain).

<details><summary>Old domain model overview</summary>

![Old domain-overview](https://www.plantuml.com/plantuml/svg/dPBTIiGm48NlynIXtXLsSRqKRxGWA0Z2wWECoT26JPCbILtNdtStszPsqgehtZKdtvoPCwdVABC51pKNjjvQWoQimruZRsfznfYVN_CtnlcLTH9TORLr_AHqk3ze83QbiusHlRwhL43saRXeyFuV3btTBJp3VMIWHA8KXozoliFw2HqHhXLgIGkin4UZGYyzLCxkV7HfV69hZG-k4S6wn3nKbfgj0mGbRgAT0grUO-DfvqiXC1cGE1UWzSoz5Ha9o_F58kVPQhdCip4oF-SLU3QU8yMpqm7gza2eNhXuZzmmNRp7bu16VizyxMg23J81Xr17sIxcKMossbd5sBBDligInqoYjnr_eT8P9giaxqYt_WCzlk8VuCdFq5Ly0W00)

</details>

<details><summary>New domain model overview</summary>

![New domain-overview](https://www.plantuml.com/plantuml/svg/bPLDKzim48Rl_XN2mw5kYTDU6PEPD5263X26cd803egymGPRIYMv9Mr-VDVnjoCduHH5--oNj7gjNYE-e98c95mkGCOHVxtZmNe1P4vZ1LOO1K0WMUWbII2PWLIMTJ1FETEHuEJm6VIfI6Z4Bz7tmo6d2HoHmuM4UVHsOjiEEP2WKyc9_V0GQhrGnyFX2_rD0y7SI0pnPyX4uch-h865BfKiJ7caXzKYfXgKpg1X0TKs9YHWY2pzq2QVohpPAYi4Vsqtr4bCxERMqvFTwM3C62ZbKudhke-wTdENTjFDjHqybvJ_IeM6W2oaO12a4aXWE9tin463p0x88iGsnNTg3CkdAg_VEW0ULC7D6Qcv6qnKfEfhjpzDnB6CEMMjThxZDVeuDaw_-QPi8VeBGSwoc2hLvSw18yF6KjBb5km-YWD6vRP8cUadbH6TnOYOcKcs2Shnl8c8OrZFWLSPHgDHZzyDPQ_qkI_psjcnw4nfIPacHkXg_OJw2liMGHpi2Z4H0TpXz3jzHHP7tcE_0XsAeAy7mJ5rohJeS_-XgOxO1UQFQ8otsjlBc7EHiO8V4MzwVtrsEpAXVYZ57uLdbofy6jxbT3BsBwRN8xoSoqXfBxUV0ZhATRGQmNlg2TV03MtSmXmaS9pjzPLDPoyu0WRk0i-28YRcan3Ogu7mvN92DGk_nYApRx-t_DKTaKVk-UFRypEVm9l6PwQwyj9ydix8sJ8gERdlm3GBQENUq8EsHrt9VdcgytrFgiffHz_v-5RqxZbke3lAft7ydeepVgzYCt1tdJbbLKf21eD1EbYDIAbgbb5G4UioJGaqcBjQQq2QEjinMmq19GENrFKU4oQunkuK6LbMGo_9QZNuH-mlhllHRl4XRQ3bjmxXZFvSqRMGL2wTu7lnUT9zwLodzyBRqLjq4QL55diUHYRLG-vQP6uhHwt8KVpRhAe-lLR79L_bokTnqrXcguQnntz3_0s5fLLb7VqqrzPsCKhp5iVL2kVA9isFo3vfMhhTxo0xTxzMWlesMrcHJsjyupFKde4YKdi6gl0-ENdaHkbfS8No6CErvRjzHniioevLBhgJijxRLb2DDUkfGctCLHcmBru7BODkxw3x1R6CkztUQiEMUZfegqbZWesEzqfZuijS_m40)



</details>


To support links to [javadoc.io](https://javadoc.io/doc/com.tngtech.archunit/archunit/latest/com/tngtech/archunit/core/domain/package-summary.html), the PlantUML diagrams are rendered as SVGs, embedded as
```html
<object type="image/svg+xml" data="domain-overview.svg" width="1989" height="982">
    <span class="alt">domain overview</span>
</object>
```
– which [may not be supported](https://caniuse.com/mdn-html_elements_object) by outdated browsers.