### PR TITLE
add haveDependenciesThat condition to  ArchConditions

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/conditions/ArchConditions.java
@@ -315,6 +315,14 @@ public final class ArchConditions {
     }
 
     @PublicAPI(usage = ACCESS)
+    public static ArchCondition<JavaClass> haveAnyDependenciesThat(DescribedPredicate<? super Dependency> predicate) {
+        return new AnyDependencyCondition(
+                "have any dependencies that " + predicate.getDescription(),
+                predicate,
+                GET_DIRECT_DEPENDENCIES_FROM_SELF);
+    }
+
+    @PublicAPI(usage = ACCESS)
     public static ArchCondition<JavaClass> transitivelyDependOnClassesThat(DescribedPredicate<? super JavaClass> predicate) {
         return new TransitiveDependencyCondition(predicate);
     }

--- a/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/lang/conditions/ArchConditionsTest.java
@@ -36,7 +36,9 @@ import static com.tngtech.archunit.lang.conditions.ArchConditions.callMethodWher
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containAnyElementThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.containOnlyElementsThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.declareThrowableOfType;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.dependOnClassesThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.have;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.haveAnyDependenciesThat;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.never;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.not;
 import static com.tngtech.archunit.lang.conditions.ArchConditions.onlyBeAccessedByAnyPackage;
@@ -161,6 +163,38 @@ public class ArchConditionsTest {
         assertThat(onlyHaveDependentsWhere(DescribedPredicate.<Dependency>alwaysTrue().as("custom")))
                 .hasDescription("only have dependents where custom")
                 .checking(accessedClass)
+                .containNoViolation();
+    }
+
+    @Test
+    public void depend_on_classes_that() {
+        JavaClasses classes = importClasses(CallingClass.class, SomeClass.class);
+        JavaClass callingClass = classes.get(CallingClass.class);
+
+        assertThat(dependOnClassesThat(alwaysFalse()))
+                .checking(callingClass)
+                .haveAtLeastOneViolationMessageMatching(String.format(".*%s.*%s.*",
+                        quote(CallingClass.class.getName()), quote(SomeClass.class.getName())));
+
+        assertThat(dependOnClassesThat(DescribedPredicate.<JavaClass>alwaysTrue().as("custom")))
+                .hasDescription("depend on classes that custom")
+                .checking(callingClass)
+                .containNoViolation();
+    }
+
+    @Test
+    public void have_any_dependencies_that() {
+        JavaClasses classes = importClasses(CallingClass.class, SomeClass.class);
+        JavaClass callingClass = classes.get(CallingClass.class);
+
+        assertThat(haveAnyDependenciesThat(alwaysFalse()))
+                .checking(callingClass)
+                .haveAtLeastOneViolationMessageMatching(String.format(".*%s.*%s.*",
+                        quote(CallingClass.class.getName()), quote(SomeClass.class.getName())));
+
+        assertThat(haveAnyDependenciesThat(DescribedPredicate.<Dependency>alwaysTrue().as("custom")))
+                .hasDescription("have any dependencies that custom")
+                .checking(callingClass)
                 .containNoViolation();
     }
 


### PR DESCRIPTION
there is not a good way to craft such a condition with current Public APIs

the use case I want this for is:
```
noClasses()
.should(
  haveAnyDependenciesThat(
    not(resideInSamePackage())
      .and(dependencyTarget(annotatedWith(Deprecated.class)))
    )
  )
``` 
where `resideInSamePackage()` is a DescribedPredicate<Dependency> which requires comparing the target and the owner in the same condition