### PR TITLE
replace `JarURLConnection.getJarFileURL()` by `.getURL()`

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileSource.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileSource.java
@@ -147,7 +147,7 @@ interface ClassFileSource extends Iterable<ClassFileLocation> {
             }
 
             private URI makeJarUri(JarEntry input) {
-                return Location.of(connection.getJarFileURL()).append(input.getName()).asURI();
+                return Location.of(connection.getURL()).append(input.getName()).asURI();
             }
 
             URI getUri() {


### PR DESCRIPTION
For typical plain JAR URLs this doesn't make a real difference, but for special JAR URLs, like Spring Boot uses, it does. The problem showed with nested JAR URLs of Spring Boot. Those have a format like
```
jar:nested:/some/file.jar/!BOOT-INF/lib/nested.jar!/
```
Here the `connection.getJarFileURL()` is
```
nested:/some/file.jar/!BOOT-INF/lib/nested.jar
```
but the `connection.getURL()` is
```
jar:nested:/some/file.jar/!BOOT-INF/lib/nested.jar!/
```
Using the latter yields the correct result and allows the custom JAR URL handler to kick in. Using the former will yield an exception that ArchUnit doesn't understand the scheme `nested`.

Resolves: #1224