### PR TITLE
Make ArchUnit compatible with Gradle test retry plugin

### DIFF
--- a/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngine.java
+++ b/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngine.java
@@ -118,7 +118,7 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
 
     private Stream<Class<?>> filterCandidatesAndLoadClasses(Stream<JavaClass> classes, EngineDiscoveryRequest discoveryRequest) {
         return classes
-                .filter(isAllowedBy(discoveryRequest))
+                .filter(isAllowedBy(discoveryRequest, JavaClass::getName))
                 .filter(this::isArchUnitTestCandidate)
                 .flatMap(this::safelyReflect);
     }
@@ -126,6 +126,7 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
     private void resolveRequestedClasses(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId, ArchUnitEngineDescriptor result) {
         discoveryRequest.getSelectorsByType(ClassSelector.class).stream()
                 .map(ClassSelector::getJavaClass)
+                .filter(isAllowedBy(discoveryRequest, Class::getName))
                 .filter(this::isArchUnitTestCandidate)
                 .forEach(clazz -> ArchUnitTestDescriptor.resolve(
                         result, ElementResolver.create(result, uniqueId, clazz), cache.get()));
@@ -170,14 +171,14 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
         });
     }
 
-    private Predicate<JavaClass> isAllowedBy(EngineDiscoveryRequest discoveryRequest) {
+    private <T> Predicate<T> isAllowedBy(EngineDiscoveryRequest discoveryRequest, Function<T, String> nameOf) {
         List<Predicate<String>> filters = Stream
                 .concat(discoveryRequest.getFiltersByType(ClassNameFilter.class).stream(),
                         discoveryRequest.getFiltersByType(PackageNameFilter.class).stream())
                 .map(Filter::toPredicate)
                 .collect(toList());
 
-        return javaClass -> filters.stream().allMatch(p -> p.test(javaClass.getName()));
+        return candidate -> filters.stream().allMatch(p -> p.test(nameOf.apply(candidate)));
     }
 
     private boolean isArchUnitTestCandidate(JavaClass javaClass) {

--- a/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit5/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
@@ -743,6 +743,19 @@ class ArchUnitTestEngineTest {
         }
 
         @Test
+        void filtering_class_selectors_by_class_name() {
+            EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest()
+                    .withClass(SimpleRuleField.class)
+                    .withClass(SimpleRuleMethod.class)
+                    .withClassNameFilter(excludeClassNamePatterns(".*Field.*"));
+
+            TestDescriptor rootDescriptor = testEngine.discover(discoveryRequest, engineId);
+
+            assertThat(toUniqueIds(rootDescriptor)).containsOnly(
+                    engineId.append(CLASS_SEGMENT_TYPE, SimpleRuleMethod.class.getName()));
+        }
+
+        @Test
         void filtering_excluded_packages() {
             EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest()
                     .withPackage(SimpleRuleLibrary.class.getPackage().getName())

--- a/archunit-junit/junit6/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngine.java
+++ b/archunit-junit/junit6/engine/src/main/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngine.java
@@ -118,7 +118,7 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
 
     private Stream<Class<?>> filterCandidatesAndLoadClasses(Stream<JavaClass> classes, EngineDiscoveryRequest discoveryRequest) {
         return classes
-                .filter(isAllowedBy(discoveryRequest))
+                .filter(isAllowedBy(discoveryRequest, JavaClass::getName))
                 .filter(this::isArchUnitTestCandidate)
                 .flatMap(this::safelyReflect);
     }
@@ -126,6 +126,7 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
     private void resolveRequestedClasses(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId, ArchUnitEngineDescriptor result) {
         discoveryRequest.getSelectorsByType(ClassSelector.class).stream()
                 .map(ClassSelector::getJavaClass)
+                .filter(isAllowedBy(discoveryRequest, Class::getName))
                 .filter(this::isArchUnitTestCandidate)
                 .forEach(clazz -> ArchUnitTestDescriptor.resolve(
                         result, ElementResolver.create(result, uniqueId, clazz), cache.get()));
@@ -170,14 +171,14 @@ public final class ArchUnitTestEngine extends HierarchicalTestEngine<ArchUnitEng
         });
     }
 
-    private Predicate<JavaClass> isAllowedBy(EngineDiscoveryRequest discoveryRequest) {
+    private <T> Predicate<T> isAllowedBy(EngineDiscoveryRequest discoveryRequest, Function<T, String> nameOf) {
         List<Predicate<String>> filters = Stream
                 .concat(discoveryRequest.getFiltersByType(ClassNameFilter.class).stream(),
                         discoveryRequest.getFiltersByType(PackageNameFilter.class).stream())
                 .map(Filter::toPredicate)
                 .collect(toList());
 
-        return javaClass -> filters.stream().allMatch(p -> p.test(javaClass.getName()));
+        return candidate -> filters.stream().allMatch(p -> p.test(nameOf.apply(candidate)));
     }
 
     private boolean isArchUnitTestCandidate(JavaClass javaClass) {

--- a/archunit-junit/junit6/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
+++ b/archunit-junit/junit6/engine/src/test/java/com/tngtech/archunit/junit/internal/ArchUnitTestEngineTest.java
@@ -743,6 +743,19 @@ class ArchUnitTestEngineTest {
         }
 
         @Test
+        void filtering_class_selectors_by_class_name() {
+            EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest()
+                    .withClass(SimpleRuleField.class)
+                    .withClass(SimpleRuleMethod.class)
+                    .withClassNameFilter(excludeClassNamePatterns(".*Field.*"));
+
+            TestDescriptor rootDescriptor = testEngine.discover(discoveryRequest, engineId);
+
+            assertThat(toUniqueIds(rootDescriptor)).containsOnly(
+                    engineId.append(CLASS_SEGMENT_TYPE, SimpleRuleMethod.class.getName()));
+        }
+
+        @Test
         void filtering_excluded_packages() {
             EngineDiscoveryTestRequest discoveryRequest = new EngineDiscoveryTestRequest()
                     .withPackage(SimpleRuleLibrary.class.getPackage().getName())


### PR DESCRIPTION
Gradle always uses individual ClassSelectors for each test class in the test task. The test retry plugin then layers filters on top to include only the tests it wants to rerun. This change ensures these filters are actually honored.

Without this, all ArchUnit tests are rerun, regardless if they failed.

Fixes #1711