### PR TITLE
add support for dependencies from caught exceptions

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -648,6 +648,11 @@ public final class JavaClass
     }
 
     @PublicAPI(usage = ACCESS)
+    public Set<TryCatchBlock> getTryCatchBlocks() {
+        return members.getTryCatchBlocks();
+    }
+
+    @PublicAPI(usage = ACCESS)
     public Set<ReferencedClassObject> getReferencedClassObjects() {
         return members.getReferencedClassObjects();
     }
@@ -1330,6 +1335,14 @@ public final class JavaClass
     @PublicAPI(usage = ACCESS)
     public Set<ThrowsDeclaration<JavaMethod>> getMethodThrowsDeclarationsWithTypeOfSelf() {
         return reverseDependencies.getMethodThrowsDeclarationsWithTypeOf(this);
+    }
+
+    /**
+     * @return {@link TryCatchBlock TryCatchBlocks} of all imported classes that declare to catch this class.
+     */
+    @PublicAPI(usage = ACCESS)
+    public Set<TryCatchBlock> getTryCatchBlocksThatCatchSelf() {
+        return reverseDependencies.getTryCatchBlocksThatCatch(this);
     }
 
     /**

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -47,6 +47,7 @@ class JavaClassDependencies {
                         returnTypeDependenciesFromSelf(),
                         codeUnitParameterDependenciesFromSelf(),
                         throwsDeclarationDependenciesFromSelf(),
+                        tryCatchBlockDependenciesFromSelf(),
                         annotationDependenciesFromSelf(),
                         instanceofCheckDependenciesFromSelf(),
                         referencedClassObjectDependenciesFromSelf(),
@@ -164,6 +165,11 @@ class JavaClassDependencies {
     private Stream<Dependency> throwsDeclarationDependenciesFromSelf() {
         return javaClass.getThrowsDeclarations().stream()
                 .flatMap(throwsDeclaration -> Dependency.tryCreateFromThrowsDeclaration(throwsDeclaration).stream());
+    }
+
+    private Stream<Dependency> tryCatchBlockDependenciesFromSelf() {
+        return javaClass.getTryCatchBlocks().stream()
+                .flatMap(tryCatchBlock -> Dependency.tryCreateFromTryCatchBlock(tryCatchBlock).stream());
     }
 
     private Stream<Dependency> annotationDependenciesFromSelf() {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassMembers.java
@@ -191,6 +191,14 @@ class JavaClassMembers {
         return result.build();
     }
 
+    Set<TryCatchBlock> getTryCatchBlocks() {
+        ImmutableSet.Builder<TryCatchBlock> result = ImmutableSet.builder();
+        for (JavaCodeUnit codeUnit : codeUnits) {
+            result.addAll(codeUnit.getTryCatchBlocks());
+        }
+        return result.build();
+    }
+
     Set<ReferencedClassObject> getReferencedClassObjects() {
         ImmutableSet.Builder<ReferencedClassObject> result = ImmutableSet.builder();
         for (JavaCodeUnit codeUnit : codeUnits) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ReverseDependencies.java
@@ -41,6 +41,7 @@ final class ReverseDependencies {
     private final SetMultimap<JavaClass, JavaMethod> methodParameterTypeDependencies;
     private final SetMultimap<JavaClass, JavaMethod> methodReturnTypeDependencies;
     private final SetMultimap<JavaClass, ThrowsDeclaration<JavaMethod>> methodsThrowsDeclarationDependencies;
+    private final SetMultimap<JavaClass, TryCatchBlock> tryCatchBlockDependencies;
     private final SetMultimap<JavaClass, JavaConstructor> constructorParameterTypeDependencies;
     private final SetMultimap<JavaClass, ThrowsDeclaration<JavaConstructor>> constructorThrowsDeclarationDependencies;
     private final SetMultimap<JavaClass, JavaAnnotation<?>> annotationTypeDependencies;
@@ -58,6 +59,7 @@ final class ReverseDependencies {
         this.methodParameterTypeDependencies = creation.methodParameterTypeDependencies.build();
         this.methodReturnTypeDependencies = creation.methodReturnTypeDependencies.build();
         this.methodsThrowsDeclarationDependencies = creation.methodsThrowsDeclarationDependencies.build();
+        this.tryCatchBlockDependencies = creation.tryCatchBlockDependencies.build();
         this.constructorParameterTypeDependencies = creation.constructorParameterTypeDependencies.build();
         this.constructorThrowsDeclarationDependencies = creation.constructorThrowsDeclarationDependencies.build();
         this.annotationTypeDependencies = creation.annotationTypeDependencies.build();
@@ -114,6 +116,10 @@ final class ReverseDependencies {
         return methodsThrowsDeclarationDependencies.get(clazz);
     }
 
+    Set<TryCatchBlock> getTryCatchBlocksThatCatch(JavaClass clazz) {
+        return tryCatchBlockDependencies.get(clazz);
+    }
+
     Set<JavaConstructor> getConstructorsWithParameterTypeOf(JavaClass clazz) {
         return constructorParameterTypeDependencies.get(clazz);
     }
@@ -150,6 +156,7 @@ final class ReverseDependencies {
         private final ImmutableSetMultimap.Builder<JavaClass, JavaMethod> methodParameterTypeDependencies = ImmutableSetMultimap.builder();
         private final ImmutableSetMultimap.Builder<JavaClass, JavaMethod> methodReturnTypeDependencies = ImmutableSetMultimap.builder();
         private final ImmutableSetMultimap.Builder<JavaClass, ThrowsDeclaration<JavaMethod>> methodsThrowsDeclarationDependencies = ImmutableSetMultimap.builder();
+        private final ImmutableSetMultimap.Builder<JavaClass, TryCatchBlock> tryCatchBlockDependencies = ImmutableSetMultimap.builder();
         private final ImmutableSetMultimap.Builder<JavaClass, JavaConstructor> constructorParameterTypeDependencies = ImmutableSetMultimap.builder();
         private final ImmutableSetMultimap.Builder<JavaClass, ThrowsDeclaration<JavaConstructor>> constructorThrowsDeclarationDependencies = ImmutableSetMultimap.builder();
         private final ImmutableSetMultimap.Builder<JavaClass, JavaAnnotation<?>> annotationTypeDependencies = ImmutableSetMultimap.builder();
@@ -200,6 +207,11 @@ final class ReverseDependencies {
                 for (ThrowsDeclaration<JavaMethod> throwsDeclaration : method.getThrowsClause()) {
                     methodsThrowsDeclarationDependencies.put(throwsDeclaration.getRawType(), throwsDeclaration);
                 }
+                for (TryCatchBlock tryCatchBlock : method.getTryCatchBlocks()) {
+                    for (JavaClass caughtThrowable : tryCatchBlock.getCaughtThrowables()) {
+                        tryCatchBlockDependencies.put(caughtThrowable.toErasure(), tryCatchBlock);
+                    }
+                }
                 for (InstanceofCheck instanceofCheck : method.getInstanceofChecks()) {
                     instanceofCheckDependencies.put(instanceofCheck.getRawType(), instanceofCheck);
                 }
@@ -213,6 +225,11 @@ final class ReverseDependencies {
                 }
                 for (ThrowsDeclaration<JavaConstructor> throwsDeclaration : constructor.getThrowsClause()) {
                     constructorThrowsDeclarationDependencies.put(throwsDeclaration.getRawType(), throwsDeclaration);
+                }
+                for (TryCatchBlock tryCatchBlock : constructor.getTryCatchBlocks()) {
+                    for (JavaClass caughtThrowable : tryCatchBlock.getCaughtThrowables()) {
+                        tryCatchBlockDependencies.put(caughtThrowable.toErasure(), tryCatchBlock);
+                    }
                 }
                 for (InstanceofCheck instanceofCheck : constructor.getInstanceofChecks()) {
                     instanceofCheckDependencies.put(instanceofCheck.getRawType(), instanceofCheck);
@@ -252,11 +269,16 @@ final class ReverseDependencies {
         }
 
         private void registerStaticInitializer(JavaClass clazz) {
-            if (clazz.getStaticInitializer().isPresent()) {
-                for (InstanceofCheck instanceofCheck : clazz.getStaticInitializer().get().getInstanceofChecks()) {
+            clazz.getStaticInitializer().ifPresent(staticInitializer -> {
+                for (TryCatchBlock tryCatchBlock : staticInitializer.getTryCatchBlocks()) {
+                    for (JavaClass caughtThrowable : tryCatchBlock.getCaughtThrowables()) {
+                        tryCatchBlockDependencies.put(caughtThrowable.toErasure(), tryCatchBlock);
+                    }
+                }
+                for (InstanceofCheck instanceofCheck : staticInitializer.getInstanceofChecks()) {
                     instanceofCheckDependencies.put(instanceofCheck.getRawType(), instanceofCheck);
                 }
-            }
+            });
         }
 
         void finish(Iterable<JavaClass> classes) {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/DependencyTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import com.google.common.base.MoreObjects;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.testobjects.ClassWithArrayDependencies;
+import com.tngtech.archunit.core.domain.testobjects.ClassWithDependencyOnCaughtException;
 import com.tngtech.archunit.core.domain.testobjects.ClassWithDependencyOnInstanceofCheck;
 import com.tngtech.archunit.core.domain.testobjects.ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget;
 import com.tngtech.archunit.core.domain.testobjects.DependenciesOnClassObjects;
@@ -192,6 +193,66 @@ public class DependencyTest {
         assertThatType(dependency.getTargetClass()).matches(IOException.class);
         assertThat(dependency.getDescription()).as("description")
                 .contains("Method <" + origin.getFullName() + "> throws type <" + IOException.class.getName() + ">");
+    }
+
+    static Stream<Arguments> with_try_catch_block_members() {
+        JavaClass javaClass = importClassesWithContext(ClassWithDependencyOnCaughtException.class, IOException.class)
+                .get(ClassWithDependencyOnCaughtException.class);
+
+        return Stream.of(
+                arguments(javaClass.getStaticInitializer().get(), 9),
+                arguments(javaClass.getConstructor(), 16),
+                arguments(javaClass.getMethod("simpleCatchClauseMethod"), 23)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("with_try_catch_block_members")
+    void Dependency_from_simple_catch_clause(JavaCodeUnit memberWithTryCatchBlock, int expectedLineNumber) {
+        TryCatchBlock tryCatchBlock = getOnlyElement(memberWithTryCatchBlock.getTryCatchBlocks());
+
+        Dependency dependency = getOnlyElement(Dependency.tryCreateFromTryCatchBlock(tryCatchBlock));
+
+        Assertions.assertThatDependency(dependency)
+                .satisfies(catchesType(IOException.class, memberWithTryCatchBlock, expectedLineNumber, ClassWithDependencyOnCaughtException.class));
+    }
+
+    private static Consumer<Dependency> catchesType(Class<? extends Throwable> targetClass, JavaCodeUnit javaCodeUnit, int expectedLineNumber, Class<?> originClass) {
+        return dependency -> Assertions.assertThatDependency(dependency)
+                .matches(originClass, targetClass)
+                .hasDescription(javaCodeUnit.getFullName(), "catches type", targetClass.getName())
+                .inLocation(originClass, expectedLineNumber);
+    }
+
+    @Test
+    void Dependency_from_union_catch_clause() {
+        JavaMethod method = importClassesWithContext(ClassWithDependencyOnCaughtException.class, IllegalStateException.class, IOException.class)
+                .get(ClassWithDependencyOnCaughtException.class)
+                .getMethod("unionCatchClauseMethod");
+        TryCatchBlock tryCatchBlock = getOnlyElement(method.getTryCatchBlocks());
+
+        Set<Dependency> dependencies = Dependency.tryCreateFromTryCatchBlock(tryCatchBlock);
+
+        Assertions.assertThatDependencies(dependencies).satisfiesExactlyInAnyOrder(
+                catchesType(IllegalStateException.class, method, 30, ClassWithDependencyOnCaughtException.class),
+                catchesType(IOException.class, method, 30, ClassWithDependencyOnCaughtException.class)
+        );
+    }
+
+    @Test
+    void Dependency_from_multiple_catch_clauses() {
+        JavaMethod method = importClassesWithContext(ClassWithDependencyOnCaughtException.class, IllegalStateException.class, IOException.class)
+                .get(ClassWithDependencyOnCaughtException.class)
+                .getMethod("multipleCatchClausesMethod");
+        TryCatchBlock tryCatchBlock = getOnlyElement(method.getTryCatchBlocks());
+
+        Set<Dependency> dependencies = Dependency.tryCreateFromTryCatchBlock(tryCatchBlock);
+
+        Assertions.assertThatDependencies(dependencies).satisfiesExactlyInAnyOrder(
+                catchesType(IllegalStateException.class, method, 37, ClassWithDependencyOnCaughtException.class),
+                catchesType(RuntimeException.class, method, 37, ClassWithDependencyOnCaughtException.class),
+                catchesType(IOException.class, method, 37, ClassWithDependencyOnCaughtException.class)
+        );
     }
 
     static Stream<Arguments> with_instanceof_check_members() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -27,13 +27,19 @@ import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.core.domain.testobjects.AAccessingB;
+import com.tngtech.archunit.core.domain.testobjects.ACatchingBException;
 import com.tngtech.archunit.core.domain.testobjects.AExtendingSuperAImplementingInterfaceForA;
 import com.tngtech.archunit.core.domain.testobjects.AReferencingB;
+import com.tngtech.archunit.core.domain.testobjects.AThrowingBException;
 import com.tngtech.archunit.core.domain.testobjects.AhavingMembersOfTypeB;
 import com.tngtech.archunit.core.domain.testobjects.AllPrimitiveDependencies;
 import com.tngtech.archunit.core.domain.testobjects.ArrayComponentTypeDependencies;
 import com.tngtech.archunit.core.domain.testobjects.B;
+import com.tngtech.archunit.core.domain.testobjects.BException1;
+import com.tngtech.archunit.core.domain.testobjects.BException2;
+import com.tngtech.archunit.core.domain.testobjects.BException3;
 import com.tngtech.archunit.core.domain.testobjects.BReferencedByA;
+import com.tngtech.archunit.core.domain.testobjects.ClassWithDependencyOnInstanceofCheck;
 import com.tngtech.archunit.core.domain.testobjects.ComponentTypeDependency;
 import com.tngtech.archunit.core.domain.testobjects.DependenciesOnClassObjects;
 import com.tngtech.archunit.core.domain.testobjects.InterfaceForA;
@@ -804,26 +810,158 @@ public class JavaClassTest {
         JavaClass javaClass = importClasses(AhavingMembersOfTypeB.class, B.class).get(AhavingMembersOfTypeB.class);
 
         assertThat(javaClass.getDirectDependenciesFromSelf())
+                .areAtLeastOne(fieldTypeDependency()
+                        .from(AhavingMembersOfTypeB.class)
+                        .to(B.class)
+                        .inLineNumber(0))
                 .areAtLeastOne(methodReturnTypeDependency()
                         .from(AhavingMembersOfTypeB.class)
                         .to(B.class)
                         .inLineNumber(0))
-                .areAtLeastOne(methodThrowsDeclarationDependency()
+                .areAtLeast(2, parameterTypeDependency()
                         .from(AhavingMembersOfTypeB.class)
-                        .to(B.BException.class)
+                        .to(B.class)
+                        .inLineNumber(0));
+    }
+
+    @Test
+    void direct_dependencies_to_self_by_member_declarations() {
+        JavaClass javaClass = importClassesWithContext(AhavingMembersOfTypeB.class, B.class).get(B.class);
+
+        assertThat(javaClass.getDirectDependenciesToSelf())
+                .areAtLeastOne(fieldTypeDependency()
+                        .from(AhavingMembersOfTypeB.class)
+                        .to(B.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(methodReturnTypeDependency()
+                        .from(AhavingMembersOfTypeB.class)
+                        .to(B.class)
                         .inLineNumber(0))
                 .areAtLeast(2, parameterTypeDependency()
                         .from(AhavingMembersOfTypeB.class)
                         .to(B.class)
-                        .inLineNumber(0))
+                        .inLineNumber(0));
+    }
+
+    @Test
+    void direct_dependencies_from_self_by_instanceof_checks() {
+        JavaClass javaClass = importClasses(ClassWithDependencyOnInstanceofCheck.class, ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                .get(ClassWithDependencyOnInstanceofCheck.class);
+
+        assertThat(javaClass.getDirectDependenciesFromSelf())
                 .areAtLeastOne(methodChecksInstanceOfDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(6))
+                .areAtLeastOne(methodChecksInstanceOfDependency()
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(9))
+                .areAtLeastOne(methodChecksInstanceOfDependency()
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(13));
+    }
+
+    @Test
+    void direct_dependencies_to_self_by_instanceof_checks() {
+        JavaClass javaClass = importClasses(ClassWithDependencyOnInstanceofCheck.class, ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                .get(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class);
+
+        assertThat(javaClass.getDirectDependenciesToSelf())
+                .areAtLeastOne(methodChecksInstanceOfDependency()
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(6))
+                .areAtLeastOne(methodChecksInstanceOfDependency()
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(9))
+                .areAtLeastOne(methodChecksInstanceOfDependency()
+                        .from(ClassWithDependencyOnInstanceofCheck.class)
+                        .to(ClassWithDependencyOnInstanceofCheck.InstanceOfCheckTarget.class)
+                        .inLineNumber(13));
+    }
+
+    @Test
+    void direct_dependencies_from_self_by_catch_clauses() {
+        JavaClass javaClass = importClasses(ACatchingBException.class, BException1.class)
+                .get(ACatchingBException.class);
+
+        assertThat(javaClass.getDirectDependenciesFromSelf())
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
                         .inLineNumber(7))
-                .areAtLeastOne(methodChecksInstanceOfDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(25));
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(14))
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(21));
+    }
+
+    @Test
+    void direct_dependencies_to_self_by_catch_clause() {
+        JavaClass javaClass = importClasses(ACatchingBException.class, BException1.class)
+                .get(BException1.class);
+
+        assertThat(javaClass.getDirectDependenciesToSelf())
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(7))
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(14))
+                .areAtLeastOne(codeUnitTryCatchDependency()
+                        .from(ACatchingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(21));
+    }
+
+    @Test
+    void direct_dependencies_from_self_by_throws_clause() {
+        JavaClass javaClass = importClasses(AThrowingBException.class, BException1.class, BException2.class, BException3.class)
+                .get(AThrowingBException.class);
+
+        assertThat(javaClass.getDirectDependenciesFromSelf())
+                .areAtLeastOne(methodThrowsDeclarationDependency()
+                        .from(AThrowingBException.class)
+                        .to(BException1.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(methodThrowsDeclarationDependency()
+                        .from(AThrowingBException.class)
+                        .to(BException2.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(methodThrowsDeclarationDependency()
+                        .from(AThrowingBException.class)
+                        .to(BException3.class)
+                        .inLineNumber(0));
+    }
+
+    static Stream<Arguments> with_throws_dependencies() {
+        return Stream.of(
+                arguments(BException1.class, AThrowingBException.class, 0),
+                arguments(BException2.class, AThrowingBException.class, 0),
+                arguments(BException3.class, AThrowingBException.class, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("with_throws_dependencies")
+    void direct_dependencies_to_self_by_throws_clause(Class<? extends Throwable> selfClass, Class<?> throwingClass, int expectedLineNumber) {
+        JavaClass javaClass = importClasses(selfClass, throwingClass)
+                .get(selfClass);
+
+        assertThat(javaClass.getDirectDependenciesToSelf())
+                .areAtLeastOne(methodThrowsDeclarationDependency()
+                        .from(throwingClass)
+                        .to(selfClass)
+                        .inLineNumber(expectedLineNumber));
     }
 
     @Test
@@ -1275,42 +1413,6 @@ public class JavaClassTest {
                 .contain(from(FirstClass.class).to(BufferedInputStream.class).inLocation(getClass(), 0)
                         .withDescriptionContaining("depends on component type <%s>", BufferedInputStream.class.getName())
                 );
-    }
-
-    @Test
-    public void direct_dependencies_to_self_by_member_declarations() {
-        JavaClass javaClass = importClassesWithContext(AhavingMembersOfTypeB.class, B.class).get(B.class);
-
-        assertThat(javaClass.getDirectDependenciesToSelf())
-                .areAtLeastOne(fieldTypeDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(0))
-                .areAtLeastOne(methodReturnTypeDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(0))
-                .areAtLeast(2, parameterTypeDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(0))
-                .areAtLeastOne(methodChecksInstanceOfDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(7))
-                .areAtLeastOne(methodChecksInstanceOfDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.class)
-                        .inLineNumber(25));
-
-        JavaClass exceptionClass = importClassesWithContext(AhavingMembersOfTypeB.class, B.BException.class)
-                .get(B.BException.class);
-
-        assertThat(exceptionClass.getDirectDependenciesToSelf())
-                .areAtLeastOne(methodThrowsDeclarationDependency()
-                        .from(AhavingMembersOfTypeB.class)
-                        .to(B.BException.class)
-                        .inLineNumber(0));
     }
 
     @Test
@@ -2090,6 +2192,10 @@ public class JavaClassTest {
 
     private static DependencyConditionCreation methodThrowsDeclarationDependency() {
         return new DependencyConditionCreation("throws type");
+    }
+
+    private static DependencyConditionCreation codeUnitTryCatchDependency() {
+        return new DependencyConditionCreation("catches type");
     }
 
     private static DependencyConditionCreation methodChecksInstanceOfDependency() {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ACatchingBException.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ACatchingBException.java
@@ -1,0 +1,25 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+@SuppressWarnings("unused")
+public class ACatchingBException {
+    static {
+        try {
+            new AThrowingBException();
+        } catch (BException1 e) {
+        }
+    }
+
+    public ACatchingBException() {
+        try {
+            new AThrowingBException();
+        } catch (BException1 e) {
+        }
+    }
+
+    void method() {
+        try {
+            new AThrowingBException();
+        } catch (BException1 e) {
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/AThrowingBException.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/AThrowingBException.java
@@ -1,0 +1,16 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+@SuppressWarnings({"unused"})
+public class AThrowingBException {
+    public AThrowingBException() throws BException1 {
+        throw new BException1();
+    }
+
+    static void throwingBException2() throws BException2 {
+        throw new BException2();
+    }
+
+    public void throwingBException3() throws BException3 {
+        throw new BException3();
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/AhavingMembersOfTypeB.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/AhavingMembersOfTypeB.java
@@ -1,12 +1,11 @@
 package com.tngtech.archunit.core.domain.testobjects;
 
 @DomainAnnotation
-@SuppressWarnings({"RedundantThrows", "unused"})
+@SuppressWarnings("unused")
 public class AhavingMembersOfTypeB {
     private B b;
-    private boolean staticInitializerInstanceofCheck = new Object() instanceof B;
 
-    public AhavingMembersOfTypeB(B b) throws B.BException {
+    public AhavingMembersOfTypeB(B b) {
         this.b = b;
     }
 
@@ -15,13 +14,5 @@ public class AhavingMembersOfTypeB {
     }
 
     void methodWithParameterTypeB(String some, B b) {
-    }
-
-    void throwingBException() throws B.BException {
-
-    }
-
-    void checkingInstanceOfB() {
-        boolean check = new Object() instanceof B;
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/B.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/B.java
@@ -6,8 +6,4 @@ public class B {
 
     void call() {
     }
-
-    public static class BException extends Exception {
-
-    }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException1.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException1.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+public class BException1 extends Exception {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException2.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException2.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+public class BException2 extends Exception {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException3.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/BException3.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+public class BException3 extends Exception {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ClassWithDependencyOnCaughtException.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/testobjects/ClassWithDependencyOnCaughtException.java
@@ -1,0 +1,43 @@
+package com.tngtech.archunit.core.domain.testobjects;
+
+import java.io.IOException;
+
+@SuppressWarnings("unused")
+public class ClassWithDependencyOnCaughtException {
+    static {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+        }
+    }
+
+    ClassWithDependencyOnCaughtException() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+        }
+    }
+
+    void simpleCatchClauseMethod() {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+        }
+    }
+
+    void unionCatchClauseMethod() {
+        try {
+            throw new IOException();
+        } catch (IllegalStateException | IOException e) {
+        }
+    }
+
+    void multipleCatchClausesMethod() {
+        try {
+            throw new IOException();
+        } catch (IllegalStateException e) {
+        } catch (RuntimeException e) {
+        } catch (IOException e) {
+        }
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAccessesTest.java
@@ -83,6 +83,7 @@ import com.tngtech.archunit.core.importer.testexamples.integration.ClassD;
 import com.tngtech.archunit.core.importer.testexamples.integration.ClassXDependingOnClassesABCD;
 import com.tngtech.archunit.core.importer.testexamples.integration.InterfaceOfClassX;
 import com.tngtech.archunit.core.importer.testexamples.specialtargets.ClassCallingSpecialTarget;
+import com.tngtech.archunit.core.importer.testexamples.trycatch.CatchClauseTargetException;
 import com.tngtech.archunit.core.importer.testexamples.trycatch.ClassHoldingMethods;
 import com.tngtech.archunit.core.importer.testexamples.trycatch.ClassWithComplexTryCatchBlocks;
 import com.tngtech.archunit.core.importer.testexamples.trycatch.ClassWithSimpleTryCatchBlocks;
@@ -889,7 +890,7 @@ public class ClassFileImporterAccessesTest {
                         .atLocation(ClassWithComplexTryCatchBlocks.class, 14)
                 ).areExactly(1, tryCatchBlock()
                         .declaredIn(constructor)
-                        .catching(IllegalArgumentException.class, UnsupportedOperationException.class)
+                        .catching(IllegalArgumentException.class, UnsupportedOperationException.class, CatchClauseTargetException.class)
                         .atLocation(ClassWithComplexTryCatchBlocks.class, 17)
                 ).areExactly(1, tryCatchBlock()
                         .declaredIn(constructor)

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/CatchClauseTargetException.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/CatchClauseTargetException.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.importer.testexamples.trycatch;
+
+public class CatchClauseTargetException extends RuntimeException {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithComplexTryCatchBlocks.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithComplexTryCatchBlocks.java
@@ -15,7 +15,7 @@ public class ClassWithComplexTryCatchBlocks {
             someOtherObject.toString();
             try {
                 instanceOne.doSomething();
-            } catch (IllegalArgumentException | UnsupportedOperationException e) {
+            } catch (IllegalArgumentException | UnsupportedOperationException | CatchClauseTargetException e) {
             }
         } catch (Exception e) {
         } finally {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithSimpleTryCatchBlocks.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/trycatch/ClassWithSimpleTryCatchBlocks.java
@@ -15,6 +15,8 @@ public class ClassWithSimpleTryCatchBlocks {
             System.out.println("Error1");
         } catch (IllegalArgumentException e) {
             System.out.println("Error2");
+        } catch (CatchClauseTargetException e) {
+            System.out.println("Error3");
         } finally {
             System.out.println("finally");
         }

--- a/archunit/src/test/java/com/tngtech/archunit/library/LayeredArchitectureTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/LayeredArchitectureTest.java
@@ -23,12 +23,14 @@ import com.tngtech.archunit.library.testclasses.dependencysettings.forbidden_bac
 import com.tngtech.archunit.library.testclasses.dependencysettings.forbidden_forwards.DependencySettingsForbiddenByMayOnlyAccess;
 import com.tngtech.archunit.library.testclasses.dependencysettings.origin.DependencySettingsOriginClass;
 import com.tngtech.archunit.library.testclasses.dependencysettings_outside.DependencySettingsOutsideOfLayersBeingAccessedByLayers;
+import com.tngtech.archunit.library.testclasses.first.any.pkg.ClassWithCatch;
 import com.tngtech.archunit.library.testclasses.first.any.pkg.FirstAnyPkgClass;
 import com.tngtech.archunit.library.testclasses.first.three.any.FirstThreeAnyClass;
 import com.tngtech.archunit.library.testclasses.mayonlyaccesslayers.forbidden.MayOnlyAccessLayersForbiddenClass;
 import com.tngtech.archunit.library.testclasses.mayonlyaccesslayers.origin.MayOnlyAccessLayersOriginClass;
 import com.tngtech.archunit.library.testclasses.second.three.any.SecondThreeAnyClass;
 import com.tngtech.archunit.library.testclasses.some.pkg.SomePkgClass;
+import com.tngtech.archunit.library.testclasses.some.pkg.SomePkgException;
 import com.tngtech.archunit.library.testclasses.some.pkg.sub.SomePkgSubclass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -208,7 +210,8 @@ public class LayeredArchitectureTest {
                         expectedAccessViolationPattern(FirstThreeAnyClass.class, "call", FirstAnyPkgClass.class, "callMe"),
                         expectedFieldTypePattern(FirstAnyPkgClass.class, "illegalTarget", SomePkgSubclass.class),
                         expectedFieldTypePattern(FirstThreeAnyClass.class, "illegalTarget", FirstAnyPkgClass.class),
-                        expectedFieldTypePattern(SecondThreeAnyClass.class, "illegalTarget", SomePkgClass.class)));
+                        expectedFieldTypePattern(SecondThreeAnyClass.class, "illegalTarget", SomePkgClass.class),
+                        expectedCatchPattern(ClassWithCatch.class, "method", SomePkgException.class)));
     }
 
     static Stream<RuleWithIgnore> toIgnore() {
@@ -481,6 +484,10 @@ public class LayeredArchitectureTest {
     @SuppressWarnings("SameParameterValue")
     private static String expectedInheritancePattern(Class<?> child, Class<?> parent) {
         return String.format("Class .*%s.* extends class .*.%s.*", child.getSimpleName(), parent.getSimpleName());
+    }
+
+    static String expectedCatchPattern(Class<?> from, String fromMethod, Class<? extends Throwable> to) {
+        return String.format(".*%s.%s().*catches type.*%s.*", quote(from.getName()), fromMethod, quote(to.getName()));
     }
 
     static String expectedEmptyLayerPattern(String layerName) {

--- a/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/dependencies/SliceTest.java
@@ -3,10 +3,12 @@ package com.tngtech.archunit.library.dependencies;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.library.testclasses.first.any.pkg.ClassOnlyDependentOnOwnPackageAndObject;
+import com.tngtech.archunit.library.testclasses.first.any.pkg.ClassWithCatch;
 import com.tngtech.archunit.library.testclasses.first.any.pkg.FirstAnyPkgClass;
 import com.tngtech.archunit.library.testclasses.first.three.any.FirstThreeAnyClass;
 import com.tngtech.archunit.library.testclasses.second.any.pkg.SecondAnyClass;
 import com.tngtech.archunit.library.testclasses.second.three.any.SecondThreeAnyClass;
+import com.tngtech.archunit.library.testclasses.some.pkg.SomePkgException;
 import com.tngtech.archunit.library.testclasses.some.pkg.sub.SomePkgSubclass;
 import org.junit.Test;
 
@@ -26,6 +28,8 @@ public class SliceTest {
                         .from(ClassOnlyDependentOnOwnPackageAndObject.class).to(Object.class)
                         .from(FirstThreeAnyClass.class).to(Object.class)
                         .from(FirstThreeAnyClass.class).to(SecondThreeAnyClass.class)
+                        .from(ClassWithCatch.class).to(Object.class)
+                        .from(ClassWithCatch.class).to(SomePkgException.class)
         );
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/first/any/pkg/ClassWithCatch.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/first/any/pkg/ClassWithCatch.java
@@ -1,0 +1,15 @@
+package com.tngtech.archunit.library.testclasses.first.any.pkg;
+
+import com.tngtech.archunit.library.testclasses.some.pkg.SomePkgException;
+
+public class ClassWithCatch {
+    void method() {
+        try {
+            callForTry();
+        } catch (SomePkgException e) {
+        }
+    }
+
+    void callForTry() {
+    }
+}

--- a/archunit/src/test/java/com/tngtech/archunit/library/testclasses/some/pkg/SomePkgException.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/testclasses/some/pkg/SomePkgException.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.library.testclasses.some.pkg;
+
+public class SomePkgException extends RuntimeException {
+}


### PR DESCRIPTION
Referencing an exception class in the `catch` clause of a try-catch block can certainly be considered a dependency on that class, similar to a `throws` clause or an `instanceof` check: if the referenced class is renamed or deleted, the dependent code will break.

To prevent this from happening, one could write architecture rules that e.g. limit the use of a certain third-party library to a specific layer, or allow-list only certain "stable" or "vetted" classes.

Unfortunately, such rules will not notice when exception classes are referenced in `catch` clauses of try-catch blocks. The reason is that so far, ArchUnit does not generate a `Dependency` for them (it only does that once a member of the exception class is used, e.g. calling a method). This behavior defeats the purpose of implementing such a rule in the first place.

Thus, we change ArchUnit so that it considers each exception type referenced in `catch` clauses of try-catch blocks to be a dependency on that type. As the information is already available in the model via `TryCatchBlock.caughtThrowables`, all it takes is wiring it up to creation and handling of `Dependency` instances.

Resolves: #1232