### PR TITLE
Do not include web fonts in javadoc jar

### DIFF
--- a/buildSrc/src/main/groovy/archunit.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/archunit.java-conventions.gradle
@@ -15,4 +15,5 @@ tasks.withType(JavaCompile) { Task task ->
 
 javadoc {
     options.addBooleanOption('html5', true)
+    options.addBooleanOption("-no-fonts", true)
 }


### PR DESCRIPTION
Commit 912abfd95233b477ffe98d362246fe5a6d348c54 advanced `maxSupportedJavaVersion`, which is also used as `languageVersion` for the `javadocTool`, from Java 21 to Java 25.

Unlike javadoc 21, javadoc 25 by default includes ~4 MB of fonts in every `*-javadoc.jar`:
`javadoc --no-fonts` reduces the total size of published `*-javadoc.jar`s by a factor of ~10, e.g.
- `archunit-javadoc.jar` from 5.4 MiB to 1.6 MiB (was 1.4 MiB with javadoc 21)
- `archunit-junit5-api-javadoc.jar` from 4.0 MiB to 0.1 MiB (was 0.1 MiB with javadoc 21)