### PR TITLE
detect custom Gradle test source sets in test import options

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ImportOption.java
@@ -99,7 +99,7 @@ public interface ImportOption {
         };
 
         static final PatternPredicate MAVEN_TEST_PATTERN = new PatternPredicate(".*/target/test-classes/.*");
-        static final PatternPredicate GRADLE_TEST_PATTERN = new PatternPredicate(".*/build/classes/([^/]+/)?test/.*");
+        static final PatternPredicate GRADLE_TEST_PATTERN = new PatternPredicate(".*/build/classes/([^/]+/)?(test|[^/]+Test)s?/.*");
         static final PatternPredicate INTELLIJ_TEST_PATTERN = new PatternPredicate(".*/out/test/.*");
         static final Predicate<Location> TEST_LOCATION = MAVEN_TEST_PATTERN.or(GRADLE_TEST_PATTERN).or(INTELLIJ_TEST_PATTERN);
         static final Predicate<Location> NO_TEST_LOCATION = TEST_LOCATION.negate();
@@ -122,6 +122,8 @@ public interface ImportOption {
      * Best effort {@link ImportOption} to check rules only on main classes.<br>
      * NOTE: This excludes all class files residing in some directory
      * ../target/test-classes/.., ../build/classes/test/.. or ../build/classes/someLang/test/.. (Maven/Gradle standard).
+     * This also covers custom Gradle test source sets that follow the {@code ...Test} naming convention,
+     * e.g. ../build/classes/someLang/integrationTest/...
      * Thus it is just a best guess, how tests can be identified,
      * in other environments, it might be necessary, to implement the correct {@link ImportOption} yourself.
      */

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportOptionsTest.java
@@ -76,6 +76,11 @@ public class ImportOptionsTest {
                 new FolderPattern("build", "classes", "main").expectMainFolder(),
                 new FolderPattern("build", "classes", "java", "main").expectMainFolder(),
                 new FolderPattern("build", "classes", "java", "main", "my", "test").expectMainFolder(),
+                new FolderPattern("build", "classes", "java", "integrationTest").expectTestFolder(),
+                new FolderPattern("build", "classes", "otherlang", "functionalTest").expectTestFolder(),
+                new FolderPattern("build", "classes", "java", "e2eTest").expectTestFolder(),
+                new FolderPattern("build", "classes", "java", "tests").expectTestFolder(),
+                new FolderPattern("build", "classes", "java", "testFixtures").expectMainFolder(),
 
                 // Maven
                 new FolderPattern("target", "classes", "test").expectMainFolder(),


### PR DESCRIPTION
## What & why
Fixes #1578. `ImportOption.DoNotIncludeTests` and `OnlyIncludeTests` did not recognize tests in custom Gradle source sets (e.g. `integrationTest`, `functionalTest`, `e2eTest`), because `GRADLE_TEST_PATTERN` only matched the standard lowercase `test` folder. Custom test classes were therefore treated as production code — not excluded by `DoNotIncludeTests`, and not included by `OnlyIncludeTests`.

## Change
- Broaden `GRADLE_TEST_PATTERN` from `.*/build/classes/([^/]+/)?test/.*` to `.*/build/classes/([^/]+/)?(test|[^/]+Test)s?/.*`, so it also matches source-set output folders that follow the Gradle `...Test` naming convention (plus the plural `tests`).
- Requiring the camelCase capital `Test` boundary keeps `main` excluded, preserves the separately handled `testFixtures` folder (`DoNotIncludeGradleTestFixtures`), and avoids false positives such as `latest`.
- Update the `DoNotIncludeTests` Javadoc accordingly.
- Add `ImportOptionsTest` data points for `integrationTest`, `functionalTest`, `e2eTest`, `tests`, and a `testFixtures` → main regression guard.

## Verification
`./gradlew :archunit:test --tests "*ImportOptionsTest"` → 92 tests, 0 failures (the new source-set folders resolve as test locations; `testFixtures`/`main` stay non-test). `:archunit:spotlessCheck` passes.

---
This change was prepared with AI assistance (Claude); I have reviewed and verified it and take responsibility for the contribution.
