### PR TITLE
enforce unix linebreaks to allow builds on windows machines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix line endings (LF) for all java files
+*.java text=auto eol=lf


### PR DESCRIPTION
When running a gradle build on a windows machine, spotless complaints about incorrect formatting after a fresh checkout, which is not fixed by `spotlessApply`. By enforcing UNIX line breaks in spotless and git, the build and style check also work on windows machines