### PR TITLE
docs: add community examples section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ public class MyArchitectureTest {
 #### Let the API guide you
 ![ArchUnit Fluent API](ArchUnit-API.gif)
 
+## Community Examples
+
+The following projects provide additional examples and best practices for using ArchUnit in real-world applications:
+
+- [devonfw-sample/archunit](https://github.com/devonfw-sample/archunit) — A complete layered architecture demo with well-crafted ArchUnit tests and a CI workflow demonstrating violation reporting.
+
 ## Where to look next
 
 For further information, check out the user guide at [https://archunit.org](https://archunit.org) 


### PR DESCRIPTION
## Summary
Adds a "Community Examples" section to the README linking to the [devonfw-sample/archunit](https://github.com/devonfw-sample/archunit) project, which provides a complete layered architecture demo with well-crafted ArchUnit tests and CI workflow.

This addresses the request raised in #1095 to help users discover community-driven best practices beyond the official examples.

## Changes
- Added `## Community Examples` section to `README.md`
- Listed devonfw-sample/archunit with a brief description

## Checklist
- [x] Documentation change only (no code changes)
- [x] Verified markdown renders correctly