### PR TITLE
cleanup obsolete frozen rules

### DIFF
--- a/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/freeze/TextFileBasedViolationStoreTest.java
@@ -2,6 +2,7 @@ package com.tngtech.archunit.library.freeze;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Properties;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import com.tngtech.archunit.lang.ArchRule;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +38,79 @@ public class TextFileBasedViolationStoreTest {
         store.initialize(propertiesOf(
                 "default.path", configuredFolder.getAbsolutePath(),
                 "default.allowStoreCreation", String.valueOf(true)));
+    }
+
+    @Test
+    public void throws_exception_when_there_are_obsolete_entries_in_storedRules_files() throws Exception {
+        // given
+        store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
+        Properties properties = readProperties(new File(configuredFolder, "stored.rules"));
+        File ruleViolationsFile = new File(configuredFolder, properties.getProperty(defaultRule().getDescription()));
+        assertThat(ruleViolationsFile.delete()).isTrue();
+
+        // when && then
+        ThrowableAssert.ThrowingCallable storeInitialization = () -> store.initialize(propertiesOf(
+                "default.path", configuredFolder.getAbsolutePath(),
+                "default.allowStoreUpdate", String.valueOf(false)));
+        assertThatThrownBy(storeInitialization)
+                .isInstanceOf(StoreUpdateFailedException.class)
+                .hasMessage("Failed to remove 1 obsolete stored rule(s). Updating frozen violations is disabled (enable by configuration freeze.store.default.allowStoreUpdate=true)");
+        assertThat(store.contains(defaultRule())).isTrue();
+    }
+
+    @Test
+    public void deletes_obsolete_entries_from_storedRules_files() throws Exception {
+        // given
+        store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
+        Properties properties = readProperties(new File(configuredFolder, "stored.rules"));
+        File ruleViolationsFile = new File(configuredFolder, properties.getProperty(defaultRule().getDescription()));
+        assertThat(ruleViolationsFile.delete()).isTrue();
+
+        // when
+        store.initialize(propertiesOf("default.path", configuredFolder.getAbsolutePath()));
+
+        // then
+        assertThat(store.contains(defaultRule())).isFalse();
+    }
+
+    @Test
+    public void throws_exception_when_there_are_unreferenced_files_in_store_directory() throws Exception {
+        // given
+        store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
+        File propertiesFile = new File(configuredFolder, "stored.rules");
+        Properties properties = readProperties(propertiesFile);
+        File ruleViolationsFile = new File(configuredFolder, properties.getProperty(defaultRule().getDescription()));
+        assertThat(ruleViolationsFile).exists();
+        properties.remove(defaultRule().getDescription());
+        storeProperties(propertiesFile, properties);
+
+        // when && then
+        ThrowableAssert.ThrowingCallable storeInitialization = () -> store.initialize(propertiesOf(
+                "default.path", configuredFolder.getAbsolutePath(),
+                "default.allowStoreUpdate", String.valueOf(false)));
+        assertThatThrownBy(storeInitialization)
+                .isInstanceOf(StoreUpdateFailedException.class)
+                .hasMessage("Failed to remove 1 unreferenced rule files. Updating frozen store is disabled (enable by configuration freeze.store.default.allowStoreUpdate=true)");
+        assertThat(ruleViolationsFile).exists();
+    }
+
+    @Test
+    public void deletes_files_not_referenced_in_storedRules() throws Exception {
+        // given
+        store.save(defaultRule(), ImmutableList.of("first violation", "second violation"));
+        File propertiesFile = new File(configuredFolder, "stored.rules");
+        Properties properties = readProperties(propertiesFile);
+        File ruleViolationsFile = new File(configuredFolder, properties.getProperty(defaultRule().getDescription()));
+        assertThat(ruleViolationsFile).exists();
+        properties.remove(defaultRule().getDescription());
+        storeProperties(propertiesFile, properties);
+
+        // when
+        store.initialize(propertiesOf("default.path", configuredFolder.getAbsolutePath()));
+
+        // then
+        assertThat(store.contains(defaultRule())).isFalse();
+        assertThat(ruleViolationsFile).doesNotExist();
     }
 
     @Test
@@ -124,6 +199,12 @@ public class TextFileBasedViolationStoreTest {
             properties.load(inputStream);
         }
         return properties;
+    }
+
+    private static void storeProperties(File propertiesFile, Properties properties) throws IOException {
+        try (FileOutputStream outputStream = new FileOutputStream(propertiesFile)) {
+            properties.store(outputStream, "");
+        }
     }
 
     private Properties propertiesOf(String... keyValuePairs) {


### PR DESCRIPTION
These changes bring 2 features
* clean up of frozen rules in `stored.rules` where the corresponding file does not exist in the store directory
* clean up of files in store directory which are not referenced in `stored.rules` file
Both of the above operations are enabled using `default.allowStoreUpdate` property. If `default.allowStoreUpdate=false` and obsolete entries or files are found by either of the above operations, the operation fails with an `StoreUpdateFailedException`.

Signed-off-by: Masoud Kiaeeha <6916434+maxxkia@users.noreply.github.com>

Resolves #1264