### PR TITLE
fix: include java.lang.IO in ACCESS_STANDARD_STREAMS (#1686)

### DIFF
--- a/archunit/build.gradle
+++ b/archunit/build.gradle
@@ -60,6 +60,7 @@ archUnitTest {
 def jdk9MainDirs = ['src/jdk9main/java']
 def jdk9TestDirs = ['src/jdk9test/java']
 def jdk16TestDirs = ['src/jdk16test/java']
+def jdk25TestDirs = ['src/jdk25test/java']
 sourceSets {
     jdk9main {
         java {
@@ -81,6 +82,13 @@ sourceSets {
         compileClasspath += sourceSets.test.compileClasspath + sourceSets.jdk9main.output.classesDirs
         runtimeClasspath += sourceSets.test.runtimeClasspath
     }
+    jdk25test {
+        java {
+            srcDirs = jdk25TestDirs
+        }
+        compileClasspath += sourceSets.test.compileClasspath + sourceSets.jdk9main.output.classesDirs
+        runtimeClasspath += sourceSets.test.runtimeClasspath
+    }
 }
 
 dependencies {
@@ -90,6 +98,8 @@ dependencies {
     jdk9testImplementation sourceSets.jdk9main.output
     jdk16testImplementation sourceSets.test.output
     jdk16testImplementation sourceSets.test.compileClasspath
+    jdk25testImplementation sourceSets.test.output
+    jdk25testImplementation sourceSets.test.compileClasspath
 
     runtimeOnly sourceSets.jdk9main.output
 }
@@ -112,6 +122,10 @@ compileJdk16testJava.with {
     ext.minimumJavaVersion = JavaVersion.VERSION_16
 }
 
+compileJdk25testJava.with {
+    ext.minimumJavaVersion = JavaVersion.VERSION_25
+}
+
 task jdk9Test(type: Test) {
     ext.minimumJavaVersion = JavaVersion.VERSION_1_9
 
@@ -126,8 +140,15 @@ task jdk16Test(type: Test) {
     classpath = sourceSets.jdk16test.runtimeClasspath
 }
 
+task jdk25Test(type: Test) {
+    ext.minimumJavaVersion = JavaVersion.VERSION_25
+
+    testClassesDirs = sourceSets.jdk25test.output.classesDirs
+    classpath = sourceSets.jdk25test.runtimeClasspath
+}
+
 assemble.dependsOn compileJdk9mainJava
 
-test.finalizedBy(jdk9Test, jdk16Test)
+test.finalizedBy(jdk9Test, jdk16Test, jdk25Test)
 
-[spotbugsJdk9test, spotbugsJdk16test]*.enabled = false
+[spotbugsJdk9test, spotbugsJdk16test, spotbugsJdk25test]*.enabled = false

--- a/archunit/src/jdk25test/java/com/tngtech/archunit/library/GeneralCodingRulesNewerJavaVersionTest.java
+++ b/archunit/src/jdk25test/java/com/tngtech/archunit/library/GeneralCodingRulesNewerJavaVersionTest.java
@@ -1,0 +1,28 @@
+package com.tngtech.archunit.library;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.library.testclasses.standardstreams.UsesJavaLangIO;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
+
+public class GeneralCodingRulesNewerJavaVersionTest {
+
+    @Test
+    public void NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS_should_fail_on_java_lang_IO() {
+        assertThatRule(NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS)
+                .checking(new ClassFileImporter().importClasses(UsesJavaLangIO.class))
+                .hasNumberOfViolations(5)
+                .hasViolationContaining("Method <%s.useIo()> calls method <java.lang.IO.println(java.lang.Object)>",
+                        UsesJavaLangIO.class.getName())
+                .hasViolationContaining("Method <%s.useIo()> calls method <java.lang.IO.println()>",
+                        UsesJavaLangIO.class.getName())
+                .hasViolationContaining("Method <%s.useIo()> calls method <java.lang.IO.print(java.lang.Object)>",
+                        UsesJavaLangIO.class.getName())
+                .hasViolationContaining("Method <%s.useIo()> calls method <java.lang.IO.readln()>",
+                        UsesJavaLangIO.class.getName())
+                .hasViolationContaining("Method <%s.useIo()> calls method <java.lang.IO.readln(java.lang.String)>",
+                        UsesJavaLangIO.class.getName());
+    }
+}

--- a/archunit/src/jdk25test/java/com/tngtech/archunit/library/testclasses/standardstreams/UsesJavaLangIO.java
+++ b/archunit/src/jdk25test/java/com/tngtech/archunit/library/testclasses/standardstreams/UsesJavaLangIO.java
@@ -1,0 +1,11 @@
+package com.tngtech.archunit.library.testclasses.standardstreams;
+
+public class UsesJavaLangIO {
+    void useIo() {
+        IO.println("foo");
+        IO.println();
+        IO.print("bar");
+        IO.readln();
+        IO.readln("prompt");
+    }
+}

--- a/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
+++ b/archunit/src/main/java/com/tngtech/archunit/library/GeneralCodingRules.java
@@ -82,7 +82,8 @@ public final class GeneralCodingRules {
     }
 
     /**
-     * A condition that matches classes that access {@code System.out} or {@code System.err}.
+     * A condition that matches classes that access {@link System#out} or {@link System#err},
+     * call methods of {@link java.lang.IO} (JDK 25+), or call {@link Throwable#printStackTrace()}.
      *
      * <p>
      * Example:
@@ -92,6 +93,10 @@ public final class GeneralCodingRules {
      *
      * OutputStream out = System.out; // matches
      * out.write(bytes);
+     *
+     * IO.println("foo"); // matches (JDK 25+)
+     * IO.print("bar"); // matches (JDK 25+)
+     * IO.readln(); // matches (JDK 25+)
      *
      * try {
      *     // ...
@@ -117,13 +122,17 @@ public final class GeneralCodingRules {
                 target(name("printStackTrace"))
                         .and(target(owner(assignableTo(Throwable.class))))
                         .and(target(rawParameterTypes(new Class[0]))));
+        // Referenced by name so ArchUnit remains loadable on JDKs that do not yet provide java.lang.IO
+        ArchCondition<JavaClass> callOfJavaLangIO = callMethodWhere(target(declaredIn("java.lang.IO")));
 
-        return accessToSystemOut.or(accessToSystemErr).or(callOfPrintStackTrace).as("access standard streams");
+        return accessToSystemOut.or(accessToSystemErr).or(callOfPrintStackTrace).or(callOfJavaLangIO)
+                .as("access standard streams");
     }
 
     /**
      * A rule that checks that none of the given classes access the standard streams
-     * {@code System.out} and {@code System.err}.
+     * {@link System#out} and {@link System#err}, call methods of {@link java.lang.IO} (JDK 25+),
+     * or call {@link Throwable#printStackTrace()}.
      *
      * <p>
      * It is generally good practice to use correct logging instead of writing to the console.
@@ -141,6 +150,10 @@ public final class GeneralCodingRules {
      *
      * OutputStream out = System.out; // violation
      * out.write(bytes);
+     *
+     * IO.println("foo"); // violation (JDK 25+)
+     * IO.print("bar"); // violation (JDK 25+)
+     * IO.readln(); // violation (JDK 25+)
      *
      * try {
      *     // ...

--- a/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/library/GeneralCodingRulesTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.library.GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE;
 import static com.tngtech.archunit.library.GeneralCodingRules.DEPRECATED_API_SHOULD_NOT_BE_USED;
+import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 import static com.tngtech.archunit.library.GeneralCodingRules.OLD_DATE_AND_TIME_CLASSES_SHOULD_NOT_BE_USED;
 import static com.tngtech.archunit.library.GeneralCodingRules.testClassesShouldResideInTheSamePackageAsImplementation;
 import static com.tngtech.archunit.testutil.Assertions.assertThatRule;
@@ -196,6 +197,28 @@ public class GeneralCodingRulesTest {
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")
     private @interface DeprecatedAnnotation {
+    }
+
+    @Test
+    public void NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS_should_fail_on_System_out_and_err_and_printStackTrace() {
+        @SuppressWarnings("unused")
+        class AccessesStandardStreams {
+            void write() {
+                System.out.println("out");
+                System.err.println("err");
+            }
+
+            void stackTrace(Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        assertThatRule(NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS)
+                .checking(new ClassFileImporter().importClasses(AccessesStandardStreams.class))
+                .hasNumberOfViolations(3)
+                .hasViolationContaining("gets field <java.lang.System.out>")
+                .hasViolationContaining("gets field <java.lang.System.err>")
+                .hasViolationContaining("calls method <%s.printStackTrace()>", Exception.class.getName());
     }
 
     @Test


### PR DESCRIPTION
## Summary

JDK 25 introduced [`java.lang.IO`](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/IO.html) as convenient access to `System.in` / `System.out`. This change extends `GeneralCodingRules.ACCESS_STANDARD_STREAMS` (and thus `NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS`) so that method calls on `java.lang.IO` are treated like access to the standard streams.

## Changes

- Match method calls whose target is declared in `java.lang.IO` (referenced by name so ArchUnit stays loadable on JDKs that do not provide the class)
- Document the new matches in the existing javadoc examples
- Add unit tests for the existing `System.out` / `System.err` / `printStackTrace` cases and for `java.lang.IO` via a precompiled fixture (works without compiling against JDK 25 APIs in the main test source set)

## Test plan

- [x] `./gradlew :archunit:test --tests com.tngtech.archunit.library.GeneralCodingRulesTest` (JDK 25) — **18/18 passed**

## DCO

Commits are signed off (`Signed-off-by: arimu1 <19286898+arimu1@users.noreply.github.com>`).

Fixes #1686