### PR TITLE
raise error for empty violation store and delete empty rule file

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/library/freeze/StoreEmptyException.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/freeze/StoreEmptyException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2025 TNG Technology Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tngtech.archunit.library.freeze;
+
+class StoreEmptyException extends RuntimeException {
+    StoreEmptyException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
These changes introduce two new features for FreezingRule default store
* Raise error when a freezing rule has zero violations. This can be enabled by setting the property `default.warnEmptyRuleViolation=true`. For backward compatibility it is disabled by default.
* Skip rule violation file creation or delete if it already exists, when there are zero violations. This can be enabled by setting the property `default.deleteEmptyRuleViolation=true`, it is disabled by default.

Signed-off-by: Masoud Kiaeeha <6916434+maxxkia@users.noreply.github.com>

Resolves #1264