### PR TITLE
Allow package info classes to be resolved as a dependency

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/DomainObjectCreationContext.java
@@ -76,6 +76,10 @@ public class DomainObjectCreationContext {
         javaClass.completeClassHierarchyFrom(importContext);
     }
 
+    public static void completePackage(JavaClass javaClass, ImportContext importContext) {
+        javaClass.completePackageInfoFrom(importContext);
+    }
+
     public static void completeEnclosingDeclaration(JavaClass javaClass, ImportContext importContext) {
         javaClass.completeEnclosingDeclarationFrom(importContext);
     }

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -16,6 +16,7 @@
 package com.tngtech.archunit.core.domain;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -1429,6 +1430,13 @@ public final class JavaClass
         completionProcess.markClassHierarchyComplete();
     }
 
+    void completePackageInfoFrom(ImportContext context) {
+        this.javaPackage = JavaPackage.from(Arrays.asList(
+                this,
+                context.resolveClass(this.getPackageName() + ".package-info")));
+        completionProcess.markPackageComplete();
+    }
+
     private void completeSuperclassFrom(ImportContext context) {
         Optional<JavaClass> rawSuperclass = context.createSuperclass(this);
         if (rawSuperclass.isPresent()) {
@@ -1663,6 +1671,10 @@ public final class JavaClass
             @Override
             public void markDependenciesComplete() {
             }
+
+            @Override
+            public void markPackageComplete() {
+            }
         };
 
         abstract boolean hasFinished();
@@ -1683,6 +1695,8 @@ public final class JavaClass
 
         public abstract void markDependenciesComplete();
 
+        public abstract void markPackageComplete();
+
         static CompletionProcess start() {
             return new FullCompletionProcess();
         }
@@ -1701,6 +1715,7 @@ public final class JavaClass
         private boolean membersComplete = false;
         private boolean annotationsComplete = false;
         private boolean dependenciesComplete = false;
+        private boolean packageComplete = false;
 
         @Override
         boolean hasFinished() {
@@ -1711,7 +1726,8 @@ public final class JavaClass
                     && genericInterfacesComplete
                     && membersComplete
                     && annotationsComplete
-                    && dependenciesComplete;
+                    && dependenciesComplete
+                    && packageComplete;
         }
 
         @Override
@@ -1752,6 +1768,11 @@ public final class JavaClass
         @Override
         public void markDependenciesComplete() {
             this.dependenciesComplete = true;
+        }
+
+        @Override
+        public void markPackageComplete() {
+            this.packageComplete = true;
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -99,7 +99,15 @@ class ClassFileProcessor {
             }
             importRecord.addInterfaces(ownerName, interfaceNames);
             dependencyResolutionProcess.registerSupertypes(interfaceNames);
-        }
+            if(!className.endsWith(".package-info")) {
+                if(className.contains(".")) {
+                    String packageName = className.substring(0, className.lastIndexOf("."));
+                    dependencyResolutionProcess.registerPackageInfo(packageName + ".package-info");
+                } else {
+                    dependencyResolutionProcess.registerPackageInfo("package-info");
+                }
+            }
+    }
 
         @Override
         public void onDeclaredTypeParameters(JavaClassTypeParametersBuilder typeParametersBuilder) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -73,6 +73,7 @@ import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.compl
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeGenericInterfaces;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeGenericSuperclass;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeMembers;
+import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completePackage;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.completeTypeParameters;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createInstanceofCheck;
 import static com.tngtech.archunit.core.domain.DomainObjectCreationContext.createJavaClasses;
@@ -119,6 +120,7 @@ class ClassGraphCreator implements ImportContext {
             completeGenericInterfaces(javaClass, this);
             completeMembers(javaClass, this);
             completeAnnotations(javaClass, this);
+            completePackage(javaClass, this);
         }
     }
 

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DependencyResolutionProcess.java
@@ -64,6 +64,11 @@ class DependencyResolutionProcess {
     private final int maxRunsForGenericSignatureTypes = getConfiguredIterations(
             MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME, MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_DEFAULT_VALUE);
 
+    static final String MAX_ITERATIONS_FOR_PACKAGE_INFO_PROPERTY_NAME = "maxIterationsForPackageInfo";
+    static final int MAX_ITERATIONS_FOR_PACKAGE_INFO_DEFAULT_VALUE = -1;
+    private final int maxRunsForPackageInfo = getConfiguredIterations(
+            MAX_ITERATIONS_FOR_PACKAGE_INFO_PROPERTY_NAME, MAX_ITERATIONS_FOR_PACKAGE_INFO_DEFAULT_VALUE);
+
     private Set<String> currentTypeNames = new HashSet<>();
     private int runNumber = 1;
     private boolean shouldContinue;
@@ -112,6 +117,12 @@ class DependencyResolutionProcess {
 
     void registerGenericSignatureType(String typeName) {
         if (runNumberHasNotExceeded(maxRunsForGenericSignatureTypes)) {
+            currentTypeNames.add(typeName);
+        }
+    }
+
+    void registerPackageInfo(String typeName) {
+        if (runNumberHasNotExceeded(maxRunsForPackageInfo)) {
             currentTypeNames.add(typeName);
         }
     }

--- a/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/metrics/MetricsComponents.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -121,7 +122,12 @@ public final class MetricsComponents<T> extends ForwardingCollection<MetricsComp
     public static MetricsComponents<JavaClass> fromPackages(Collection<JavaPackage> packages) {
         ImmutableSet.Builder<MetricsComponent<JavaClass>> components = ImmutableSet.builder();
         for (JavaPackage javaPackage : packages) {
-            components.add(MetricsComponent.of(javaPackage.getName(), javaPackage.getClassesInPackageTree()));
+            components.add(MetricsComponent.of(
+                    javaPackage.getName(),
+                    javaPackage.getClassesInPackageTree().stream()
+                            .filter(jc -> !jc.getSimpleName().equals("package-info"))
+                            .collect(Collectors.toList())
+            ));
         }
         return MetricsComponents.of(components.build());
     }

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.tngtech.archunit.base.ArchUnitException.InvalidSyntaxUsageException;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.base.HasDescription;
+import com.tngtech.archunit.core.domain.packageexamples.annotated.PackageLevelAnnotation;
+import com.tngtech.archunit.core.domain.packageexamples.annotated.WithinAnnotatedPackage;
 import com.tngtech.archunit.core.domain.testobjects.AAccessingB;
 import com.tngtech.archunit.core.domain.testobjects.AExtendingSuperAImplementingInterfaceForA;
 import com.tngtech.archunit.core.domain.testobjects.AReferencingB;
@@ -1593,6 +1595,13 @@ public class JavaClassTest {
         assertThat(JavaClass.Functions.GET_PACKAGE_NAME.apply(javaClass))
                 .as("result of GET_PACKAGE_NAME(clazz)")
                 .isEqualTo(javaClass.getPackageName());
+
+        JavaClass javaClassInAnnotatedPackage = importClassWithContext(WithinAnnotatedPackage.class);
+
+        assertThat(JavaClass.Functions.GET_PACKAGE.apply(javaClassInAnnotatedPackage)
+                .isAnnotatedWith(PackageLevelAnnotation.class))
+                .as("package info is available")
+                .isTrue();
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaPackageTest.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.packageexamples.annotated.PackageLevelAnnotation;
@@ -423,6 +424,15 @@ public class JavaPackageTest {
         JavaPackage nonAnnotatedPackage = importPackage("packageexamples");
 
         assertThat(annotatedPackage.getPackageInfo()).isNotNull();
+        assertThat(annotatedPackage.getClasses())
+                .hasSize(3);
+        assertThat(annotatedPackage.getClasses().stream().map(JavaClass::getFullName).collect(Collectors.toList()))
+                .as("all classes and package-info are loaded as JavaClass")
+                .containsExactlyInAnyOrder(
+                        "com.tngtech.archunit.core.domain.packageexamples.annotated.package-info",
+                        "com.tngtech.archunit.core.domain.packageexamples.annotated.PackageLevelAnnotation",
+                        "com.tngtech.archunit.core.domain.packageexamples.annotated.WithinAnnotatedPackage"
+                );
 
         assertThatThrownBy(nonAnnotatedPackage::getPackageInfo)
                 .isInstanceOf(IllegalArgumentException.class)

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/annotated/WithinAnnotatedPackage.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/packageexamples/annotated/WithinAnnotatedPackage.java
@@ -1,0 +1,4 @@
+package com.tngtech.archunit.core.domain.packageexamples.annotated;
+
+public class WithinAnnotatedPackage {
+}

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAutomaticResolutionTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -22,10 +23,12 @@ import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaConstructorReference;
 import com.tngtech.archunit.core.domain.JavaEnumConstant;
+import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaMethodReference;
+import com.tngtech.archunit.core.domain.JavaPackage;
 import com.tngtech.archunit.core.domain.JavaParameterizedType;
 import com.tngtech.archunit.core.domain.JavaType;
 import com.tngtech.archunit.core.domain.JavaWildcardType;
@@ -33,6 +36,7 @@ import com.tngtech.archunit.core.domain.ReferencedClassObject;
 import com.tngtech.archunit.core.domain.ThrowsDeclaration;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.core.importer.DependencyResolutionProcessTestUtils.ImporterWithAdjustedResolutionRuns;
+import com.tngtech.archunit.core.importer.testexamples.OtherClass;
 import com.tngtech.archunit.core.importer.testexamples.SomeAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.ClassWithUnimportedAnnotation;
 import com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters;
@@ -44,9 +48,11 @@ import com.tngtech.archunit.core.importer.testexamples.annotationresolution.Anot
 import com.tngtech.archunit.core.importer.testexamples.annotationresolution.SomeAnnotationWithAnnotationParameter;
 import com.tngtech.archunit.core.importer.testexamples.annotationresolution.SomeAnnotationWithClassParameter;
 import com.tngtech.archunit.core.importer.testexamples.classhierarchyresolution.Child;
+import com.tngtech.archunit.core.importer.testexamples.packageinforesolution.ClassThatReferencesOtherClass;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,6 +66,7 @@ import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_GENERIC_SIGNATURE_TYPES_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_SUPERTYPES_PROPERTY_NAME;
+import static com.tngtech.archunit.core.importer.DependencyResolutionProcess.MAX_ITERATIONS_FOR_PACKAGE_INFO_PROPERTY_NAME;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.OTHER_VALUE;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.SOME_VALUE;
 import static com.tngtech.archunit.core.importer.testexamples.annotatedparameters.ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithTwoAnnotations;
@@ -619,6 +626,33 @@ public class ClassFileImporterAutomaticResolutionTest {
         JavaClass outermost = lessOuter.getEnclosingClass().get();
         assertThat(outermost).isFullyImported(true);
         assertThatType(outermost).matches(Outermost.class);
+    }
+
+    @Test
+    public void automatically_resolves_packages() {
+        JavaClass otherClass = new ClassFileImporter()
+                .importClass(OtherClass.class);
+
+        JavaPackage checkedClassPackageInfo = otherClass.getPackage();
+        assertThat(checkedClassPackageInfo.getAnnotations()).hasSize(1);
+        assertThat(checkedClassPackageInfo.isAnnotatedWith(SomeAnnotation.class)).isTrue();
+    }
+
+    @Test
+    public void automatically_resolves_dependency_packages() {
+        JavaClass checkedClass = ImporterWithAdjustedResolutionRuns
+                .disableAllIterationsExcept(MAX_ITERATIONS_FOR_PACKAGE_INFO_PROPERTY_NAME, MAX_ITERATIONS_FOR_MEMBER_TYPES_PROPERTY_NAME)
+                .importClass(ClassThatReferencesOtherClass.class);
+
+        Optional<JavaField> firstField = checkedClass.getAllFields().stream().findFirst();
+        assertThat(firstField).isPresent();
+        JavaClass otherClass = firstField.get().getRawType();
+        assertThat(otherClass).isFullyImported(true);
+
+        JavaPackage otherClassPackageInfo = otherClass.getPackage();
+
+        Assertions.assertThat(otherClassPackageInfo.getAnnotations()).hasSize(1);
+        Assertions.assertThat(otherClassPackageInfo.isAnnotatedWith(SomeAnnotation.class)).isTrue();
     }
 
     @DataProvider

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/packageinforesolution/ClassThatReferencesOtherClass.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/packageinforesolution/ClassThatReferencesOtherClass.java
@@ -1,0 +1,7 @@
+package com.tngtech.archunit.core.importer.testexamples.packageinforesolution;
+
+import com.tngtech.archunit.core.importer.testexamples.OtherClass;
+
+public class ClassThatReferencesOtherClass {
+    OtherClass otherClass;
+}


### PR DESCRIPTION
Allow package info classes to be resolved as a dependency 
exclude package-info classes from package metrics calculations

Resolves #1564