### PR TITLE
make tests included via `ArchTests` report outer class as test location

### DIFF
--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchRuleDeclaration.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchRuleDeclaration.java
@@ -82,11 +82,11 @@ abstract class ArchRuleDeclaration<T extends AnnotatedElement> {
             Class<? extends Annotation> archTestAnnotationType, boolean forceIgnore) {
 
         return ArchTests.class.isAssignableFrom(field.getType()) ?
-                toDeclarations(getArchRulesIn(field, fieldOwner), testClass, archTestAnnotationType, forceIgnore || elementShouldBeIgnored(fieldOwner, field)) :
+                toDeclarations(getArchTestsIn(field, fieldOwner), testClass, archTestAnnotationType, forceIgnore || elementShouldBeIgnored(fieldOwner, field)) :
                 singleton(ArchRuleDeclaration.from(testClass, field, fieldOwner, forceIgnore));
     }
 
-    private static ArchTests getArchRulesIn(Field field, Class<?> fieldOwner) {
+    private static ArchTests getArchTestsIn(Field field, Class<?> fieldOwner) {
         ArchTests value = getValue(field, fieldOwner);
         return checkNotNull(value, "Field %s.%s is not initialized", fieldOwner.getName(), field.getName());
     }

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchTestExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchTestExecution.java
@@ -16,6 +16,8 @@
 package com.tngtech.archunit.junit.internal;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Stream;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.junit.runner.Description;
@@ -23,13 +25,16 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.getValueOrThrowException;
+import static java.util.stream.Collectors.joining;
 
 abstract class ArchTestExecution {
-    final Class<?> testClass;
+    final List<Class<?>> testClassPath;
+    final Class<?> ruleDeclaringClass;
     private final boolean ignore;
 
-    ArchTestExecution(Class<?> testClass, boolean ignore) {
-        this.testClass = testClass;
+    ArchTestExecution(List<Class<?>> testClassPath, Class<?> ruleDeclaringClass, boolean ignore) {
+        this.testClassPath = testClassPath;
+        this.ruleDeclaringClass = ruleDeclaringClass;
         this.ignore = ignore;
     }
 
@@ -40,6 +45,21 @@ abstract class ArchTestExecution {
     @Override
     public String toString() {
         return describeSelf().toString();
+    }
+
+    Class<?> getTestClass() {
+        return testClassPath.get(0);
+    }
+
+    String formatWithPath(String testName) {
+        if (testClassPath.size() <= 1) {
+            return testName;
+        }
+
+        return Stream.concat(
+                testClassPath.subList(1, testClassPath.size()).stream().map(Class::getSimpleName),
+                Stream.of(testName)
+        ).collect(joining(" > "));
     }
 
     abstract String getName();

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchTestMethodExecution.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchTestMethodExecution.java
@@ -17,6 +17,7 @@ package com.tngtech.archunit.junit.internal;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -28,8 +29,8 @@ import static com.tngtech.archunit.junit.internal.ReflectionUtils.invokeMethod;
 class ArchTestMethodExecution extends ArchTestExecution {
     private final Method testMethod;
 
-    ArchTestMethodExecution(Class<?> testClass, Method testMethod, boolean ignore) {
-        super(testClass, ignore);
+    ArchTestMethodExecution(List<Class<?>> testClassPath, Class<?> ruleDeclaringClass, Method testMethod, boolean ignore) {
+        super(testClassPath, ruleDeclaringClass, ignore);
         this.testMethod = testMethod;
     }
 
@@ -49,12 +50,13 @@ class ArchTestMethodExecution extends ArchTestExecution {
                 "Methods annotated with @%s must have exactly one parameter of type %s",
                 ArchTest.class.getSimpleName(), JavaClasses.class.getSimpleName());
 
-        invokeMethod(testMethod, testClass, classes);
+        invokeMethod(testMethod, ruleDeclaringClass, classes);
     }
 
     @Override
     Description describeSelf() {
-        return Description.createTestDescription(testClass, determineDisplayName(testMethod.getName()), testMethod.getAnnotations());
+        String testName = formatWithPath(testMethod.getName());
+        return Description.createTestDescription(getTestClass(), determineDisplayName(testName), testMethod.getAnnotations());
     }
 
     @Override

--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
@@ -94,7 +94,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
     private Set<ArchTestExecution> findArchRulesIn(FrameworkField ruleField) {
         boolean ignore = elementShouldBeIgnored(getTestClass().getJavaClass(), ruleField.getField());
         if (ruleField.getType() == ArchTests.class) {
-            return asTestExecutions(getArchRules(ruleField.getField()), ignore);
+            return asTestExecutions(getArchTests(ruleField.getField()), ignore);
         }
         return singleton(new ArchRuleExecution(getTestClass().getJavaClass(), ruleField.getField(), ignore));
     }
@@ -107,7 +107,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
         return executionTransformer.getExecutions();
     }
 
-    private ArchTests getArchRules(Field field) {
+    private ArchTests getArchTests(Field field) {
         return getValue(field, field.getDeclaringClass());
     }
 

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleFieldsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleFieldsTest.java
@@ -223,12 +223,15 @@ public class ArchUnitRunnerRunsRuleFieldsTest {
         verifyTestFinishedSuccessfully(runNotifier, descriptionCaptor, expectedDescriptionMethodName);
     }
 
-    static void verifyTestFinishedSuccessfully(RunNotifier runNotifier, ArgumentCaptor<Description> descriptionCaptor,
-            String expectedDescriptionMethodName) {
+    static void verifyTestFinishedSuccessfully(
+            RunNotifier runNotifier,
+            ArgumentCaptor<Description> descriptionCaptor,
+            String expectedDescriptionMethodName
+    ) {
         verify(runNotifier, never()).fireTestFailure(any(Failure.class));
         verify(runNotifier).fireTestFinished(descriptionCaptor.capture());
         Description description = descriptionCaptor.getValue();
-        assertThat(description.getMethodName()).isEqualTo(expectedDescriptionMethodName);
+        assertThat(description.getMethodName()).endsWith(expectedDescriptionMethodName);
     }
 
     @AnalyzeClasses(packages = "some.pkg")

--- a/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
+++ b/archunit-junit/junit4/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerRunsRuleSetsTest.java
@@ -92,20 +92,40 @@ public class ArchUnitRunnerRunsRuleSetsTest {
 
     @Test
     public void should_find_children_in_rule_set() {
-        assertThat(runnerForRuleSet.getChildren()).as("Rules defined in Test Class").hasSize(2);
-        assertThat(runnerForRuleSet.getChildren())
-                .extracting(resultOf("describeSelf"))
-                .extractingResultOf("getMethodName")
-                .as("Descriptions").containsOnly(someFieldRuleName, someMethodRuleName);
+        assertThat(runnerForRuleSet.getChildren()).as("Rules defined in Test Class")
+                .hasSize(2)
+                .map(ArchTestExecution::describeSelf)
+                .containsExactlyInAnyOrder(
+                        Description.createTestDescription(
+                                ArchTestWithRuleSet.class,
+                                Rules.class.getSimpleName() + " > " + someFieldRuleName
+                        ),
+                        Description.createTestDescription(
+                                ArchTestWithRuleSet.class,
+                                Rules.class.getSimpleName() + " > " + someMethodRuleName
+                        )
+                );
     }
 
     @Test
     public void should_find_children_in_rule_library() {
-        assertThat(runnerForRuleLibrary.getChildren()).as("Rules defined in Library").hasSize(3);
-        assertThat(runnerForRuleLibrary.getChildren())
-                .extracting(resultOf("describeSelf"))
-                .extractingResultOf("getMethodName")
-                .as("Descriptions").containsOnly(someFieldRuleName, someMethodRuleName, someOtherMethodRuleName);
+        assertThat(runnerForRuleLibrary.getChildren()).as("Rules defined in Library")
+                .hasSize(3)
+                .map(ArchTestExecution::describeSelf)
+                .containsExactlyInAnyOrder(
+                        Description.createTestDescription(
+                                ArchTestWithRuleLibrary.class,
+                                ArchTestWithRuleSet.class.getSimpleName() + " > " + Rules.class.getSimpleName() + " > " + someFieldRuleName
+                        ),
+                        Description.createTestDescription(
+                                ArchTestWithRuleLibrary.class,
+                                ArchTestWithRuleSet.class.getSimpleName() + " > " + Rules.class.getSimpleName() + " > " + someMethodRuleName
+                        ),
+                        Description.createTestDescription(
+                                ArchTestWithRuleLibrary.class.getName(),
+                                someOtherMethodRuleName
+                        )
+                );
     }
 
     @Test
@@ -116,13 +136,6 @@ public class ArchUnitRunnerRunsRuleSetsTest {
     @Test
     public void can_run_rule_method() {
         run(someMethodRuleName, runnerForRuleSet, verifyTestRan());
-    }
-
-    @Test
-    public void describes_nested_rules_within_their_declaring_class() {
-        for (ArchTestExecution execution : runnerForRuleSet.getChildren()) {
-            assertThat(execution.describeSelf().getTestClass()).isEqualTo(Rules.class);
-        }
     }
 
     @Test

--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/AbstractArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/AbstractArchUnitTestDescriptor.java
@@ -21,7 +21,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import com.tngtech.archunit.core.domain.Formatters;
 import com.tngtech.archunit.junit.ArchIgnore;
 import com.tngtech.archunit.junit.ArchTag;
 import org.junit.platform.commons.support.AnnotationSupport;
@@ -33,6 +35,7 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.hierarchical.Node;
 
 import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 abstract class AbstractArchUnitTestDescriptor extends AbstractTestDescriptor implements Node<ArchUnitEngineExecutionContext> {
@@ -68,5 +71,16 @@ abstract class AbstractArchUnitTestDescriptor extends AbstractTestDescriptor imp
         Set<TestTag> result = new HashSet<>(tags);
         result.addAll(getParent().map(TestDescriptor::getTags).orElse(emptySet()));
         return result;
+    }
+
+    static String formatWithPath(UniqueId uniqueId, String name) {
+        return Stream.concat(
+                uniqueId.getSegments().stream()
+                        .filter(it -> it.getType().equals(ArchUnitTestDescriptor.CLASS_SEGMENT_TYPE))
+                        .skip(1)
+                        .map(UniqueId.Segment::getValue)
+                        .map(Formatters::ensureSimpleName),
+                Stream.of(name)
+        ).collect(joining(" > "));
     }
 }

--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestDescriptor.java
@@ -32,6 +32,7 @@ import com.tngtech.archunit.junit.LocationProvider;
 import com.tngtech.archunit.junit.engine_api.FieldSource;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -151,7 +152,7 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
         private final Supplier<JavaClasses> classes;
 
         ArchUnitRuleDescriptor(UniqueId uniqueId, ArchRule rule, Supplier<JavaClasses> classes, TestMember<Field> field) {
-            super(uniqueId, determineDisplayName(field.getName()), FieldSource.from(field.member), field.member);
+            super(uniqueId, determineDisplayName(formatWithPath(uniqueId, field.getName())), FieldSource.from(field.member), field.member);
             this.rule = rule;
             this.classes = classes;
         }
@@ -174,7 +175,7 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
 
         ArchUnitMethodDescriptor(UniqueId uniqueId, TestMember<Method> method, Supplier<JavaClasses> classes) {
             super(uniqueId.append("method", method.member.getName()),
-                    determineDisplayName(method.member.getName()),
+                    determineDisplayName(formatWithPath(uniqueId, method.member.getName())),
                     MethodSource.from(method.member),
                     method.member);
 
@@ -211,11 +212,19 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
 
             super(resolver.getUniqueId(),
                     archTests.getDisplayName(),
-                    ClassSource.from(archTests.getDefinitionLocation()),
+                    noSource(),
                     field.member,
                     archTests.getDefinitionLocation());
             this.archTests = archTests;
             this.classes = classes;
+        }
+
+        /**
+         * We don't pass a ClassSource for intermediary descriptors or it will be used as test location by test executors.
+         * We want the root class declaring <code>@AnalyzeClasses</code> to be used for this.
+         */
+        private static TestSource noSource() {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
So far, if we include rules from other test classes, e.g.
```
@AnalyzeClasses(..)
class ExampleTest {
  @ArchTest
  static final ArchTests nested = ArchTests.in(Other.class);
}
```
then the nested class (`Other.class` in this case) will be used as test location.
This can cause confusion, because by this if `Other.class` is included in two separate test classes,
analyzing different locations via `@AnalyzeClasses`,
the results will be reported for the same test class `Other.class`.
We now report the outermost class that started the test (the one with `@AnalyzeClasses)
as the test location for both JUnit 4 and JUnit 5.
To make it easy to understand through which path a rule is included in more complex scenarios,
we extend the display name to include the path of nested classes.

Resolves: #452