### PR TITLE
Exclude test @ test_java_version=8 on macos-latest from CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
           - 8
           - 11
           - 17
+        exclude:
+          - os: macos-latest
+            test_java_version: 8
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
because that JDK cannot be resolved with Gradle 7.6 anymore:

```
A problem occurred evaluating project ':archunit-maven-test'.
> Unable to download toolchain matching the requirements ({languageVersion=8, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse'.
   > Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating project ':archunit-maven-test'.
[...]
Caused by: org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService$MissingToolchainException: Unable to download toolchain matching the requirements ({languageVersion=8, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse'.
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.provisionInstallation(DefaultJavaToolchainProvisioningService.java:143)
	at org.gradle.jvmf.toolchain.internal.install.DefaultJavaToolchainProvisioningService.tryInstall(DefaultJavaToolchainProvisioningService.java:109)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.downloadToolchain(JavaToolchainQueryService.java:138)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.lambda$query$2(JavaToolchainQueryService.java:134)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.query(JavaToolchainQueryService.java:134)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.handleMatchingToolchainUnknown(JavaToolchainQueryService.java:111)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.lambda$findMatchingToolchain$0(JavaToolchainQueryService.java:94)
	at org.gradle.api.internal.provider.DefaultProvider.calculateOwnValue(DefaultProvider.java:72)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:107)
	at org.gradle.api.internal.provider.WithSideEffectProvider.calculateOwnValue(WithSideEffectProvider.java:54)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:107)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:73)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateOwnPresentValue(AbstractMinimalProvider.java:72)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.get(AbstractMinimalProvider.java:92)
	at org.gradle.api.provider.Provider$get.call(Unknown Source)
	at build_5b4tva9yt7dnxo9793h4av88e.run(/Users/runner/work/ArchUnit/ArchUnit/archunit-maven-test/build.gradle:11)
 	at build_5b4tva9yt7dnxo9793h4av88e.run(/Users/runner/work/ArchUnit/ArchUnit/archunit-maven-test/build.gradle:11)
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
	... 161 more
Caused by: org.gradle.api.resources.MissingResourceException: Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.
	at org.gradle.internal.resource.ResourceExceptions.getMissing(ResourceExceptions.java:53)
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.getFileName(DefaultJavaToolchainProvisioningService.java:151)
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.provisionInstallation(DefaultJavaToolchainProvisioningService.java:129)
	... 177 more
```