### PR TITLE
#1382 make TYPE_USE annotations visible as dependencies

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/ImportContext.java
@@ -47,6 +47,8 @@ public interface ImportContext {
 
     Map<String, JavaAnnotation<JavaMember>> createAnnotations(JavaMember owner);
 
+    Set<JavaAnnotation<JavaClass>> createTypeAnnotations(JavaClass owner);
+
     Optional<JavaClass> createEnclosingClass(JavaClass owner);
 
     Optional<JavaCodeUnit> createEnclosingCodeUnit(JavaClass owner);

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClass.java
@@ -68,6 +68,7 @@ import static com.tngtech.archunit.core.domain.properties.HasType.Functions.GET_
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
 
 @PublicAPI(usage = ACCESS)
@@ -126,6 +127,7 @@ public final class JavaClass
     private EnclosingDeclaration enclosingDeclaration = EnclosingDeclaration.ABSENT;
     private Optional<JavaClass> componentType = Optional.empty();
     private Map<String, JavaAnnotation<JavaClass>> annotations = emptyMap();
+    private Set<JavaAnnotation<JavaClass>> typeAnnotations = emptySet();
     private JavaClassDependencies javaClassDependencies = new JavaClassDependencies(this);  // just for stubs; will be overwritten for imported classes
     private ReverseDependencies reverseDependencies = ReverseDependencies.EMPTY;  // just for stubs; will be overwritten for imported classes
     private final CompletionProcess completionProcess;
@@ -1480,8 +1482,18 @@ public final class JavaClass
 
     void completeAnnotations(ImportContext context) {
         annotations = context.createAnnotations(this);
+        typeAnnotations = context.createTypeAnnotations(this);
         members.completeAnnotations(context);
         completionProcess.markAnnotationsComplete();
+    }
+
+    /**
+     * TYPE_USE annotations (JVMS §4.7.20) attributed to this class. Unlike {@link #getAnnotations() declaration
+     * annotations} these are not positioned within the annotated type; they are captured only so that the
+     * referenced annotation type surfaces as a {@link Dependency dependency} of this class.
+     */
+    Set<JavaAnnotation<JavaClass>> getTypeAnnotations() {
+        return typeAnnotations;
     }
 
     JavaClassDependencies completeFrom(ImportContext context) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/domain/JavaClassDependencies.java
@@ -48,6 +48,7 @@ class JavaClassDependencies {
                         codeUnitParameterDependenciesFromSelf(),
                         throwsDeclarationDependenciesFromSelf(),
                         annotationDependenciesFromSelf(),
+                        typeAnnotationDependenciesFromSelf(),
                         instanceofCheckDependenciesFromSelf(),
                         referencedClassObjectDependenciesFromSelf(),
                         typeParameterDependenciesFromSelf()
@@ -246,9 +247,17 @@ class JavaClassDependencies {
         return annotatedObjects.stream().flatMap(this::annotationDependencies);
     }
 
+    private Stream<Dependency> typeAnnotationDependenciesFromSelf() {
+        return dependenciesOfAnnotations(javaClass.getTypeAnnotations());
+    }
+
     private <T extends HasDescription & HasAnnotations<?>> Stream<Dependency> annotationDependencies(T annotated) {
+        return dependenciesOfAnnotations(annotated.getAnnotations());
+    }
+
+    private Stream<Dependency> dependenciesOfAnnotations(Iterable<? extends JavaAnnotation<?>> annotations) {
         Stream.Builder<Dependency> addToStream = Stream.builder();
-        for (JavaAnnotation<?> annotation : annotated.getAnnotations()) {
+        for (JavaAnnotation<?> annotation : annotations) {
             Dependency.tryCreateFromAnnotation(annotation).forEach(addToStream);
             annotation.accept(new DefaultParameterVisitor() {
                 @Override

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileImportRecord.java
@@ -75,6 +75,7 @@ class ClassFileImportRecord {
     private final SetMultimap<String, JavaConstructorBuilder> constructorBuildersByOwner = HashMultimap.create();
     private final Map<String, JavaStaticInitializerBuilder> staticInitializerBuildersByOwner = new HashMap<>();
     private final SetMultimap<String, JavaAnnotationBuilder> annotationsByOwner = HashMultimap.create();
+    private final SetMultimap<String, JavaAnnotationBuilder> typeAnnotationsByOwner = HashMultimap.create();
     private final Map<String, JavaAnnotationBuilder.ValueBuilder> annotationDefaultValuesByOwner = new HashMap<>();
     private final EnclosingDeclarationsByInnerClasses enclosingDeclarationsByOwner = new EnclosingDeclarationsByInnerClasses();
 
@@ -140,6 +141,10 @@ class ClassFileImportRecord {
         this.annotationsByOwner.putAll(getMemberKey(declaringClassName, memberName, descriptor), annotations);
     }
 
+    void addTypeAnnotations(String ownerName, Set<JavaAnnotationBuilder> annotations) {
+        this.typeAnnotationsByOwner.putAll(ownerName, annotations);
+    }
+
     void addAnnotationDefaultValue(String declaringClassName, String methodName, String descriptor, JavaAnnotationBuilder.ValueBuilder valueBuilder) {
         annotationDefaultValuesByOwner.put(getMemberKey(declaringClassName, methodName, descriptor), valueBuilder);
     }
@@ -201,6 +206,10 @@ class ClassFileImportRecord {
 
     Set<JavaAnnotationBuilder> getAnnotationsFor(JavaMember owner) {
         return annotationsByOwner.get(getMemberKey(owner));
+    }
+
+    Set<JavaAnnotationBuilder> getTypeAnnotationsFor(JavaClass owner) {
+        return typeAnnotationsByOwner.get(owner.getName());
     }
 
     Optional<JavaAnnotationBuilder.ValueBuilder> getAnnotationDefaultValueBuilderFor(JavaMethod method) {

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassFileProcessor.java
@@ -152,6 +152,12 @@ class ClassFileProcessor {
             registerAnnotationTypesToResolve(annotationBuilders);
         }
 
+        @Override
+        public void onDeclaredTypeAnnotations(Set<JavaAnnotationBuilder> annotationBuilders) {
+            importRecord.addTypeAnnotations(ownerName, annotationBuilders);
+            registerAnnotationTypesToResolve(annotationBuilders);
+        }
+
         private void registerAnnotationTypesToResolve(Set<JavaAnnotationBuilder> annotationBuilders) {
             for (JavaAnnotationBuilder annotationBuilder : annotationBuilders) {
                 dependencyResolutionProcess.registerAnnotationType(annotationBuilder.getFullyQualifiedClassName());

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/ClassGraphCreator.java
@@ -359,6 +359,17 @@ class ClassGraphCreator implements ImportContext {
     }
 
     @Override
+    public Set<JavaAnnotation<JavaClass>> createTypeAnnotations(JavaClass owner) {
+        // Unlike declaration annotations, several type-use annotations of the same type can be attributed to a
+        // single class (e.g. two @Nullable fields), so we collect them into a Set instead of a Map keyed by type.
+        ImmutableSet.Builder<JavaAnnotation<JavaClass>> result = ImmutableSet.builder();
+        for (DomainBuilders.JavaAnnotationBuilder annotationBuilder : importRecord.getTypeAnnotationsFor(owner)) {
+            result.add(annotationBuilder.build(owner, classes));
+        }
+        return result.build();
+    }
+
+    @Override
     public Optional<JavaClass> createEnclosingClass(JavaClass owner) {
         Optional<String> enclosingClassName = importRecord.getEnclosingClassFor(owner.getName());
         return enclosingClassName.map(classes::getOrResolve);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DeclarationHandler.java
@@ -45,6 +45,8 @@ interface DeclarationHandler {
 
     void onDeclaredMemberAnnotations(String memberName, String descriptor, Set<DomainBuilders.JavaAnnotationBuilder> annotations);
 
+    void onDeclaredTypeAnnotations(Set<DomainBuilders.JavaAnnotationBuilder> annotations);
+
     void onDeclaredAnnotationValueType(String valueTypeName);
 
     void onDeclaredAnnotationDefaultValue(String methodName, String methodDescriptor, DomainBuilders.JavaAnnotationBuilder.ValueBuilder valueBuilder);

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/JavaClassProcessor.java
@@ -57,6 +57,7 @@ import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,7 @@ class JavaClassProcessor extends ClassVisitor {
 
     private DomainBuilders.JavaClassBuilder javaClassBuilder;
     private final Set<JavaAnnotationBuilder> annotations = new HashSet<>();
+    private final Set<JavaAnnotationBuilder> typeAnnotations = new HashSet<>();
     private final SourceDescriptor sourceDescriptor;
     private final DeclarationHandler declarationHandler;
     private final AccessHandler accessHandler;
@@ -300,6 +302,18 @@ class JavaClassProcessor extends ClassVisitor {
         return new AnnotationProcessor(annotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
     }
 
+    // Type annotations (JVMS §4.7.20, e.g. Checker Framework's TYPE_USE @Nullable) are stored in a separate
+    // attribute from declaration annotations. We don't model their exact position within a type, but we do
+    // capture the referenced annotation type (and its members) so that it surfaces as a dependency of this class.
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        if (importAborted()) {
+            return super.visitTypeAnnotation(typeRef, typePath, desc, visible);
+        }
+
+        return new AnnotationProcessor(typeAnnotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
+    }
+
     @Override
     public void visitEnd() {
         if (importAborted()) {
@@ -307,6 +321,7 @@ class JavaClassProcessor extends ClassVisitor {
         }
 
         declarationHandler.onDeclaredClassAnnotations(annotations);
+        declarationHandler.onDeclaredTypeAnnotations(typeAnnotations);
         LOG.trace("Done analyzing {}", className);
     }
 
@@ -316,6 +331,7 @@ class JavaClassProcessor extends ClassVisitor {
         private final DomainBuilders.JavaCodeUnitBuilder<?, ?> codeUnitBuilder;
         private final DeclarationHandler declarationHandler;
         private final Set<JavaAnnotationBuilder> annotations = new HashSet<>();
+        private final Set<JavaAnnotationBuilder> typeAnnotations = new HashSet<>();
         private final SetMultimap<Integer, JavaAnnotationBuilder> parameterAnnotationsByIndex = HashMultimap.create();
         private int actualLineNumber;
 
@@ -395,6 +411,13 @@ class JavaClassProcessor extends ClassVisitor {
             return new AnnotationProcessor(annotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
         }
 
+        // Captures TYPE_USE annotations on the method signature (return type, formal parameter types,
+        // throws types, type parameters). We attribute them to the declaring class as a dependency.
+        @Override
+        public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+            return new AnnotationProcessor(typeAnnotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
+        }
+
         @Override
         public AnnotationVisitor visitAnnotationDefault() {
             return new AnnotationDefaultProcessor(declaringClassName, codeUnitBuilder, declarationHandler);
@@ -421,6 +444,7 @@ class JavaClassProcessor extends ClassVisitor {
         @Override
         public void visitEnd() {
             declarationHandler.onDeclaredMemberAnnotations(codeUnitBuilder.getName(), codeUnitBuilder.getDescriptor(), annotations);
+            declarationHandler.onDeclaredTypeAnnotations(typeAnnotations);
             accessHandler.onMethodEnd();
         }
 
@@ -585,6 +609,7 @@ class JavaClassProcessor extends ClassVisitor {
         private final DomainBuilders.JavaFieldBuilder fieldBuilder;
         private final DeclarationHandler declarationHandler;
         private final Set<JavaAnnotationBuilder> annotations = new HashSet<>();
+        private final Set<JavaAnnotationBuilder> typeAnnotations = new HashSet<>();
 
         private FieldProcessor(DomainBuilders.JavaFieldBuilder fieldBuilder, DeclarationHandler declarationHandler) {
             super(ASM_API_VERSION);
@@ -598,9 +623,17 @@ class JavaClassProcessor extends ClassVisitor {
             return new AnnotationProcessor(annotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
         }
 
+        // Captures TYPE_USE annotations on the field type (e.g. @Nullable String field), attributed to the
+        // declaring class as a dependency.
+        @Override
+        public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+            return new AnnotationProcessor(typeAnnotations::add, declarationHandler, handleAnnotationAnnotationProperty(desc, declarationHandler));
+        }
+
         @Override
         public void visitEnd() {
             declarationHandler.onDeclaredMemberAnnotations(fieldBuilder.getName(), fieldBuilder.getDescriptor(), annotations);
+            declarationHandler.onDeclaredTypeAnnotations(typeAnnotations);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/domain/JavaClassTest.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FilterInputStream;
 import java.io.Serializable;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.nio.Buffer;
 import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
@@ -99,6 +100,7 @@ import static com.tngtech.archunit.testutil.Conditions.codeUnitWithSignature;
 import static com.tngtech.archunit.testutil.Conditions.containing;
 import static com.tngtech.archunit.testutil.ReflectionTestUtils.getHierarchy;
 import static com.tngtech.archunit.testutil.assertion.DependenciesAssertion.from;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Collections.singletonList;
 import static java.util.regex.Pattern.quote;
@@ -859,6 +861,38 @@ public class JavaClassTest {
                 .areAtLeastOne(annotationMemberOfTypeDependency()
                         .from(ClassWithAnnotationDependencies.class)
                         .to(B.class)
+                        .inLineNumber(0));
+    }
+
+    @Test
+    public void direct_dependencies_from_self_by_type_annotation() {
+        JavaClass javaClass = importClasses(ClassWithTypeAnnotationDependencies.class)
+                .get(ClassWithTypeAnnotationDependencies.class);
+
+        assertThat(javaClass.getDirectDependenciesFromSelf())
+                .areAtLeastOne(annotationTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeUseAnnotationOnField.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(annotationTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeUseAnnotationOnTypeArgument.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(annotationTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeUseAnnotationOnReturnType.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(annotationTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeUseAnnotationOnParameterType.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(annotationTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeUseAnnotationWithMember.class)
+                        .inLineNumber(0))
+                .areAtLeastOne(annotationMemberOfTypeDependency()
+                        .from(ClassWithTypeAnnotationDependencies.class)
+                        .to(TypeAnnotationMemberType.class)
                         .inLineNumber(0));
     }
 
@@ -2509,6 +2543,55 @@ public class JavaClassTest {
 
         void method(@OnMethodParam String param) {
         }
+    }
+
+    @SuppressWarnings("unused")
+    private static class ClassWithTypeAnnotationDependencies {
+        @TypeUseAnnotationOnField
+        List<@TypeUseAnnotationOnTypeArgument TypeAnnotatedType> field;
+
+        @TypeUseAnnotationOnReturnType
+        TypeAnnotatedType method() {
+            return null;
+        }
+
+        void method(@TypeUseAnnotationOnParameterType TypeAnnotatedType param) {
+        }
+
+        void methodWithAnnotationMember(@TypeUseAnnotationWithMember(TypeAnnotationMemberType.class) TypeAnnotatedType param) {
+        }
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface TypeUseAnnotationOnField {
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface TypeUseAnnotationOnTypeArgument {
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface TypeUseAnnotationOnReturnType {
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface TypeUseAnnotationOnParameterType {
+    }
+
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface TypeUseAnnotationWithMember {
+        Class<?> value();
+    }
+
+    private static class TypeAnnotatedType {
+    }
+
+    private static class TypeAnnotationMemberType {
     }
 
     private @interface OnClass {

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ImportTestUtils.java
@@ -392,6 +392,11 @@ public class ImportTestUtils {
         }
 
         @Override
+        public Set<JavaAnnotation<JavaClass>> createTypeAnnotations(JavaClass owner) {
+            return Collections.emptySet();
+        }
+
+        @Override
         public Optional<JavaClass> createEnclosingClass(JavaClass owner) {
             return Optional.empty();
         }

--- a/type-use-annotations-summary.md
+++ b/type-use-annotations-summary.md
@@ -1,0 +1,102 @@
+# Making TYPE_USE annotations visible as dependencies
+
+## Problem
+
+Annotations declared with `@Target(TYPE_USE)` (or `TYPE_PARAMETER`) only — the most
+prominent example being Checker Framework's `@Nullable` — are invisible to ArchUnit.
+
+Because such an annotation has no `FIELD`/`METHOD`/`PARAMETER` target, `javac` does **not**
+write it into the normal declaration-annotation tables (`RuntimeVisible/InvisibleAnnotations`).
+It writes it into the separate type-annotation table (`RuntimeVisibleTypeAnnotations`,
+JVMS §4.7.20). ArchUnit's importer never read that table, so:
+
+- `javaClass.getDirectDependenciesFromSelf()` never contained the annotation type, and
+- `dependOnClassesThat().resideInAPackage("org.checkerframework.checker.nullness.qual")`
+  found nothing.
+
+## Scope of this change ("the moderate path")
+
+Make TYPE_USE annotations surface as **dependencies of the enclosing class**. This is the
+smallest, self-contained increment that fixes the reported problem.
+
+It deliberately does **not** attach the annotation to a specific type-usage position
+(e.g. `@Nullable` on _this field's_ type vs. _that type argument_). Full positional modeling
+would require decoding ASM's `TypeReference`/`TypePath` and introducing annotated-type nodes
+across ~17 positions — a much larger feature, out of scope here.
+
+## How it works
+
+The data flow mirrors how declaration annotations are already handled:
+
+1. **ASM capture** — `JavaClassProcessor` now overrides
+   `visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible)` on the
+   class visitor, `FieldProcessor`, and `MethodProcessor`. Each reuses the existing
+   `AnnotationProcessor`, so annotation **values** (e.g. `@Foo(Bar.class)`) are parsed too.
+   This covers field types, method return / formal-parameter / throws / type-parameter
+   positions, and nested positions such as `List<@X SomeType>`.
+2. **Storage / wiring** — a new `DeclarationHandler.onDeclaredTypeAnnotations(...)` callback,
+   implemented by `ClassFileProcessor.ClassDetailsRecorder` (attributes to the class currently
+   being processed and registers the annotation types for resolution), stores the builders
+   per class in `ClassFileImportRecord` (`typeAnnotationsByOwner`).
+3. **Model build** — a new `ImportContext.createTypeAnnotations(JavaClass)` method, implemented
+   in `ClassGraphCreator`, builds real `JavaAnnotation<JavaClass>` objects (owner = the class)
+   into a `Set`, populated on `JavaClass` during `completeAnnotations`.
+4. **Dependency derivation** — `JavaClassDependencies` gains a `typeAnnotationDependenciesFromSelf()`
+   stream that reuses the existing annotation-dependency logic (`Dependency.tryCreateFromAnnotation`
+   plus the member visitor). So both the annotation type itself and any class/enum members it
+   references become dependencies, with origin = the annotated class.
+
+## Files changed
+
+Production (`archunit/src/main/java`):
+
+| File | Change |
+|------|--------|
+| `core/importer/JavaClassProcessor.java` | Override `visitTypeAnnotation` on class/field/method visitors; collect per-processor and emit at `visitEnd`. Import `org.objectweb.asm.TypePath`. |
+| `core/importer/DeclarationHandler.java` | New `onDeclaredTypeAnnotations(Set<JavaAnnotationBuilder>)`. |
+| `core/importer/ClassFileProcessor.java` | Implement `onDeclaredTypeAnnotations` (store + register types to resolve). |
+| `core/importer/ClassFileImportRecord.java` | `typeAnnotationsByOwner` storage + `addTypeAnnotations` / `getTypeAnnotationsFor`. |
+| `core/domain/ImportContext.java` | New `createTypeAnnotations(JavaClass)`. |
+| `core/importer/ClassGraphCreator.java` | Implement `createTypeAnnotations` (build a `Set<JavaAnnotation<JavaClass>>`). |
+| `core/domain/JavaClass.java` | `typeAnnotations` field, populate in `completeAnnotations`, package-private `getTypeAnnotations()`. |
+| `core/domain/JavaClassDependencies.java` | Refactor shared `dependenciesOfAnnotations(...)`; add `typeAnnotationDependenciesFromSelf()` to the dependency set. |
+
+Tests (`archunit/src/test/java`):
+
+| File | Change |
+|------|--------|
+| `core/domain/JavaClassTest.java` | New test `direct_dependencies_from_self_by_type_annotation` + TYPE_USE example classes/annotations. |
+| `core/importer/ImportTestUtils.java` | Implement `createTypeAnnotations` on the `ImportContextStub`. |
+
+## Design decisions
+
+- **Class-level granularity.** Every type-use annotation is attributed to its enclosing class,
+  not to an exact type node. `TypePath`/`TypeReference` are intentionally ignored.
+- **No new public API.** `JavaClass.getTypeAnnotations()` is package-private (used only for
+  dependency derivation), so there is no `@PublicAPI` surface change. Exposing a public
+  accessor to *query* type-use annotations would be a natural follow-up.
+- **`Set`, not `Map`.** Several type-use annotations of the same type can attach to one class
+  (e.g. two `@Nullable` fields), so a `Set` is built directly rather than the
+  map-keyed-by-type produced by `buildAnnotations`.
+- **Both retention kinds captured.** Like the existing `visitAnnotation`, the `visible` flag is
+  ignored, so both `RuntimeVisible-` and `RuntimeInvisibleTypeAnnotations` are read. (Checker's
+  `@Nullable` is `RUNTIME`.)
+
+## Verification
+
+- New test `JavaClassTest.direct_dependencies_from_self_by_type_annotation` passes. It uses
+  `@Target(TYPE_USE)`-only annotations on a field type, a type argument, a method return type,
+  a parameter type, and an annotation-with-class-member, and asserts each appears in
+  `getDirectDependenciesFromSelf()` (annotation type + annotation-member dependencies).
+- Full regression: `JavaClassTest` (110 tests) and `ClassFileImporterAnnotationsTest` (26 tests)
+  both pass with 0 failures / 0 errors.
+- `./gradlew :archunit:compileTestJava` compiles cleanly.
+
+## Not covered (possible follow-ups)
+
+- Type-use annotations inside **method bodies** (local variables, casts, `instanceof`, `new`) via
+  `visitInsnAnnotation` / `visitLocalVariableAnnotation` / `visitTryCatchAnnotation`.
+- **Record components** (`visitRecordComponent().visitTypeAnnotation`) — currently covered only
+  indirectly via the generated field/accessor.
+- A **public** `getTypeAnnotations()` accessor and/or **positional** modeling of type-use
+  annotations on the type nodes themselves.


### PR DESCRIPTION
Many of you will have the same problem I have: migrating to JSpecify and making sure that no-one uses "the wrong nullability" annotations. Enforcing this is currently not possible with ArchUnit, since at least the Checker Framework annotations are also `TYPE_USE` annotations (like JSpecify), and thus are "invisible" to ArchUnit. (I had to use CheckStyle RegExes to achieve the desired result)

It turns out that solving this issue for ArchUnit is not _that_ hard, it took Claude around 20 minutes. I just want to show the result to you for discussion - I am aware that this is not "mergeable" in its current state and other questions around JSpecify raised in #1382  need the exact position of the annotations as well, which is *much* more complicated. See https://github.com/TNG/ArchUnit/blob/0469f887876b311a7e63a077c2f96133f0ee316c/type-use-annotations-summary.md