### PR TITLE
Ignore major JUnit Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.vintage:junit-vintage-engine"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
ArchUnit deliberately maintains JUnit 5 and JUnit 6 test configurations side by side. Dependabot otherwise proposes changing the explicit JUnit 5 Jupiter and Vintage dependencies to JUnit 6.

Ignore only semantic-major updates so both baselines continue to receive their minor and patch updates.