### PR TITLE
fix `OnionArchitecture` losing `optionalLayers` after `as`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -790,12 +790,14 @@ public final class Architectures {
                 Optional<DescribedPredicate<? super JavaClass>> domainServicePredicate,
                 Optional<DescribedPredicate<? super JavaClass>> applicationPredicate,
                 Map<String, DescribedPredicate<? super JavaClass>> adapterPredicates,
+                boolean optionalLayers,
                 List<IgnoredDependency> ignoredDependencies,
                 Optional<String> overriddenDescription) {
             this.domainModelPredicate = domainModelPredicate;
             this.domainServicePredicate = domainServicePredicate;
             this.applicationPredicate = applicationPredicate;
             this.adapterPredicates = adapterPredicates;
+            this.optionalLayers = optionalLayers;
             this.ignoredDependencies = ignoredDependencies;
             this.overriddenDescription = overriddenDescription;
         }
@@ -1036,8 +1038,8 @@ public final class Architectures {
         }
 
         @Override
-        public ArchRule because(String reason) {
-            return ArchRule.Factory.withBecause(this, reason);
+        public OnionArchitecture because(String reason) {
+            return (OnionArchitecture) Factory.withBecause(this, reason);
         }
 
         /**
@@ -1052,7 +1054,7 @@ public final class Architectures {
         @Override
         public OnionArchitecture as(String newDescription) {
             return new OnionArchitecture(domainModelPredicate, domainServicePredicate,
-                    applicationPredicate, adapterPredicates, ignoredDependencies,
+                    applicationPredicate, adapterPredicates, optionalLayers, ignoredDependencies,
                     Optional.of(newDescription));
         }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/Architectures.java
@@ -792,7 +792,8 @@ public final class Architectures {
                 Map<String, DescribedPredicate<? super JavaClass>> adapterPredicates,
                 boolean optionalLayers,
                 List<IgnoredDependency> ignoredDependencies,
-                Optional<String> overriddenDescription) {
+                Optional<String> overriddenDescription,
+                AllClassesAreContainedInArchitectureCheck allClassesAreContainedInArchitectureCheck) {
             this.domainModelPredicate = domainModelPredicate;
             this.domainServicePredicate = domainServicePredicate;
             this.applicationPredicate = applicationPredicate;
@@ -800,6 +801,7 @@ public final class Architectures {
             this.optionalLayers = optionalLayers;
             this.ignoredDependencies = ignoredDependencies;
             this.overriddenDescription = overriddenDescription;
+            this.allClassesAreContainedInArchitectureCheck = allClassesAreContainedInArchitectureCheck;
         }
 
         /**
@@ -1053,9 +1055,15 @@ public final class Architectures {
 
         @Override
         public OnionArchitecture as(String newDescription) {
-            return new OnionArchitecture(domainModelPredicate, domainServicePredicate,
-                    applicationPredicate, adapterPredicates, optionalLayers, ignoredDependencies,
-                    Optional.of(newDescription));
+            return new OnionArchitecture(
+                    domainModelPredicate,
+                    domainServicePredicate,
+                    applicationPredicate,
+                    adapterPredicates,
+                    optionalLayers,
+                    ignoredDependencies,
+                    Optional.of(newDescription),
+                    allClassesAreContainedInArchitectureCheck);
         }
 
         @Override

--- a/archunit/src/test/java/com/tngtech/archunit/library/OnionArchitectureTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/OnionArchitectureTest.java
@@ -220,12 +220,13 @@ public class OnionArchitectureTest {
     }
 
     @Test
-    public void onion_architecture_ensure_all_classes_are_contained_in_architecture() {
+    @UseDataProvider("ruleTextModifications")
+    public void onion_architecture_ensure_all_classes_are_contained_in_architecture(Function<OnionArchitecture, OnionArchitecture> modifyRule) {
         JavaClasses classes = new ClassFileImporter().importClasses(First.class, Second.class);
 
-        OnionArchitecture architectureNotCoveringAllClasses = onionArchitecture().withOptionalLayers(true)
+        OnionArchitecture architectureNotCoveringAllClasses = modifyRule.apply(onionArchitecture().withOptionalLayers(true)
                 .domainModels("..first..")
-                .ensureAllClassesAreContainedInArchitecture();
+                .ensureAllClassesAreContainedInArchitecture());
 
         assertThatRule(architectureNotCoveringAllClasses).checking(classes)
                 .hasOnlyOneViolation("Class <" + Second.class.getName() + "> is not contained in architecture");


### PR DESCRIPTION
The `OnionArchitecture.as(..)` method (and transitively `because(..)`) didn't pass the `optionalLayers` property along when creating a `new OnionArchitecture(..)` on return. Thus, once a test called `as(..)` or `because(..)` on the rule text `optionalLayers` would be reset to `false`.

Resolves: #1185