### PR TITLE
improve rule to not fail for classes with no tests in their packages

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
@@ -5,6 +5,7 @@ import com.tngtech.archunit.library.testclasses.packages.correct.customsuffix.Im
 import com.tngtech.archunit.library.testclasses.packages.correct.defaultsuffix.ImplementationClassWithCorrectPackage;
 import com.tngtech.archunit.library.testclasses.packages.correct.notest.ImplementationClassWithoutTestClass;
 import com.tngtech.archunit.library.testclasses.packages.correct.onedirmatching.ImplementationClassWithOneTestPackageMatchingOutOfTwo;
+import com.tngtech.archunit.library.testclasses.packages.correct.twoimplementationsonetestdir1.SimpleNameThatOccursInSeveralPackages;
 import com.tngtech.archunit.library.testclasses.packages.incorrect.nodirmatching.ImplementationClassWithMultipleTestsNotMatchingImplementationClassPackage;
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.customsuffix.ImplementationClassWithWrongTestClassPackageCustomSuffix;
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.customsuffix.subdir.ImplementationClassWithWrongTestClassPackageCustomSuffixTestingScenario;
@@ -87,6 +88,16 @@ public class GeneralCodingRulesTest {
                         "does not reside in same package as implementation class <"
                                 + ImplementationClassWithMultipleTestsNotMatchingImplementationClassPackage.class.getName() + ">"
                 );
+    }
+
+    @Test
+    public void should_pass_when_only_one_of_two_implementations_have_test_class_and_it_is_in_implementation_package() {
+        assertThatRule(testClassesShouldResideInTheSamePackageAsImplementation())
+                .checking(new ClassFileImporter().importPackagesOf(
+                        SimpleNameThatOccursInSeveralPackages.class,
+                        com.tngtech.archunit.library.testclasses.packages.incorrect.twoimplementationsonetestdir2.SimpleNameThatOccursInSeveralPackages.class
+                ))
+                .hasNoViolation();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/twoimplementationsonetestdir1/SimpleNameThatOccursInSeveralPackages.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/twoimplementationsonetestdir1/SimpleNameThatOccursInSeveralPackages.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.correct.twoimplementationsonetestdir1;
+
+public class SimpleNameThatOccursInSeveralPackages {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/twoimplementationsonetestdir1/SimpleNameThatOccursInSeveralPackagesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/correct/twoimplementationsonetestdir1/SimpleNameThatOccursInSeveralPackagesTest.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.correct.twoimplementationsonetestdir1;
+
+class SimpleNameThatOccursInSeveralPackagesTest {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/twoimplementationsonetestdir2/SimpleNameThatOccursInSeveralPackages.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/packages/incorrect/twoimplementationsonetestdir2/SimpleNameThatOccursInSeveralPackages.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.packages.incorrect.twoimplementationsonetestdir2;
+
+public class SimpleNameThatOccursInSeveralPackages {
+}


### PR DESCRIPTION
This will improve the existing rule to test that test classes reside in the same package as their implementation. In particular the rule:

Should not fail if there are multiple test classes with the same simple name and some of the classes have no tests at all

Issue: #1367