### PR TITLE
Release 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ framework.
 ###### Gradle
 
 ```
-testImplementation 'com.tngtech.archunit:archunit:1.4.1'
+testImplementation 'com.tngtech.archunit:archunit:1.4.2'
 ```
 
 ###### Maven
@@ -26,7 +26,7 @@ testImplementation 'com.tngtech.archunit:archunit:1.4.1'
 <dependency>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/archunit-maven-test/build.gradle
+++ b/archunit-maven-test/build.gradle
@@ -16,8 +16,8 @@ def repositoryUrls = [
                 releases : 'https://nexus.int.tngtech.com/repository/maven-releases'
         ],
         sonatype: [
-                snapshots: 'https://oss.sonatype.org/content/repositories/snapshots',
-                releases : 'https://oss.sonatype.org/content/repositories/releases'
+                snapshots: 'https://central.sonatype.com/repository/maven-snapshots',
+                releases : 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
         ]
 ]
 def createRepositoriesTag = { repoUrls ->

--- a/build-steps/release/publish.gradle
+++ b/build-steps/release/publish.gradle
@@ -7,6 +7,8 @@ nexusPublishing {
     packageGroup = 'com.tngtech'
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username = findProperty("sonatypeUsername")
             password = findProperty("sonatypePassword")
         }

--- a/build-steps/release/test-release.gradle
+++ b/build-steps/release/test-release.gradle
@@ -9,13 +9,20 @@ task testRelease() {
             text = text.replace('mavenCentral()', '''
             mavenCentral()
             maven {
-                url "https://oss.sonatype.org/content/repositories/staging/"
-                credentials {
-                    username project.getProperty('sonatypeUsername')
-                    password project.getProperty('sonatypePassword')
+                url "https://central.sonatype.com/api/v1/publisher/deployments/download/"
+                credentials(HttpHeaderCredentials) {
+                    name = "Authorization"
+                    value = "Bearer " + (project.getProperty('sonatypeUsername') + ":" + project.getProperty('sonatypePassword')).bytes.encodeBase64()
+                }
+                authentication {
+                    header(HttpHeaderAuthentication)
                 }
             }''')
         }
+    }
+
+    def configureHttpSocketTimeout = {
+        new File(testReleaseDir, 'gradle.properties') << 'systemProp.org.gradle.internal.http.socketTimeout=600000\n'
     }
 
     def testExampleProject = { String exampleProjectName ->
@@ -47,6 +54,7 @@ task testRelease() {
         updateArchUnitExampleVersion(testReleaseDir)
 
         configureStagingRepository()
+        configureHttpSocketTimeout()
 
         testExampleProject('example-plain')
         testExampleProject('example-junit4')

--- a/buildSrc/src/main/groovy/archunit.java-release-check-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-release-check-conventions.gradle
@@ -38,23 +38,25 @@ ext.getExpectedPomFileContent = {
 
 task checkUploadedArtifacts {
     doLast {
-        def tngRepoId = project.findProperty('tngRepoId') ?: rootProject.closeSonatypeStagingRepository.stagingRepositoryId.get()
-        def rootUrl = "https://oss.sonatype.org/service/local/repositories/${tngRepoId}/content/com/tngtech/archunit"
-
-        def createArtifactUrl = { String artifactId ->
-            "${rootUrl}/${artifactId}/${version}/${artifactId}-${version}"
+        def getArtifact = { String artifactId, String fullEnding ->
+            def repositoryUrl = 'https://central.sonatype.com/api/v1/publisher/deployments/download'
+            def artifactUrl = "$repositoryUrl/com/tngtech/archunit/$artifactId/$version/$artifactId-$version$fullEnding"
+            def connection = new URL(artifactUrl).openConnection()
+            def token = (project.getProperty('sonatypeUsername') + ':' + project.getProperty('sonatypePassword')).bytes.encodeBase64()
+            connection.setRequestProperty("Authorization", "Bearer $token")
+            return connection.inputStream
         }
 
         def getUploadedFile = { String artifactId, String ending, String suffix ->
             def fullEnding = (!suffix.isEmpty() ? "-${suffix}" : '') + ".${ending}"
             def tempDir = Files.createTempDirectory('release-check').toFile()
             File result = new File(tempDir, "${artifactId}${fullEnding}")
-            result.bytes = new URL("${createArtifactUrl(artifactId)}${fullEnding}").bytes
+            result.bytes = getArtifact(artifactId, fullEnding).bytes
             result
         }
 
         def getUploadedPomFileContent = {
-            new URL("${createArtifactUrl(project.name)}.pom").text.stripIndent()
+            getArtifact(project.name, ".pom").text.stripIndent()
         }
 
         def checkPom = {

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -10,6 +10,6 @@ main:
   - title: "User Guide"
     url: /userguide/html/000_Index.html
   - title: "API"
-    url: https://javadoc.io/doc/com.tngtech.archunit/archunit/1.4.1
+    url: https://javadoc.io/doc/com.tngtech.archunit/archunit/1.4.2
   - title: "About"
     url: /about

--- a/docs/_pages/getting-started.md
+++ b/docs/_pages/getting-started.md
@@ -15,7 +15,7 @@ ArchUnit can be obtained from Maven Central.
 <dependency>
     <groupId>com.tngtech.archunit</groupId>
     <artifactId>archunit</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -23,7 +23,7 @@ ArchUnit can be obtained from Maven Central.
 #### Gradle
 ```groovy
 dependencies {
-    testImplementation 'com.tngtech.archunit:archunit:1.4.1'
+    testImplementation 'com.tngtech.archunit:archunit:1.4.2'
 }
 ```
 

--- a/docs/_posts/2026-04-18-release-v1.4.2.markdown
+++ b/docs/_posts/2026-04-18-release-v1.4.2.markdown
@@ -1,0 +1,8 @@
+---
+layout: splash
+title:  "New release of ArchUnit (v1.4.2)"
+date:   2026-04-18 12:00:00
+categories: news release
+---
+
+A new release of ArchUnit (v1.4.2) is out. For details see [the release on GitHub](https://github.com/TNG/ArchUnit/releases/tag/v1.4.2 "ArchUnit v1.4.2 on GitHub").

--- a/docs/userguide/html/000_Index.html
+++ b/docs/userguide/html/000_Index.html
@@ -450,7 +450,7 @@ h4 {
 <div id="header">
 <h1>ArchUnit User Guide</h1>
 <div class="details">
-<span id="revnumber">version 1.4.1</span>
+<span id="revnumber">version 1.4.2</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -619,7 +619,7 @@ Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code class="language-xml hljs" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit-junit4&lt;/artifactId&gt;
-    &lt;version&gt;1.4.1&lt;/version&gt;
+    &lt;version&gt;1.4.2&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -628,7 +628,7 @@ Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-    testImplementation 'com.tngtech.archunit:archunit-junit4:1.4.1'
+    testImplementation 'com.tngtech.archunit:archunit-junit4:1.4.2'
 }</code></pre>
 </div>
 </div>
@@ -649,7 +649,7 @@ from Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code class="language-xml hljs" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit-junit5&lt;/artifactId&gt;
-    &lt;version&gt;1.4.1&lt;/version&gt;
+    &lt;version&gt;1.4.2&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -658,7 +658,7 @@ from Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-    testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.2'
 }</code></pre>
 </div>
 </div>
@@ -675,7 +675,7 @@ context, include the core ArchUnit dependency from Maven Central:</p>
 <pre class="highlightjs highlight nowrap"><code class="language-xml hljs" data-lang="xml">&lt;dependency&gt;
     &lt;groupId&gt;com.tngtech.archunit&lt;/groupId&gt;
     &lt;artifactId&gt;archunit&lt;/artifactId&gt;
-    &lt;version&gt;1.4.1&lt;/version&gt;
+    &lt;version&gt;1.4.2&lt;/version&gt;
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
 </div>
@@ -684,7 +684,7 @@ context, include the core ArchUnit dependency from Maven Central:</p>
 <div class="title">build.gradle</div>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">dependencies {
-   testImplementation 'com.tngtech.archunit:archunit:1.4.1'
+   testImplementation 'com.tngtech.archunit:archunit:1.4.2'
 }</code></pre>
 </div>
 </div>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 archunit.group=com.tngtech.archunit
-archunit.version=1.5.0-SNAPSHOT
+archunit.version=1.4.2-SNAPSHOT
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 archunit.group=com.tngtech.archunit
-archunit.version=1.4.2-SNAPSHOT
+archunit.version=1.4.2
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 archunit.group=com.tngtech.archunit
-archunit.version=1.4.2
+archunit.version=1.5.0-SNAPSHOT
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED


### PR DESCRIPTION
* migrate from ([meanwhile shut down](https://central.sonatype.org/news/20250326_ossrh_sunset/)) OSSRH to Central Publisher Portal using the [Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/), still [testing the uploaded artifacts](https://central.sonatype.org/publish/publish-portal-api/#manually-testing-a-deployment-bundle) before finally releasing them

* As the snapshots repository is currently not used, its configuration is just a best guess at this point.

resolves #1599