### PR TITLE
fix `getAllInvolvedRawTypes()` recursing infinitely

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ArchUnit
-Copyright 2016 and onwards Peter Gafert <peter.gafert@tngtech.com>
+Copyright 2016 and onwards Peter Gafert <peter.gafert@archunit.org>
 
 This product includes software developed at
 TNG Technology Consulting GmbH (https://www.tngtech.com/).

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -662,6 +662,11 @@ public final class JavaClass
         return ImmutableSet.of(getBaseComponentType());
     }
 
+    @Override
+    public void traverseSignature(SignatureVisitor visitor) {
+        SignatureTraversal.from(visitor).visitClass(this);
+    }
+
     @PublicAPI(usage = ACCESS)
     public Optional<JavaClass> getRawSuperclass() {
         return superclass.getRaw();

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -45,6 +45,7 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaClassBuilder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Sets.immutableEnumSet;
 import static com.google.common.collect.Sets.union;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.base.ClassLoaders.getCurrentClassLoader;
@@ -138,7 +139,7 @@ public final class JavaClass
         isRecord = builder.isRecord();
         isAnonymousClass = builder.isAnonymousClass();
         isMemberClass = builder.isMemberClass();
-        modifiers = checkNotNull(builder.getModifiers());
+        modifiers = immutableEnumSet(builder.getModifiers());
         reflectSupplier = Suppliers.memoize(new ReflectClassSupplier());
         sourceCodeLocation = SourceCodeLocation.of(this);
         javaPackage = JavaPackage.simple(this);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -658,11 +658,6 @@ public final class JavaClass
     }
 
     @Override
-    public Set<JavaClass> getAllInvolvedRawTypes() {
-        return ImmutableSet.of(getBaseComponentType());
-    }
-
-    @Override
     public void traverseSignature(SignatureVisitor visitor) {
         SignatureTraversal.from(visitor).visitClass(this);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
@@ -75,6 +75,11 @@ public final class JavaGenericArrayType implements JavaType {
     }
 
     @Override
+    public void traverseSignature(SignatureVisitor visitor) {
+        SignatureTraversal.from(visitor).visitGenericArrayType(this);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + '{' + getName() + '}';
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaGenericArrayType.java
@@ -15,8 +15,6 @@
  */
 package com.tngtech.archunit.core.domain;
 
-import java.util.Set;
-
 import com.tngtech.archunit.PublicAPI;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -67,11 +65,6 @@ public final class JavaGenericArrayType implements JavaType {
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
-    }
-
-    @Override
-    public Set<JavaClass> getAllInvolvedRawTypes() {
-        return this.componentType.getAllInvolvedRawTypes();
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameterizedType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaParameterizedType.java
@@ -35,4 +35,9 @@ public interface JavaParameterizedType extends JavaType {
      */
     @PublicAPI(usage = ACCESS)
     List<JavaType> getActualTypeArguments();
+
+    @Override
+    default void traverseSignature(SignatureVisitor visitor) {
+        SignatureTraversal.from(visitor).visitParameterizedType(this);
+    }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -16,13 +16,22 @@
 package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
+import com.google.common.collect.Iterables;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.core.domain.properties.HasName;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.PublicAPI.Usage.INHERITANCE;
+import static com.tngtech.archunit.core.domain.JavaType.SignatureVisitor.Result.CONTINUE;
+import static com.tngtech.archunit.core.domain.JavaType.SignatureVisitor.Result.STOP;
+import static java.util.Collections.singleton;
 
 /**
  * Represents a general Java type. This can e.g. be a class like {@code java.lang.String}, a parameterized type
@@ -85,6 +94,94 @@ public interface JavaType extends HasName {
     Set<JavaClass> getAllInvolvedRawTypes();
 
     /**
+     * Traverses through the signature of this {@link JavaType}.<br>
+     * This method considers the type signature as a tree,
+     * where e.g. a {@link JavaClass} is a simple leaf,
+     * but a {@link JavaParameterizedType} has the type as root and then
+     * branches out into its actual type arguments, which in turn can have type arguments
+     * or upper/lower bounds in case of {@link JavaTypeVariable} or {@link JavaWildcardType}.<br>
+     * The following is a simple visualization of such a signature tree:
+     * <pre><code>
+     * List&lt;Map&lt;? extends Serializable, String[]&gt;&gt;
+     *                    |
+     *    Map&lt;? extends Serializable, String[]&gt;
+     *              /                   \
+     *  ? extends Serializable         String[]
+     *            |
+     *      Serializable
+     * </code></pre>
+     * For every node visited the respective method of the provided {@code visitor}
+     * will be invoked. The traversal happens depth first, i.e. in this case the {@code visitor}
+     * would be invoked for all types down to {@code Serializable} before visiting the {@code String[]}
+     * array type of the second branch. At every step it is possible to continue the traversal
+     * by returning {@link SignatureVisitor.Result#CONTINUE CONTINUE} or stop at that point by
+     * returning {@link SignatureVisitor.Result#STOP STOP}.<br><br>
+     * Note that the traversal will continue to traverse bounds of type variables,
+     * even if that type variable isn't declared in this signature itself.<br>
+     * E.g. take the following scenario
+     * <pre><code>
+     * class Example&lt;T extends String&gt; {
+     *     T field;
+     * }</code></pre>
+     * Traversing the {@link JavaField#getType() field type} of {@code field} will continue
+     * down to the upper bounds of the type variable {@code T} and thus end at the type {@code String}.<br><br>
+     * Also, note that the traversal will not continue down the type parameters of a raw type
+     * declared in a signature.<br>
+     * E.g. given the signature {@code class Example<T extends Map>} the traversal would stop at
+     * {@code Map} and not traverse down the type parameters {@code K} and {@code V} of {@code Map}.
+     *
+     * @param visitor A {@link SignatureVisitor} to invoke for every encountered {@link JavaType}
+     *                while traversing this signature.
+     */
+    @PublicAPI(usage = ACCESS)
+    void traverseSignature(SignatureVisitor visitor);
+
+    /**
+     * @see #traverseSignature(SignatureVisitor)
+     */
+    @PublicAPI(usage = INHERITANCE)
+    interface SignatureVisitor {
+        default Result visitClass(JavaClass type) {
+            return CONTINUE;
+        }
+
+        default Result visitParameterizedType(JavaParameterizedType type) {
+            return CONTINUE;
+        }
+
+        default Result visitTypeVariable(JavaTypeVariable<?> type) {
+            return CONTINUE;
+        }
+
+        default Result visitGenericArrayType(JavaGenericArrayType type) {
+            return CONTINUE;
+        }
+
+        default Result visitWildcardType(JavaWildcardType type) {
+            return CONTINUE;
+        }
+
+        /**
+         * Result of a single step {@link #traverseSignature(SignatureVisitor) traversing a signature}.
+         * After each step it's possible to either {@link #STOP stop} or {@link #CONTINUE continue}
+         * the traversal.
+         */
+        @PublicAPI(usage = ACCESS)
+        enum Result {
+            /**
+             * Causes the traversal to continue
+             */
+            @PublicAPI(usage = ACCESS)
+            CONTINUE,
+            /**
+             * Causes the traversal to stop
+             */
+            @PublicAPI(usage = ACCESS)
+            STOP
+        }
+    }
+
+    /**
      * Predefined {@link ChainableFunction functions} to transform {@link JavaType}.
      */
     @PublicAPI(usage = ACCESS)
@@ -99,5 +196,83 @@ public interface JavaType extends HasName {
                 return input.toErasure();
             }
         };
+    }
+}
+
+class SignatureTraversal implements JavaType.SignatureVisitor {
+    private final Set<JavaType> visited = new HashSet<>();
+    private final JavaType.SignatureVisitor delegate;
+    private Result lastResult;
+
+    private SignatureTraversal(JavaType.SignatureVisitor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Result visitClass(JavaClass type) {
+        // We only traverse type parameters of a JavaClass if the traversal was started *at the JavaClass* itself.
+        // Otherwise, we can only encounter a regular class as a raw type in a type signature.
+        // In these cases we don't want to traverse further down, as that would be surprising behavior
+        // (consider `class MyClass<T extends Map>`, traversing into the type variables `K` and `V` of `Map` would be surprising).
+        Supplier<Iterable<JavaTypeVariable<JavaClass>>> getFurtherTypesToTraverse = visited.isEmpty() ? type::getTypeParameters : Collections::emptyList;
+        return visit(type, delegate::visitClass, getFurtherTypesToTraverse);
+    }
+
+    @Override
+    public Result visitParameterizedType(JavaParameterizedType type) {
+        return visit(type, delegate::visitParameterizedType, type::getActualTypeArguments);
+    }
+
+    @Override
+    public Result visitTypeVariable(JavaTypeVariable<?> type) {
+        return visit(type, delegate::visitTypeVariable, type::getUpperBounds);
+    }
+
+    @Override
+    public Result visitGenericArrayType(JavaGenericArrayType type) {
+        return visit(type, delegate::visitGenericArrayType, () -> singleton(type.getComponentType()));
+    }
+
+    @Override
+    public Result visitWildcardType(JavaWildcardType type) {
+        return visit(type, delegate::visitWildcardType, () -> Iterables.concat(type.getUpperBounds(), type.getLowerBounds()));
+    }
+
+    private <CURRENT extends JavaType, NEXT extends JavaType> Result visit(
+            CURRENT type,
+            Function<CURRENT, Result> visitCurrent,
+            Supplier<Iterable<NEXT>> nextTypes
+    ) {
+        if (visited.contains(type)) {
+            // if we've encountered this type already we continue traversing the siblings,
+            // but we won't descend further into this type signature
+            return setLast(CONTINUE);
+        }
+        visited.add(type);
+        if (visitCurrent.apply(type) == CONTINUE) {
+            Result result = visit(nextTypes.get());
+            return setLast(result);
+        } else {
+            return setLast(STOP);
+        }
+    }
+
+    private Result visit(Iterable<? extends JavaType> types) {
+        for (JavaType nextType : types) {
+            nextType.traverseSignature(this);
+            if (lastResult == STOP) {
+                return STOP;
+            }
+        }
+        return CONTINUE;
+    }
+
+    private Result setLast(Result result) {
+        lastResult = result;
+        return result;
+    }
+
+    static SignatureTraversal from(JavaType.SignatureVisitor visitor) {
+        return visitor instanceof SignatureTraversal ? (SignatureTraversal) visitor : new SignatureTraversal(visitor);
     }
 }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaType.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
@@ -91,7 +92,23 @@ public interface JavaType extends HasName {
      * @return All raw types involved in this {@link JavaType}
      */
     @PublicAPI(usage = ACCESS)
-    Set<JavaClass> getAllInvolvedRawTypes();
+    default Set<JavaClass> getAllInvolvedRawTypes() {
+        ImmutableSet.Builder<JavaClass> result = ImmutableSet.builder();
+        traverseSignature(new SignatureVisitor() {
+            @Override
+            public Result visitClass(JavaClass type) {
+                result.add(type.getBaseComponentType());
+                return CONTINUE;
+            }
+
+            @Override
+            public Result visitParameterizedType(JavaParameterizedType type) {
+                result.add(type.toErasure());
+                return CONTINUE;
+            }
+        });
+        return result.build();
+    }
 
     /**
      * Traverses through the signature of this {@link JavaType}.<br>

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
@@ -17,7 +17,6 @@ package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.TypeVariable;
 import java.util.List;
-import java.util.Set;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.HasDescription;
@@ -29,7 +28,6 @@ import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.properties.HasName.Functions.GET_NAME;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Represents a type variable used by generic types and members.<br>
@@ -119,14 +117,6 @@ public final class JavaTypeVariable<OWNER extends HasDescription> implements Jav
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
-    }
-
-    @Override
-    public Set<JavaClass> getAllInvolvedRawTypes() {
-        return this.upperBounds.stream()
-                .map(JavaType::getAllInvolvedRawTypes)
-                .flatMap(Set::stream)
-                .collect(toSet());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaTypeVariable.java
@@ -130,6 +130,11 @@ public final class JavaTypeVariable<OWNER extends HasDescription> implements Jav
     }
 
     @Override
+    public void traverseSignature(SignatureVisitor visitor) {
+        SignatureTraversal.from(visitor).visitTypeVariable(this);
+    }
+
+    @Override
     public String toString() {
         String bounds = printExtendsClause() ? " extends " + joinTypeNames(upperBounds) : "";
         return getClass().getSimpleName() + '{' + getName() + bounds + '}';

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -17,8 +17,6 @@ package com.tngtech.archunit.core.domain;
 
 import java.lang.reflect.WildcardType;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.core.domain.properties.HasUpperBounds;
@@ -27,7 +25,6 @@ import com.tngtech.archunit.core.importer.DomainBuilders.JavaWildcardTypeBuilder
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 import static com.tngtech.archunit.core.domain.Formatters.ensureCanonicalArrayTypeName;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Represents a wildcard type in a type signature (compare the JLS).
@@ -96,14 +93,6 @@ public final class JavaWildcardType implements JavaType, HasUpperBounds {
     @PublicAPI(usage = ACCESS)
     public JavaClass toErasure() {
         return erasure;
-    }
-
-    @Override
-    public Set<JavaClass> getAllInvolvedRawTypes() {
-        return Stream.concat(upperBounds.stream(), lowerBounds.stream())
-                .map(JavaType::getAllInvolvedRawTypes)
-                .flatMap(Set::stream)
-                .collect(toSet());
     }
 
     @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaWildcardType.java
@@ -107,6 +107,11 @@ public final class JavaWildcardType implements JavaType, HasUpperBounds {
     }
 
     @Override
+    public void traverseSignature(SignatureVisitor visitor) {
+        SignatureTraversal.from(visitor).visitWildcardType(this);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + '{' + getName() + '}';
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -88,7 +88,6 @@ import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.core.domain.properties.HasName.Utils.namesOf;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
 
 @Internal
 @SuppressWarnings("UnusedReturnValue")
@@ -1215,14 +1214,6 @@ public final class DomainBuilders {
         @Override
         public JavaClass toErasure() {
             return type.toErasure();
-        }
-
-        @Override
-        public Set<JavaClass> getAllInvolvedRawTypes() {
-            return Stream.concat(
-                    type.getAllInvolvedRawTypes().stream(),
-                    typeArguments.stream().map(JavaType::getAllInvolvedRawTypes).flatMap(Set::stream)
-            ).collect(toSet());
         }
 
         @Override

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -164,6 +164,58 @@ public class JavaClassTest {
         assertThatType(twoDimArray.tryGetComponentType().get().tryGetComponentType().get()).isEqualTo(type);
     }
 
+    @DataProvider
+    public static Object[][] data_imported_array_types_match_Reflection_API() {
+        @SuppressWarnings("unused")
+        class PublicClassArray {
+            String[] array;
+        }
+        @SuppressWarnings("unused")
+        class PublicClassMultiDimArray {
+            String[][] array;
+        }
+        @SuppressWarnings("unused")
+        class PrimitiveClassArray {
+            int[] array;
+        }
+        class LocalClass {
+        }
+        @SuppressWarnings("unused")
+        class LocalClassArray {
+            LocalClass[] array;
+        }
+        @SuppressWarnings("unused")
+        class PrivateClassArray {
+            SomePrivateClass[] array;
+        }
+        @SuppressWarnings("unused")
+        class ProtectedClassArray {
+            SomeProtectedClass[] array;
+        }
+        @SuppressWarnings("unused")
+        class InnerPackagePrivateClassArray {
+            SomePackagePrivateClass[] array;
+        }
+        return $$(
+                $(PublicClassArray.class, String[].class),
+                $(PublicClassMultiDimArray.class, String[][].class),
+                $(PrimitiveClassArray.class, int[].class),
+                $(LocalClassArray.class, LocalClass[].class),
+                $(PrivateClassArray.class, SomePrivateClass[].class),
+                $(ProtectedClassArray.class, SomeProtectedClass[].class),
+                $(InnerPackagePrivateClassArray.class, SomePackagePrivateClass[].class)
+        );
+    }
+
+    @Test
+    @UseDataProvider
+    public void test_imported_array_types_match_Reflection_API(Class<?> classWithArrayField, Class<?> expectedReflectionType) {
+        JavaClass classWithArray = new ClassFileImporter().importClass(classWithArrayField);
+        JavaClass arrayClassObject = classWithArray.getField("array").getRawType();
+
+        assertThatType(arrayClassObject).matches(expectedReflectionType);
+    }
+
     @Test
     public void erased_type_of_class_is_the_class_itself() {
         class SimpleClass {
@@ -2651,5 +2703,14 @@ public class JavaClassTest {
 
         void throwableSelfReference() throws ClassWithSelfReferences {
         }
+    }
+
+    private class SomePrivateClass {
+    }
+
+    class SomePackagePrivateClass {
+    }
+
+    protected class SomeProtectedClass {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaCodeUnitTest.java
@@ -46,6 +46,19 @@ public class JavaCodeUnitTest {
     }
 
     @Test
+    public void finding_all_involved_raw_types_terminates_for_recursive_type_parameters() {
+        @SuppressWarnings("unused")
+        abstract class SomeClass<T extends SomeClass<T>> {
+            public abstract T method();
+        }
+
+        JavaMethod method = new ClassFileImporter().importClass(SomeClass.class).getMethod("method");
+
+        assertThatTypes(method.getAllInvolvedRawTypes())
+                .matchInAnyOrder(SomeClass.class);
+    }
+
+    @Test
     public void offers_all_calls_from_Self() {
         JavaMethod method = importClassWithContext(ClassAccessingOtherClass.class).getMethod("access", ClassBeingAccessed.class);
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaGenericArrayTypeTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaGenericArrayTypeTest.java
@@ -1,0 +1,24 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+
+public class JavaGenericArrayTypeTest {
+
+    @Test
+    public void all_involved_raw_types_of_generic_array() {
+        class SampleClass<T extends String & List<Serializable>> {
+            @SuppressWarnings("unused")
+            private T[][] field;
+        }
+
+        JavaGenericArrayType typeVariable = (JavaGenericArrayType) new ClassFileImporter().importClass(SampleClass.class).getField("field").getType();
+
+        assertThatTypes(typeVariable.getAllInvolvedRawTypes()).matchInAnyOrder(String.class, List.class, Serializable.class);
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeTraversalTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeTraversalTest.java
@@ -1,0 +1,440 @@
+package com.tngtech.archunit.core.domain;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.tngtech.archunit.base.ForwardingList;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.tngtech.archunit.testutil.Assertions.assertThatTypes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JavaTypeTraversalTest {
+
+    @Test
+    public void traverses_simple_class() {
+        class SimpleClass {
+        }
+
+        JavaClass clazz = new ClassFileImporter().importClass(SimpleClass.class);
+
+        List<JavaType> traversedClasses = new ArrayList<>();
+        clazz.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitClass(JavaClass type) {
+                traversedClasses.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThatTypes(traversedClasses).matchExactly(SimpleClass.class);
+    }
+
+    @Test
+    public void traverses_array_type() {
+        class SimpleClass {
+            @SuppressWarnings("unused")
+            private SimpleClass[][] field;
+        }
+
+        JavaType arrayType = new ClassFileImporter().importClass(SimpleClass.class).getField("field").getType();
+
+        List<JavaType> traversedClasses = new ArrayList<>();
+        arrayType.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitClass(JavaClass type) {
+                traversedClasses.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThatTypes(traversedClasses).matchExactly(SimpleClass[][].class);
+    }
+
+    @Test
+    public void traverses_type_variable() {
+        @SuppressWarnings("unused")
+        class SomeClass<T> {
+            T field;
+        }
+        JavaTypeVariable<?> typeVariable = (JavaTypeVariable<?>) new ClassFileImporter()
+                .importClass(SomeClass.class)
+                .getField("field")
+                .getType();
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        typeVariable.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitTypeVariable(JavaTypeVariable<?> type) {
+                traversedTypes.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThat(traversedTypes).containsOnly(typeVariable);
+    }
+
+    @Test
+    public void traverses_parameterized_type() {
+        @SuppressWarnings("unused")
+        class SomeClass {
+            List<String> field;
+        }
+        JavaParameterizedType parameterizedType = (JavaParameterizedType) new ClassFileImporter()
+                .importClass(SomeClass.class)
+                .getField("field")
+                .getType();
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        parameterizedType.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitParameterizedType(JavaParameterizedType type) {
+                traversedTypes.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThat(traversedTypes).containsOnly(parameterizedType);
+    }
+
+    @Test
+    public void traverses_wildcard_type() {
+        @SuppressWarnings("unused")
+        class SomeClass {
+            List<?> field;
+        }
+        JavaParameterizedType parameterizedType = (JavaParameterizedType) new ClassFileImporter()
+                .importClass(SomeClass.class)
+                .getField("field")
+                .getType();
+
+        JavaWildcardType wildcardType = (JavaWildcardType) getOnlyElement(parameterizedType.getActualTypeArguments());
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        wildcardType.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitWildcardType(JavaWildcardType type) {
+                traversedTypes.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThat(traversedTypes).containsOnly(wildcardType);
+    }
+
+    @Test
+    public void traverses_generic_array_type() {
+        @SuppressWarnings("unused")
+        class SomeClass<T> {
+            T[] field;
+        }
+        JavaGenericArrayType genericArrayType = (JavaGenericArrayType) new ClassFileImporter()
+                .importClass(SomeClass.class)
+                .getField("field")
+                .getType();
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        genericArrayType.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitGenericArrayType(JavaGenericArrayType type) {
+                traversedTypes.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThat(traversedTypes).containsOnly(genericArrayType);
+    }
+
+    @Test
+    public void traverses_complex_signature_of_JavaClass() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends Map<? extends T[][], List<?>>, U extends List<? super int[][]>, V extends File & Set<?>> {
+        }
+
+        JavaClass classWithComplexSignature = new ClassFileImporter().importClass(SomeClass.class);
+
+        List<JavaTypeVariable<JavaClass>> typeParameters = classWithComplexSignature.getTypeParameters();
+
+        ExpectedTypes types = new ExpectedTypes();
+        types.expect(classWithComplexSignature);
+        // Type variable T
+        JavaTypeVariable<JavaClass> typeVariableT = types.expect(typeParameters.get(0));
+        JavaParameterizedType mapType = types.expect(typeVariableT.getUpperBounds().get(0));
+        JavaWildcardType mapKeyWildCard = types.expect(mapType.getActualTypeArguments().get(0));
+        JavaGenericArrayType genericArrayType2DimT = types.expect(mapKeyWildCard.getUpperBounds().get(0));
+        types.expect(genericArrayType2DimT.getComponentType());
+        JavaParameterizedType mapValueParameterizedTypeList = types.expect(mapType.getActualTypeArguments().get(1));
+        types.expect(mapValueParameterizedTypeList.getActualTypeArguments().get(0));
+        // Type variable U
+        JavaTypeVariable<JavaClass> typeVariableU = types.expect(typeParameters.get(1));
+        JavaParameterizedType listType = types.expect(typeVariableU.getUpperBounds().get(0));
+        JavaWildcardType listWildCard = types.expect(listType.getActualTypeArguments().get(0));
+        types.expect(listWildCard.getLowerBounds().get(0));
+        // Type variable V
+        JavaTypeVariable<JavaClass> typeVariableV = types.expect(typeParameters.get(2));
+        types.expect(typeVariableV.getUpperBounds().get(0));
+        JavaParameterizedType setType = types.expect(typeVariableV.getUpperBounds().get(1));
+        types.expect(setType.getActualTypeArguments().get(0));
+        // End expected types
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        classWithComplexSignature.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void traverses_complex_signature_of_JavaTypeVariable() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends Map<? extends T[][], List<?>>> {
+        }
+
+        JavaType typeVariable = new ClassFileImporter().importClass(SomeClass.class)
+                .getTypeParameters().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaTypeVariable<JavaClass> typeVariableT = types.expect(typeVariable);
+        JavaParameterizedType mapType = types.expect(typeVariableT.getUpperBounds().get(0));
+        JavaWildcardType mapKeyWildCard = types.expect(mapType.getActualTypeArguments().get(0));
+        JavaGenericArrayType genericArrayType2DimT = types.expect(mapKeyWildCard.getUpperBounds().get(0));
+        types.expect(genericArrayType2DimT.getComponentType());
+        JavaParameterizedType mapValueParameterizedTypeList = types.expect(mapType.getActualTypeArguments().get(1));
+        types.expect(mapValueParameterizedTypeList.getActualTypeArguments().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        typeVariable.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void traverses_complex_signature_of_JavaParameterizedType() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends Map<? extends T[][], List<?>>> {
+        }
+
+        JavaType parameterizedType = new ClassFileImporter().importClass(SomeClass.class)
+                .getTypeParameters().get(0).getUpperBounds().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaParameterizedType mapType = types.expect(parameterizedType);
+        JavaWildcardType mapKeyWildCard = types.expect(mapType.getActualTypeArguments().get(0));
+        JavaGenericArrayType genericArrayType2DimT = types.expect(mapKeyWildCard.getUpperBounds().get(0));
+        JavaGenericArrayType genericArrayType1DimT = types.expect(genericArrayType2DimT.getComponentType());
+        types.expect(genericArrayType1DimT.getComponentType());
+        JavaParameterizedType mapValueParameterizedTypeList = types.expect(mapType.getActualTypeArguments().get(1));
+        types.expect(mapValueParameterizedTypeList.getActualTypeArguments().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        parameterizedType.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void traverses_complex_signature_of_generic_array_type_from_type_variable() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends File> {
+            T[][] field;
+        }
+
+        JavaType arrayType = new ClassFileImporter().importClass(SomeClass.class)
+                .getField("field").getType();
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaGenericArrayType tArray2Dim = types.expect(arrayType);
+        JavaGenericArrayType tArray1Dim = types.expect(tArray2Dim.getComponentType());
+        JavaTypeVariable<?> typeVariableT = types.expect(tArray1Dim.getComponentType());
+        types.expect(typeVariableT.getUpperBounds().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        arrayType.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void traverses_complex_signature_of_JavaWildcardType() {
+        @SuppressWarnings("unused")
+        class SomeClass<T extends Map<? extends T[][], List<?>>> {
+        }
+
+        JavaParameterizedType mapType = (JavaParameterizedType) new ClassFileImporter().importClass(SomeClass.class)
+                .getTypeParameters().get(0).getUpperBounds().get(0);
+        JavaType mapKeyWildcard = mapType.getActualTypeArguments().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaWildcardType mapKeyWildCard = types.expect(mapKeyWildcard);
+        JavaGenericArrayType genericArrayType2DimT = types.expect(mapKeyWildCard.getUpperBounds().get(0));
+        JavaGenericArrayType genericArrayType1DimT = types.expect(genericArrayType2DimT.getComponentType());
+        types.expect(genericArrayType1DimT.getComponentType());
+        // from here on we recurse through type variable in the signature
+        types.expect(mapType);
+        JavaParameterizedType mapValueParameterizedTypeList = types.expect(mapType.getActualTypeArguments().get(1));
+        types.expect(mapValueParameterizedTypeList.getActualTypeArguments().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        mapKeyWildcard.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void does_not_traverse_into_type_variables_of_raw_type_in_signature() {
+        @SuppressWarnings({"unused", "rawtypes"})
+        class SomeClass<T extends Map> {
+        }
+
+        JavaType type = new ClassFileImporter().importClasses(SomeClass.class, Map.class)
+                .get(SomeClass.class).getTypeParameters().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaTypeVariable<?> typeVariable = types.expect(type);
+        types.expect(typeVariable.getUpperBounds().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        type.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void traverses_into_type_variables_of_method_signature_type() {
+        @SuppressWarnings("unused")
+        class SomeClass {
+            <T extends List<?>> void method(Set<? extends T> param) {
+            }
+        }
+
+        JavaType type = new ClassFileImporter().importClass(SomeClass.class)
+                .getMethod("method", Set.class).getParameterTypes().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaParameterizedType setType = types.expect(type);
+        JavaWildcardType wildcardType = types.expect(setType.getActualTypeArguments().get(0));
+        JavaTypeVariable<?> typeVariableT = types.expect(wildcardType.getUpperBounds().get(0));
+        JavaParameterizedType listType = types.expect(typeVariableT.getUpperBounds().get(0));
+        types.expect(listType.getActualTypeArguments().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        type.traverseSignature(newTrackingVisitor(traversedTypes));
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    @Test
+    public void stops_depth_first_traversal_once_STOP_is_received() {
+        @SuppressWarnings("unused")
+        class SomeClass {
+            <T extends Map<String, File> & Serializable> void method(T param) {
+            }
+        }
+
+        JavaType type = new ClassFileImporter().importClass(SomeClass.class)
+                .getMethod("method", Map.class).getParameterTypes().get(0);
+
+        ExpectedTypes types = new ExpectedTypes();
+        JavaTypeVariable<?> typeVariableT = types.expect(type);
+        types.expect(typeVariableT.getUpperBounds().get(0));
+
+        List<JavaType> traversedTypes = new ArrayList<>();
+        type.traverseSignature(new AllRejectingSignatureVisitor() {
+            @Override
+            public Result visitTypeVariable(JavaTypeVariable<?> type) {
+                traversedTypes.add(type);
+                return Result.CONTINUE;
+            }
+
+            @Override
+            public Result visitParameterizedType(JavaParameterizedType type) {
+                traversedTypes.add(type);
+                return Result.STOP;
+            }
+        });
+
+        assertThat(traversedTypes).containsExactlyElementsOf(types);
+    }
+
+    private static JavaType.SignatureVisitor newTrackingVisitor(List<JavaType> traversedTypes) {
+        return new JavaType.SignatureVisitor() {
+            @Override
+            public Result visitClass(JavaClass type) {
+                traversedTypes.add(type);
+                return JavaType.SignatureVisitor.super.visitClass(type);
+            }
+
+            @Override
+            public Result visitParameterizedType(JavaParameterizedType type) {
+                traversedTypes.add(type);
+                return JavaType.SignatureVisitor.super.visitParameterizedType(type);
+            }
+
+            @Override
+            public Result visitTypeVariable(JavaTypeVariable<?> type) {
+                traversedTypes.add(type);
+                return JavaType.SignatureVisitor.super.visitTypeVariable(type);
+            }
+
+            @Override
+            public Result visitGenericArrayType(JavaGenericArrayType type) {
+                traversedTypes.add(type);
+                return JavaType.SignatureVisitor.super.visitGenericArrayType(type);
+            }
+
+            @Override
+            public Result visitWildcardType(JavaWildcardType type) {
+                traversedTypes.add(type);
+                return JavaType.SignatureVisitor.super.visitWildcardType(type);
+            }
+        };
+    }
+
+    private static class ExpectedTypes extends ForwardingList<JavaType> {
+        private final List<JavaType> delegate = new ArrayList<>();
+
+        @Override
+        protected List<JavaType> delegate() {
+            return delegate;
+        }
+
+        // some inherently unsafe syntactic sugar, trust the caller
+        @SuppressWarnings("unchecked")
+        <T extends JavaType> T expect(JavaType javaType) {
+            add(javaType);
+            return (T) javaType;
+        }
+    }
+
+    private static class AllRejectingSignatureVisitor implements JavaType.SignatureVisitor {
+        @Override
+        public Result visitClass(JavaClass type) {
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public Result visitParameterizedType(JavaParameterizedType type) {
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public Result visitTypeVariable(JavaTypeVariable<?> type) {
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public Result visitGenericArrayType(JavaGenericArrayType type) {
+            throw new UnsupportedOperationException("should not be called");
+        }
+
+        @Override
+        public Result visitWildcardType(JavaWildcardType type) {
+            throw new UnsupportedOperationException("should not be called");
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaTypeVariableTest.java
@@ -133,18 +133,6 @@ public class JavaTypeVariableTest {
     }
 
     @Test
-    public void all_involved_raw_types_of_generic_array() {
-        class SampleClass<T extends String & List<Serializable>> {
-            @SuppressWarnings("unused")
-            private T[][] field;
-        }
-
-        JavaGenericArrayType typeVariable = (JavaGenericArrayType) new ClassFileImporter().importClass(SampleClass.class).getField("field").getType();
-
-        assertThatTypes(typeVariable.getAllInvolvedRawTypes()).matchInAnyOrder(String.class, List.class, Serializable.class);
-    }
-
-    @Test
     public void toString_unbounded() {
         @SuppressWarnings("unused")
         class Unbounded<NAME> {

--- a/buildSrc/src/main/groovy/archunit.java-release-publishing-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-release-publishing-conventions.gradle
@@ -40,7 +40,7 @@ publishing {
                     developer {
                         id = 'codecholeric'
                         name = 'Peter Gafert'
-                        email = 'peter.gafert@tngtech.com'
+                        email = 'peter.gafert@archunit.org'
                     }
                     developer {
                         id = 'rweisleder'

--- a/buildSrc/src/main/resources/release_check/archunit-junit4.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit4.pom
@@ -23,7 +23,7 @@
         <developer>
             <id>codecholeric</id>
             <name>Peter Gafert</name>
-            <email>peter.gafert@tngtech.com</email>
+            <email>peter.gafert@archunit.org</email>
         </developer>
         <developer>
             <id>rweisleder</id>

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-api.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-api.pom
@@ -23,7 +23,7 @@
         <developer>
             <id>codecholeric</id>
             <name>Peter Gafert</name>
-            <email>peter.gafert@tngtech.com</email>
+            <email>peter.gafert@archunit.org</email>
         </developer>
         <developer>
             <id>rweisleder</id>

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
@@ -24,7 +24,7 @@
         <developer>
             <id>codecholeric</id>
             <name>Peter Gafert</name>
-            <email>peter.gafert@tngtech.com</email>
+            <email>peter.gafert@archunit.org</email>
         </developer>
         <developer>
             <id>rweisleder</id>

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-engine.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-engine.pom
@@ -24,7 +24,7 @@
         <developer>
             <id>codecholeric</id>
             <name>Peter Gafert</name>
-            <email>peter.gafert@tngtech.com</email>
+            <email>peter.gafert@archunit.org</email>
         </developer>
         <developer>
             <id>rweisleder</id>

--- a/buildSrc/src/main/resources/release_check/archunit-junit5.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5.pom
@@ -24,7 +24,7 @@
     <developer>
       <id>codecholeric</id>
       <name>Peter Gafert</name>
-      <email>peter.gafert@tngtech.com</email>
+      <email>peter.gafert@archunit.org</email>
     </developer>
     <developer>
       <id>rweisleder</id>

--- a/buildSrc/src/main/resources/release_check/archunit.pom
+++ b/buildSrc/src/main/resources/release_check/archunit.pom
@@ -28,7 +28,7 @@
         <developer>
             <id>codecholeric</id>
             <name>Peter Gafert</name>
-            <email>peter.gafert@tngtech.com</email>
+            <email>peter.gafert@archunit.org</email>
         </developer>
         <developer>
             <id>rweisleder</id>

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM jekyll/jekyll:stable
 
-MAINTAINER Peter Gafert <peter.gafert@tngtech.com>
+MAINTAINER Peter Gafert <peter.gafert@archunit.org>
 
 WORKDIR /srv/jekyll
 

--- a/docs/_config-dev.yml
+++ b/docs/_config-dev.yml
@@ -21,9 +21,9 @@ twitter:
 author:
   name             : "Peter Gafert"
   avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
-  bio: "I'm a Principal Consultant at TNG Technology Consulting GmbH and everyday software architecture enthusiast striving for a clear, common understanding of architecture in agile environments. Besides my daily project work, I develop the open source library ArchUnit to support everyday architecture maintenance and consistency."
+  bio              : "I'm Principal Software Architect at tado° and everyday software architecture enthusiast striving for a clear, common understanding of architecture in agile environments. Besides my daily project work, I develop the open source library ArchUnit to support everyday architecture maintenance and consistency."
   location         : "Munich"
-  email            : "peter.gafert@tngtech.com"
+  email            : "peter.gafert@archunit.org"
   github           : "codecholeric"
   twitter          : "codecholeric"
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,9 +21,9 @@ twitter:
 author:
   name             : "Peter Gafert"
   avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
-  bio              : "I'm a Senior Consultant at TNG Technology Consulting GmbH and everyday software architecture enthusiast striving for a clear, common understanding of architecture in agile environments. Besides my daily project work, I develop the open source library ArchUnit to support everyday architecture maintenance and consistency."
+  bio              : "I'm Principal Software Architect at tado° and everyday software architecture enthusiast striving for a clear, common understanding of architecture in agile environments. Besides my daily project work, I develop the open source library ArchUnit to support everyday architecture maintenance and consistency."
   location         : "Munich"
-  email            : "peter.gafert@tngtech.com"
+  email            : "peter.gafert@archunit.org"
   github           : "codecholeric"
   twitter          : "codecholeric"
 


### PR DESCRIPTION
This fixes the problem of recursing infinitely when calling `JavaType.getAllInvolvedRawTypes()`
for a recursive type parameter declaration (e.g. `class Example<T extends Example<T>>`).
It also adds a new public API to conveniently traverse `JavaType` signatures
without the need to add chains of `instanceof` checks and manually handle how to traverse further.

Resolves: #1237