### PR TITLE
Upgrade ASM & further dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     googleRelocationPackage = "${thirdPartyRelocationPackage}.com.google"
 
     dependency = [
-            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.6'],
+            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.7'],
             guava               : [group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'],
             addGuava            : { dependencyHandler ->
                                       dependencyHandler(dependency.guava) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
 
     dependency = [
             asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.7'],
-            guava               : [group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'],
+            guava               : [group: 'com.google.guava', name: 'guava', version: '33.1.0-jre'],
             addGuava            : { dependencyHandler ->
                                       dependencyHandler(dependency.guava) {
                                           exclude module: 'listenablefuture'
@@ -46,24 +46,24 @@ ext {
                                           exclude module: 'j2objc-annotations'
                                       }
                                   },
-            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.9'],
-            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.21.1'],
-            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.21.1'],
-            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.21.1'],
+            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.12'],
+            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.23.1'],
+            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.23.1'],
+            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.23.1'],
 
             junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.1'],
-            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.1'],
-            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.1'],
-            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.10.1'],
-            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.10.1'],
-            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.10.1'],
+            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.2'],
+            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.2'],
+            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.10.2'],
+            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.10.2'],
+            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.10.2'],
+            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.10.2'],
             hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'],
             junit_dataprovider  : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
-            mockito             : [group: 'org.mockito', name: 'mockito-core', version: '4.6.1'],
+            mockito             : [group: 'org.mockito', name: 'mockito-core', version: '4.11.0'],  // mockito 5 requires Java 11
             mockito_junit5      : [group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'],
-            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.24.2'],
-            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.24.2'],
+            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.25.3'],
+            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.25.3'],
 
             // Dependencies for example projects / tests
             javaxAnnotationApi  : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],
@@ -75,7 +75,7 @@ ext {
             // NOTE: The pure javaee-api dependencies are crippled, so to run any test we need to choose a full implementation provider
             geronimoEjb         : [group: 'org.apache.geronimo.specs', name: 'geronimo-ejb_3.1_spec', version: '1.0.2'],
             geronimoJpa         : [group: 'org.apache.geronimo.specs', name: 'geronimo-jpa_2.0_spec', version: '1.1'],
-            jodaTime            : [group: 'joda-time', name: 'joda-time', version: '2.12.5'],
+            jodaTime            : [group: 'joda-time', name: 'joda-time', version: '2.12.7'],
             joox                : [group: 'org.jooq', name: 'joox-java-6', version: '1.6.0']
     ]
 

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.10.1</version>
+            <version>1.10.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/buildSrc/src/main/resources/release_check/archunit.pom
+++ b/buildSrc/src/main/resources/release_check/archunit.pom
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.12</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### Upgrade ASM to 9.7

to [support Java 23 / class file major version 67](https://asm.ow2.io/versions.html)

resolves #1274
 
### Upgrade further dependencies

* `com.google.guava:guava:`
  32.1.2-jre → 33.1.0-jre

* `org.slf4j:slf4j-api`
  2.0.9 → 2.0.12
* `org.apache.logging.log4j:log4j-{api,core,slf4j2-impl}`
  2.21.1 → 2.23.1

* `org.junit.jupiter:junit-{jupiter-api,jupiter-engine,vintage-engine}`
  5.10.1 → 5.10.2
* `org.junit.platform:junit-platform-{runner,commons,engine}`
  1.10.1 → 1.10.2

#### for tests:

* `org.mockito:mockito-core`
  4.6.1 → 4.11.0

* `org.assertj:assertj-{core,guava}`
  3.24.2 → 3.25.3

* `joda-time:joda-time`
  2.12.5 → 2.12.7 
