### PR TITLE
fix update gradle wrapper GitHub action

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -3,6 +3,7 @@ name: Update Gradle Wrapper
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   update-gradle-wrapper:
@@ -10,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Gradle JDK
         uses: actions/setup-java@v5.2.0


### PR DESCRIPTION
The action previously failed:
```
Pushing branch
/usr/bin/git push --force-with-lease origin HEAD:refs/heads/gradlew-update-9.5.1
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/TNG/ArchUnit/': The requested URL returned error: 400
Creating Pull Request
Error: ❌ Validation Failed: {"resource":"PullRequest","field":"head","code":"invalid"} -
       https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

This strongly suggests both checkout and the wrapper-update action are configuring GitHub auth, resulting in two Authorization headers on Git HTTP requests.

Fix: Disable persisted credentials in actions/checkout, so only the update action manages auth.
Note: Simply dropping the repo-token for the update-gradle-wrapper-action did not work either.