### PR TITLE
Add support for packages and components in puml files

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlArchCondition.java
@@ -57,12 +57,21 @@ import static java.util.stream.Collectors.joining;
  * classes().should(adhereToPlantUmlDiagram(someDiagramUrl, consideringAllDependencies()));
  * </code></pre>
  * The supported diagram syntax uses component diagram stereotypes to associate package patterns
- * (compare {@link PackageMatcher}) with components. An example could look like
+ * (compare {@link PackageMatcher}) with components. Components can be declared using the
+ * short brackets notation or the long {@code component} notation.
  * <pre><code>
  * [Some Source] &lt;&lt;..some.source..&gt;&gt;
  * [Some Target] &lt;&lt;..some.target..&gt;&gt;
  *
  * [Some Source] --&gt; [Some Target]
+ * </code></pre>
+ * For simplicity and to conform to UML, packages can be used instead of components,
+ * and dependencies can use dashed lines instead of solid lines.
+ * <pre><code>
+ * package "Some Source" &lt;&lt;..some.source..&gt;&gt; as source
+ * package "Some Target" &lt;&lt;..some.target..&gt;&gt; as target
+ *
+ * source ..&gt; target
  * </code></pre>
  * Applying such a diagram as an ArchUnit rule would demand dependencies only from <code>..some.source..</code>
  * to <code>..some.target..</code>, but forbid them vice versa.<br>
@@ -83,12 +92,15 @@ import static java.util.stream.Collectors.joining;
  * <br>
  * A PlantUML diagram used with ArchUnit must abide by a certain set of rules:
  * <ol>
- *     <li>Components must have a name</li>
+ *     <li>Components must have a name, using either the short notation, e.g. <code>[Some Component]</code>,
+ *         or the long notation, e.g. <code>component "Some Component"</code>. Alternately, packages can be used
+ *         instead of components, e.g. <code>package "Some Package"</code>.</li>
  *     <li>Components must have at least one stereotype. Each stereotype in the diagram must be unique</li>
  *     <li>Components may have an optional alias</li>
  *     <li>Components may have an optional color</li>
  *     <li>Components must be defined before declaring dependencies</li>
- *     <li>Dependencies must use arrows only consisting of dashes, pointing right, e.g. <code>--&gt;</code></li>
+ *     <li>Dependencies must use arrows only consisting of dashes, e.g. <code>--&gt;</code>, or points, e
+ *     .g. <code>..&gt;</code></li>
  * </ol>
  */
 @PublicAPI(usage = ACCESS)

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlComponent.java
@@ -91,7 +91,7 @@ class PlantUmlComponent {
                 "componentName=" + componentName +
                 ", stereotypes=" + stereotypes +
                 ", alias=" + alias +
-                ", dependencies=" + dependencies +
+                ", dependencies=" + dependencies.size() +
                 '}';
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
@@ -36,6 +36,7 @@ import static java.util.Collections.singletonList;
 class PlantUmlPatterns {
     private static final String OPTIONAL_COMPONENT_KEYWORD_FORMAT = "(?:component)?";
     private static final String COMPONENT_NAME_GROUP_NAME = "componentName";
+    private static final String LONG_COMPONENT_NAME_GROUP_NAME = "longComponentName";
     private static final String COMPONENT_NAME_FORMAT = "\\[" + capture(anythingBut("\\[\\]"), COMPONENT_NAME_GROUP_NAME) + "]";
 
     private static final String STEREOTYPE_FORMAT = "(?:<<" + capture(anythingBut("<>")) + ">>\\s*)";
@@ -46,9 +47,12 @@ class PlantUmlPatterns {
 
     private static final String COLOR_FORMAT = "\\s*(?:#" + anyOf("\\w|/\\\\-") + "+)?";
 
+    private static final String COMPONENT_PACKAGE_IDENTIFIER = "(?:component|package)";
     private static final Pattern PLANTUML_COMPONENT_PATTERN = Pattern.compile(
-            "^\\s*" + OPTIONAL_COMPONENT_KEYWORD_FORMAT
-                    + "\\s*" + COMPONENT_NAME_FORMAT
+            "^\\s*"
+                    + "(?:" + OPTIONAL_COMPONENT_KEYWORD_FORMAT + "\\s*" + COMPONENT_NAME_FORMAT
+                    + "|" + COMPONENT_PACKAGE_IDENTIFIER + "\\s+\""
+                    + capture("[^\"]*", "longComponentName") + "\")"
                     + "\\s*" + STEREOTYPE_FORMAT + "*"
                     + ALIAS_FORMAT
                     + COLOR_FORMAT
@@ -105,7 +109,11 @@ class PlantUmlPatterns {
         }
 
         String matchComponentName() {
-            return componentMatcher.group(COMPONENT_NAME_GROUP_NAME);
+            String name = componentMatcher.group(COMPONENT_NAME_GROUP_NAME);
+            if (name == null) {
+                return componentMatcher.group(LONG_COMPONENT_NAME_GROUP_NAME);
+            }
+            return name;
         }
 
         Set<String> matchStereoTypes() {

--- a/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlPatterns.java
@@ -36,6 +36,7 @@ import static java.util.Collections.singletonList;
 class PlantUmlPatterns {
     private static final String OPTIONAL_COMPONENT_KEYWORD_FORMAT = "(?:component)?";
     private static final String COMPONENT_NAME_GROUP_NAME = "componentName";
+    private static final String LONG_COMPONENT_NAME_GROUP_NAME = "longComponentName";
     private static final String COMPONENT_NAME_FORMAT = "\\[" + capture(anythingBut("\\[\\]"), COMPONENT_NAME_GROUP_NAME) + "]";
 
     private static final String STEREOTYPE_FORMAT = "(?:<<" + capture(anythingBut("<>")) + ">>\\s*)";
@@ -46,9 +47,12 @@ class PlantUmlPatterns {
 
     private static final String COLOR_FORMAT = "\\s*(?:#" + anyOf("\\w|/\\\\-") + "+)?";
 
+    private static final String COMPONENT_PACKAGE_IDENTIFIER = "(?:component|package)";
     private static final Pattern PLANTUML_COMPONENT_PATTERN = Pattern.compile(
-            "^\\s*" + OPTIONAL_COMPONENT_KEYWORD_FORMAT
-                    + "\\s*" + COMPONENT_NAME_FORMAT
+            "^\\s*"
+                    + "(?:" + OPTIONAL_COMPONENT_KEYWORD_FORMAT + "\\s*" + COMPONENT_NAME_FORMAT
+                    + "|" + COMPONENT_PACKAGE_IDENTIFIER + "\\s+\""
+                    + capture("[^\"]*", "longComponentName") + "\")"
                     + "\\s*" + STEREOTYPE_FORMAT + "*"
                     + ALIAS_FORMAT
                     + COLOR_FORMAT
@@ -105,7 +109,11 @@ class PlantUmlPatterns {
         }
 
         String matchComponentName() {
-            return componentMatcher.group(COMPONENT_NAME_GROUP_NAME);
+            String name = componentMatcher.group(COMPONENT_NAME_GROUP_NAME);
+            if (name == null) {
+                return componentMatcher.group(LONG_COMPONENT_NAME_GROUP_NAME);
+            }
+            return name;
         }
 
         Set<String> matchStereoTypes() {
@@ -124,8 +132,8 @@ class PlantUmlPatterns {
     static class PlantUmlDependencyMatcher {
         private static final String COLOR_REGEX = "\\[[^]]+]"; // for arrows like '--[#green]->'
         private static final String DEPENDENCY_ARROW_CENTER_REGEX = "(left|right|up|down|" + COLOR_REGEX + ")?";
-        private static final Pattern DEPENDENCY_RIGHT_ARROW_PATTERN = Pattern.compile("\\s-+" + DEPENDENCY_ARROW_CENTER_REGEX + "-*>\\s");
-        private static final Pattern DEPENDENCY_LEFT_ARROW_PATTERN = Pattern.compile("\\s<-*" + DEPENDENCY_ARROW_CENTER_REGEX + "-+\\s");
+        private static final Pattern DEPENDENCY_RIGHT_ARROW_PATTERN = Pattern.compile("\\s[-.]+" + DEPENDENCY_ARROW_CENTER_REGEX + "[-.]*>\\s");
+        private static final Pattern DEPENDENCY_LEFT_ARROW_PATTERN = Pattern.compile("\\s<[-.]*" + DEPENDENCY_ARROW_CENTER_REGEX + "[-.]+\\s");
 
         private final String origin;
         private final String target;

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
@@ -35,6 +35,64 @@ public class PlantUmlParserTest {
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
+    public void parses_long_syntax_from_file() {
+        PlantUmlDiagram diagram = parseFile("components-long-syntax.puml");
+
+        verifyComponentLayers(diagram);
+        verifyComponentAlias(diagram);
+    }
+
+    @Test
+    public void parses_packages_from_file() {
+        PlantUmlDiagram diagram = parseFile("packages-long-syntax.puml");
+
+        verifyComponentLayers(diagram);
+        verifyComponentAlias(diagram);
+    }
+
+    private void verifyComponentAlias(PlantUmlDiagram diagram) {
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .satisfiesExactlyInAnyOrder(
+                        c -> assertThat(c.getAlias()).contains(new Alias("web")),
+                        c -> assertThat(c.getAlias()).contains(new Alias("usecase")),
+                        c -> assertThat(c.getAlias()).contains(new Alias("persistence")));
+    }
+
+    @Test
+    public void parses_components_from_file() {
+        PlantUmlDiagram diagram = parseFile("components-short-syntax.puml");
+
+        verifyComponentLayers(diagram);
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .allSatisfy(c -> assertThat(c.getAlias()).isEmpty());
+    }
+
+    private PlantUmlDiagram parseFile(final String fileName) {
+        return parser.parse(PlantUmlParserTest.class.getResource(fileName));
+    }
+
+    private void verifyComponentLayers(PlantUmlDiagram diagram) {
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .satisfiesExactlyInAnyOrder(
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Web API"));
+                            assertThat(c.getDependencies()).hasSize(1);
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..web"));
+                        },
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Use Cases"));
+                            assertThat(c.getDependencies()).hasSize(1);
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..usecase"));
+                        },
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Persistence"));
+                            assertThat(c.getDependencies()).isEmpty();
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..persistence"));
+                        }
+                );
+    }
+
+    @Test
     public void parses_correct_number_of_components() {
         PlantUmlDiagram diagram = createDiagram(TestDiagram.in(temporaryFolder)
                 .component("SomeOrigin").withStereoTypes("..origin..")

--- a/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/plantuml/rules/PlantUmlParserTest.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +29,57 @@ public class PlantUmlParserTest {
 
     @TempDir
     public File temporaryFolder;
+
+    @ParameterizedTest(name = "fileName = {0}")
+    @ValueSource(strings = {"components-long-syntax.puml", "packages-long-syntax.puml"})
+    void parses_long_syntax_from_file(final String fileName) {
+        PlantUmlDiagram diagram = parseFile(fileName);
+
+        verifyComponentLayers(diagram);
+        verifyComponentAlias(diagram);
+    }
+
+    private void verifyComponentAlias(PlantUmlDiagram diagram) {
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .satisfiesExactlyInAnyOrder(
+                        c -> assertThat(c.getAlias()).contains(new Alias("web")),
+                        c -> assertThat(c.getAlias()).contains(new Alias("usecase")),
+                        c -> assertThat(c.getAlias()).contains(new Alias("persistence")));
+    }
+
+    @Test
+    public void parses_components_from_file() {
+        PlantUmlDiagram diagram = parseFile("components-short-syntax.puml");
+
+        verifyComponentLayers(diagram);
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .allSatisfy(c -> assertThat(c.getAlias()).isEmpty());
+    }
+
+    private PlantUmlDiagram parseFile(final String fileName) {
+        return parser.parse(PlantUmlParserTest.class.getResource(fileName));
+    }
+
+    private void verifyComponentLayers(PlantUmlDiagram diagram) {
+        assertThat(diagram.getAllComponents()).hasSize(3)
+                .satisfiesExactlyInAnyOrder(
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Web API"));
+                            assertThat(c.getDependencies()).hasSize(1);
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..web"));
+                        },
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Use Cases"));
+                            assertThat(c.getDependencies()).hasSize(1);
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..usecase"));
+                        },
+                        c -> {
+                            assertThat(c.getComponentName()).isEqualTo(new ComponentName("Persistence"));
+                            assertThat(c.getDependencies()).isEmpty();
+                            assertThat(c.getStereotypes()).contains(new Stereotype("..persistence"));
+                        }
+                );
+    }
 
     @Test
     public void parses_correct_number_of_components() {

--- a/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/components-long-syntax.puml
+++ b/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/components-long-syntax.puml
@@ -1,0 +1,9 @@
+@startuml
+component "Web API" <<..web>> as web
+component "Use Cases" <<..usecase>> as usecase
+component "Persistence" <<..persistence>> as persistence
+
+web --> usecase
+usecase --> persistence
+
+@enduml

--- a/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/components-short-syntax.puml
+++ b/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/components-short-syntax.puml
@@ -1,0 +1,8 @@
+@startuml
+[Web API] <<..web>>
+[Use Cases] <<..usecase>>
+[Persistence] <<..persistence>>
+
+[Web API] --> [Use Cases]
+[Use Cases] --> [Persistence]
+@enduml

--- a/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/packages-long-syntax.puml
+++ b/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/packages-long-syntax.puml
@@ -1,0 +1,9 @@
+@startuml
+package "Web API" <<..web>> as web
+package "Use Cases" <<..usecase>> as usecase
+package "Persistence" <<..persistence>> as persistence
+
+web --> usecase
+usecase --> persistence
+
+@enduml

--- a/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/packages-long-syntax.puml
+++ b/archunit/src/test/resources/com/tngtech/archunit/library/plantuml/rules/packages-long-syntax.puml
@@ -1,0 +1,9 @@
+@startuml
+package "Web API" <<..web>> as web
+package "Use Cases" <<..usecase>> as usecase
+package "Persistence" <<..persistence>> as persistence
+
+web ..> usecase
+usecase ..> persistence
+
+@enduml

--- a/docs/userguide/008_The_Library_API.adoc
+++ b/docs/userguide/008_The_Library_API.adoc
@@ -382,6 +382,26 @@ The way this works is to use the respective package identifiers (compare
 @enduml
 ----
 
+Alternately, packages can be used instead of components:
+
+[plantuml, "long-plantuml-archrule-example", svg, opts=interactive]
+----
+package "Some Source" <<..some.source..>> as source
+package "Some Target" <<..some.target..>> as target
+
+source ..> target
+----
+
+[source,options="nowrap"]
+----
+@startuml
+package "Some Source" <<..some.source..>> as source
+package "Some Target" <<..some.target..>> as target
+
+source ..> target
+@enduml
+----
+
 Consider this diagram applied as a rule via `adhereToPlantUmlDiagram(..)`, then for example
 a class `some.target.Target` accessing `some.source.Source` would be reported as a violation.
 
@@ -418,15 +438,16 @@ classes().should(adhereToPlantUmlDiagram(mydiagram).ignoreDependencies(predicate
 
 A PlantUML diagram used with ArchUnit must abide by a certain set of rules:
 
-1. Components must be declared in the bracket notation (i.e. `[Some Component]`)
+1. Components must be declared using bracket notation (i.e. `[Some Component]`) or long notation
+(i.e. `component "Some Component"`. Alternately, packages can be used instead of components, e.g. `package "Some Package"`.
 2. Components must have at least one (possible multiple) stereotype(s). Each stereotype in the diagram
 must be unique and represent a valid <<Package Identifiers,package identifier>>
 (e.g. `\<<..example..>>` where `..` represents an arbitrary number of packages; compare the core API)
 3. Components may have an optional alias (e.g. `[Some Component] \<<..example..>> as myalias`). The alias must be alphanumeric and must not be quoted.
 4. Components may have an optional color (e.g. `[Some Component] \<<..example..>> #OrangeRed`)
-5. Dependencies must use arrows only consisting of dashes (e.g. `-\->`)
+5. Dependencies must use arrows only consisting of dashes (e.g. `-\->`) or points (e.g. `..>`)
 6. Dependencies may go from left to right `-\->` or right to left `\<--`
-7. Dependencies may consist of any number of dashes (e.g `\->` or `----\->`)
+7. Dependencies may consist of any number of dashes (e.g. `\->` or `----\->`) or points (e.g. `..>` or `.....>`)
 8. Dependencies may contain direction hints (e.g. `-up\->`) or color directives (e.g. `-[#green]\->`)
 
 You can compare this


### PR DESCRIPTION
It makes sense to use packages **or** components as the items that define the allowed dependencies that are checked with the `adhereToPlantUmlDiagram` method (see [documentation](https://www.archunit.org/userguide/html/000_Index.html#_plantuml_component_diagrams_as_rules)). Additionally, the UML typically uses dashed lines to represent dependencies so this PR adds support for dashed or solid lines.

This PR changes the allowed syntax so that the following examples are valid input definitions for `adhereToPlantUmlDiagram`:

```
@startuml
component "Web API" <<..web>> as web
component "Use Cases" <<..usecase>> as usecase
component "Persistence" <<..persistence>> as persistence

web --> usecase
usecase --> persistence
@enduml
```

![components-long-syntax](https://github.com/TNG/ArchUnit/assets/503338/136885c6-4c8e-4a80-9e02-14af0ed57568)

```
@startuml
package "Web API" <<..web>> as web
package "Use Cases" <<..usecase>> as usecase
package "Persistence" <<..persistence>> as persistence

web --> usecase
usecase --> persistence
@enduml
```

<img width="145" height="350" alt="packages-long-syntax" src="https://github.com/user-attachments/assets/c798493a-8d5d-4b0f-97e6-37d6ea84bdd1" />


Note: to keep the regexp simple, the format `component name` without quotation marks is not supported yet, so you always need to specify the name as `component "name"`
