### PR TITLE
General Coding rule to detect usages of old time and date classes (#1384 / #1385)

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
@@ -509,4 +509,18 @@ public final class GeneralCodingRules {
                     .should(accessTargetWhere(JavaAccess.Predicates.target(annotatedWith(Deprecated.class))).as("access @Deprecated members"))
                     .orShould(dependOnClassesThat(annotatedWith(Deprecated.class)).as("depend on @Deprecated classes"))
                     .because("there should be a better alternative");
+
+    /**
+     * A rule checking that no classes uses old date and time classes and point out to use the Java 8 time API.
+     */
+    @PublicAPI(usage = ACCESS)
+    public static final ArchRule OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED =
+            noClasses()
+                    .should().dependOnClassesThat().haveFullyQualifiedName("java.sql.Date")
+                    .orShould().dependOnClassesThat().haveFullyQualifiedName("java.sql.Time")
+                    .orShould().dependOnClassesThat().haveFullyQualifiedName("java.sql.Timestamp")
+                    .orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Calendar")
+                    .orShould().dependOnClassesThat().haveFullyQualifiedName("java.util.Date")
+                    .as("java.time API should be used")
+                    .because("legacy date/time APIs have been replaced since Java 8 (JSR 310)");
 }

--- a/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
@@ -10,11 +10,17 @@ import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.c
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.customsuffix.subdir.ImplementationClassWithWrongTestClassPackageCustomSuffixTestingScenario;
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.defaultsuffix.ImplementationClassWithWrongTestClassPackage;
 import com.tngtech.archunit.library.testclasses.packages.incorrect.wrongsubdir.defaultsuffix.subdir.ImplementationClassWithWrongTestClassPackageTest;
+import com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaSqlDate;
+import com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaSqlTime;
+import com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaSqlTimestamp;
+import com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaUtilCalender;
+import com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaUtilDate;
 import org.junit.Test;
 
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.library.GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE;
 import static com.tngtech.archunit.library.GeneralCodingRules.DEPRECATED_API_SHOULD_NOT_BE_USED;
+import static com.tngtech.archunit.library.GeneralCodingRules.OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED;
 import static com.tngtech.archunit.library.GeneralCodingRules.testClassesShouldResideInTheSamePackageAsImplementation;
 import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
 
@@ -179,5 +185,45 @@ public class GeneralCodingRulesTest {
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")
     private @interface DeprecatedAnnotation {
+    }
+
+    @Test
+    public void OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_util_date() {
+        assertThatRule(OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED)
+                .hasDescription("java.time API should be used, because legacy date/time APIs have been replaced since Java 8 (JSR 310)")
+                .checking(new ClassFileImporter().importClasses(UsesJavaUtilDate.class))
+                .hasViolationContaining("calls method <java.util.Date");
+    }
+
+    @Test
+    public void OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_sql_timestamp() {
+        assertThatRule(OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED)
+                .hasDescription("java.time API should be used, because legacy date/time APIs have been replaced since Java 8 (JSR 310)")
+                .checking(new ClassFileImporter().importClasses(UsesJavaSqlTimestamp.class))
+                .hasViolationContaining("calls constructor <java.sql.Timestamp");
+    }
+
+    @Test
+    public void OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_sql_time() {
+        assertThatRule(OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED)
+                .hasDescription("java.time API should be used, because legacy date/time APIs have been replaced since Java 8 (JSR 310)")
+                .checking(new ClassFileImporter().importClasses(UsesJavaSqlTime.class))
+                .hasViolationContaining("calls constructor <java.sql.Time");
+    }
+
+    @Test
+    public void OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_sql_date() {
+        assertThatRule(OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED)
+                .hasDescription("java.time API should be used, because legacy date/time APIs have been replaced since Java 8 (JSR 310)")
+                .checking(new ClassFileImporter().importClasses(UsesJavaSqlDate.class))
+                .hasViolationContaining("calls constructor <java.sql.Date");
+    }
+
+    @Test
+    public void OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_util_calender() {
+        assertThatRule(OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED)
+                .hasDescription("java.time API should be used, because legacy date/time APIs have been replaced since Java 8 (JSR 310)")
+                .checking(new ClassFileImporter().importClasses(UsesJavaUtilCalender.class))
+                .hasViolationContaining("calls method <java.util.Calendar");
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlDate.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlDate.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.library.testclasses.timeapi.incorrect;
+
+import java.sql.Date;
+
+public class UsesJavaSqlDate {
+
+    void usesSqlDate() {
+        Date badUsage = new Date(System.currentTimeMillis());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlTime.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlTime.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.library.testclasses.timeapi.incorrect;
+
+import java.sql.Time;
+
+public class UsesJavaSqlTime {
+
+    void usesSqlTimestamp() {
+        Time badUsage = new Time(System.currentTimeMillis());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlTimestamp.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaSqlTimestamp.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.library.testclasses.timeapi.incorrect;
+
+import java.sql.Timestamp;
+
+public class UsesJavaSqlTimestamp {
+
+    void usesSqlTimestamp() {
+        Timestamp badUsage = new Timestamp(System.currentTimeMillis());
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaUtilCalender.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaUtilCalender.java
@@ -1,0 +1,10 @@
+package com.tngtech.archunit.library.testclasses.timeapi.incorrect;
+
+import java.util.Calendar;
+
+public class UsesJavaUtilCalender {
+
+    void usesJavaUtilCalender() {
+        Calendar badUsage = Calendar.getInstance();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaUtilDate.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/timeapi/incorrect/UsesJavaUtilDate.java
@@ -1,0 +1,11 @@
+package com.tngtech.archunit.library.testclasses.timeapi.incorrect;
+
+import java.time.Instant;
+import java.util.Date;
+
+public class UsesJavaUtilDate {
+
+    void usesJavaUtilDate() {
+        Date badDate = Date.from(Instant.now());
+    }
+}


### PR DESCRIPTION
Update:

Provided commit message

```
General coding rule to detect usages of old time and date classes (#1384 / #1385)

With this commit new general rules are added which detect the usages of old
time and date classes, e.g. java.util.Date.

closes #1384
```


-------------------
I would like to provide rules for #1384, but I'm failing with the `OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED_should_fail_when_class_uses_java_util_date` test as my violation is not captured, but this

> [violation details (should have some detail containing 'since Java 8 (and JavaEE 7 if JPA is needed) java.time-API should be used.')] 
Expecting any elements of:
  ["Method <com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaUtilDate.usesJavaUtilDate()> calls method <java.util.Date.from(java.time.Instant)> in (UsesJavaUtilDate.java:9)"]
to match given predicate but none did.
java.lang.AssertionError: [violation details (should have some detail containing 'since Java 8 (and JavaEE 7 if JPA is needed) java.time-API should be used.')] 
Expecting any elements of:
  ["Method <com.tngtech.archunit.library.testclasses.timeapi.incorrect.UsesJavaUtilDate.usesJavaUtilDate()> calls method <java.util.Date.from(java.time.Instant)> in (UsesJavaUtilDate.java:9)"]
to match given predicate but none did.


Can anyone give me a hint how to fix that?


P.S. I know that my formatting (e.g. star import) are not yet correct. Will fix this when my tests are working and before changing this draft into a real PR, including providing a real commit message.
