### PR TITLE
fix fail test run with enabled junit.testFilter option

### DIFF
--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitSystemPropertyTestFilterJUnit5.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitSystemPropertyTestFilterJUnit5.java
@@ -48,7 +48,7 @@ class ArchUnitSystemPropertyTestFilterJUnit5 {
         ImmutableSet.copyOf(descriptor.getChildren())
                 .forEach(child -> removeNonMatching(child, shouldRunPredicate));
 
-        if (descriptor.getChildren().isEmpty() && !shouldRunPredicate.test(descriptor)) {
+        if (!descriptor.isRoot() && descriptor.getChildren().isEmpty() && !shouldRunPredicate.test(descriptor)) {
             descriptor.removeFromHierarchy();
         }
     }


### PR DESCRIPTION
Hi! There is a problem if you enable the `junit.testFilter` setting, and there are other tests in the project besides arch-unit
Exception:
```
Caused by: org.junit.platform.commons.PreconditionViolationException: cannot remove the root of a hierarchy
```

In PR fix a condition so that non-ArchUnit descriptors are not checked
Tested the changes in my test repository https://github.com/Sparkymann/archunit-test
Failed workflow: https://github.com/Sparkymann/archunit-test/pull/1/checks
Corrected: https://github.com/Sparkymann/archunit-test/pull/3/checks