### PR TITLE
Enable generate display name config in examples

### DIFF
--- a/archunit-example/example-junit4/src/test/resources/archunit.properties
+++ b/archunit-example/example-junit4/src/test/resources/archunit.properties
@@ -1,1 +1,2 @@
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true

--- a/archunit-example/example-junit5/src/test/resources/archunit.properties
+++ b/archunit-example/example-junit5/src/test/resources/archunit.properties
@@ -1,1 +1,2 @@
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true

--- a/archunit-example/example-plain/src/test/resources/archunit.properties
+++ b/archunit-example/example-plain/src/test/resources/archunit.properties
@@ -1,3 +1,4 @@
 extension.archunit-example-extension.enabled=false
 extension.archunit-example-extension.example-prop=exampleValue
 freeze.store.default.path=src/test/resources/frozen
+junit.displayName.replaceUnderscoresBySpaces=true


### PR DESCRIPTION


Enable the config to "generate more readable names in the test report by replacing underscores in the original rule names by space" in the examples

#Hacktoberfest
