### PR TITLE
Add temporary publication to formally deprecate the legacy `archunit-junit` package

### DIFF
--- a/archunit-junit/relocation/build.gradle
+++ b/archunit-junit/relocation/build.gradle
@@ -1,0 +1,88 @@
+/**
+ * Temporary publication to formally deprecate `archunit-junit`, which has been moved to `archunit-junit4`.
+ * Will be removed again after this is published (probably with the release of ArchUnit 1.6.0).
+ * The removal of this subproject is tracked in https://github.com/TNG/ArchUnit/issues/1674.
+ */
+
+plugins {
+    id 'maven-publish'
+    id 'signing'
+}
+
+group = getProperty('archunit.group')
+version = '0.9.0'
+description = "Deprecated 'archunit-junit' module, use 'archunit-junit4' instead"
+
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
+publishing {
+    publications {
+        relocation(MavenPublication) {
+            artifactId = 'archunit-junit'
+
+            pom {
+                name = app.name
+                packaging = 'pom' // pom.xml only without jar or war
+                description = project.description
+                url = app.urls.entry
+
+                licenses {
+                    license {
+                        name = app.license.name
+                        url = app.license.url
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'codecholeric'
+                        name = 'Peter Gafert'
+                        email = 'peter.gafert@archunit.org'
+                    }
+                    developer {
+                        id = 'rweisleder'
+                        name = 'Roland Weisleder'
+                        email = 'roland.weisleder@googlemail.com'
+                    }
+                    developer {
+                        id = 'hankem'
+                        name = 'Manfred Hanke'
+                        email = 'manfred.hanke@tngtech.com'
+                    }
+                }
+
+                organization {
+                    name = company.name
+                    url = company.url
+                }
+
+                scm {
+                    url = app.urls.source
+                    connection = "scm:${app.gitRepo}"
+                    developerConnection = "scm:${app.gitRepo}"
+                }
+
+                withXml {
+                    def relocation = asNode()
+                            .appendNode('distributionManagement')
+                            .appendNode('relocation')
+                    relocation.appendNode('artifactId', 'archunit-junit4')
+                    relocation.appendNode('message', 'The artifact archunit-junit has been renamed to archunit-junit4.')
+                }
+            }
+        }
+    }
+}
+
+def publishArchUnit = rootProject.tasks.getByName('publishArchUnit')
+
+signing {
+    required {
+        gradle.taskGraph.hasTask(publishArchUnit)
+    }
+    useInMemoryPgpKeys(findProperty('signingKey'), findProperty('signingPassword'))
+    sign publishing.publications.relocation
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'archunit',
         'archunit-integration-test:shared', 'archunit-integration-test:junit4', 'archunit-integration-test:junit5', 'archunit-integration-test:junit6',
         'archunit-java-modules-test', 'archunit-3rd-party-test',
         'archunit-junit',
+        'archunit-junit-relocation',
         'archunit-junit4',
         'archunit-junit5-api', 'archunit-junit5-engine-api', 'archunit-junit5-engine', 'archunit-junit5',
         'archunit-junit6-api', 'archunit-junit6-engine-api', 'archunit-junit6-engine', 'archunit-junit6',
@@ -17,6 +18,7 @@ include 'archunit',
         'docs'
 
 project(':archunit-junit4').projectDir = file('archunit-junit/junit4')
+project(':archunit-junit-relocation').projectDir = file('archunit-junit/relocation')
 project(':archunit-junit5-api').projectDir = file('archunit-junit/junit5/api')
 project(':archunit-junit5-engine-api').projectDir = file('archunit-junit/junit5/engine-api')
 project(':archunit-junit5-engine').projectDir = file('archunit-junit/junit5/engine')


### PR DESCRIPTION
To validate:
- Run the `publishToMavenLocal` task
- Gradle: 
  - On your local machine, create `build.gradle` with the following contents:
    ```
    plugins {
        id 'java'
    }
    
    description = 'Demonstrates resolution of the relocated archunit-junit artifact'
    
    repositories {
        mavenLocal()
        mavenCentral()
    }
    
    dependencies {
        implementation 'com.tngtech.archunit:archunit-junit:0.9.0'
    }
    ```
  - Create an empty `settings.gradle` next to it
  - Run `gradle dependencies`. Note how the dependency is resolved to `archunit-junit4:0.9.0`
- Maven:
  - On your local machine, create a `pom.xml` with the following contents:
    ```
    <project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
      <modelVersion>4.0.0</modelVersion>
  
      <groupId>com.tngtech.archunit.demo</groupId>
      <artifactId>archunit-junit-relocation-maven-demo</artifactId>
      <version>1.0-SNAPSHOT</version>
  
      <dependencies>
          <dependency>
              <groupId>com.tngtech.archunit</groupId>
              <artifactId>archunit-junit</artifactId>
              <version>0.9.0</version>
          </dependency>
      </dependencies>
    </project>
    ```
    - Run `mvn install`. A warning should be shown that `archunit-junit` was renamed to `archunit-junit4`
- Compare the local `pom.xml` in your local Maven store to the one of `archunit-junit:0.8.3`. The diff should be sensible.

Closes #1663 