### PR TITLE
Add Documentation regarding ArchRule priority

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/lang/Priority.java
+++ b/archunit/src/main/java/com/tngtech/archunit/lang/Priority.java
@@ -16,9 +16,17 @@
 package com.tngtech.archunit.lang;
 
 import com.tngtech.archunit.PublicAPI;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 
 import static com.tngtech.archunit.PublicAPI.Usage.ACCESS;
 
+/**
+ * Classifies the importance of an {@link EvaluationResult}, which is the result of {@link ArchRule#evaluate(JavaClasses)}.
+ * <p>
+ * {@link ArchRuleDefinition#priority(Priority)} can be used to create {@link ArchRule} implementations with a given priority.
+ * </p>
+ */
 @PublicAPI(usage = ACCESS)
 public enum Priority {
     @PublicAPI(usage = ACCESS)

--- a/docs/userguide/007_The_Lang_API.adoc
+++ b/docs/userguide/007_The_Lang_API.adoc
@@ -330,6 +330,21 @@ classes().that(haveAFieldAnnotatedWithPayload).should(onlyBeAccessedBySecuredMet
     .as("Payload may only be accessed in a secure way");
 ----
 
+=== Priority
+
+Most entrypoints in `ArchRuleDefinition` create ``ArchRule``s that evaluate to ``EvaluationResult``s with ``Priority.MEDIUM``; `ArchRuleDefinition.priority` allows to create rules with other `Priority`, e.g.:
+
+[source,java,options="nowrap"]
+----
+ArchRule rule = ArchRuleDefinition.priority(Priority.LOW).noClasses() // ...
+----
+
+The resulting error messages show the priority accordingly:
+
+[source,bash]
+----
+java.lang.AssertionError: Architecture Violation [Priority: LOW] - Rule 'no classes // ...
+----
 === Ignoring Violations
 
 In legacy projects there might be too many violations to fix at once. Nevertheless, that code


### PR DESCRIPTION
As pointed out in #1633 we lack documentation how to configure the ArchRule priority.

Besides updating the userguide I also added JavaDoc for the priority enum. It might be beneficial to also add JavaDoc to the ArchRuleDefinition method `priorities` to support IDE users. However I think this should be a dedicated task where we document all public methods of that class or even all of the language package.