### PR TITLE
fix description of targetOwner predicate

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -15,9 +15,6 @@
  */
 package com.tngtech.archunit.core.domain;
 
-import java.util.Collections;
-import java.util.Set;
-
 import com.tngtech.archunit.PublicAPI;
 import com.tngtech.archunit.base.ChainableFunction;
 import com.tngtech.archunit.base.DescribedPredicate;
@@ -28,6 +25,9 @@ import com.tngtech.archunit.core.domain.properties.HasOwner;
 import com.tngtech.archunit.core.domain.properties.HasOwner.Functions.Get;
 import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
+
+import java.util.Collections;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -112,7 +112,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
     @Override
     public String toString() {
         return getClass().getSimpleName() +
-                "{origin=" + origin + ", target=" + target + ", lineNumber=" + getLineNumber() + additionalToStringFields() + '}';
+               "{origin=" + origin + ", target=" + target + ", lineNumber=" + getLineNumber() + additionalToStringFields() + '}';
     }
 
     String additionalToStringFields() {
@@ -168,12 +168,16 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaAccess<?>> targetOwner(DescribedPredicate<? super JavaClass> predicate) {
-            return target(Get.<JavaClass>owner().is(predicate));
+            DescribedPredicate<JavaAccess<?>> targetPredicate =
+                    predicate.onResultOf(JavaAccess.Functions.Get.target()
+                            .then(HasOwner.Functions.Get.owner()));
+            return targetPredicate.as("owner %s", predicate.getDescription());
         }
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaAccess<?>> target(DescribedPredicate<? super AccessTarget> predicate) {
-            return new TargetPredicate<>(predicate);
+            DescribedPredicate<JavaAccess<?>> targetPredicate = predicate.onResultOf(JavaAccess.Functions.Get.target());
+            return targetPredicate.as("target %s", predicate.getDescription());
         }
 
         private static class OriginOwnerEqualsTargetOwnerPredicate extends DescribedPredicate<JavaAccess<?>> {

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
@@ -61,6 +61,32 @@ public class JavaAccessTest {
     }
 
     @Test
+    public void target_predicate() {
+        DescribedPredicate<JavaAccess<?>> predicate =
+                JavaAccess.Predicates.target(DescribedPredicate.<AccessTarget>alwaysTrue().as("some text"));
+
+        assertThat(predicate)
+                .hasDescription("target some text")
+                .accepts(anyAccess());
+
+        predicate = JavaAccess.Predicates.target(alwaysFalse());
+        assertThat(predicate).rejects(anyAccess());
+    }
+
+    @Test
+    public void targetOwner_predicate() {
+        DescribedPredicate<JavaAccess<?>> predicate =
+                JavaAccess.Predicates.targetOwner(DescribedPredicate.<JavaClass>alwaysTrue().as("some text"));
+
+        assertThat(predicate)
+                .hasDescription("owner some text")
+                .accepts(anyAccess());
+
+        predicate = JavaAccess.Predicates.targetOwner(alwaysFalse());
+        assertThat(predicate).rejects(anyAccess());
+    }
+
+    @Test
     public void convertTo() {
         TestJavaAccess access = javaAccessFrom(importClassWithContext(String.class), "toString")
                 .to(Object.class, "toString")


### PR DESCRIPTION

targetOwner was producing the same message as target() eg. "access target where target is annotated with..." instead of "access target where owner is annotated with..."