### PR TITLE
enforce unix line endings for all text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Enforce Unix line endings (LF) for all java files
-*.java text=auto eol=lf
+# Enforce Unix line endings (LF) for all files
+* text=auto eol=lf


### PR DESCRIPTION
Restoring @StefanGraeber's original suggestion of #1602:
Only configuring the line endings of Java files in 0ce7916dec74072eb8ff8b1704a527ad9ac568b3 was actually not enough as the build itself modifies them using `archunit.header.template`, which needs to use LF line endings as well.

(I merged #1602 despite spotless failures on Windows, as it seemed plausible that these were caused by `.gitattributes` settings only applying when git writes files to the working tree – not when switching the branch; a behavior I had observed locally. Therefore, I assumed that the CI build for #1602 might still have used the line endings from `main`, and that the failure would heal itself once the `.gitattributes` are on `main`. However, that assumption turned out to be incorrect. 🙈)