### PR TITLE
fix `@ArchIgnore` not being fully respected by JUnit 4 support

### DIFF
--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchRuleDeclaration.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchRuleDeclaration.java
@@ -18,7 +18,6 @@ package com.tngtech.archunit.junit.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
-import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -56,17 +55,13 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
         return new AsField(testClass, field, fieldOwner, forceIgnore);
     }
 
-    static <T extends AnnotatedElement & Member> boolean elementShouldBeIgnored(T member) {
-        return elementShouldBeIgnored(member.getDeclaringClass(), member);
-    }
-
-    static boolean elementShouldBeIgnored(Class<?> testClass, AnnotatedElement ruleDeclaration) {
-        return testClass.getAnnotation(ArchIgnore.class) != null ||
+    static boolean elementShouldBeIgnored(Class<?> owner, AnnotatedElement ruleDeclaration) {
+        return owner.getAnnotation(ArchIgnore.class) != null ||
                 ruleDeclaration.getAnnotation(ArchIgnore.class) != null;
     }
 
     boolean shouldBeIgnored() {
-        return forceIgnore || elementShouldBeIgnored(testClass, declaration);
+        return forceIgnore || elementShouldBeIgnored(owner, declaration);
     }
 
     static Set<ArchRuleDeclaration<?>> toDeclarations(
@@ -87,7 +82,7 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
             Class<? extends Annotation> archTestAnnotationType, boolean forceIgnore) {
 
         return ArchTests.class.isAssignableFrom(field.getType()) ?
-                toDeclarations(getArchRulesIn(field, fieldOwner), testClass, archTestAnnotationType, forceIgnore || elementShouldBeIgnored(field)) :
+                toDeclarations(getArchRulesIn(field, fieldOwner), testClass, archTestAnnotationType, forceIgnore || elementShouldBeIgnored(fieldOwner, field)) :
                 singleton(ArchRuleDeclaration.from(testClass, field, fieldOwner, forceIgnore));
     }
 

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
@@ -92,7 +92,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
     }
 
     private Set<ArchTestExecution> findArchRulesIn(FrameworkField ruleField) {
-        boolean ignore = elementShouldBeIgnored(ruleField.getField());
+        boolean ignore = elementShouldBeIgnored(getTestClass().getJavaClass(), ruleField.getField());
         if (ruleField.getType() == ArchTests.class) {
             return asTestExecutions(getArchRules(ruleField.getField()), ignore);
         }
@@ -114,7 +114,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
     private Collection<ArchTestExecution> findArchRuleMethods() {
         List<ArchTestExecution> result = new ArrayList<>();
         for (FrameworkMethod testMethod : getTestClass().getAnnotatedMethods(ArchTest.class)) {
-            boolean ignore = elementShouldBeIgnored(testMethod.getMethod());
+            boolean ignore = elementShouldBeIgnored(getTestClass().getJavaClass(), testMethod.getMethod());
             result.add(new ArchTestMethodExecution(getTestClass().getJavaClass(), testMethod.getMethod(), ignore));
         }
         return result;

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsMethodsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsMethodsTest.java
@@ -31,6 +31,8 @@ import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.ArchTestWithTestMethod.testSomething;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.IgnoredArchTest.toBeIgnoredOne;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.IgnoredArchTest.toBeIgnoredTwo;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.IgnoredArchTestWithBaseClass.toBeIgnoredOneInBaseClass;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsMethodsTest.IgnoredArchTestWithBaseClass.toBeIgnoredTwoInBaseClass;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerTestUtils.BE_SATISFIED;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerTestUtils.getRule;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerTestUtils.newRunnerFor;
@@ -117,6 +119,18 @@ public class ArchUnitRunnerRunsMethodsTest {
         assertThat(descriptionCaptor.getAllValues()).extractingResultOf("getMethodName")
                 .contains(toBeIgnoredOne)
                 .contains(toBeIgnoredTwo);
+    }
+
+    @Test
+    public void ignores_all_methods_in_base_classes_of_classes_annotated_with_ArchIgnore() {
+        ArchUnitRunnerInternal runner = newRunnerFor(IgnoredArchTestWithBaseClass.class);
+
+        runner.runChild(getRule(toBeIgnoredOneInBaseClass, runner), runNotifier);
+        runner.runChild(getRule(toBeIgnoredTwoInBaseClass, runner), runNotifier);
+        verify(runNotifier, times(2)).fireTestIgnored(descriptionCaptor.capture());
+        assertThat(descriptionCaptor.getAllValues()).extractingResultOf("getMethodName")
+                .contains(toBeIgnoredOneInBaseClass)
+                .contains(toBeIgnoredTwoInBaseClass);
     }
 
     @Test
@@ -230,6 +244,23 @@ public class ArchUnitRunnerRunsMethodsTest {
         static final String toBeIgnoredOne = "toBeIgnoredOne";
         static final String toBeIgnoredTwo = "toBeIgnoredTwo";
 
+        @ArchTest
+        public static void toBeIgnoredOne(JavaClasses classes) {
+        }
+
+        @ArchTest
+        public static void toBeIgnoredTwo(JavaClasses classes) {
+        }
+    }
+
+    @ArchIgnore
+    @AnalyzeClasses(packages = "some.pkg")
+    public static class IgnoredArchTestWithBaseClass extends BaseClass {
+        static final String toBeIgnoredOneInBaseClass = "toBeIgnoredOne";
+        static final String toBeIgnoredTwoInBaseClass = "toBeIgnoredTwo";
+    }
+
+    public static class BaseClass {
         @ArchTest
         public static void toBeIgnoredOne(JavaClasses classes) {
         }

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleFieldsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleFieldsTest.java
@@ -27,6 +27,8 @@ import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContex
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.ArchTestWithPrivateInstanceField.PRIVATE_RULE_FIELD_NAME;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTest.RULE_ONE_IN_IGNORED_TEST;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTest.RULE_TWO_IN_IGNORED_TEST;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTestWithBaseClass.RULE_ONE_IN_IGNORED_BASE_CLASS;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.IgnoredArchTestWithBaseClass.RULE_TWO_IN_IGNORED_BASE_CLASS;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.FAILING_FIELD_NAME;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.IGNORED_FIELD_NAME;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleFieldsTest.SomeArchTest.SATISFIED_FIELD_NAME;
@@ -164,6 +166,19 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
     }
 
     @Test
+    public void should_skip_ignored_test_with_rule_in_base_class() {
+        ArchUnitRunnerInternal runner = newRunnerFor(IgnoredArchTestWithBaseClass.class, cache);
+
+        runner.runChild(ArchUnitRunnerTestUtils.getRule(RULE_ONE_IN_IGNORED_BASE_CLASS, runner), runNotifier);
+        runner.runChild(ArchUnitRunnerTestUtils.getRule(RULE_TWO_IN_IGNORED_BASE_CLASS, runner), runNotifier);
+
+        verify(runNotifier, times(2)).fireTestIgnored(descriptionCaptor.capture());
+
+        assertThat(descriptionCaptor.getAllValues()).extractingResultOf("getMethodName")
+                .contains(RULE_ONE_IN_IGNORED_BASE_CLASS, RULE_TWO_IN_IGNORED_BASE_CLASS);
+    }
+
+    @Test
     public void should_pass_annotations_of_rule_field() {
         ArchUnitRunnerInternal runner = newRunnerFor(ArchTestWithFieldWithAdditionalAnnotation.class, cache);
 
@@ -268,6 +283,21 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
         static final String RULE_ONE_IN_IGNORED_TEST = "someRuleOne";
         static final String RULE_TWO_IN_IGNORED_TEST = "someRuleTwo";
 
+        @ArchTest
+        public static final ArchRule someRuleOne = classes().should(NEVER_BE_SATISFIED);
+
+        @ArchTest
+        public static final ArchRule someRuleTwo = classes().should(NEVER_BE_SATISFIED);
+    }
+
+    @ArchIgnore
+    @AnalyzeClasses(packages = "some.pkg")
+    public static class IgnoredArchTestWithBaseClass extends BaseClass {
+        static final String RULE_ONE_IN_IGNORED_BASE_CLASS = "someRuleOne";
+        static final String RULE_TWO_IN_IGNORED_BASE_CLASS = "someRuleTwo";
+    }
+
+    public static abstract class BaseClass {
         @ArchTest
         public static final ArchRule someRuleOne = classes().should(NEVER_BE_SATISFIED);
 

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
@@ -29,12 +29,17 @@ import org.mockito.junit.MockitoRule;
 import static com.google.common.base.Preconditions.checkState;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.ArchTestWithRuleLibrary.someOtherMethodRuleName;
-import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredRules.someIgnoredFieldRuleName;
-import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredRules.someIgnoredMethodRuleName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.FullyIgnoredRules.someFieldRuleInBaseClassOfIgnoredClassName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.FullyIgnoredRules.someFieldRuleInIgnoredClassName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.FullyIgnoredRules.someMethodRuleInBaseClassOfIgnoredClassName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.FullyIgnoredRules.someMethodRuleInIgnoredClassName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredSubRules.someIgnoredSubFieldRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredSubRules.someIgnoredSubMethodRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredSubRules.someNonIgnoredSubFieldRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.IgnoredSubRules.someNonIgnoredSubMethodRuleName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.OtherRules.someOtherFieldRuleName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.PartiallyIgnoredRules.someIgnoredFieldRuleName;
+import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.PartiallyIgnoredRules.someIgnoredMethodRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.Rules.someFieldRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerRunsRuleSetsTest.Rules.someMethodRuleName;
 import static com.tngtech.archunit.junit.internal.ArchUnitRunnerTestUtils.getRule;
@@ -73,6 +78,9 @@ public class ArchUnitRunnerRunsRuleSetsTest {
 
     @InjectMocks
     private ArchUnitRunnerInternal runnerForIgnoredRuleLibrary = newRunnerFor(ArchTestWithIgnoredRuleLibrary.class);
+
+    @InjectMocks
+    private ArchUnitRunnerInternal runnerForFullyIgnoredRuleLibrary = newRunnerFor(ArchTestWithFullyIgnoredRuleLibrary.class);
 
     private final JavaClasses cachedClasses = importClassesWithContext(ArchUnitRunnerRunsRuleSetsTest.class);
 
@@ -135,6 +143,31 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @Test
     public void ignores_nested_method_rule() {
         run(someIgnoredMethodRuleName, runnerForIgnoredRuleLibrary, verifyTestIgnored());
+    }
+
+    @Test
+    public void ignores_nested_field_rule_of_ignored_class() {
+        run(someFieldRuleInIgnoredClassName, runnerForFullyIgnoredRuleLibrary, verifyTestIgnored());
+    }
+
+    @Test
+    public void ignores_nested_method_rule_of_ignored_class() {
+        run(someMethodRuleInIgnoredClassName, runnerForFullyIgnoredRuleLibrary, verifyTestIgnored());
+    }
+
+    @Test
+    public void ignores_nested_field_rule_in_base_class_of_ignored_class() {
+        run(someFieldRuleInBaseClassOfIgnoredClassName, runnerForFullyIgnoredRuleLibrary, verifyTestIgnored());
+    }
+
+    @Test
+    public void ignores_nested_method_rule_in_base_class_of_ignored_class() {
+        run(someMethodRuleInBaseClassOfIgnoredClassName, runnerForFullyIgnoredRuleLibrary, verifyTestIgnored());
+    }
+
+    @Test
+    public void ignores_nested_rule_set_in_base_class_of_ignored_class() {
+        run(someOtherFieldRuleName, runnerForFullyIgnoredRuleLibrary, verifyTestIgnored());
     }
 
     @Test
@@ -248,7 +281,13 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @AnalyzeClasses(packages = "some.pkg")
     public static class ArchTestWithIgnoredRuleLibrary {
         @ArchTest
-        public static final ArchTests rules = ArchTests.in(IgnoredRules.class);
+        public static final ArchTests rules = ArchTests.in(PartiallyIgnoredRules.class);
+    }
+
+    @AnalyzeClasses(packages = "some.pkg")
+    public static class ArchTestWithFullyIgnoredRuleLibrary {
+        @ArchTest
+        public static final ArchTests rules = ArchTests.in(FullyIgnoredRules.class);
     }
 
     public static class Rules {
@@ -263,7 +302,7 @@ public class ArchUnitRunnerRunsRuleSetsTest {
         }
     }
 
-    public static class IgnoredRules {
+    public static class PartiallyIgnoredRules {
         static final String someIgnoredFieldRuleName = "someIgnoredFieldRule";
         static final String someIgnoredMethodRuleName = "someIgnoredMethodRule";
 
@@ -282,6 +321,40 @@ public class ArchUnitRunnerRunsRuleSetsTest {
         @ArchTest
         @ArchIgnore
         public static final ArchTests ignoredSubRules = ArchTests.in(Rules.class);
+    }
+
+    @ArchIgnore
+    public static class FullyIgnoredRules extends BaseClass {
+        static final String someFieldRuleInIgnoredClassName = "someFieldRuleInIgnoredClass";
+        static final String someMethodRuleInIgnoredClassName = "someMethodRuleInIgnoredClass";
+        static final String someFieldRuleInBaseClassOfIgnoredClassName = "someFieldRuleInBaseClass";
+        static final String someMethodRuleInBaseClassOfIgnoredClassName = "someMethodRuleInBaseClass";
+
+        @ArchTest
+        public static final ArchRule someFieldRuleInIgnoredClass = classes().should(satisfySomething());
+
+        @ArchTest
+        public static void someMethodRuleInIgnoredClass(JavaClasses classes) {
+        }
+    }
+
+    public static class BaseClass {
+        @ArchTest
+        public static final ArchRule someFieldRuleInBaseClass = classes().should(satisfySomething());
+
+        @ArchTest
+        public static void someMethodRuleInBaseClass(JavaClasses classes) {
+        }
+
+        @ArchTest
+        public static final ArchTests someSubRulesInBaseClass = ArchTests.in(OtherRules.class);
+    }
+
+    public static class OtherRules {
+        static final String someOtherFieldRuleName = "someOtherFieldRule";
+
+        @ArchTest
+        public static final ArchRule someOtherFieldRule = classes().should(satisfySomething());
     }
 
     public static class IgnoredSubRules {


### PR DESCRIPTION
In the case of inheritance we were looking at the wrong class for an `@ArchIgnore`. I.e. rule declarations in base classes would only be ignored if the base class was annotated with `@ArchIgnore`, not the actual class. We now check the actual class for the annotation instead. If the base class is annotated with `@ArchIgnore` we ignore it for now, since this is a corner case and one could argue for both, either ignoring all subclasses or not ignoring subclasses.