### PR TITLE
fix descriptions of targetOwner and originOwner predicates in JavaAccess

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaAccess.java
@@ -25,13 +25,13 @@ import com.tngtech.archunit.base.HasDescription;
 import com.tngtech.archunit.core.Convertible;
 import com.tngtech.archunit.core.domain.properties.HasName;
 import com.tngtech.archunit.core.domain.properties.HasOwner;
-import com.tngtech.archunit.core.domain.properties.HasOwner.Functions.Get;
 import com.tngtech.archunit.core.domain.properties.HasSourceCodeLocation;
 import com.tngtech.archunit.core.importer.DomainBuilders.JavaAccessBuilder;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
+import static com.tngtech.archunit.core.domain.properties.HasOwner.Predicates.With.owner;
 
 @PublicAPI(usage = ACCESS)
 public abstract class JavaAccess<TARGET extends AccessTarget>
@@ -153,7 +153,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaAccess<?>> originOwner(DescribedPredicate<? super JavaClass> predicate) {
-            return origin(Get.<JavaClass>owner().is(predicate));
+            return origin(owner(predicate));
         }
 
         @PublicAPI(usage = ACCESS)
@@ -168,7 +168,7 @@ public abstract class JavaAccess<TARGET extends AccessTarget>
 
         @PublicAPI(usage = ACCESS)
         public static DescribedPredicate<JavaAccess<?>> targetOwner(DescribedPredicate<? super JavaClass> predicate) {
-            return target(Get.<JavaClass>owner().is(predicate));
+            return target(owner(predicate));
         }
 
         @PublicAPI(usage = ACCESS)

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaAccessTest.java
@@ -1,13 +1,13 @@
 package com.tngtech.archunit.core.domain;
 
-import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.domain.JavaAccess.Functions.Get;
+import com.tngtech.archunit.core.domain.TestUtils.CapturingDescribedPredicate;
 import com.tngtech.archunit.core.importer.testexamples.SomeClass;
 import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 import org.junit.Test;
 
-import static com.tngtech.archunit.base.DescribedPredicate.alwaysFalse;
+import static com.tngtech.archunit.core.domain.TestUtils.alwaysTrueCapturingPredicateWithDescription;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.importClassesWithContext;
 import static com.tngtech.archunit.core.domain.TestUtils.newMethodCallBuilder;
@@ -49,15 +49,50 @@ public class JavaAccessTest {
 
     @Test
     public void origin_predicate() {
-        DescribedPredicate<JavaAccess<?>> predicate =
-                JavaAccess.Predicates.origin(DescribedPredicate.<JavaCodeUnit>alwaysTrue().as("some text"));
+        TestJavaAccess testedAccess = anyAccess();
+        CapturingDescribedPredicate<JavaCodeUnit> nestedPredicate = alwaysTrueCapturingPredicateWithDescription("some text");
 
-        assertThat(predicate)
+        assertThat(JavaAccess.Predicates.origin(nestedPredicate))
                 .hasDescription("origin some text")
-                .accepts(anyAccess());
+                .accepts(testedAccess);
 
-        predicate = JavaAccess.Predicates.origin(alwaysFalse());
-        assertThat(predicate).rejects(anyAccess());
+        assertThat(nestedPredicate.getCapturedValue()).isEqualTo(testedAccess.getOrigin());
+    }
+
+    @Test
+    public void originOwner_predicate() {
+        TestJavaAccess testedAccess = anyAccess();
+        CapturingDescribedPredicate<JavaClass> nestedPredicate = alwaysTrueCapturingPredicateWithDescription("some text");
+
+        assertThat(JavaAccess.Predicates.originOwner(nestedPredicate))
+                .hasDescription("origin owner some text")
+                .accepts(testedAccess);
+
+        assertThat(nestedPredicate.getCapturedValue()).isEqualTo(testedAccess.getOriginOwner());
+    }
+
+    @Test
+    public void target_predicate() {
+        TestJavaAccess testedAccess = anyAccess();
+        CapturingDescribedPredicate<AccessTarget> nestedPredicate = alwaysTrueCapturingPredicateWithDescription("some text");
+
+        assertThat(JavaAccess.Predicates.target(nestedPredicate))
+                .hasDescription("target some text")
+                .accepts(testedAccess);
+
+        assertThat(nestedPredicate.getCapturedValue()).isEqualTo(testedAccess.getTarget());
+    }
+
+    @Test
+    public void targetOwner_predicate() {
+        TestJavaAccess testedAccess = anyAccess();
+        CapturingDescribedPredicate<JavaClass> nestedPredicate = alwaysTrueCapturingPredicateWithDescription("some text");
+
+        assertThat(JavaAccess.Predicates.targetOwner(nestedPredicate))
+                .hasDescription("target owner some text")
+                .accepts(testedAccess);
+
+        assertThat(nestedPredicate.getCapturedValue()).isEqualTo(testedAccess.getTargetOwner());
     }
 
     @Test

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/TestUtils.java
@@ -2,10 +2,12 @@ package com.tngtech.archunit.core.domain;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
@@ -31,6 +33,7 @@ import static com.tngtech.archunit.testutil.ReflectionTestUtils.getHierarchy;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Files.newTemporaryFile;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
@@ -102,8 +105,39 @@ public class TestUtils {
         return new AccessesSimulator();
     }
 
-    public static DescribedPredicate<Object> predicateWithDescription(String description) {
-        return DescribedPredicate.alwaysTrue().as(description);
+    public static <T> DescribedPredicate<T> predicateWithDescription(String description) {
+        return DescribedPredicate.<T>alwaysTrue().as(description);
+    }
+
+    public static <T> CapturingDescribedPredicate<T> alwaysTrueCapturingPredicateWithDescription(String description) {
+        return new CapturingDescribedPredicate<>(true, description);
+    }
+
+    public static class CapturingDescribedPredicate<T> extends DescribedPredicate<T> {
+
+        private final List<T> capturedValues;
+        private final Predicate<T> check;
+
+        public CapturingDescribedPredicate(boolean result, String description, Object... params) {
+            this(o -> result, description, params);
+        }
+
+        public CapturingDescribedPredicate(Predicate<T> check, String description, Object... params) {
+            super(description, params);
+            this.check = check;
+            this.capturedValues = new ArrayList<>();
+        }
+
+        @Override
+        public boolean test(T t) {
+            this.capturedValues.add(t);
+            return check.test(t);
+        }
+
+        public T getCapturedValue() {
+            assertThat(capturedValues).as("to get the captured value, exactly one value must have been captured").hasSize(1);
+            return capturedValues.get(0);
+        }
     }
 
     public static MethodCallTarget resolvedTargetFrom(JavaMethod target) {


### PR DESCRIPTION
targetOwner and originOwner() were producing the same message as target() and origin() e.g. "access target where target is annotated with..." instead of "access target where target owner is annotated with..." The existing test is also updated to assert that the correct element is passed to the given predicate, for which new testUtils are introduced.

replacement for #1579