### PR TITLE
Explicitly set up external JDK for `test` job @ CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,32 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ env.build_java_version }}
+      - name: Set up Test JDK
+        uses: actions/setup-java@v4.2.1
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.test_java_version }}
+      - name: Provide installed JDKs
+        uses: actions/github-script@v7
+        id: provideJdkPaths
+        with:
+          script: |
+            for ( let envVarName in process.env ) {
+              if (/JAVA_HOME_\d.*64/.test(envVarName)) {
+                const version = envVarName.match(/JAVA_HOME_(\d+).*64/)[1];
+                if (version === "${{ matrix.test_java_version }}") {
+                  core.exportVariable('test_jdk_path', process.env[envVarName]);
+                } else if (version === "${{ env.build_java_version }}") {
+                  core.exportVariable('build_jdk_path', process.env[envVarName]);
+                }
+              }
+            }
       - name: Test
         uses: gradle/actions/setup-gradle@v3
+        env:
+          JAVA_HOME: ${{ env.build_jdk_path }}
         with:
-          arguments: test -PallTests -PtestJavaVersion=${{ matrix.test_java_version }}
+          arguments: test -PallTests -PtestJavaVersion=${{ matrix.test_java_version }} -Porg.gradle.java.installations.paths=${{ env.test_jdk_path }}
           cache-disabled: true
 
   integration-test:


### PR DESCRIPTION
(i.e. apply the same workaround as for the `integration-test` job)

because the JDK for `test_java_version=8` @ `macos-latest` cannot be resolved with Gradle 7.6's toolchain anymore:

```
A problem occurred evaluating project ':archunit-maven-test'.
> Unable to download toolchain matching the requirements ({languageVersion=8, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse'.
   > Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.

* Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating project ':archunit-maven-test'.
[...]
Caused by: org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService$MissingToolchainException: Unable to download toolchain matching the requirements ({languageVersion=8, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse'.
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.provisionInstallation(DefaultJavaToolchainProvisioningService.java:143)
	at org.gradle.jvmf.toolchain.internal.install.DefaultJavaToolchainProvisioningService.tryInstall(DefaultJavaToolchainProvisioningService.java:109)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.downloadToolchain(JavaToolchainQueryService.java:138)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.lambda$query$2(JavaToolchainQueryService.java:134)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.query(JavaToolchainQueryService.java:134)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.handleMatchingToolchainUnknown(JavaToolchainQueryService.java:111)
	at org.gradle.jvm.toolchain.internal.JavaToolchainQueryService.lambda$findMatchingToolchain$0(JavaToolchainQueryService.java:94)
	at org.gradle.api.internal.provider.DefaultProvider.calculateOwnValue(DefaultProvider.java:72)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:107)
	at org.gradle.api.internal.provider.WithSideEffectProvider.calculateOwnValue(WithSideEffectProvider.java:54)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:107)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:73)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateOwnPresentValue(AbstractMinimalProvider.java:72)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.get(AbstractMinimalProvider.java:92)
	at org.gradle.api.provider.Provider$get.call(Unknown Source)
	at build_5b4tva9yt7dnxo9793h4av88e.run(/Users/runner/work/ArchUnit/ArchUnit/archunit-maven-test/build.gradle:11)
 	at build_5b4tva9yt7dnxo9793h4av88e.run(/Users/runner/work/ArchUnit/ArchUnit/archunit-maven-test/build.gradle:11)
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
	... 161 more
Caused by: org.gradle.api.resources.MissingResourceException: Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.
	at org.gradle.internal.resource.ResourceExceptions.getMissing(ResourceExceptions.java:53)
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.getFileName(DefaultJavaToolchainProvisioningService.java:151)
	at org.gradle.jvm.toolchain.internal.install.DefaultJavaToolchainProvisioningService.provisionInstallation(DefaultJavaToolchainProvisioningService.java:129)
	... 177 more
```