### PR TITLE
cleanup ClassFileImporterAnnotationsTest and minor other locations

### DIFF
--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/DomainBuilders.java
@@ -616,7 +616,7 @@ public final class DomainBuilders {
     }
 
     interface JavaTypeCreationProcess<OWNER> {
-        JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes);
+        JavaType finish(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes);
 
         abstract class JavaTypeFinisher {
             private JavaTypeFinisher() {
@@ -697,9 +697,8 @@ public final class DomainBuilders {
             return name;
         }
 
-        @SuppressWarnings("unchecked") // Iterable is covariant
         public List<JavaType> getUpperBounds(Iterable<? extends JavaTypeVariable<?>> allGenericParametersInContext) {
-            return buildJavaTypes(upperBounds, owner, (Iterable<JavaTypeVariable<?>>) allGenericParametersInContext, importedClasses);
+            return buildJavaTypes(upperBounds, owner, allGenericParametersInContext, importedClasses);
         }
     }
 
@@ -780,7 +779,7 @@ public final class DomainBuilders {
     }
 
     interface JavaTypeBuilder<OWNER extends HasDescription> {
-        JavaType build(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses importedClasses);
+        JavaType build(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses importedClasses);
     }
 
     @Internal
@@ -788,7 +787,7 @@ public final class DomainBuilders {
         private final List<JavaTypeCreationProcess<OWNER>> lowerBoundCreationProcesses = new ArrayList<>();
         private final List<JavaTypeCreationProcess<OWNER>> upperBoundCreationProcesses = new ArrayList<>();
         private OWNER owner;
-        private Iterable<JavaTypeVariable<?>> allTypeParametersInContext;
+        private Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext;
         private ImportedClasses importedClasses;
 
         JavaWildcardTypeBuilder() {
@@ -805,7 +804,7 @@ public final class DomainBuilders {
         }
 
         @Override
-        public JavaWildcardType build(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses importedClasses) {
+        public JavaWildcardType build(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses importedClasses) {
             this.owner = owner;
             this.allTypeParametersInContext = allTypeParametersInContext;
             this.importedClasses = importedClasses;
@@ -838,7 +837,7 @@ public final class DomainBuilders {
         }
 
         @Override
-        public JavaType build(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
+        public JavaType build(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
             List<JavaType> typeArguments = buildJavaTypes(typeArgumentCreationProcesses, owner, allTypeParametersInContext, classes);
             return typeArguments.isEmpty()
                     ? classes.getOrResolve(type.getFullyQualifiedClassName())
@@ -855,7 +854,9 @@ public final class DomainBuilders {
         }
     }
 
-    private static <OWNER> List<JavaType> buildJavaTypes(List<? extends JavaTypeCreationProcess<OWNER>> typeCreationProcesses, OWNER owner, Iterable<JavaTypeVariable<?>> allGenericParametersInContext, ImportedClasses classes) {
+    private static <OWNER> List<JavaType> buildJavaTypes(
+            List<? extends JavaTypeCreationProcess<OWNER>> typeCreationProcesses, OWNER owner, Iterable<? extends JavaTypeVariable<?>> allGenericParametersInContext, ImportedClasses classes
+    ) {
         ImmutableList.Builder<JavaType> result = ImmutableList.builder();
         for (JavaTypeCreationProcess<OWNER> typeCreationProcess : typeCreationProcesses) {
             result.add(typeCreationProcess.finish(owner, allGenericParametersInContext, classes));

--- a/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeArgumentProcessor.java
+++ b/archunit/src/main/java/com/tngtech/archunit/core/importer/SignatureTypeArgumentProcessor.java
@@ -166,7 +166,7 @@ class SignatureTypeArgumentProcessor<TYPE extends HasDescription> extends Signat
         }
 
         @Override
-        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
+        public JavaType finish(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
             JavaType type = builder.build(owner, allTypeParametersInContext, classes);
             return typeFinisher.finish(type, classes);
         }
@@ -186,11 +186,11 @@ class SignatureTypeArgumentProcessor<TYPE extends HasDescription> extends Signat
         }
 
         @Override
-        public JavaType finish(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
+        public JavaType finish(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
             return finisher.finish(createTypeVariable(owner, allTypeParametersInContext, classes), classes);
         }
 
-        private JavaType createTypeVariable(OWNER owner, Iterable<JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
+        private JavaType createTypeVariable(OWNER owner, Iterable<? extends JavaTypeVariable<?>> allTypeParametersInContext, ImportedClasses classes) {
             for (JavaTypeVariable<?> existingTypeVariable : allTypeParametersInContext) {
                 if (existingTypeVariable.getName().equals(typeVariableName)) {
                     return existingTypeVariable;

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -450,7 +450,7 @@ public class ClassFileImporterAnnotationsTest {
         Set<JavaAnnotation<JavaParameter>> annotations = getOnlyElement(parameterAnnotations);
 
         assertThat(annotations).isEqualTo(getOnlyElement(method.getParameters()).getAnnotations());
-        assertThatAnnotations(annotations).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[0]));
+        assertThatAnnotations(annotations).match(method.reflect().getParameterAnnotations()[0]);
     }
 
     @Test
@@ -464,7 +464,7 @@ public class ClassFileImporterAnnotationsTest {
         List<JavaParameter> parameters = method.getParameters();
         for (int i = 0; i < 2; i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[i]));
+            assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
         }
     }
 
@@ -484,7 +484,7 @@ public class ClassFileImporterAnnotationsTest {
         List<JavaParameter> parameters = method.getParameters();
         for (int i = 0; i < 4; i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(method.reflect().getParameterAnnotations()[i]));
+            assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
         }
     }
 
@@ -509,7 +509,7 @@ public class ClassFileImporterAnnotationsTest {
         List<JavaParameter> parameters = constructor.getParameters();
         for (int i = 0; i < parameterAnnotations.size(); i++) {
             assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(ImmutableSet.copyOf(constructor.reflect().getParameterAnnotations()[i]));
+            assertThatAnnotations(parameterAnnotations.get(i)).match(constructor.reflect().getParameterAnnotations()[i]);
         }
     }
 

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/ClassFileImporterAnnotationsTest.java
@@ -2,6 +2,8 @@ package com.tngtech.archunit.core.importer;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +33,8 @@ import com.tngtech.archunit.core.importer.testexamples.annotationmethodimport.Me
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationParameter;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.AnnotationToImport;
 import com.tngtech.archunit.core.importer.testexamples.simpleimport.EnumToImport;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.tngtech.archunit.core.importer.testexamples.SomeEnum.OTHER_VALUE;
@@ -49,7 +52,7 @@ import static java.util.Collections.emptySet;
 public class ClassFileImporterAnnotationsTest {
 
     @Test
-    public void imports_simple_annotation() {
+    void imports_simple_annotation() {
         JavaClass javaClass = new ClassFileImporter().importPackagesOf(AnnotationToImport.class).get(AnnotationToImport.class);
 
         assertThat(javaClass)
@@ -67,7 +70,7 @@ public class ClassFileImporterAnnotationsTest {
     }
 
     @Test
-    public void imports_annotation_defaults() {
+    void imports_annotation_defaults() {
         JavaClass annotationType = new ClassFileImporter().importPackagesOf(TypeAnnotationWithEnumAndArrayValue.class).get(TypeAnnotationWithEnumAndArrayValue.class);
 
         assertThat((JavaEnumConstant) annotationType.getMethod("valueWithDefault")
@@ -90,494 +93,518 @@ public class ClassFileImporterAnnotationsTest {
                 .as("default of clazzWithDefault()").matchExactly(Serializable.class, List.class);
     }
 
-    @Test
-    public void distinguishes_between_explicitly_set_values_and_default_values() {
-        @SuppressWarnings("DefaultAnnotationParam")
-        @SimpleAnnotationWithDefaultValues(
-                // this value is explicitly set to a different value than the default
-                defaultValue2 = "overwritten",
-                // this value is explicitly set, but actually the same as the default
-                defaultValue3 = "defaultValue3",
-                noDefault = "mustBeSet")
-        class AnnotatedClass {
+    @Nested
+    class AnnotationParameters {
+        @Test
+        void distinguishes_between_explicitly_set_values_and_default_values() {
+            @SuppressWarnings("DefaultAnnotationParam")
+            @SimpleAnnotationWithDefaultValues(
+                    // this value is explicitly set to a different value than the default
+                    defaultValue2 = "overwritten",
+                    // this value is explicitly set, but actually the same as the default
+                    defaultValue3 = "defaultValue3",
+                    noDefault = "mustBeSet")
+            class AnnotatedClass {
+            }
+
+            JavaAnnotation<?> annotation = new ClassFileImporter().importClasses(AnnotatedClass.class)
+                    .get(AnnotatedClass.class).getAnnotationOfType(SimpleAnnotationWithDefaultValues.class.getName());
+
+            assertThatAnnotation(annotation)
+                    .hasExplicitlyDeclaredStringProperty("defaultValue2", "overwritten")
+                    .hasExplicitlyDeclaredStringProperty("defaultValue3", "defaultValue3")
+                    .hasExplicitlyDeclaredStringProperty("noDefault", "mustBeSet")
+
+                    .hasNoExplicitlyDeclaredProperty("defaultValue1")
+                    .hasStringProperty("defaultValue1", "defaultValue1");
         }
 
-        JavaAnnotation<?> annotation = new ClassFileImporter().importClasses(AnnotatedClass.class)
-                .get(AnnotatedClass.class).getAnnotationOfType(SimpleAnnotationWithDefaultValues.class.getName());
 
-        assertThatAnnotation(annotation)
-                .hasExplicitlyDeclaredStringProperty("defaultValue2", "overwritten")
-                .hasExplicitlyDeclaredStringProperty("defaultValue3", "defaultValue3")
-                .hasExplicitlyDeclaredStringProperty("noDefault", "mustBeSet")
-
-                .hasNoExplicitlyDeclaredProperty("defaultValue1")
-                .hasStringProperty("defaultValue1", "defaultValue1");
     }
 
-    @Test
-    public void imports_class_with_one_annotation_correctly() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithOneAnnotation.class)
-                .get(ClassWithOneAnnotation.class);
+    @Nested
+    class Classes {
+        @Test
+        void imports_class_with_one_annotation_correctly() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithOneAnnotation.class)
+                    .get(ClassWithOneAnnotation.class);
 
-        JavaAnnotation<JavaClass> annotation = clazz.getAnnotationOfType(SimpleAnnotation.class.getName());
-        assertThatType(annotation.getRawType()).matches(SimpleAnnotation.class);
-        assertThatType(annotation.getOwner()).isEqualTo(clazz);
+            JavaAnnotation<JavaClass> annotation = clazz.getAnnotationOfType(SimpleAnnotation.class.getName());
+            assertThatType(annotation.getRawType()).matches(SimpleAnnotation.class);
+            assertThatType(annotation.getOwner()).isEqualTo(clazz);
 
-        JavaAnnotation<?> annotationByName = clazz.getAnnotationOfType(SimpleAnnotation.class.getName());
-        assertThat(annotationByName).isEqualTo(annotation);
+            JavaAnnotation<?> annotationByName = clazz.getAnnotationOfType(SimpleAnnotation.class.getName());
+            assertThat(annotationByName).isEqualTo(annotation);
 
-        assertThat(annotation.get("value").get()).isEqualTo("test");
+            assertThat(annotation.get("value").get()).isEqualTo("test");
 
-        assertThatType(clazz).matches(ClassWithOneAnnotation.class);
-    }
-
-    @Test
-    public void class_handles_optional_annotation_correctly() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithOneAnnotation.class)
-                .get(ClassWithOneAnnotation.class);
-
-        assertThat(clazz.tryGetAnnotationOfType(SimpleAnnotation.class)).isPresent();
-        assertThat(clazz.tryGetAnnotationOfType(Deprecated.class)).isEmpty();
-    }
-
-    @Test
-    public void imports_class_with_complex_annotations_correctly() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithComplexAnnotations.class)
-                .get(ClassWithComplexAnnotations.class);
-
-        assertThat(clazz.getAnnotations()).as("annotations of " + clazz.getSimpleName()).hasSize(2);
-
-        JavaAnnotation<JavaClass> annotation = clazz.getAnnotationOfType(TypeAnnotationWithEnumAndArrayValue.class.getName());
-        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
-        assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
-        JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
-        assertThat(subAnnotation.get("value").get()).isEqualTo("sub");
-        assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(clazz);
-        assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
-                .isEqualTo("default");
-        JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
-        assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("otherFirst");
-        assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(clazz);
-        assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
-                .isEqualTo("first");
-        assertThatType((JavaClass) annotation.get("clazz").get()).matches(Serializable.class);
-        assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
-        assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Serializable.class, String.class);
-        assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
-
-        assertThatType(clazz).matches(ClassWithComplexAnnotations.class);
-    }
-
-    @Test
-    public void imports_class_with_annotation_with_empty_array() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotationWithEmptyArrays.class)
-                .get(ClassWithAnnotationWithEmptyArrays.class);
-
-        JavaAnnotation<?> annotation = clazz.getAnnotationOfType(ClassAnnotationWithArrays.class.getName());
-
-        assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
-        assertThat(Array.getLength(annotation.get("objects").get())).isZero();
-        assertThat(Array.getLength(annotation.get("enums").get())).isZero();
-        assertThat(Array.getLength(annotation.get("classes").get())).isZero();
-        assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
-
-        ClassAnnotationWithArrays reflected = clazz.getAnnotationOfType(ClassAnnotationWithArrays.class);
-        assertThat(reflected.primitives()).isEmpty();
-        assertThat(reflected.objects()).isEmpty();
-        assertThat(reflected.enums()).isEmpty();
-        assertThat(reflected.classes()).isEmpty();
-        assertThat(reflected.annotations()).isEmpty();
-    }
-
-    @Test
-    public void imports_fields_with_one_annotation_correctly() throws Exception {
-        JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
-                .get(ClassWithAnnotatedFields.class).getField("stringAnnotatedField");
-
-        JavaAnnotation<JavaField> annotation = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
-        assertThatType(annotation.getRawType()).matches(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class);
-        assertThat(annotation.get("value").get()).isEqualTo("something");
-        assertThat(annotation.getOwner()).as("owning field").isEqualTo(field);
-
-        assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("stringAnnotatedField"));
-    }
-
-    @Test
-    public void fields_handle_optional_annotation_correctly() {
-        JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
-                .get(ClassWithAnnotatedFields.class).getField("stringAnnotatedField");
-
-        assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class)).isPresent();
-        assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class)).isEmpty();
-
-        Optional<JavaAnnotation<JavaField>> optionalAnnotation = field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
-        assertThat(optionalAnnotation.get().getOwner()).as("owner of optional annotation").isEqualTo(field);
-        assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class.getName()))
-                .as("optional annotation").isEmpty();
-    }
-
-    @Test
-    public void imports_fields_with_two_annotations_correctly() throws Exception {
-        JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
-                .get(ClassWithAnnotatedFields.class).getField("stringAndIntAnnotatedField");
-
-        Set<JavaAnnotation<JavaField>> annotations = field.getAnnotations();
-        assertThat(annotations).hasSize(2);
-        assertThat(annotations).extractingResultOf("getOwner").containsOnly(field);
-        assertThat(annotations).extractingResultOf("getAnnotatedElement").containsOnly(field);
-
-        JavaAnnotation<JavaField> annotationWithString = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
-        assertThat(annotationWithString.get("value").get()).isEqualTo("otherThing");
-
-        JavaAnnotation<JavaField> annotationWithInt = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithIntValue.class.getName());
-        assertThat(annotationWithInt.get("intValue").get()).as("Annotation value with default").isEqualTo(0);
-        assertThat(annotationWithInt.get("otherValue").get()).isEqualTo("overridden");
-
-        assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("stringAndIntAnnotatedField"));
-    }
-
-    @Test
-    public void imports_fields_with_complex_annotations_correctly() throws Exception {
-        JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
-                .get(ClassWithAnnotatedFields.class).getField("enumAndArrayAnnotatedField");
-
-        JavaAnnotation<JavaField> annotation = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class.getName());
-        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
-        assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
-        JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
-        assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
-        assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(field);
-        assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
-                .isEqualTo("default");
-        JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
-        assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
-        assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(field);
-        assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
-                .isEqualTo("first");
-        assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
-        assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
-        assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
-        assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
-
-        assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("enumAndArrayAnnotatedField"));
-    }
-
-    @Test
-    public void imports_fields_with_annotation_with_empty_array() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class).get(ClassWithAnnotatedFields.class);
-
-        JavaAnnotation<?> annotation = clazz.getField("fieldAnnotatedWithEmptyArrays")
-                .getAnnotationOfType(FieldAnnotationWithArrays.class.getName());
-
-        assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
-        assertThat(Array.getLength(annotation.get("objects").get())).isZero();
-        assertThat(Array.getLength(annotation.get("enums").get())).isZero();
-        assertThat(Array.getLength(annotation.get("classes").get())).isZero();
-        assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
-
-        FieldAnnotationWithArrays reflected = annotation.as(FieldAnnotationWithArrays.class);
-        assertThat(reflected.primitives()).isEmpty();
-        assertThat(reflected.objects()).isEmpty();
-        assertThat(reflected.enums()).isEmpty();
-        assertThat(reflected.classes()).isEmpty();
-        assertThat(reflected.annotations()).isEmpty();
-    }
-
-    @Test
-    public void imports_methods_with_one_annotation_correctly() throws Exception {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
-                .get(ClassWithAnnotatedMethods.class).getMethod(stringAnnotatedMethod);
-
-        JavaAnnotation<JavaMethod> annotation = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
-        assertThatType(annotation.getRawType()).matches(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class);
-        assertThat(annotation.getOwner()).isEqualTo(method);
-        assertThat(annotation.get("value").get()).isEqualTo("something");
-
-        assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(stringAnnotatedMethod));
-    }
-
-    @Test
-    public void methods_handle_optional_annotation_correctly() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
-                .get(ClassWithAnnotatedMethods.class).getMethod(stringAnnotatedMethod);
-
-        assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class)).isPresent();
-        assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class)).isEmpty();
-
-        Optional<JavaAnnotation<JavaMethod>> optionalAnnotation = method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
-        assertThat(optionalAnnotation.get().getOwner()).as("owner of optional annotation").isEqualTo(method);
-        assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName())).isEmpty();
-    }
-
-    @Test
-    public void imports_methods_with_two_annotations_correctly() throws Exception {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
-                .get(ClassWithAnnotatedMethods.class).getMethod(stringAndIntAnnotatedMethod);
-
-        Set<JavaAnnotation<JavaMethod>> annotations = method.getAnnotations();
-        assertThat(annotations).hasSize(2);
-        assertThat(annotations).extractingResultOf("getOwner").containsOnly(method);
-        assertThat(annotations).extractingResultOf("getAnnotatedElement").containsOnly(method);
-
-        JavaAnnotation<?> annotationWithString = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
-        assertThat(annotationWithString.get("value").get()).isEqualTo("otherThing");
-
-        JavaAnnotation<?> annotationWithInt = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithIntValue.class.getName());
-        assertThat(annotationWithInt.get("otherValue").get()).isEqualTo("overridden");
-
-        assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(stringAndIntAnnotatedMethod));
-    }
-
-    @Test
-    public void imports_methods_with_complex_annotations_correctly() throws Exception {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
-                .get(ClassWithAnnotatedMethods.class).getMethod(enumAndArrayAnnotatedMethod);
-
-        JavaAnnotation<?> annotation = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName());
-        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
-        assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
-        JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
-        assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
-        assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(method);
-        assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
-                .isEqualTo("default");
-        JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
-        assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
-        assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(method);
-        assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
-                .isEqualTo("first");
-        assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
-        assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
-        assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
-        assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
-
-        assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(enumAndArrayAnnotatedMethod));
-    }
-
-    @Test
-    public void imports_method_with_annotation_with_empty_array() {
-        JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class).get(ClassWithAnnotatedMethods.class);
-
-        JavaAnnotation<?> annotation = clazz.getMethod(methodAnnotatedWithEmptyArrays)
-                .getAnnotationOfType(MethodAnnotationWithArrays.class.getName());
-
-        assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
-        assertThat(Array.getLength(annotation.get("objects").get())).isZero();
-        assertThat(Array.getLength(annotation.get("enums").get())).isZero();
-        assertThat(Array.getLength(annotation.get("classes").get())).isZero();
-        assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
-
-        MethodAnnotationWithArrays reflected = annotation.as(MethodAnnotationWithArrays.class);
-        assertThat(reflected.primitives()).isEmpty();
-        assertThat(reflected.objects()).isEmpty();
-        assertThat(reflected.enums()).isEmpty();
-        assertThat(reflected.classes()).isEmpty();
-        assertThat(reflected.annotations()).isEmpty();
-    }
-
-    @Test
-    public void imports_empty_parameter_annotations_for_method_without_annotated_parameters() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
-                .get(ClassWithMethodWithAnnotatedParameters.class)
-                .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoUnannotatedParameters, String.class, int.class);
-
-        for (JavaParameter parameter : method.getParameters()) {
-            assertThat(parameter.getAnnotations()).isEmpty();
+            assertThatType(clazz).matches(ClassWithOneAnnotation.class);
         }
-        assertThat(method.getParameterAnnotations()).containsExactly(
-                emptySet(), emptySet());
-    }
 
-    @Test
-    public void imports_method_with_one_parameter_with_one_annotation() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
-                .get(ClassWithMethodWithAnnotatedParameters.class)
-                .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithOneAnnotation, String.class);
+        @Test
+        void class_handles_optional_annotation_correctly() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithOneAnnotation.class)
+                    .get(ClassWithOneAnnotation.class);
 
-        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+            assertThat(clazz.tryGetAnnotationOfType(SimpleAnnotation.class)).isPresent();
+            assertThat(clazz.tryGetAnnotationOfType(Deprecated.class)).isEmpty();
+        }
 
-        JavaParameter parameter = getOnlyElement(method.getParameters());
-        JavaAnnotation<JavaParameter> annotation = getOnlyElement(getOnlyElement(parameterAnnotations));
+        @Test
+        void imports_class_with_complex_annotations_correctly() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithComplexAnnotations.class)
+                    .get(ClassWithComplexAnnotations.class);
 
-        assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
-        assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
-        assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
-        JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
-        assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
-        assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(parameter);
-        assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
-                .isEqualTo("default");
-        JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
-        assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("one");
-        assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(parameter);
-        assertThat(subAnnotationArray[1].get("value").get()).isEqualTo("two");
-        assertThat(subAnnotationArray[1].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotationArray[1].getAnnotatedElement()).isEqualTo(parameter);
-        assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
-                .isEqualTo("first");
-        assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
-        assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
-        assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
-        assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
+            assertThat(clazz.getAnnotations()).as("annotations of " + clazz.getSimpleName()).hasSize(2);
 
-        assertThatAnnotation(getOnlyElement(parameter.getAnnotations())).matches(method.reflect().getParameterAnnotations()[0][0]);
-        assertThatAnnotation(annotation).matches(method.reflect().getParameterAnnotations()[0][0]);
-    }
+            JavaAnnotation<JavaClass> annotation = clazz.getAnnotationOfType(TypeAnnotationWithEnumAndArrayValue.class.getName());
+            assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+            assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
+            JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
+            assertThat(subAnnotation.get("value").get()).isEqualTo("sub");
+            assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(clazz);
+            assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
+                    .isEqualTo("default");
+            JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
+            assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("otherFirst");
+            assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(clazz);
+            assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
+                    .isEqualTo("first");
+            assertThatType((JavaClass) annotation.get("clazz").get()).matches(Serializable.class);
+            assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
+            assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Serializable.class, String.class);
+            assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
 
-    @Test
-    public void imports_method_with_one_parameter_with_two_annotations() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
-                .get(ClassWithMethodWithAnnotatedParameters.class)
-                .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithTwoAnnotations, String.class);
+            assertThatType(clazz).matches(ClassWithComplexAnnotations.class);
+        }
 
-        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+        @Test
+        void imports_class_with_annotation_with_empty_array() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotationWithEmptyArrays.class)
+                    .get(ClassWithAnnotationWithEmptyArrays.class);
 
-        Set<JavaAnnotation<JavaParameter>> annotations = getOnlyElement(parameterAnnotations);
+            JavaAnnotation<?> annotation = clazz.getAnnotationOfType(ClassAnnotationWithArrays.class.getName());
 
-        assertThat(annotations).isEqualTo(getOnlyElement(method.getParameters()).getAnnotations());
-        assertThatAnnotations(annotations).match(method.reflect().getParameterAnnotations()[0]);
-    }
+            assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
+            assertThat(Array.getLength(annotation.get("objects").get())).isZero();
+            assertThat(Array.getLength(annotation.get("enums").get())).isZero();
+            assertThat(Array.getLength(annotation.get("classes").get())).isZero();
+            assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
 
-    @Test
-    public void imports_methods_with_multiple_parameters_with_annotations() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
-                .get(ClassWithMethodWithAnnotatedParameters.class)
-                .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoAnnotatedParameters, String.class, int.class);
-
-        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
-
-        List<JavaParameter> parameters = method.getParameters();
-        for (int i = 0; i < 2; i++) {
-            assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
+            ClassAnnotationWithArrays reflected = clazz.getAnnotationOfType(ClassAnnotationWithArrays.class);
+            assertThat(reflected.primitives()).isEmpty();
+            assertThat(reflected.objects()).isEmpty();
+            assertThat(reflected.enums()).isEmpty();
+            assertThat(reflected.classes()).isEmpty();
+            assertThat(reflected.annotations()).isEmpty();
         }
     }
 
-    @Test
-    public void imports_methods_with_multiple_parameters_with_annotations_but_unannotated_parameters_in_between() {
-        JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
-                .get(ClassWithMethodWithAnnotatedParameters.class)
-                .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithAnnotatedParametersGap, String.class, int.class, Object.class, List.class);
+    @Nested
+    class Fields {
 
-        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+        @Test
+        void imports_fields_with_one_annotation_correctly() throws Exception {
+            JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
+                    .get(ClassWithAnnotatedFields.class).getField("stringAnnotatedField");
 
-        assertThatAnnotations(parameterAnnotations.get(0)).isNotEmpty();
-        assertThatAnnotations(parameterAnnotations.get(1)).isEmpty();
-        assertThatAnnotations(parameterAnnotations.get(2)).isEmpty();
-        assertThatAnnotations(parameterAnnotations.get(3)).isNotEmpty();
+            JavaAnnotation<JavaField> annotation = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
+            assertThatType(annotation.getRawType()).matches(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class);
+            assertThat(annotation.get("value").get()).isEqualTo("something");
+            assertThat(annotation.getOwner()).as("owning field").isEqualTo(field);
 
-        List<JavaParameter> parameters = method.getParameters();
-        for (int i = 0; i < 4; i++) {
-            assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
+            assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("stringAnnotatedField"));
+        }
+
+        @Test
+        void fields_handle_optional_annotation_correctly() {
+            JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
+                    .get(ClassWithAnnotatedFields.class).getField("stringAnnotatedField");
+
+            assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class)).isPresent();
+            assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class)).isEmpty();
+
+            Optional<JavaAnnotation<JavaField>> optionalAnnotation = field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
+            assertThat(optionalAnnotation.get().getOwner()).as("owner of optional annotation").isEqualTo(field);
+            assertThat(field.tryGetAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class.getName()))
+                    .as("optional annotation").isEmpty();
+        }
+
+        @Test
+        void imports_fields_with_two_annotations_correctly() throws Exception {
+            JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
+                    .get(ClassWithAnnotatedFields.class).getField("stringAndIntAnnotatedField");
+
+            Set<JavaAnnotation<JavaField>> annotations = field.getAnnotations();
+            assertThat(annotations).hasSize(2);
+            assertThat(annotations).extractingResultOf("getOwner").containsOnly(field);
+            assertThat(annotations).extractingResultOf("getAnnotatedElement").containsOnly(field);
+
+            JavaAnnotation<JavaField> annotationWithString = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithStringValue.class.getName());
+            assertThat(annotationWithString.get("value").get()).isEqualTo("otherThing");
+
+            JavaAnnotation<JavaField> annotationWithInt = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithIntValue.class.getName());
+            assertThat(annotationWithInt.get("intValue").get()).as("Annotation value with default").isEqualTo(0);
+            assertThat(annotationWithInt.get("otherValue").get()).isEqualTo("overridden");
+
+            assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("stringAndIntAnnotatedField"));
+        }
+
+        @Test
+        void imports_fields_with_complex_annotations_correctly() throws Exception {
+            JavaField field = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class)
+                    .get(ClassWithAnnotatedFields.class).getField("enumAndArrayAnnotatedField");
+
+            JavaAnnotation<JavaField> annotation = field.getAnnotationOfType(ClassWithAnnotatedFields.FieldAnnotationWithEnumClassAndArrayValue.class.getName());
+            assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+            assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
+            JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
+            assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
+            assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(field);
+            assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
+                    .isEqualTo("default");
+            JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
+            assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
+            assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(field);
+            assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
+                    .isEqualTo("first");
+            assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
+            assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
+            assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
+            assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
+
+            assertThat(field).isEquivalentTo(field.getOwner().reflect().getDeclaredField("enumAndArrayAnnotatedField"));
+        }
+
+        @Test
+        void imports_fields_with_annotation_with_empty_array() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedFields.class).get(ClassWithAnnotatedFields.class);
+
+            JavaAnnotation<?> annotation = clazz.getField("fieldAnnotatedWithEmptyArrays")
+                    .getAnnotationOfType(FieldAnnotationWithArrays.class.getName());
+
+            assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
+            assertThat(Array.getLength(annotation.get("objects").get())).isZero();
+            assertThat(Array.getLength(annotation.get("enums").get())).isZero();
+            assertThat(Array.getLength(annotation.get("classes").get())).isZero();
+            assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
+
+            FieldAnnotationWithArrays reflected = annotation.as(FieldAnnotationWithArrays.class);
+            assertThat(reflected.primitives()).isEmpty();
+            assertThat(reflected.objects()).isEmpty();
+            assertThat(reflected.enums()).isEmpty();
+            assertThat(reflected.classes()).isEmpty();
+            assertThat(reflected.annotations()).isEmpty();
         }
     }
 
-    @Test
-    public void imports_parameter_annotations_correctly_for_synthetic_constructor_parameter() {
-        @SuppressWarnings("unused")
-        class LocalClassThusSyntheticFirstConstructorParameter {
-            LocalClassThusSyntheticFirstConstructorParameter(Object notAnnotated, @SimpleAnnotation("test") List<String> annotated) {
+    @Nested
+    class Methods {
+        @Test
+        void imports_methods_with_one_annotation_correctly() throws Exception {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
+                    .get(ClassWithAnnotatedMethods.class).getMethod(stringAnnotatedMethod);
+
+            JavaAnnotation<JavaMethod> annotation = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
+            assertThatType(annotation.getRawType()).matches(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class);
+            assertThat(annotation.getOwner()).isEqualTo(method);
+            assertThat(annotation.get("value").get()).isEqualTo("something");
+
+            assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(stringAnnotatedMethod));
+        }
+
+        @Test
+        void methods_handle_optional_annotation_correctly() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
+                    .get(ClassWithAnnotatedMethods.class).getMethod(stringAnnotatedMethod);
+
+            assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class)).isPresent();
+            assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class)).isEmpty();
+
+            Optional<JavaAnnotation<JavaMethod>> optionalAnnotation = method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
+            assertThat(optionalAnnotation.get().getOwner()).as("owner of optional annotation").isEqualTo(method);
+            assertThat(method.tryGetAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName())).isEmpty();
+        }
+
+        @Test
+        void imports_methods_with_two_annotations_correctly() throws Exception {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
+                    .get(ClassWithAnnotatedMethods.class).getMethod(stringAndIntAnnotatedMethod);
+
+            Set<JavaAnnotation<JavaMethod>> annotations = method.getAnnotations();
+            assertThat(annotations).hasSize(2);
+            assertThat(annotations).extractingResultOf("getOwner").containsOnly(method);
+            assertThat(annotations).extractingResultOf("getAnnotatedElement").containsOnly(method);
+
+            JavaAnnotation<?> annotationWithString = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithStringValue.class.getName());
+            assertThat(annotationWithString.get("value").get()).isEqualTo("otherThing");
+
+            JavaAnnotation<?> annotationWithInt = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithIntValue.class.getName());
+            assertThat(annotationWithInt.get("otherValue").get()).isEqualTo("overridden");
+
+            assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(stringAndIntAnnotatedMethod));
+        }
+
+        @Test
+        void imports_methods_with_complex_annotations_correctly() throws Exception {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
+                    .get(ClassWithAnnotatedMethods.class).getMethod(enumAndArrayAnnotatedMethod);
+
+            JavaAnnotation<?> annotation = method.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName());
+            assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+            assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
+            JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
+            assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
+            assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(method);
+            assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
+                    .isEqualTo("default");
+            JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
+            assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
+            assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(method);
+            assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
+                    .isEqualTo("first");
+            assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
+            assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
+            assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
+            assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
+
+            assertThat(method).isEquivalentTo(ClassWithAnnotatedMethods.class.getMethod(enumAndArrayAnnotatedMethod));
+        }
+
+        @Test
+        void imports_method_with_annotation_with_empty_array() {
+            JavaClass clazz = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class).get(ClassWithAnnotatedMethods.class);
+
+            JavaAnnotation<?> annotation = clazz.getMethod(methodAnnotatedWithEmptyArrays)
+                    .getAnnotationOfType(MethodAnnotationWithArrays.class.getName());
+
+            assertThat(Array.getLength(annotation.get("primitives").get())).isZero();
+            assertThat(Array.getLength(annotation.get("objects").get())).isZero();
+            assertThat(Array.getLength(annotation.get("enums").get())).isZero();
+            assertThat(Array.getLength(annotation.get("classes").get())).isZero();
+            assertThat(Array.getLength(annotation.get("annotations").get())).isZero();
+
+            MethodAnnotationWithArrays reflected = annotation.as(MethodAnnotationWithArrays.class);
+            assertThat(reflected.primitives()).isEmpty();
+            assertThat(reflected.objects()).isEmpty();
+            assertThat(reflected.enums()).isEmpty();
+            assertThat(reflected.classes()).isEmpty();
+            assertThat(reflected.annotations()).isEmpty();
+        }
+    }
+
+    @Nested
+    class MethodAndConstructorParameters {
+        @Test
+        void imports_empty_parameter_annotations_for_method_without_annotated_parameters() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
+                    .get(ClassWithMethodWithAnnotatedParameters.class)
+                    .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoUnannotatedParameters, String.class, int.class);
+
+            for (JavaParameter parameter : method.getParameters()) {
+                assertThat(parameter.getAnnotations()).isEmpty();
+            }
+            assertThat(method.getParameterAnnotations()).containsExactly(
+                    emptySet(), emptySet());
+        }
+
+        @Test
+        void imports_method_with_one_parameter_with_one_annotation() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
+                    .get(ClassWithMethodWithAnnotatedParameters.class)
+                    .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithOneAnnotation, String.class);
+
+            List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+
+            JavaParameter parameter = getOnlyElement(method.getParameters());
+            JavaAnnotation<JavaParameter> annotation = getOnlyElement(getOnlyElement(parameterAnnotations));
+
+            assertThat((JavaEnumConstant) annotation.get("value").get()).isEquivalentTo(OTHER_VALUE);
+            assertThat((JavaEnumConstant) annotation.get("valueWithDefault").get()).isEquivalentTo(SOME_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArray").get())).matches(SOME_VALUE, OTHER_VALUE);
+            assertThat(((JavaEnumConstant[]) annotation.get("enumArrayWithDefault").get())).matches(OTHER_VALUE);
+            JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
+            assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
+            assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(parameter);
+            assertThat(((JavaAnnotation<?>) annotation.get("subAnnotationWithDefault").get()).get("value").get())
+                    .isEqualTo("default");
+            JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
+            assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("one");
+            assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(parameter);
+            assertThat(subAnnotationArray[1].get("value").get()).isEqualTo("two");
+            assertThat(subAnnotationArray[1].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotationArray[1].getAnnotatedElement()).isEqualTo(parameter);
+            assertThat(((JavaAnnotation<?>[]) annotation.get("subAnnotationArrayWithDefault").get())[0].get("value").get())
+                    .isEqualTo("first");
+            assertThatType((JavaClass) annotation.get("clazz").get()).matches(Map.class);
+            assertThatType((JavaClass) annotation.get("clazzWithDefault").get()).matches(String.class);
+            assertThat((JavaClass[]) annotation.get("classes").get()).matchExactly(Object.class, Serializable.class);
+            assertThat((JavaClass[]) annotation.get("classesWithDefault").get()).matchExactly(Serializable.class, List.class);
+
+            assertThatAnnotation(getOnlyElement(parameter.getAnnotations())).matches(method.reflect().getParameterAnnotations()[0][0]);
+            assertThatAnnotation(annotation).matches(method.reflect().getParameterAnnotations()[0][0]);
+        }
+
+        @Test
+        void imports_method_with_one_parameter_with_two_annotations() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
+                    .get(ClassWithMethodWithAnnotatedParameters.class)
+                    .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithOneAnnotatedParameterWithTwoAnnotations, String.class);
+
+            List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+
+            Set<JavaAnnotation<JavaParameter>> annotations = getOnlyElement(parameterAnnotations);
+
+            assertThat(annotations).isEqualTo(getOnlyElement(method.getParameters()).getAnnotations());
+            assertThatAnnotations(annotations).match(method.reflect().getParameterAnnotations()[0]);
+        }
+
+        @Test
+        void imports_methods_with_multiple_parameters_with_annotations() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
+                    .get(ClassWithMethodWithAnnotatedParameters.class)
+                    .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithTwoAnnotatedParameters, String.class, int.class);
+
+            List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
+
+            List<JavaParameter> parameters = method.getParameters();
+            for (int i = 0; i < 2; i++) {
+                assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
+                assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
             }
         }
 
-        JavaConstructor constructor = getOnlyElement(new ClassFileImporter().importClasses(LocalClassThusSyntheticFirstConstructorParameter.class, String.class)
-                .get(LocalClassThusSyntheticFirstConstructorParameter.class)
-                .getConstructors());
+        @Test
+        void imports_methods_with_multiple_parameters_with_annotations_but_unannotated_parameters_in_between() {
+            JavaMethod method = new ClassFileImporter().importPackagesOf(ClassWithMethodWithAnnotatedParameters.class)
+                    .get(ClassWithMethodWithAnnotatedParameters.class)
+                    .getMethod(ClassWithMethodWithAnnotatedParameters.methodWithAnnotatedParametersGap, String.class, int.class, Object.class, List.class);
 
-        List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = constructor.getParameterAnnotations();
+            List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = method.getParameterAnnotations();
 
-        assertThat(parameterAnnotations).as("parameter annotations").hasSize(2);
-        assertThatAnnotations(parameterAnnotations.get(0)).isEmpty();
-        assertThatAnnotations(parameterAnnotations.get(1)).isNotEmpty();
+            assertThatAnnotations(parameterAnnotations.get(0)).isNotEmpty();
+            assertThatAnnotations(parameterAnnotations.get(1)).isEmpty();
+            assertThatAnnotations(parameterAnnotations.get(2)).isEmpty();
+            assertThatAnnotations(parameterAnnotations.get(3)).isNotEmpty();
 
-        List<JavaParameter> parameters = constructor.getParameters();
-        for (int i = 0; i < parameterAnnotations.size(); i++) {
-            assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
-            assertThatAnnotations(parameterAnnotations.get(i)).match(constructor.reflect().getParameterAnnotations()[i]);
+            List<JavaParameter> parameters = method.getParameters();
+            for (int i = 0; i < 4; i++) {
+                assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
+                assertThatAnnotations(parameterAnnotations.get(i)).match(method.reflect().getParameterAnnotations()[i]);
+            }
+        }
+
+        @Test
+        void imports_parameter_annotations_correctly_for_synthetic_constructor_parameter() {
+            @SuppressWarnings("unused")
+            class LocalClassThusSyntheticFirstConstructorParameter {
+                LocalClassThusSyntheticFirstConstructorParameter(Object notAnnotated, @ClassWithMethodWithAnnotatedParameters.SimpleParameterAnnotation("test") List<String> annotated) {
+                }
+            }
+
+            JavaConstructor constructor = getOnlyElement(new ClassFileImporter().importClasses(LocalClassThusSyntheticFirstConstructorParameter.class, String.class)
+                    .get(LocalClassThusSyntheticFirstConstructorParameter.class)
+                    .getConstructors());
+
+            List<Set<JavaAnnotation<JavaParameter>>> parameterAnnotations = constructor.getParameterAnnotations();
+
+            assertThat(parameterAnnotations).as("parameter annotations").hasSize(2);
+            assertThatAnnotations(parameterAnnotations.get(0)).isEmpty();
+            assertThatAnnotations(parameterAnnotations.get(1)).isNotEmpty();
+
+            List<JavaParameter> parameters = constructor.getParameters();
+            for (int i = 0; i < parameterAnnotations.size(); i++) {
+                assertThat(parameterAnnotations.get(i)).isEqualTo(parameters.get(i).getAnnotations());
+                assertThatAnnotations(parameterAnnotations.get(i)).match(constructor.reflect().getParameterAnnotations()[i]);
+            }
         }
     }
 
-    @Test
-    public void imports_constructors_with_complex_annotations_correctly() throws Exception {
-        JavaConstructor constructor = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
-                .get(ClassWithAnnotatedMethods.class).getConstructor();
+    @Nested
+    class Constructors {
+        @Test
+        void imports_constructors_with_complex_annotations_correctly() throws Exception {
+            JavaConstructor constructor = new ClassFileImporter().importPackagesOf(ClassWithAnnotatedMethods.class)
+                    .get(ClassWithAnnotatedMethods.class).getConstructor();
 
-        JavaAnnotation<JavaConstructor> annotation = constructor.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName());
-        assertThat((Object[]) annotation.get("classes").get()).extracting("name")
-                .containsExactly(Object.class.getName(), Serializable.class.getName());
-        assertThat(annotation.getOwner()).isEqualTo(constructor);
-        JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
-        assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
-        assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(constructor);
-        JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
-        assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
-        assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
-        assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(constructor);
+            JavaAnnotation<JavaConstructor> annotation = constructor.getAnnotationOfType(ClassWithAnnotatedMethods.MethodAnnotationWithEnumAndArrayValue.class.getName());
+            assertThat((Object[]) annotation.get("classes").get()).extracting("name")
+                    .containsExactly(Object.class.getName(), Serializable.class.getName());
+            assertThat(annotation.getOwner()).isEqualTo(constructor);
+            JavaAnnotation<?> subAnnotation = (JavaAnnotation<?>) annotation.get("subAnnotation").get();
+            assertThat(subAnnotation.get("value").get()).isEqualTo("changed");
+            assertThat(subAnnotation.getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotation.getAnnotatedElement()).isEqualTo(constructor);
+            JavaAnnotation<?>[] subAnnotationArray = (JavaAnnotation<?>[]) annotation.get("subAnnotationArray").get();
+            assertThat(subAnnotationArray[0].get("value").get()).isEqualTo("another");
+            assertThat(subAnnotationArray[0].getOwner()).isEqualTo(annotation);
+            assertThat(subAnnotationArray[0].getAnnotatedElement()).isEqualTo(constructor);
 
-        assertThat(constructor).isEquivalentTo(ClassWithAnnotatedMethods.class.getConstructor());
+            assertThat(constructor).isEquivalentTo(ClassWithAnnotatedMethods.class.getConstructor());
+        }
     }
 
-    @Test
-    public void classes_know_which_annotations_have_their_type() {
-        JavaClasses classes = new ClassFileImporter().importClasses(ClassWithOneAnnotation.class, SimpleAnnotation.class);
+    @Nested
+    class Usages {
+        @Test
+        void classes_know_which_annotations_have_their_type() {
+            JavaClasses classes = new ClassFileImporter().importClasses(ClassWithOneAnnotation.class, SimpleAnnotation.class);
 
-        Set<JavaAnnotation<?>> annotations = classes.get(SimpleAnnotation.class).getAnnotationsWithTypeOfSelf();
+            Set<JavaAnnotation<?>> annotations = classes.get(SimpleAnnotation.class).getAnnotationsWithTypeOfSelf();
 
-        assertThat(getOnlyElement(annotations).getOwner()).isEqualTo(classes.get(ClassWithOneAnnotation.class));
-    }
+            assertThat(getOnlyElement(annotations).getOwner()).isEqualTo(classes.get(ClassWithOneAnnotation.class));
+        }
 
-    @Test
-    public void classes_know_which_annotation_members_have_their_type() {
-        @SuppressWarnings("unused")
-        @ParameterAnnotation(value = String.class)
-        class Dependent {
+        @Test
+        void classes_know_which_annotation_members_have_their_type() {
+            @SuppressWarnings("unused")
             @ParameterAnnotation(value = String.class)
-            String field;
+            class Dependent {
+                @ParameterAnnotation(value = String.class)
+                String field;
 
-            @ParameterAnnotation(value = String.class)
-            Dependent() {
+                @ParameterAnnotation(value = String.class)
+                Dependent() {
+                }
+
+                @ParameterAnnotation(value = String.class)
+                void method() {
+                }
+
+                @ParameterAnnotation(value = List.class)
+                void notToFind() {
+                }
             }
 
-            @ParameterAnnotation(value = String.class)
-            void method() {
+            JavaClasses classes = new ClassFileImporter().importClasses(Dependent.class, ParameterAnnotation.class, String.class);
+            Set<JavaAnnotation<?>> annotations = classes.get(String.class).getAnnotationsWithParameterTypeOfSelf();
+
+            for (JavaAnnotation<?> annotation : annotations) {
+                assertThatAnnotation(annotation).hasType(ParameterAnnotation.class);
             }
 
-            @ParameterAnnotation(value = List.class)
-            void notToFind() {
-            }
+            Set<JavaAnnotation<?>> expected = ImmutableSet.of(
+                    classes.get(Dependent.class).getAnnotationOfType(ParameterAnnotation.class.getName()),
+                    classes.get(Dependent.class).getField("field").getAnnotationOfType(ParameterAnnotation.class.getName()),
+                    classes.get(Dependent.class).getConstructor(getClass()).getAnnotationOfType(ParameterAnnotation.class.getName()),
+                    classes.get(Dependent.class).getMethod("method").getAnnotationOfType(ParameterAnnotation.class.getName())
+            );
+            assertThat(annotations).as("annotations with parameter type " + String.class.getSimpleName()).hasSameElementsAs(expected);
         }
-
-        JavaClasses classes = new ClassFileImporter().importClasses(Dependent.class, ParameterAnnotation.class, String.class);
-        Set<JavaAnnotation<?>> annotations = classes.get(String.class).getAnnotationsWithParameterTypeOfSelf();
-
-        for (JavaAnnotation<?> annotation : annotations) {
-            assertThatAnnotation(annotation).hasType(ParameterAnnotation.class);
-        }
-
-        Set<JavaAnnotation<?>> expected = ImmutableSet.of(
-                classes.get(Dependent.class).getAnnotationOfType(ParameterAnnotation.class.getName()),
-                classes.get(Dependent.class).getField("field").getAnnotationOfType(ParameterAnnotation.class.getName()),
-                classes.get(Dependent.class).getConstructor(getClass()).getAnnotationOfType(ParameterAnnotation.class.getName()),
-                classes.get(Dependent.class).getMethod("method").getAnnotationOfType(ParameterAnnotation.class.getName())
-        );
-        assertThat(annotations).as("annotations with parameter type " + String.class.getSimpleName()).hasSameElementsAs(expected);
     }
 
     @SuppressWarnings({"unchecked", "unused"})
@@ -586,6 +613,7 @@ public class ClassFileImporterAnnotationsTest {
     }
 
     @SuppressWarnings("unused")
+    @Target(ElementType.TYPE)
     private @interface SimpleAnnotationWithDefaultValues {
         String defaultValue1() default "defaultValue1";
 
@@ -596,109 +624,7 @@ public class ClassFileImporterAnnotationsTest {
         String noDefault();
     }
 
-    @SuppressWarnings("unused")
-    private @interface MetaAnnotationWithParameters {
-        SomeEnum someEnum();
-
-        SomeEnum someEnumDefault() default SomeEnum.VARIABLE;
-
-        ParameterAnnotation parameterAnnotation();
-
-        ParameterAnnotation parameterAnnotationDefault() default @ParameterAnnotation(Integer.class);
-    }
-
-    @SuppressWarnings("unused")
-    private @interface SomeMetaMetaMetaAnnotationWithParameters {
-        Class<?> classParam();
-
-        Class<?> classParamDefault() default String.class;
-
-        SomeMetaMetaMetaAnnotationEnumParameter enumParam();
-
-        SomeMetaMetaMetaAnnotationEnumParameter enumParamDefault() default SomeMetaMetaMetaAnnotationEnumParameter.CONSTANT;
-
-        SomeMetaMetaMetaParameterAnnotation annotationParam();
-
-        SomeMetaMetaMetaParameterAnnotation annotationParamDefault() default @SomeMetaMetaMetaParameterAnnotation(Boolean.class);
-    }
-
-    @SomeMetaMetaMetaAnnotationWithParameters(
-            classParam = SomeMetaMetaMetaAnnotationClassParameter.class,
-            enumParam = SomeMetaMetaMetaAnnotationEnumParameter.VALUE,
-            annotationParam = @SomeMetaMetaMetaParameterAnnotation(SomeMetaMetaMetaParameterAnnotationClassParameter.class)
-    )
-    private @interface SomeMetaMetaAnnotation {
-    }
-
-    @SomeMetaMetaAnnotation
-    private @interface SomeMetaAnnotation {
-    }
-
-    @MetaAnnotationWithParameters(
-            someEnum = SomeEnum.CONSTANT,
-            parameterAnnotation = @ParameterAnnotation(SomeAnnotationParameterType.class)
-    )
-    @SomeMetaAnnotation
-    private @interface MetaAnnotatedAnnotation {
-    }
-
-    private enum SomeEnum {
-        CONSTANT,
-        VARIABLE
-    }
-
     private @interface ParameterAnnotation {
         Class<?> value();
-    }
-
-    private static class SomeAnnotationParameterType {
-    }
-
-
-    @SuppressWarnings("unused")
-    private static class ClassWithMetaAnnotatedField {
-        @MetaAnnotatedAnnotation
-        int metaAnnotatedField;
-    }
-
-    @SuppressWarnings("unused")
-    private static class ClassWithMetaAnnotatedMethod {
-        @MetaAnnotatedAnnotation
-        void metaAnnotatedMethod() {
-        }
-    }
-
-    @SuppressWarnings("unused")
-    private static class ClassWithMetaAnnotatedConstructor {
-        @MetaAnnotatedAnnotation
-        ClassWithMetaAnnotatedConstructor() {
-        }
-    }
-
-    @SuppressWarnings("unused")
-    private static class ClassWithMetaAnnotatedConstructorParameter {
-        ClassWithMetaAnnotatedConstructorParameter(@MetaAnnotatedAnnotation String param) {
-        }
-    }
-
-    @SuppressWarnings("unused")
-    private static class ClassWithMetaAnnotatedMethodParameter {
-        void method(@MetaAnnotatedAnnotation String param) {
-        }
-    }
-
-    private static class SomeMetaMetaMetaAnnotationClassParameter {
-    }
-
-    private enum SomeMetaMetaMetaAnnotationEnumParameter {
-        VALUE,
-        CONSTANT
-    }
-
-    private @interface SomeMetaMetaMetaParameterAnnotation {
-        Class<?> value();
-    }
-
-    private static class SomeMetaMetaMetaParameterAnnotationClassParameter {
     }
 }

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedclassimport/ClassAnnotationWithArrays.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedclassimport/ClassAnnotationWithArrays.java
@@ -1,11 +1,14 @@
 package com.tngtech.archunit.core.importer.testexamples.annotatedclassimport;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+@Target(ElementType.TYPE)
 @Retention(RUNTIME)
 public @interface ClassAnnotationWithArrays {
     int[] primitives();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedclassimport/SimpleAnnotation.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedclassimport/SimpleAnnotation.java
@@ -1,8 +1,11 @@
 package com.tngtech.archunit.core.importer.testexamples.annotatedclassimport;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SimpleAnnotation {
     String value();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedparameters/ClassWithMethodWithAnnotatedParameters.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotatedparameters/ClassWithMethodWithAnnotatedParameters.java
@@ -1,7 +1,9 @@
 package com.tngtech.archunit.core.importer.testexamples.annotatedparameters;
 
 import java.io.Serializable;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,8 +29,8 @@ public class ClassWithMethodWithAnnotatedParameters {
             @SomeParameterAnnotation(
                     value = OTHER_VALUE,
                     enumArray = {SOME_VALUE, OTHER_VALUE},
-                    subAnnotation = @SimpleAnnotation("changed"),
-                    subAnnotationArray = {@SimpleAnnotation("one"), @SimpleAnnotation("two")},
+                    subAnnotation = @SimpleParameterAnnotation("changed"),
+                    subAnnotationArray = {@SimpleParameterAnnotation("one"), @SimpleParameterAnnotation("two")},
                     clazz = Map.class,
                     classes = {Object.class, Serializable.class}
             ) String param
@@ -40,8 +42,8 @@ public class ClassWithMethodWithAnnotatedParameters {
             @SomeParameterAnnotation(
                     value = OTHER_VALUE,
                     enumArray = {SOME_VALUE, OTHER_VALUE},
-                    subAnnotation = @SimpleAnnotation("changed"),
-                    subAnnotationArray = {@SimpleAnnotation("one"), @SimpleAnnotation("two")},
+                    subAnnotation = @SimpleParameterAnnotation("changed"),
+                    subAnnotationArray = {@SimpleParameterAnnotation("one"), @SimpleParameterAnnotation("two")},
                     clazz = Map.class,
                     classes = {Object.class, Serializable.class}
             ) String param
@@ -52,8 +54,8 @@ public class ClassWithMethodWithAnnotatedParameters {
             @SomeParameterAnnotation(
                     value = OTHER_VALUE,
                     enumArray = {SOME_VALUE, OTHER_VALUE},
-                    subAnnotation = @SimpleAnnotation("first"),
-                    subAnnotationArray = {@SimpleAnnotation("first_one"), @SimpleAnnotation("first_two")},
+                    subAnnotation = @SimpleParameterAnnotation("first"),
+                    subAnnotationArray = {@SimpleParameterAnnotation("first_one"), @SimpleParameterAnnotation("first_two")},
                     clazz = String.class,
                     classes = {String.class, Serializable.class}
             ) String first,
@@ -61,8 +63,8 @@ public class ClassWithMethodWithAnnotatedParameters {
             @SomeParameterAnnotation(
                     value = SOME_VALUE,
                     enumArray = {OTHER_VALUE, SOME_VALUE},
-                    subAnnotation = @SimpleAnnotation("second"),
-                    subAnnotationArray = {@SimpleAnnotation("second_one"), @SimpleAnnotation("second_two")},
+                    subAnnotation = @SimpleParameterAnnotation("second"),
+                    subAnnotationArray = {@SimpleParameterAnnotation("second_one"), @SimpleParameterAnnotation("second_two")},
                     clazz = List.class,
                     classes = {Set.class, Map.class}
             ) int second
@@ -70,13 +72,14 @@ public class ClassWithMethodWithAnnotatedParameters {
     }
 
     <T> void methodWithAnnotatedParametersGap(
-            @SimpleAnnotation("first") String first,
+            @SimpleParameterAnnotation("first") String first,
             int second,
             T third,
-            @SimpleAnnotation("fourth") List<String> fourth
+            @SimpleParameterAnnotation("fourth") List<String> fourth
     ) {
     }
 
+    @Target(ElementType.PARAMETER)
     @Retention(RUNTIME)
     public @interface SomeParameterAnnotation {
         SomeEnum value();
@@ -87,13 +90,13 @@ public class ClassWithMethodWithAnnotatedParameters {
 
         SomeEnum[] enumArrayWithDefault() default {OTHER_VALUE};
 
-        SimpleAnnotation subAnnotation();
+        SimpleParameterAnnotation subAnnotation();
 
-        SimpleAnnotation subAnnotationWithDefault() default @SimpleAnnotation("default");
+        SimpleParameterAnnotation subAnnotationWithDefault() default @SimpleParameterAnnotation("default");
 
-        SimpleAnnotation[] subAnnotationArray();
+        SimpleParameterAnnotation[] subAnnotationArray();
 
-        SimpleAnnotation[] subAnnotationArrayWithDefault() default {@SimpleAnnotation("first"), @SimpleAnnotation("second")};
+        SimpleParameterAnnotation[] subAnnotationArrayWithDefault() default {@SimpleParameterAnnotation("first"), @SimpleParameterAnnotation("second")};
 
         Class<?> clazz();
 
@@ -104,11 +107,13 @@ public class ClassWithMethodWithAnnotatedParameters {
         Class<?>[] classesWithDefault() default {Serializable.class, List.class};
     }
 
+    @Target(ElementType.PARAMETER)
     @Retention(RUNTIME)
-    public @interface SimpleAnnotation {
+    public @interface SimpleParameterAnnotation {
         String value();
     }
 
+    @Target(ElementType.PARAMETER)
     @Retention(RUNTIME)
     public @interface OtherParameterAnnotation {
         Class<?> value();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotationfieldimport/FieldAnnotationWithArrays.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotationfieldimport/FieldAnnotationWithArrays.java
@@ -1,12 +1,15 @@
 package com.tngtech.archunit.core.importer.testexamples.annotationfieldimport;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.SimpleAnnotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+@Target(ElementType.FIELD)
 @Retention(RUNTIME)
 public @interface FieldAnnotationWithArrays {
     int[] primitives();

--- a/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotationmethodimport/MethodAnnotationWithArrays.java
+++ b/archunit/src/test/java/com/tngtech/archunit/core/importer/testexamples/annotationmethodimport/MethodAnnotationWithArrays.java
@@ -1,12 +1,15 @@
 package com.tngtech.archunit.core.importer.testexamples.annotationmethodimport;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 import com.tngtech.archunit.core.importer.testexamples.SomeEnum;
 import com.tngtech.archunit.core.importer.testexamples.annotatedclassimport.SimpleAnnotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+@Target(ElementType.METHOD)
 @Retention(RUNTIME)
 public @interface MethodAnnotationWithArrays {
     int[] primitives();

--- a/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaAnnotationsAssertion.java
+++ b/archunit/src/test/java/com/tngtech/archunit/testutil/assertion/JavaAnnotationsAssertion.java
@@ -19,9 +19,11 @@ public class JavaAnnotationsAssertion extends AbstractIterableAssert<JavaAnnotat
         super((Set) javaAnnotations, JavaAnnotationsAssertion.class);
     }
 
-    public JavaAnnotationsAssertion match(Collection<Annotation> annotations) {
-        assertThat(actual).hasSameSizeAs(annotations);
+    public JavaAnnotationsAssertion match(Annotation[] annotations) {
+        return match(ImmutableSet.copyOf(annotations));
+    }
 
+    public JavaAnnotationsAssertion match(Collection<Annotation> annotations) {
         Map<String, JavaAnnotation<?>> actualByClassName = annotationsByClassName(actual);
         Map<String, Annotation> reflectionByClassName = reflectionByClassName(annotations);
         assertThat(actualByClassName.keySet())


### PR DESCRIPTION
This a small preparation change for #1382 
ClassFileImporterAnnotationsTest will be extended with many more new test cases for TYPE_USE annotations.
To prepare these new tests, the test class is migrated to junit5, grouped into Nested test suites and the annotation assertions are extended with a new overload for simpler usage.

In addition to that, the productive JavaTypeCreationProcess gets some minor changes to method signatures to get rid of uncheck warnings (and their supressions)