### PR TITLE
Update ASM to 9.10, supporting Java 27 & bump various other dependencies

### DIFF
--- a/archunit-java-modules-test/build.gradle
+++ b/archunit-java-modules-test/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'archunit.java-conventions'
-    id 'org.javamodularity.moduleplugin' version '2.0.0'
+    id 'org.javamodularity.moduleplugin' version '2.0.1'
 }
 
 ext.moduleName = 'com.tngtech.archunit.javamodulestest'

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'archunit.base-conventions'
     id 'com.gradleup.shadow' version '8.3.9' apply false
-    id 'com.github.spotbugs' version '6.4.8' apply false
+    id 'com.github.spotbugs' version '6.5.4' apply false
     id "io.github.gradle-nexus.publish-plugin" version "2.0.0" apply false
-    id "com.diffplug.spotless" version "8.2.0" apply false
-    id 'com.github.ben-manes.versions' version '0.53.0' apply false
+    id "com.diffplug.spotless" version "8.5.0" apply false
+    id 'com.github.ben-manes.versions' version '0.54.0' apply false
 }
 
 def appAndSourceUrl = 'https://github.com/TNG/ArchUnit'

--- a/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
+++ b/buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>1.14.2</version>
+            <version>1.14.4</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/buildSrc/src/main/resources/release_check/archunit.pom
+++ b/buildSrc/src/main/resources/release_check/archunit.pom
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.18</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 log4j = "2.26.0"
-junit5 = "5.14.2"
-junitPlatform = "1.14.2" # in sync with buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
+junit5 = "5.14.4"
+junitPlatform = "1.14.4" # in sync with buildSrc/src/main/resources/release_check/archunit-junit5-engine-api.pom
 assertj = "3.27.7"
 
 [libraries]
 asm = { group = "org.ow2.asm", name = "asm", version = "9.10" }
-guava = { group = "com.google.guava", name = "guava", version = "33.5.0-jre" }
-slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.17" }
+guava = { group = "com.google.guava", name = "guava", version = "33.6.0-jre" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.18" } # in sync with buildSrc/src/main/resources/release_check/archunit.pom
 log4j_api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j_core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
 log4j_slf4j = { group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version.ref = "log4j" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ junitPlatform = "1.14.2" # in sync with buildSrc/src/main/resources/release_chec
 assertj = "3.27.7"
 
 [libraries]
-asm = { group = "org.ow2.asm", name = "asm", version = "9.9.1" }
+asm = { group = "org.ow2.asm", name = "asm", version = "9.10" }
 guava = { group = "com.google.guava", name = "guava", version = "33.5.0-jre" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.17" }
 log4j_api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }


### PR DESCRIPTION
- update ASM 9.9.1 →  9.10 (supporting Java 27, cf. https://asm.ow2.io/versions.html; resolves #1617)
- Guava 33.5.0-jre → 33.6.0-jre
- SLF4J 2.0.17 → 2.0.18
- JUnit Jupiter 5.14.2 → 5.14.4
- JUnit Platform 1.14.2 → 1.14.4
- SpotBugs plugin 6.4.8 → 6.5.4
- Spotless plugin 8.2.0 → 8.5.0
- Versions plugin 0.53.0 → 0.54.0
- Java Modularity plugin 2.0.0 → 2.0.1