### PR TITLE
enable `@AnalyzeClasses` annotation to be used as meta annotation

### DIFF
--- a/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
+++ b/archunit-junit/junit4/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitRunnerInternal.java
@@ -43,6 +43,7 @@ import org.junit.runners.model.Statement;
 import static com.tngtech.archunit.junit.internal.ArchRuleDeclaration.elementShouldBeIgnored;
 import static com.tngtech.archunit.junit.internal.ArchRuleDeclaration.toDeclarations;
 import static com.tngtech.archunit.junit.internal.ArchTestExecution.getValue;
+import static com.tngtech.archunit.junit.internal.ReflectionUtils.findAnnotation;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -53,7 +54,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
 
     ArchUnitRunnerInternal(Class<?> testClass) throws InitializationError {
         super(testClass);
-        checkAnnotation(testClass);
+        checkTestRunnable(testClass);
 
         try {
             ArchUnitSystemPropertyTestFilterJunit4.filter(this);
@@ -62,12 +63,8 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
         }
     }
 
-    private static AnalyzeClasses checkAnnotation(Class<?> testClass) {
-        AnalyzeClasses analyzeClasses = testClass.getAnnotation(AnalyzeClasses.class);
-        ArchTestInitializationException.check(analyzeClasses != null,
-                "Class %s must be annotated with @%s",
-                testClass.getSimpleName(), AnalyzeClasses.class.getSimpleName());
-        return analyzeClasses;
+    private static void checkTestRunnable(Class<?> testClass) {
+        findAnnotation(testClass, AnalyzeClasses.class);
     }
 
     @Override
@@ -180,7 +177,7 @@ final class ArchUnitRunnerInternal extends ParentRunner<ArchTestExecution> imple
         private final AnalyzeClasses analyzeClasses;
 
         JUnit4ClassAnalysisRequest(Class<?> testClass) {
-            analyzeClasses = checkAnnotation(testClass);
+            analyzeClasses = findAnnotation(testClass, AnalyzeClasses.class);
         }
 
         @Override

--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestDescriptor.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestDescriptor.java
@@ -39,12 +39,13 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.tngtech.archunit.junit.internal.DisplayNameResolver.determineDisplayName;
+import static com.tngtech.archunit.junit.internal.ReflectionUtils.findAnnotation;
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.getAllFields;
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.getAllMethods;
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.getValueOrThrowException;
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.invokeMethod;
+import static com.tngtech.archunit.junit.internal.ReflectionUtils.tryFindAnnotation;
 import static com.tngtech.archunit.junit.internal.ReflectionUtils.withAnnotation;
 
 class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements CreatesChildren {
@@ -71,8 +72,8 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
     }
 
     private static void createTestDescriptor(TestDescriptor parent, ClassCache classCache, Class<?> clazz, ElementResolver childResolver) {
-        if (clazz.getAnnotation(AnalyzeClasses.class) == null) {
-            LOG.warn("Class {} is not annotated with @{} and thus cannot run as a top level test. "
+        if (!tryFindAnnotation(clazz, AnalyzeClasses.class).isPresent()) {
+            LOG.warn("Class {} is not (meta-)annotated with @{} and thus cannot run as a top level test. "
                             + "This warning can be ignored if {} is only used as part of a rules library included via {}.in({}.class).",
                     clazz.getName(), AnalyzeClasses.class.getSimpleName(),
                     clazz.getSimpleName(), ArchTests.class.getSimpleName(), clazz.getSimpleName());
@@ -291,15 +292,7 @@ class ArchUnitTestDescriptor extends AbstractArchUnitTestDescriptor implements C
         private final AnalyzeClasses analyzeClasses;
 
         JUnit5ClassAnalysisRequest(Class<?> testClass) {
-            analyzeClasses = checkAnnotation(testClass);
-        }
-
-        private static AnalyzeClasses checkAnnotation(Class<?> testClass) {
-            AnalyzeClasses analyzeClasses = testClass.getAnnotation(AnalyzeClasses.class);
-            checkArgument(analyzeClasses != null,
-                    "Class %s must be annotated with @%s",
-                    testClass.getSimpleName(), AnalyzeClasses.class.getSimpleName());
-            return analyzeClasses;
+            analyzeClasses = findAnnotation(testClass, AnalyzeClasses.class);
         }
 
         @Override

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
@@ -27,6 +27,7 @@ import com.tngtech.archunit.junit.internal.testexamples.ComplexTags;
 import com.tngtech.archunit.junit.internal.testexamples.FullAnalyzeClassesSpec;
 import com.tngtech.archunit.junit.internal.testexamples.LibraryWithPrivateTests;
 import com.tngtech.archunit.junit.internal.testexamples.SimpleRuleLibrary;
+import com.tngtech.archunit.junit.internal.testexamples.TestClassWithMetaAnnotationForAnalyzeClasses;
 import com.tngtech.archunit.junit.internal.testexamples.TestClassWithMetaTag;
 import com.tngtech.archunit.junit.internal.testexamples.TestClassWithMetaTags;
 import com.tngtech.archunit.junit.internal.testexamples.TestClassWithTags;
@@ -167,6 +168,20 @@ class ArchUnitTestEngineTest {
             assertThat(child.getDisplayName()).isEqualTo(SimpleRuleField.class.getSimpleName());
             assertThat(child.getType()).isEqualTo(CONTAINER);
             assertThat(child.getParent().get()).isEqualTo(descriptor);
+        }
+
+        @Test
+        void a_test_class_with_meta_annotated_analyze_classes() {
+            EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest().withClass(TestClassWithMetaAnnotationForAnalyzeClasses.class);
+
+            TestDescriptor descriptor = testEngine.discover(discoveryRequest, engineId);
+
+            TestDescriptor child = getOnlyElement(descriptor.getChildren());
+            assertThat(child).isInstanceOf(ArchUnitTestDescriptor.class);
+            assertThat(child.getUniqueId()).isEqualTo(engineId.append(CLASS_SEGMENT_TYPE, TestClassWithMetaAnnotationForAnalyzeClasses.class.getName()));
+            assertThat(child.getDisplayName()).isEqualTo(TestClassWithMetaAnnotationForAnalyzeClasses.class.getSimpleName());
+            assertThat(child.getType()).isEqualTo(CONTAINER);
+            assertThat(child.getParent()).get().isEqualTo(descriptor);
         }
 
         @Test
@@ -505,10 +520,10 @@ class ArchUnitTestEngineTest {
             expectedLeafIds.add(simpleRuleFieldTestId(engineId));
             expectedLeafIds.add(simpleRuleMethodTestId(engineId));
             Stream.concat(
-                    SimpleRules.RULE_FIELD_NAMES.stream().map(fieldName ->
-                            simpleRulesId(engineId).append(FIELD_SEGMENT_TYPE, fieldName)),
-                    SimpleRules.RULE_METHOD_NAMES.stream().map(methodName ->
-                            simpleRulesId(engineId).append(METHOD_SEGMENT_TYPE, methodName)))
+                            SimpleRules.RULE_FIELD_NAMES.stream().map(fieldName ->
+                                    simpleRulesId(engineId).append(FIELD_SEGMENT_TYPE, fieldName)),
+                            SimpleRules.RULE_METHOD_NAMES.stream().map(methodName ->
+                                    simpleRulesId(engineId).append(METHOD_SEGMENT_TYPE, methodName)))
                     .forEach(expectedLeafIds::add);
 
             assertThat(getAllLeafUniqueIds(rootDescriptor))
@@ -1073,6 +1088,21 @@ class ArchUnitTestEngineTest {
             verify(classCache, times(1)).clear(SimpleRuleLibrary.class);
             verify(classCache, atLeastOnce()).getClassesToAnalyzeFor(any(Class.class), any(ClassAnalysisRequest.class));
             verifyNoMoreInteractions(classCache);
+        }
+
+        @Test
+        void a_class_with_analyze_classes_as_meta_annotation() {
+            execute(createEngineId(), TestClassWithMetaAnnotationForAnalyzeClasses.class);
+
+            verify(classCache).getClassesToAnalyzeFor(eq(TestClassWithMetaAnnotationForAnalyzeClasses.class), classAnalysisRequestCaptor.capture());
+            ClassAnalysisRequest request = classAnalysisRequestCaptor.getValue();
+            AnalyzeClasses expected = TestClassWithMetaAnnotationForAnalyzeClasses.class.getAnnotation(TestClassWithMetaAnnotationForAnalyzeClasses.MetaAnalyzeClasses.class)
+                    .annotationType().getAnnotation(AnalyzeClasses.class);
+            assertThat(request.getPackageNames()).isEqualTo(expected.packages());
+            assertThat(request.getPackageRoots()).isEqualTo(expected.packagesOf());
+            assertThat(request.getLocationProviders()).isEqualTo(expected.locations());
+            assertThat(request.scanWholeClasspath()).as("scan whole classpath").isTrue();
+            assertThat(request.getImportOptions()).isEqualTo(expected.importOptions());
         }
     }
 

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/TestClassWithMetaAnnotationForAnalyzeClasses.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/testexamples/TestClassWithMetaAnnotationForAnalyzeClasses.java
@@ -1,0 +1,21 @@
+package com.tngtech.archunit.junit.internal.testexamples;
+
+import java.lang.annotation.Retention;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@TestClassWithMetaAnnotationForAnalyzeClasses.MetaAnalyzeClasses
+public class TestClassWithMetaAnnotationForAnalyzeClasses {
+
+  @ArchTest
+  public static final ArchRule rule_in_class_with_meta_analyze_class_annotation = RuleThatFails.on(UnwantedClass.class);
+
+  @Retention(RUNTIME)
+  @AnalyzeClasses(wholeClasspath = true)
+  public @interface MetaAnalyzeClasses {
+  }
+}

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ArchTestInitializationException.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ArchTestInitializationException.java
@@ -1,7 +1,7 @@
 package com.tngtech.archunit.junit.internal;
 
 class ArchTestInitializationException extends RuntimeException {
-    private ArchTestInitializationException(String message, Object... args) {
+    ArchTestInitializationException(String message, Object... args) {
         super(String.format(message, args));
     }
 

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
@@ -72,16 +72,6 @@ class ReflectionUtils {
         return com.tngtech.archunit.base.ReflectionUtils.newInstanceOf(type);
     }
 
-    @SuppressWarnings("unchecked") // callers must know, what they do here, we can't make this compile safe anyway
-    private static <T> T getValue(Field field, Object owner) {
-        try {
-            field.setAccessible(true);
-            return (T) field.get(owner);
-        } catch (IllegalAccessException e) {
-            throw new ReflectionException(e);
-        }
-    }
-
     static <T> T getValueOrThrowException(Field field, Class<?> fieldOwner, Function<Throwable, ? extends RuntimeException> exceptionConverter) {
         try {
             if (Modifier.isStatic(field.getModifiers())) {
@@ -94,6 +84,16 @@ class ReflectionUtils {
         }
     }
 
+    @SuppressWarnings("unchecked") // callers must know what they do here, we can't make this compile safe anyway
+    private static <T> T getValue(Field field, Object owner) {
+        try {
+            field.setAccessible(true);
+            return (T) field.get(owner);
+        } catch (IllegalAccessException e) {
+            throw new ReflectionException(e);
+        }
+    }
+
     static <T> T invokeMethod(Method method, Class<?> methodOwner, Object... args) {
         if (Modifier.isStatic(method.getModifiers())) {
             return invoke(null, method, args);
@@ -102,7 +102,7 @@ class ReflectionUtils {
         }
     }
 
-    @SuppressWarnings("unchecked") // callers must know, what they do here, we can't make this compile safe anyway
+    @SuppressWarnings("unchecked") // callers must know what they do here, we can't make this compile safe anyway
     private static <T> T invoke(Object owner, Method method, Object... args) {
         method.setAccessible(true);
         try {

--- a/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
+++ b/archunit-junit/src/main/java/com/tngtech/archunit/junit/internal/ReflectionUtils.java
@@ -38,20 +38,6 @@ class ReflectionUtils {
     private ReflectionUtils() {
     }
 
-    static Set<Class<?>> getAllSupertypes(Class<?> type) {
-        if (type == null) {
-            return Collections.emptySet();
-        }
-
-        ImmutableSet.Builder<Class<?>> result = ImmutableSet.<Class<?>>builder()
-                .add(type)
-                .addAll(getAllSupertypes(type.getSuperclass()));
-        for (Class<?> c : type.getInterfaces()) {
-            result.addAll(getAllSupertypes(c));
-        }
-        return result.build();
-    }
-
     static Collection<Field> getAllFields(Class<?> owner, Predicate<? super Field> predicate) {
         return getAll(owner, Class::getDeclaredFields).filter(predicate).collect(toList());
     }
@@ -64,6 +50,20 @@ class ReflectionUtils {
         Stream.Builder<T> result = Stream.builder();
         for (Class<?> t : getAllSupertypes(type)) {
             stream(collector.apply(t)).forEach(result);
+        }
+        return result.build();
+    }
+
+    private static Set<Class<?>> getAllSupertypes(Class<?> type) {
+        if (type == null) {
+            return Collections.emptySet();
+        }
+
+        ImmutableSet.Builder<Class<?>> result = ImmutableSet.<Class<?>>builder()
+                .add(type)
+                .addAll(getAllSupertypes(type.getSuperclass()));
+        for (Class<?> c : type.getInterfaces()) {
+            result.addAll(getAllSupertypes(c));
         }
         return result.build();
     }

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
@@ -39,14 +39,6 @@ public class ReflectionUtilsTest {
     }
 
     @Test
-    public void getAllSupertypes() {
-        assertThat(ReflectionUtils.getAllSupertypes(Child.class)).containsOnly(
-                Child.class, ChildInterface.class, UpperMiddle.class, LowerMiddle.class, Parent.class,
-                SomeInterface.class, OtherInterface.class, Object.class
-        );
-    }
-
-    @Test
     public void getAllMethods_of_interface() {
         assertThat(ReflectionUtils.getAllMethods(Subinterface.class, alwaysTrue()))
                 .containsOnly(

--- a/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
+++ b/archunit-junit/src/test/java/com/tngtech/archunit/junit/internal/ReflectionUtilsTest.java
@@ -6,7 +6,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.base.Predicates.alwaysTrue;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.field;
@@ -14,6 +14,7 @@ import static com.tngtech.archunit.testutil.ReflectionTestUtils.method;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReflectionUtilsTest {
+
     @Test
     public void getAllFields() {
         Collection<Field> fields = ReflectionUtils.getAllFields(Child.class, named("field"));

--- a/docs/userguide/009_JUnit_Support.adoc
+++ b/docs/userguide/009_JUnit_Support.adoc
@@ -123,6 +123,25 @@ To import the whole classpath, instead of just the package of the test class, us
 @AnalyzeClasses(wholeClasspath = true)
 ----
 
+Note that `@AnalyzeClasses` can also be used as a meta-annotation to avoid repeating the same configuration:
+
+[source,java,options="nowrap"]
+----
+@Retention(RetentionPolicy.RUNTIME)
+@AnalyzeClasses(packagesOf = MyApplicationRoot.class, importOptions = DoNotIncludeTests.class)
+public @interface AnalyzeMainClasses {}
+----
+
+This annotation can then be used on test classes without repeating the specific configuration of `@AnalyzeClasses`:
+
+[source,java,options="nowrap"]
+----
+@AnalyzeMainClasses
+public class ArchitectureTest {
+    // ...
+}
+----
+
 ==== Controlling the Cache
 
 By default, all classes will be cached by location. This means that between different


### PR DESCRIPTION
so far users are forced to repeat `@AnalyzeClasses` annotation an every test class. This cause additional maintenance overhead when common properties (e.g. package structure) changes. To support the DRY approach, `@AnalzyeClasses` annotation can now be used as meta annotation.

Resolves: #182