### PR TITLE
support optional `component` keyword in PlantUML diagram rules

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
@@ -34,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 class PlantUmlPatterns {
+    private static final String OPTIONAL_COMPONENT_KEYWORD_FORMAT = "(?:component)?";
     private static final String COMPONENT_NAME_GROUP_NAME = "componentName";
     private static final String COMPONENT_NAME_FORMAT = "\\[" + capture(anythingBut("\\[\\]"), COMPONENT_NAME_GROUP_NAME) + "]";
 
@@ -46,7 +47,13 @@ class PlantUmlPatterns {
     private static final String COLOR_FORMAT = "\\s*(?:#" + anyOf("\\w|/\\\\-") + "+)?";
 
     private static final Pattern PLANTUML_COMPONENT_PATTERN = Pattern.compile(
-            "^\\s*" + COMPONENT_NAME_FORMAT + "\\s*" + STEREOTYPE_FORMAT + "*" + ALIAS_FORMAT + COLOR_FORMAT + "\\s*");
+            "^\\s*" + OPTIONAL_COMPONENT_KEYWORD_FORMAT
+                    + "\\s*" + COMPONENT_NAME_FORMAT
+                    + "\\s*" + STEREOTYPE_FORMAT + "*"
+                    + ALIAS_FORMAT
+                    + COLOR_FORMAT
+                    + "\\s*"
+    );
 
     private static String capture(String pattern) {
         return "(" + pattern + ")";

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
@@ -437,6 +437,23 @@ public class PlantUmlParserTest {
         assertThat(b.getDependencies()).isEmpty();
     }
 
+    @Test
+    public void supports_components_declared_with_component_keyword() {
+        File file = TestDiagram.in(temporaryFolder)
+                .rawLine("component [CompA] <<..c1..>>")
+                .rawLine("component [Comp B] <<..c2..>> as CompB")
+                .dependencyFrom("CompA").to("CompB")
+                .write();
+
+        PlantUmlDiagram diagram = createDiagram(file);
+
+        PlantUmlComponent a = getComponentWithName("CompA", diagram);
+        PlantUmlComponent b = getComponentWithAlias(new Alias("CompB"), diagram);
+
+        assertThat(a.getDependencies()).containsOnly(b);
+        assertThat(b.getDependencies()).isEmpty();
+    }
+
     private PlantUmlComponent getComponentWithName(String componentName, PlantUmlDiagram diagram) {
         PlantUmlComponent component = diagram.getAllComponents().stream()
                 .filter(c -> c.getComponentName().asString().equals(componentName))


### PR DESCRIPTION
It is valid PlantUML syntax to prepend the `component` keyword to a component
declaration, e.g.

```
component [MyComponent] <<..mycmp..>>
```

Since it doesn't create a big overhead to support this as an optional part
of the component declaration, we can add it to make it easier for users
that distinguish their components from other types of objects like databases.