### PR TITLE
Upgrade dependencies: Support Java 25's class file major version 69

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ ext {
     googleRelocationPackage = "${thirdPartyRelocationPackage}.com.google"
 
     dependency = [
-            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.8'],
-            guava               : [group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'],
-            addGuava            : { dependencyHandler ->
+            asm                  : [group: 'org.ow2.asm', name: 'asm', version: '9.8'],
+            guava                : [group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'],
+            addGuava             : { dependencyHandler ->
                 dependencyHandler(dependency.guava) {
                     exclude module: 'listenablefuture'
                     exclude module: 'jspecify'
@@ -45,36 +45,37 @@ ext {
                     exclude module: 'j2objc-annotations'
                 }
             },
-            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.17'],
-            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.24.3'],
-            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.3'],
-            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.24.3'],
+            slf4j                : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.17'],
+            log4j_api            : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.24.3'],
+            log4j_core           : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.3'],
+            log4j_slf4j          : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.24.3'],
 
-            junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit5Jupiter       : [group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.2'],
-            junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.11.2'],
-            junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.11.2'],
-            junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.11.2'],
-            junitPlatformEngine : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.11.2'],
-            hamcrest            : [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'],
-            junit_dataprovider  : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
-            mockito             : [group: 'org.mockito', name: 'mockito-core', version: '4.11.0'],  // mockito 5 requires Java 11
-            mockito_junit5      : [group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'],
-            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.27.3'],
-            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.27.3'],
+            junit4               : [group: 'junit', name: 'junit', version: '4.13.2'],
+            junit5Jupiter        : [group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.12.2'],
+            junit5VintageEngine  : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.12.2'],
+            junitPlatform        : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.12.2'],
+            junitPlatformCommons : [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.12.2'],
+            junitPlatformEngine  : [group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.12.2'],
+            junitPlatformLauncher: [group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.12.2'],
+            hamcrest             : [group: 'org.hamcrest', name: 'hamcrest-core', version: '1.3'],
+            junit_dataprovider   : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
+            mockito              : [group: 'org.mockito', name: 'mockito-core', version: '4.11.0'],  // mockito 5 requires Java 11
+            mockito_junit5       : [group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'],
+            assertj              : [group: 'org.assertj', name: 'assertj-core', version: '3.27.3'],
+            assertj_guava        : [group: 'org.assertj', name: 'assertj-guava', version: '3.27.3'],
 
             // Dependencies for example projects / tests
-            javaxAnnotationApi  : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],
-            springBeans         : [group: 'org.springframework', name: 'spring-beans', version: '5.3.23'],
-            springBootLoader    : [group: 'org.springframework.boot', name: 'spring-boot-loader', version: '2.7.13'],
-            jakartaInject       : [group: 'jakarta.inject', name: 'jakarta.inject-api', version: '2.0.1'],
-            jakartaAnnotations  : [group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '2.1.1'],
-            guice               : [group: 'com.google.inject', name: 'guice', version: '5.1.0'],
+            javaxAnnotationApi   : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],
+            springBeans          : [group: 'org.springframework', name: 'spring-beans', version: '5.3.23'],
+            springBootLoader     : [group: 'org.springframework.boot', name: 'spring-boot-loader', version: '2.7.13'],
+            jakartaInject        : [group: 'jakarta.inject', name: 'jakarta.inject-api', version: '2.0.1'],
+            jakartaAnnotations   : [group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '2.1.1'],
+            guice                : [group: 'com.google.inject', name: 'guice', version: '5.1.0'],
             // NOTE: The pure javaee-api dependencies are crippled, so to run any test we need to choose a full implementation provider
-            geronimoEjb         : [group: 'org.apache.geronimo.specs', name: 'geronimo-ejb_3.1_spec', version: '1.0.2'],
-            geronimoJpa         : [group: 'org.apache.geronimo.specs', name: 'geronimo-jpa_2.0_spec', version: '1.1'],
-            jodaTime            : [group: 'joda-time', name: 'joda-time', version: '2.12.7'],
-            joox                : [group: 'org.jooq', name: 'joox-java-6', version: '1.6.0']
+            geronimoEjb          : [group: 'org.apache.geronimo.specs', name: 'geronimo-ejb_3.1_spec', version: '1.0.2'],
+            geronimoJpa          : [group: 'org.apache.geronimo.specs', name: 'geronimo-jpa_2.0_spec', version: '1.1'],
+            jodaTime             : [group: 'joda-time', name: 'joda-time', version: '2.12.7'],
+            joox                 : [group: 'org.jooq', name: 'joox-java-6', version: '1.6.0']
     ]
 
     minSupportedJavaVersion = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,11 @@ ext {
 
     dependency = [
             asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.8'],
-            guava               : [group: 'com.google.guava', name: 'guava', version: '33.3.1-jre'],
+            guava               : [group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'],
             addGuava            : { dependencyHandler ->
                 dependencyHandler(dependency.guava) {
                     exclude module: 'listenablefuture'
-                    exclude module: 'jsr305'
-                    exclude module: 'checker-qual'
+                    exclude module: 'jspecify'
                     exclude module: 'error_prone_annotations'
                     exclude module: 'j2objc-annotations'
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,10 @@ ext {
                     exclude module: 'j2objc-annotations'
                 }
             },
-            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'],
-            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.24.1'],
-            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.1'],
-            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.24.1'],
+            slf4j               : [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.17'],
+            log4j_api           : [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.24.3'],
+            log4j_core          : [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.3'],
+            log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.24.3'],
 
             junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
             junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.11.2'],
@@ -61,8 +61,8 @@ ext {
             junit_dataprovider  : [group: 'com.tngtech.java', name: 'junit-dataprovider', version: '1.11.0'],
             mockito             : [group: 'org.mockito', name: 'mockito-core', version: '4.11.0'],  // mockito 5 requires Java 11
             mockito_junit5      : [group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.6.1'],
-            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.26.3'],
-            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.26.3'],
+            assertj             : [group: 'org.assertj', name: 'assertj-core', version: '3.27.3'],
+            assertj_guava       : [group: 'org.assertj', name: 'assertj-guava', version: '3.27.3'],
 
             // Dependencies for example projects / tests
             javaxAnnotationApi  : [group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'],

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     googleRelocationPackage = "${thirdPartyRelocationPackage}.com.google"
 
     dependency = [
-            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.7.1'],
+            asm                 : [group: 'org.ow2.asm', name: 'asm', version: '9.8'],
             guava               : [group: 'com.google.guava', name: 'guava', version: '33.3.1-jre'],
             addGuava            : { dependencyHandler ->
                 dependencyHandler(dependency.guava) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,7 @@ ext {
             log4j_slf4j         : [group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.24.3'],
 
             junit4              : [group: 'junit', name: 'junit', version: '4.13.2'],
-            junit5JupiterApi    : [group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.11.2'],
-            junit5JupiterEngine : [group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.11.2'],
+            junit5Jupiter       : [group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.2'],
             junit5VintageEngine : [group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.11.2'],
             junitPlatform       : [group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.11.2'],
             junitPlatformCommons: [group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.11.2'],

--- a/buildSrc/src/main/groovy/archunit.java-testing-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-testing-conventions.gradle
@@ -9,9 +9,8 @@ abstract class ArchUnitTestExtension {
 ext.archUnitTest = extensions.create('archUnitTest', ArchUnitTestExtension)
 
 dependencies {
-    testImplementation dependency.junit5JupiterApi
+    testImplementation dependency.junit5Jupiter
 
-    testRuntimeOnly dependency.junit5JupiterEngine
     testRuntimeOnly dependency.junit5VintageEngine
     testRuntimeOnly dependency.log4j_slf4j
 }

--- a/buildSrc/src/main/groovy/archunit.java-testing-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-testing-conventions.gradle
@@ -12,6 +12,7 @@ dependencies {
     testImplementation dependency.junit5Jupiter
 
     testRuntimeOnly dependency.junit5VintageEngine
+    testRuntimeOnly dependency.junitPlatformLauncher
     testRuntimeOnly dependency.log4j_slf4j
 }
 

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.11.2</version>
+            <version>1.12.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/buildSrc/src/main/resources/release_check/archunit.pom
+++ b/buildSrc/src/main/resources/release_check/archunit.pom
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR upgrades

* [ASM](https://asm.ow2.io/versions.html): 9.7.1 → 9.8 – supporting Java 25's class file major version 69 
  * resolves #1439
* [Guava](https://github.com/google/guava): 33.3.1-jre → 33.4.8-jre
* [SLF4J](http://www.slf4j.org): 2.0.16 → 2.0.17
* [JUnit](https://junit.org/junit5/): 5.11.2 → 5.12.2

and for tests:
* [Log4j](https://logging.apache.org/log4j/2.x/): 2.24.1 → 2.24.3
* [AssertJ](https://assertj.github.io/doc/): 3.26.3 → 3.27.3

It reduces the memory footprint of  `ClassFileImporterSlowTest` by exluding classes from `sun` packages.
* resolves #1446 